### PR TITLE
feat: sistema de alérgenos automático (Bloque 2.2)

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -27,7 +27,7 @@ class ProductController extends Controller
    */
   public function index(): View
   {
-    $products = Product::where('user_id', Auth::id())->paginate(15);
+    $products = Product::where('user_id', Auth::id())->with('allergens')->paginate(15);
     return view('products.index', compact('products'));
   }
 
@@ -98,6 +98,8 @@ class ProductController extends Controller
 
         abort_if($product->user_id !== Auth::id(), 403, 'No tienes permiso para editar este plato.');
  
+        $product->load('allergens');
+
         $categories = Category::where('user_id', Auth::id())->get();
 
         return view('products.edit', compact('product', 'categories'));

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -53,6 +53,19 @@ class Product extends Model
     }
 
     /**
+     * Devuelve solo los ingredientes del plato que están marcados como alérgeno.
+     * Se actualiza automáticamente al modificar los ingredientes del plato.
+     *
+     * @return BelongsToMany
+     */
+    public function allergens(): BelongsToMany
+    {
+        return $this->belongsToMany(Ingredient::class, 'ingredient_product')
+            ->where('is_allergen', true)
+            ->withTimestamps();
+    }
+
+    /**
      * Transforma el input del formulario al formato que espera Eloquent sync().
      *
      * @param array $ingredientsInput Array del formulario indexado por ingredient_id

--- a/resources/views/components/allergen-badge.blade.php
+++ b/resources/views/components/allergen-badge.blade.php
@@ -1,0 +1,46 @@
+@php
+/**
+ * Componente: allergen-badge
+ *
+ * Muestra el icono y nombre de un alérgeno según los 14 alérgenos de la UE.
+ * El icono se selecciona por coincidencia de keywords en el nombre del ingrediente.
+ *
+ * @prop \App\Models\Ingredient $allergen
+ */
+
+$name = mb_strtolower($allergen->name);
+
+$map = [
+    '🌾' => ['gluten','trigo','cebada','centeno','avena','pan','harina','cereal','espelta','kamut'],
+    '🦐' => ['crustáceo','crustaceo','gamba','langosta','cangrejo','langostino','bogavante','nécora','necora'],
+    '🥚' => ['huevo','huevos','clara','yema'],
+    '🐟' => ['pescado','atún','atun','salmón','salmon','merluza','bacalao','anchoa','sardina','trucha','dorada','lubina','boquerón'],
+    '🥜' => ['cacahuete','maní','mani','groundnut'],
+    '🫘' => ['soja','tofu','edamame'],
+    '🥛' => ['lácteo','lacteo','leche','nata','queso','mantequilla','yogur','lactosa','caseína','caseina','requesón'],
+    '🌰' => ['fruto seco','nuez','nueces','almendra','avellana','pistacho','anacardo','castaña','macadamia','pecana','nogal'],
+    '🥬' => ['apio'],
+    '🌻' => ['mostaza'],
+    '🌱' => ['sésamo','sesamo','tahini'],
+    '🍷' => ['sulfito','sulfitos','dióxido de azufre','so2'],
+    '🌸' => ['altramuz','altramuces','lupino'],
+    '🦪' => ['molusco','moluscos','almeja','mejillón','mejillon','ostra','calamar','pulpo','caracol','sepia'],
+];
+
+$icon = '⚠️';
+foreach ($map as $emoji => $keywords) {
+    foreach ($keywords as $keyword) {
+        if (str_contains($name, $keyword)) {
+            $icon = $emoji;
+            break 2;
+        }
+    }
+}
+@endphp
+
+<span role="listitem"
+      title="{{ $allergen->name }}"
+      class="inline-flex items-center gap-1 bg-red-100 text-red-700 text-xs font-semibold px-2 py-0.5 rounded-full border border-red-200">
+    <span aria-hidden="true">{{ $icon }}</span>
+    <span>{{ $allergen->name }}</span>
+</span>

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -46,6 +46,20 @@
             </button>
         </form>
 
+        @if($product->allergens->isNotEmpty())
+        <div class="mt-4 pt-4 border-t border-gray-200">
+            <p class="text-sm font-medium text-gray-700 mb-2">Alérgenos detectados:</p>
+            <div class="flex flex-wrap gap-1" role="list" aria-label="Alérgenos de {{ $product->name }}">
+                @foreach($product->allergens as $allergen)
+                    <span role="listitem"
+                          class="inline-flex items-center gap-1 bg-red-100 text-red-700 text-xs font-semibold px-2 py-1 rounded-full border border-red-200">
+                        <span aria-hidden="true">⚠️</span>{{ $allergen->name }}
+                    </span>
+                @endforeach
+            </div>
+        </div>
+        @endif
+
         <div class="mt-4 pt-4 border-t dark:border-gray-700">
             <a href="{{ route('products.ingredients.edit', $product) }}"
                class="w-full flex justify-center py-2 px-4 border border-orange-500

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -51,10 +51,7 @@
             <p class="text-sm font-medium text-gray-700 mb-2">Alérgenos detectados:</p>
             <div class="flex flex-wrap gap-1" role="list" aria-label="Alérgenos de {{ $product->name }}">
                 @foreach($product->allergens as $allergen)
-                    <span role="listitem"
-                          class="inline-flex items-center gap-1 bg-red-100 text-red-700 text-xs font-semibold px-2 py-1 rounded-full border border-red-200">
-                        <span aria-hidden="true">⚠️</span>{{ $allergen->name }}
-                    </span>
+                    <x-allergen-badge :allergen="$allergen" />
                 @endforeach
             </div>
         </div>

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -40,10 +40,7 @@
               @if($product->allergens->isNotEmpty())
                 <div class="flex flex-wrap gap-1" role="list" aria-label="Alérgenos de {{ $product->name }}">
                   @foreach($product->allergens as $allergen)
-                    <span role="listitem"
-                          class="inline-flex items-center gap-1 bg-red-100 text-red-700 text-xs font-medium px-2 py-0.5 rounded-full border border-red-200">
-                      <span aria-hidden="true">⚠️</span>{{ $allergen->name }}
-                    </span>
+                    <x-allergen-badge :allergen="$allergen" />
                   @endforeach
                 </div>
               @else

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -20,6 +20,7 @@
             <th class="hidden sm:table-cell px-4 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Imagen</th>
             <th class="px-4 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Nombre</th>
             <th class="hidden md:table-cell px-4 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Precio</th>
+            <th class="hidden lg:table-cell px-4 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Alérgenos</th>
             <th class="px-4 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase">Acciones</th>
           </tr>
         </thead>
@@ -35,6 +36,20 @@
             </td>
             <td class="px-4 sm:px-6 py-4 whitespace-nowrap font-medium text-gray-900 text-sm sm:text-base">{{ $product->name }}</td>
             <td class="hidden md:table-cell px-4 sm:px-6 py-4 whitespace-nowrap text-gray-500">{{ number_format($product->price, 2) }} €</td>
+            <td class="hidden lg:table-cell px-4 sm:px-6 py-4">
+              @if($product->allergens->isNotEmpty())
+                <div class="flex flex-wrap gap-1" role="list" aria-label="Alérgenos de {{ $product->name }}">
+                  @foreach($product->allergens as $allergen)
+                    <span role="listitem"
+                          class="inline-flex items-center gap-1 bg-red-100 text-red-700 text-xs font-medium px-2 py-0.5 rounded-full border border-red-200">
+                      <span aria-hidden="true">⚠️</span>{{ $allergen->name }}
+                    </span>
+                  @endforeach
+                </div>
+              @else
+                <span class="text-gray-400 text-xs">Ninguno</span>
+              @endif
+            </td>
             <td class="px-4 sm:px-6 py-4 whitespace-nowrap text-sm font-medium">
               <div class="flex flex-col sm:flex-row gap-2">
                 <a href="{{ route('products.edit', $product) }}" class="text-indigo-600 hover:text-indigo-900 bg-indigo-100 px-3 py-1 rounded text-center">Editar</a>


### PR DESCRIPTION
## Resumen

- Añade `allergens()` en el modelo `Product` — relación N:M filtrada por `is_allergen = true`
- Eager-load de alérgenos en `ProductController` (index y edit) sin N+1
- Nuevo componente `<x-allergen-badge>` con mapeo a los 14 alérgenos de la UE
- Badges con icono específico por alérgeno en la vista de listado y edición de productos
- Actualización automática al modificar ingredientes del plato (consulta en vivo)

## Test plan

- [ ] Crear un ingrediente con `is_allergen = true` y asignarlo a un producto
- [ ] Verificar que aparece el badge con el icono correcto en `Mi Carta Digital`
- [ ] Verificar que aparece en la vista de edición del producto
- [ ] Cambiar el nombre del ingrediente a una keyword conocida (ej: "Huevo") y comprobar que el icono cambia a 🥚
- [ ] Desasignar el ingrediente del plato y comprobar que el badge desaparece
- [ ] Comprobar que un producto sin alérgenos muestra "Ninguno" en el listado

🤖 Generated with [Claude Code](https://claude.com/claude-code)