### PR TITLE
style: mobile-first responsive fixes across product and category views

### DIFF
--- a/resources/views/categories/create.blade.php
+++ b/resources/views/categories/create.blade.php
@@ -6,7 +6,7 @@
   </x-slot>
 
   <div class="py-12">
-    <div class="max-w-4xl mx-auto sm:px-6 lg:px-8">
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
 
         <form method="POST" action="{{ route('categories.store') }}">

--- a/resources/views/products/create.blade.php
+++ b/resources/views/products/create.blade.php
@@ -1,8 +1,8 @@
 <x-app-layout>
-  <div class="max-w-2xl mx-auto p-6 bg-white rounded-lg shadow-md mt-10">
-    <h2 class="text-2xl font-bold mb-6 text-gray-800">Añadir Nuevo Plato</h2>
+  <div class="max-w-2xl mx-auto px-4 sm:px-6 py-4 sm:p-6 bg-white rounded-lg shadow-md mt-4 sm:mt-10">
+    <h2 class="text-xl sm:text-2xl font-bold mb-4 sm:mb-6 text-gray-800">Añadir Nuevo Plato</h2>
 
-    <form action="{{ route('products.store') }}" method="POST" enctype="multipart/form-data" class="space-y-4">
+    <form action="{{ route('products.store') }}" method="POST" enctype="multipart/form-data" class="space-y-3 sm:space-y-4">
       @csrf
       <div>
         <label for="name" class="block text-sm font-medium text-gray-700">Nombre del plato</label>

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -1,8 +1,8 @@
 <x-app-layout>
-    <div class="max-w-2xl mx-auto p-6 bg-white rounded-lg shadow-md mt-10">
-        <h2 class="text-2xl font-bold mb-6 text-gray-800">Editar Plato: {{ $product->name }}</h2>
+    <div class="max-w-2xl mx-auto px-4 sm:px-6 py-4 sm:p-6 bg-white rounded-lg shadow-md mt-4 sm:mt-10">
+        <h2 class="text-xl sm:text-2xl font-bold mb-4 sm:mb-6 text-gray-800">Editar Plato: {{ $product->name }}</h2>
 
-        <form action="{{ route('products.update', $product) }}" method="POST" enctype="multipart/form-data" class="space-y-4">
+        <form action="{{ route('products.update', $product) }}" method="POST" enctype="multipart/form-data" class="space-y-3 sm:space-y-4">
             @csrf
             @method('PUT')
             <div>
@@ -34,7 +34,7 @@
                 <label class="block text-sm font-medium text-gray-700">Foto del plato (Max: 2MB)</label>
                 @if($product->image)
                 <div class="my-2">
-                    <img src="{{ asset('storage/' . $product->image) }}" class="h-20 w-20 object-cover rounded-md border">
+                    <img src="{{ asset('storage/' . $product->image) }}" class="h-16 w-16 sm:h-20 sm:w-20 object-cover rounded-md border">
                     <p class="text-xs text-gray-500 mt-1">Imagen actual. Sube una nueva si deseas reemplazarla.</p>
                 </div>
                 @endif

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -1,8 +1,8 @@
 <x-app-layout>
-  <div class="max-w-6xl mx-auto p-6 mt-10">
-    <div class="flex justify-between items-center mb-6">
-      <h2 class="text-2xl font-bold text-gray-800">Mi Carta Digital</h2>
-      <a href="{{ route('products.create') }}" class="bg-green-600 text-white px-4 py-2 rounded-md hover:bg-green-700">
+  <div class="max-w-6xl mx-auto px-4 sm:px-6 py-6 mt-4 sm:mt-10">
+    <div class="flex justify-between items-center mb-4 sm:mb-6">
+      <h2 class="text-xl sm:text-2xl font-bold text-gray-800">Mi Carta Digital</h2>
+      <a href="{{ route('products.create') }}" class="bg-green-600 text-white px-3 py-2 sm:px-4 rounded-md hover:bg-green-700 text-sm sm:text-base">
         + Añadir Plato
       </a>
     </div>
@@ -13,35 +13,37 @@
     </div>
     @endif
 
-    <div class="bg-white shadow-md rounded-lg overflow-hidden">
+    <div class="bg-white shadow-md rounded-lg overflow-x-auto">
       <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Imagen</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Nombre</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Precio</th>
-            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Acciones</th>
+            <th class="hidden sm:table-cell px-4 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Imagen</th>
+            <th class="px-4 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Nombre</th>
+            <th class="hidden md:table-cell px-4 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Precio</th>
+            <th class="px-4 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Acciones</th>
           </tr>
         </thead>
         <tbody class="bg-white divide-y divide-gray-200">
           @foreach($products as $product)
           <tr>
-            <td class="px-6 py-4 whitespace-nowrap">
+            <td class="hidden sm:table-cell px-4 sm:px-6 py-4 whitespace-nowrap">
               @if($product->image)
-              <img src="{{ asset('storage/' . $product->image) }}" alt="Foto de {{ $product->name }}" class="h-12 w-12 object-cover rounded-md">
+              <img src="{{ asset('storage/' . $product->image) }}" alt="Foto de {{ $product->name }}" class="h-10 w-10 sm:h-12 sm:w-12 object-cover rounded-md">
               @else
               <span class="text-gray-400 text-sm">Sin imagen</span>
               @endif
             </td>
-            <td class="px-6 py-4 whitespace-nowrap font-medium text-gray-900">{{ $product->name }}</td>
-            <td class="px-6 py-4 whitespace-nowrap text-gray-500">{{ number_format($product->price, 2) }} €</td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium flex space-x-2">
-              <a href="{{ route('products.edit', $product) }}" class="text-indigo-600 hover:text-indigo-900 bg-indigo-100 px-3 py-1 rounded">Editar</a>
-              <form action="{{ route('products.destroy', $product) }}" method="POST" onsubmit="return confirm('¿Seguro que quieres borrar este plato?');">
-                  @csrf
-                  @method('DELETE')
-                  <button type="submit" class="text-red-600 hover:text-red-900 bg-red-100 px-3 py-1 rounded">Borrar</button>
-              </form>
+            <td class="px-4 sm:px-6 py-4 whitespace-nowrap font-medium text-gray-900 text-sm sm:text-base">{{ $product->name }}</td>
+            <td class="hidden md:table-cell px-4 sm:px-6 py-4 whitespace-nowrap text-gray-500">{{ number_format($product->price, 2) }} €</td>
+            <td class="px-4 sm:px-6 py-4 whitespace-nowrap text-sm font-medium">
+              <div class="flex flex-col sm:flex-row gap-2">
+                <a href="{{ route('products.edit', $product) }}" class="text-indigo-600 hover:text-indigo-900 bg-indigo-100 px-3 py-1 rounded text-center">Editar</a>
+                <form action="{{ route('products.destroy', $product) }}" method="POST" onsubmit="return confirm('¿Seguro que quieres borrar este plato?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="w-full text-red-600 hover:text-red-900 bg-red-100 px-3 py-1 rounded">Borrar</button>
+                </form>
+              </div>
             </td>
           </tr>
           @endforeach


### PR DESCRIPTION
## Summary
- `products/index`: tabla con `overflow-x-auto`, columnas Imagen y Precio ocultas en móvil (`hidden sm/md:table-cell`), botones en columna en móvil (`flex-col sm:flex-row`)
- `products/create`: padding `p-4 sm:p-6`, heading `text-xl sm:text-2xl`, spacing `space-y-3 sm:space-y-4`
- `products/edit`: mismos ajustes que create + imagen preview `h-16 w-16 sm:h-20 sm:w-20`
- `categories/create`: añadido `px-4` base para móvil < 640px (antes los inputs tocaban el borde)

## Test plan
- [x] Verificar en Chrome DevTools con viewport 375px (iPhone SE)
- [x] Verificar en viewport 768px (tablet)
- [x] Verificar que la tabla de productos hace scroll horizontal en móvil
- [ ] Verificar que los botones Editar/Borrar se apilan en móvil