### PR TITLE
fix: trust proxies for ngrok and reverse proxy support

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->trustProxies(at: '*');
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //


### PR DESCRIPTION
## Summary
- Configure `trustProxies(at: '*')` in `bootstrap/app.php` so Laravel respects `X-Forwarded-*` headers from reverse proxies (ngrok, nginx, load balancers)
- Without this, asset URLs are generated with `http://127.0.0.1:8000/...` instead of the real public domain, causing CSS/JS to fail to load

## Test plan
- [x] Verify CSS and JS load correctly when accessing the app through ngrok
- [x] Verify the app works normally through `php artisan serve` directly