### PR TITLE
[feat] allergen-type-db — columna y modelo para alérgenos UE

### DIFF
--- a/app/Http/Controllers/IngredientController.php
+++ b/app/Http/Controllers/IngredientController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Ingredient;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 /**
  * Class IngredientController
@@ -14,6 +15,7 @@ use Illuminate\Support\Facades\Auth;
  *
  * @package App\Http\Controllers
  * @author BenjaminDTS
+ * @author AyrtonAlania
  */
 class IngredientController extends Controller
 {
@@ -49,8 +51,9 @@ class IngredientController extends Controller
     public function store(Request $request): \Illuminate\Http\RedirectResponse
     {
         $validated = $request->validate([
-            'name'        => 'required|string|max:255',
-            'is_allergen' => 'boolean',
+            'name'         => 'required|string|max:255',
+            'is_allergen'  => 'boolean',
+            'allergen_type' => ['nullable', 'string', Rule::in(array_keys(Ingredient::ALLERGEN_TYPES))],
         ]);
 
         $request->user()->ingredients()->create($validated);
@@ -91,8 +94,9 @@ class IngredientController extends Controller
         abort_if($ingredient->user_id !== Auth::id(), 403, 'Acceso denegado.');
 
         $validated = $request->validate([
-            'name'        => 'required|string|max:255',
-            'is_allergen' => 'boolean',
+            'name'         => 'required|string|max:255',
+            'is_allergen'  => 'boolean',
+            'allergen_type' => ['nullable', 'string', Rule::in(array_keys(Ingredient::ALLERGEN_TYPES))],
         ]);
 
         $ingredient->update($validated);

--- a/app/Models/Ingredient.php
+++ b/app/Models/Ingredient.php
@@ -15,12 +15,37 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property string $name           Nombre del ingrediente
  * @property boolean $is_allergen   Si se considera alérgeno importante
+ * @property string|null $allergen_type Tipo de alérgeno según Reglamento UE 1169/2011
+ *
+ * @author AyrtonAlania
  */
 class Ingredient extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['user_id', 'name', 'is_allergen'];
+    protected $fillable = ['user_id', 'name', 'is_allergen', 'allergen_type'];
+
+    /**
+     * Slugs válidos para allergen_type.
+     * Coinciden con los nombres de los SVGs en public/images/allergens/
+     * Basados en el Reglamento UE 1169/2011 de información alimentaria.
+     */
+    public const ALLERGEN_TYPES = [
+        'gluten'          => 'Cereales con gluten',
+        'crustaceos'      => 'Crustáceos',
+        'huevos'          => 'Huevos',
+        'pescado'         => 'Pescado',
+        'cacahuetes'      => 'Cacahuetes',
+        'soja'            => 'Soja',
+        'lacteos'         => 'Lácteos',
+        'frutos-cascara'  => 'Frutos de cáscara',
+        'apio'            => 'Apio',
+        'mostaza'         => 'Mostaza',
+        'sesamo'          => 'Granos de sésamo',
+        'sulfitos'        => 'Dióxido de azufre y sulfitos',
+        'altramuces'      => 'Altramuces',
+        'moluscos'        => 'Moluscos',
+    ];
 
     /**
      * El restaurante dueño de este ingrediente.
@@ -37,5 +62,27 @@ class Ingredient extends Model
     {
         return $this->belongsToMany(Product::class, 'ingredient_product')
             ->withPivot(['quantity_base', 'is_removable', 'is_extra', 'extra_price']);
+    }
+
+    /**
+     * Devuelve la URL del SVG oficial del alérgeno.
+     * Retorna null si no tiene allergen_type asignado.
+     *
+     * @return string|null
+     */
+    public function allergenIconPath(): ?string
+    {
+        if (!$this->allergen_type) return null;
+        return asset('images/allergens/' . $this->allergen_type . '.svg');
+    }
+
+    /**
+     * Devuelve el nombre legible del tipo de alérgeno.
+     *
+     * @return string|null
+     */
+    public function allergenTypeName(): ?string
+    {
+        return self::ALLERGEN_TYPES[$this->allergen_type] ?? null;
     }
 }

--- a/database/migrations/2026_04_06_201504_add_allergen_type_to_ingredients_table.php
+++ b/database/migrations/2026_04_06_201504_add_allergen_type_to_ingredients_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->string('allergen_type')->nullable()->after('is_allergen');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->dropColumn('allergen_type');
+        });
+    }
+};


### PR DESCRIPTION
## Qué se implementa
- Columna allergen_type (string nullable) en ingredients
- Constante ALLERGEN_TYPES con los 14 alérgenos oficiales UE (Reglamento 1169/2011)
- Helpers allergenIconPath() y allergenTypeName() en Ingredient
- Validación Rule::in() para allergen_type en IngredientController

## Por qué
- Base de datos para el sistema de iconos oficiales UE
- Sin dependencia de nombres de ingredientes (sin mapa de keywords)
- El gerente selecciona explícitamente el tipo de alérgeno

## Checklist CLAUDE.md
- [x] Rama parte de main actualizado
- [x] Un commit por archivo modificado
- [x] Migración nueva, NO se modificó ninguna migración original
- [x] @author según regla (sin duplicados, sin borrar existentes)
- [x] migrate:status limpio

## Archivos modificados
- database/migrations/ (1 nueva)
- app/Models/Ingredient.php
- app/Http/Controllers/IngredientController.php