### PR TITLE
[feat] allergen-icons-views — iconos oficiales UE en vistas

### DIFF
--- a/app/Http/Controllers/IngredientController.php
+++ b/app/Http/Controllers/IngredientController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Ingredient;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 /**
  * Class IngredientController
@@ -14,6 +15,7 @@ use Illuminate\Support\Facades\Auth;
  *
  * @package App\Http\Controllers
  * @author BenjaminDTS
+ * @author AyrtonAlania
  */
 class IngredientController extends Controller
 {
@@ -49,8 +51,9 @@ class IngredientController extends Controller
     public function store(Request $request): \Illuminate\Http\RedirectResponse
     {
         $validated = $request->validate([
-            'name'        => 'required|string|max:255',
-            'is_allergen' => 'boolean',
+            'name'         => 'required|string|max:255',
+            'is_allergen'  => 'boolean',
+            'allergen_type' => ['nullable', 'string', Rule::in(array_keys(Ingredient::ALLERGEN_TYPES))],
         ]);
 
         $request->user()->ingredients()->create($validated);
@@ -91,8 +94,9 @@ class IngredientController extends Controller
         abort_if($ingredient->user_id !== Auth::id(), 403, 'Acceso denegado.');
 
         $validated = $request->validate([
-            'name'        => 'required|string|max:255',
-            'is_allergen' => 'boolean',
+            'name'         => 'required|string|max:255',
+            'is_allergen'  => 'boolean',
+            'allergen_type' => ['nullable', 'string', Rule::in(array_keys(Ingredient::ALLERGEN_TYPES))],
         ]);
 
         $ingredient->update($validated);

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -33,7 +33,13 @@ class MenuController extends Controller
                     $query->where('is_active', true)
                           ->with([
                               'ingredients' => function ($q) {
-                                  $q->where('is_allergen', true);
+                                  $q->where('is_allergen', true)
+                                    ->select([
+                                        'ingredients.id',
+                                        'ingredients.name',
+                                        'ingredients.is_allergen',
+                                        'ingredients.allergen_type',
+                                    ]);
                               },
                           ])
                           ->orderBy('name');

--- a/app/Models/Ingredient.php
+++ b/app/Models/Ingredient.php
@@ -15,12 +15,37 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  *
  * @property string $name           Nombre del ingrediente
  * @property boolean $is_allergen   Si se considera alérgeno importante
+ * @property string|null $allergen_type Tipo de alérgeno según Reglamento UE 1169/2011
+ *
+ * @author AyrtonAlania
  */
 class Ingredient extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['user_id', 'name', 'is_allergen'];
+    protected $fillable = ['user_id', 'name', 'is_allergen', 'allergen_type'];
+
+    /**
+     * Slugs válidos para allergen_type.
+     * Coinciden con los nombres de los SVGs en public/images/allergens/
+     * Basados en el Reglamento UE 1169/2011 de información alimentaria.
+     */
+    public const ALLERGEN_TYPES = [
+        'gluten'          => 'Cereales con gluten',
+        'crustaceos'      => 'Crustáceos',
+        'huevos'          => 'Huevos',
+        'pescado'         => 'Pescado',
+        'cacahuetes'      => 'Cacahuetes',
+        'soja'            => 'Soja',
+        'lacteos'         => 'Lácteos',
+        'frutos-cascara'  => 'Frutos de cáscara',
+        'apio'            => 'Apio',
+        'mostaza'         => 'Mostaza',
+        'sesamo'          => 'Granos de sésamo',
+        'sulfitos'        => 'Dióxido de azufre y sulfitos',
+        'altramuces'      => 'Altramuces',
+        'moluscos'        => 'Moluscos',
+    ];
 
     /**
      * El restaurante dueño de este ingrediente.
@@ -37,5 +62,27 @@ class Ingredient extends Model
     {
         return $this->belongsToMany(Product::class, 'ingredient_product')
             ->withPivot(['quantity_base', 'is_removable', 'is_extra', 'extra_price']);
+    }
+
+    /**
+     * Devuelve la URL del SVG oficial del alérgeno.
+     * Retorna null si no tiene allergen_type asignado.
+     *
+     * @return string|null
+     */
+    public function allergenIconPath(): ?string
+    {
+        if (!$this->allergen_type) return null;
+        return asset('images/allergens/' . $this->allergen_type . '.svg');
+    }
+
+    /**
+     * Devuelve el nombre legible del tipo de alérgeno.
+     *
+     * @return string|null
+     */
+    public function allergenTypeName(): ?string
+    {
+        return self::ALLERGEN_TYPES[$this->allergen_type] ?? null;
     }
 }

--- a/database/migrations/2026_04_06_201504_add_allergen_type_to_ingredients_table.php
+++ b/database/migrations/2026_04_06_201504_add_allergen_type_to_ingredients_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->string('allergen_type')->nullable()->after('is_allergen');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->dropColumn('allergen_type');
+        });
+    }
+};

--- a/public/images/allergens/altramuces.svg
+++ b/public/images/allergens/altramuces.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-altramuces">
+  <title id="title-altramuces">Altramuces</title>
+  <circle cx="32" cy="32" r="32" fill="#FF8C00"/>
+  <path fill="white" d="M32 14 C32 14 36 20 32 26 C28 20 32 14 32 14 Z M32 26 L32 50 M22 20 C22 20 28 24 26 30 C22 26 22 20 22 20 Z M42 20 C42 20 36 24 38 30 C42 26 42 20 42 20 Z M18 32 C18 32 24 34 24 40 C18 38 18 32 18 32 Z M46 32 C46 32 40 34 40 40 C46 38 46 32 46 32 Z"/>
+</svg>

--- a/public/images/allergens/apio.svg
+++ b/public/images/allergens/apio.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-apio">
+  <title id="title-apio">Apio</title>
+  <circle cx="32" cy="32" r="32" fill="#2E7D32"/>
+  <path fill="none" stroke="white" stroke-width="3" stroke-linecap="round" d="M32 52 L32 28 M32 28 C32 28 22 20 20 12 M32 28 C32 28 42 20 44 12 M32 36 C32 36 24 32 20 24 M32 36 C32 36 40 32 44 24"/>
+</svg>

--- a/public/images/allergens/cacahuetes.svg
+++ b/public/images/allergens/cacahuetes.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-cacahuetes">
+  <title id="title-cacahuetes">Cacahuetes</title>
+  <circle cx="32" cy="32" r="32" fill="#8B4513"/>
+  <path fill="white" d="M32 14 C26 14 22 18 22 23 C22 26 24 29 26 30 C24 31 22 34 22 37 C22 42 26 46 32 46 C38 46 42 42 42 37 C42 34 40 31 38 30 C40 29 42 26 42 23 C42 18 38 14 32 14 Z M26 30 Q32 28 38 30" stroke="white" stroke-width="1.5" fill="none"/>
+</svg>

--- a/public/images/allergens/crustaceos.svg
+++ b/public/images/allergens/crustaceos.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-crustaceos">
+  <title id="title-crustaceos">Crustáceos</title>
+  <circle cx="32" cy="32" r="32" fill="#D95B2E"/>
+  <path d="M32 16 C26 16 22 20 22 26 C22 32 26 38 32 42 C38 38 42 32 42 26 C42 20 38 16 32 16 Z M24 30 L18 28 M24 34 L18 36 M40 30 L46 28 M40 34 L46 36 M29 20 L26 14 M35 20 L38 14" stroke="white" stroke-width="2" fill="none"/>
+</svg>

--- a/public/images/allergens/frutos-cascara.svg
+++ b/public/images/allergens/frutos-cascara.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-frutos-cascara">
+  <title id="title-frutos-cascara">Frutos de cáscara</title>
+  <circle cx="32" cy="32" r="32" fill="#A0522D"/>
+  <path fill="white" d="M32 16 C24 16 18 22 18 30 C18 38 24 48 32 50 C40 48 46 38 46 30 C46 22 40 16 32 16 Z M18 30 Q32 26 46 30 M26 20 Q32 28 38 20" stroke="white" stroke-width="1.5" fill="none"/>
+</svg>

--- a/public/images/allergens/gluten.svg
+++ b/public/images/allergens/gluten.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-gluten">
+  <title id="title-gluten">Gluten</title>
+  <circle cx="32" cy="32" r="32" fill="#E8821A"/>
+  <path d="M32 8 L32 56 M28 20 C28 20 24 18 24 14 C24 10 28 10 28 14 M36 20 C36 20 40 18 40 14 C40 10 36 10 36 14 M28 28 C28 28 24 26 24 22 C24 18 28 18 28 22 M36 28 C36 28 40 26 40 22 C40 18 36 18 36 22 M28 36 C28 36 24 34 24 30 C24 26 28 26 28 30 M36 36 C36 36 40 34 40 30 C40 26 36 26 36 30" stroke="white" stroke-width="2" fill="none"/>
+</svg>

--- a/public/images/allergens/huevos.svg
+++ b/public/images/allergens/huevos.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-huevos">
+  <title id="title-huevos">Huevos</title>
+  <circle cx="32" cy="32" r="32" fill="#F5C400"/>
+  <ellipse cx="32" cy="34" rx="14" ry="18" fill="none" stroke="white" stroke-width="3"/>
+  <ellipse cx="32" cy="36" rx="7" ry="8" fill="white"/>
+</svg>

--- a/public/images/allergens/lacteos.svg
+++ b/public/images/allergens/lacteos.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-lacteos">
+  <title id="title-lacteos">Lácteos</title>
+  <circle cx="32" cy="32" r="32" fill="#5DADE2"/>
+  <rect x="22" y="20" width="20" height="28" rx="3" fill="none" stroke="white" stroke-width="3"/>
+  <path d="M22 28 Q32 24 42 28" stroke="white" stroke-width="2" fill="none"/>
+  <path d="M24 16 L22 20 M32 14 L32 20 M40 16 L42 20" stroke="white" stroke-width="2"/>
+</svg>

--- a/public/images/allergens/moluscos.svg
+++ b/public/images/allergens/moluscos.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-moluscos">
+  <title id="title-moluscos">Moluscos</title>
+  <circle cx="32" cy="32" r="32" fill="#1A3A5C"/>
+  <path fill="white" d="M32 48 C20 48 14 40 14 32 C14 22 22 16 32 16 C42 16 50 22 50 32 C50 40 44 48 32 48 Z M32 16 L32 48 M14 32 Q32 28 50 32 M18 22 Q32 36 46 22 M20 42 Q32 38 44 42" fill="none" stroke="white" stroke-width="2"/>
+  <path fill="white" d="M32 48 L26 56 L32 52 L38 56 Z"/>
+</svg>

--- a/public/images/allergens/mostaza.svg
+++ b/public/images/allergens/mostaza.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-mostaza">
+  <title id="title-mostaza">Mostaza</title>
+  <circle cx="32" cy="32" r="32" fill="#C8A400"/>
+  <circle cx="32" cy="32" r="8" fill="none" stroke="white" stroke-width="3"/>
+  <path fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" d="M32 14 L32 22 M32 42 L32 50 M14 32 L22 32 M42 32 L50 32 M20 20 L26 26 M38 38 L44 44 M44 20 L38 26 M26 38 L20 44"/>
+</svg>

--- a/public/images/allergens/pescado.svg
+++ b/public/images/allergens/pescado.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-pescado">
+  <title id="title-pescado">Pescado</title>
+  <circle cx="32" cy="32" r="32" fill="#1E73BE"/>
+  <path fill="white" d="M44 32 C44 32 36 22 24 24 C16 25 14 32 14 32 C14 32 16 39 24 40 C36 42 44 32 44 32 Z M44 32 L52 24 M44 32 L52 40 M52 24 L52 40 M28 30 C28 30 28 32 28 32" stroke="white" stroke-width="0" />
+  <circle cx="26" cy="30" r="2" fill="#1E73BE"/>
+</svg>

--- a/public/images/allergens/sesamo.svg
+++ b/public/images/allergens/sesamo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-sesamo">
+  <title id="title-sesamo">Sésamo</title>
+  <circle cx="32" cy="32" r="32" fill="#D4A843"/>
+  <ellipse cx="24" cy="24" rx="5" ry="8" fill="white" transform="rotate(-20 24 24)"/>
+  <ellipse cx="32" cy="20" rx="5" ry="8" fill="white" transform="rotate(10 32 20)"/>
+  <ellipse cx="40" cy="24" rx="5" ry="8" fill="white" transform="rotate(20 40 24)"/>
+  <ellipse cx="26" cy="38" rx="5" ry="8" fill="white" transform="rotate(-10 26 38)"/>
+  <ellipse cx="38" cy="38" rx="5" ry="8" fill="white" transform="rotate(15 38 38)"/>
+</svg>

--- a/public/images/allergens/soja.svg
+++ b/public/images/allergens/soja.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-soja">
+  <title id="title-soja">Soja</title>
+  <circle cx="32" cy="32" r="32" fill="#4CAF50"/>
+  <path fill="white" d="M32 12 C32 12 44 20 44 32 C44 44 32 52 32 52 C32 52 20 44 20 32 C20 20 32 12 32 12 Z M32 12 L32 52 M32 32 C32 32 24 28 22 20 M32 32 C32 32 40 28 42 20"/>
+</svg>

--- a/public/images/allergens/sulfitos.svg
+++ b/public/images/allergens/sulfitos.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-sulfitos">
+  <title id="title-sulfitos">Sulfitos</title>
+  <circle cx="32" cy="32" r="32" fill="#C0392B"/>
+  <text x="32" y="38" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="white" text-anchor="middle">SO₂</text>
+  <circle cx="32" cy="32" r="20" fill="none" stroke="white" stroke-width="2.5"/>
+</svg>

--- a/resources/views/components/allergen-badge.blade.php
+++ b/resources/views/components/allergen-badge.blade.php
@@ -1,46 +1,26 @@
-@php
-/**
- * Componente: allergen-badge
- *
- * Muestra el icono y nombre de un alérgeno según los 14 alérgenos de la UE.
- * El icono se selecciona por coincidencia de keywords en el nombre del ingrediente.
- *
- * @prop \App\Models\Ingredient $allergen
- */
+@props(['ingredient'])
 
-$name = mb_strtolower($allergen->name);
-
-$map = [
-    '🌾' => ['gluten','trigo','cebada','centeno','avena','pan','harina','cereal','espelta','kamut'],
-    '🦐' => ['crustáceo','crustaceo','gamba','langosta','cangrejo','langostino','bogavante','nécora','necora'],
-    '🥚' => ['huevo','huevos','clara','yema'],
-    '🐟' => ['pescado','atún','atun','salmón','salmon','merluza','bacalao','anchoa','sardina','trucha','dorada','lubina','boquerón'],
-    '🥜' => ['cacahuete','maní','mani','groundnut'],
-    '🫘' => ['soja','tofu','edamame'],
-    '🥛' => ['lácteo','lacteo','leche','nata','queso','mantequilla','yogur','lactosa','caseína','caseina','requesón'],
-    '🌰' => ['fruto seco','nuez','nueces','almendra','avellana','pistacho','anacardo','castaña','macadamia','pecana','nogal'],
-    '🥬' => ['apio'],
-    '🌻' => ['mostaza'],
-    '🌱' => ['sésamo','sesamo','tahini'],
-    '🍷' => ['sulfito','sulfitos','dióxido de azufre','so2'],
-    '🌸' => ['altramuz','altramuces','lupino'],
-    '🦪' => ['molusco','moluscos','almeja','mejillón','mejillon','ostra','calamar','pulpo','caracol','sepia'],
-];
-
-$icon = '⚠️';
-foreach ($map as $emoji => $keywords) {
-    foreach ($keywords as $keyword) {
-        if (str_contains($name, $keyword)) {
-            $icon = $emoji;
-            break 2;
-        }
-    }
-}
-@endphp
-
-<span role="listitem"
-      title="{{ $allergen->name }}"
-      class="inline-flex items-center gap-1 bg-red-100 text-red-700 text-xs font-semibold px-2 py-0.5 rounded-full border border-red-200">
-    <span aria-hidden="true">{{ $icon }}</span>
-    <span>{{ $allergen->name }}</span>
-</span>
+@if($ingredient->allergen_type)
+    <span class="inline-flex items-center gap-1
+                 bg-orange-50 dark:bg-orange-900/30
+                 border border-orange-200 dark:border-orange-700
+                 rounded-full px-2 py-0.5 text-xs
+                 text-orange-800 dark:text-orange-200"
+          title="{{ $ingredient->allergenTypeName() }}">
+        <img src="{{ $ingredient->allergenIconPath() }}"
+             alt="{{ $ingredient->allergenTypeName() }}"
+             class="h-4 w-4 rounded-full"
+             loading="lazy">
+        <span>{{ $ingredient->allergenTypeName() }}</span>
+    </span>
+@elseif($ingredient->is_allergen)
+    <span class="inline-flex items-center gap-1
+                 bg-yellow-50 dark:bg-yellow-900/30
+                 border border-yellow-200 dark:border-yellow-700
+                 rounded-full px-2 py-0.5 text-xs
+                 text-yellow-800 dark:text-yellow-200"
+          title="Alérgeno (tipo no especificado)">
+        <span aria-hidden="true">⚠️</span>
+        <span>{{ $ingredient->name }}</span>
+    </span>
+@endif

--- a/resources/views/ingredients/create.blade.php
+++ b/resources/views/ingredients/create.blade.php
@@ -1,4 +1,5 @@
 {{-- @author SebastianBCF --}}
+{{-- @author AyrtonAlania --}}
 <x-app-layout>
   <x-slot name="header">
     <h2 class="font-semibold text-xl sm:text-2xl text-gray-800 dark:text-gray-200 leading-tight">
@@ -38,27 +39,46 @@
             </div>
 
             {{-- Campo: Es alérgeno --}}
-            <fieldset>
+            <fieldset x-data="{ isAllergen: {{ old('is_allergen') ? 'true' : 'false' }} }">
               <legend class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Clasificación alérgeno
               </legend>
               <div class="flex items-center gap-3">
-                <input
-                  type="hidden"
-                  name="is_allergen"
-                  value="0"
-                >
+                <input type="hidden" name="is_allergen" value="0">
                 <input
                   type="checkbox"
                   name="is_allergen"
                   id="is_allergen"
                   value="1"
                   {{ old('is_allergen') ? 'checked' : '' }}
+                  @change="isAllergen = $event.target.checked"
                   class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-green-600 focus:ring-green-500 focus:outline-none focus:ring-2 focus:ring-offset-2"
                 >
                 <label for="is_allergen" class="text-sm text-gray-700 dark:text-gray-300">
                   Marcar como alérgeno
                 </label>
+              </div>
+
+              {{-- Selector de tipo de alérgeno oficial UE — visible solo si is_allergen está marcado --}}
+              <div x-show="isAllergen" x-cloak class="mt-4">
+                <label for="allergen_type" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Tipo de alérgeno oficial (UE)
+                </label>
+                <select
+                  name="allergen_type"
+                  id="allergen_type"
+                  class="w-full rounded-md border-gray-300 dark:bg-gray-900 dark:text-white shadow-sm focus:border-orange-500 focus:ring-orange-500"
+                >
+                  <option value="">— Selecciona el alérgeno oficial —</option>
+                  @foreach(\App\Models\Ingredient::ALLERGEN_TYPES as $slug => $label)
+                    <option value="{{ $slug }}" {{ old('allergen_type') === $slug ? 'selected' : '' }}>
+                      {{ $label }}
+                    </option>
+                  @endforeach
+                </select>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  Según el Reglamento UE 1169/2011 de información alimentaria.
+                </p>
               </div>
             </fieldset>
 

--- a/resources/views/ingredients/edit.blade.php
+++ b/resources/views/ingredients/edit.blade.php
@@ -1,4 +1,5 @@
 {{-- @author SebastianBCF --}}
+{{-- @author AyrtonAlania --}}
 <x-app-layout>
   <x-slot name="header">
     <h2 class="font-semibold text-xl sm:text-2xl text-gray-800 dark:text-gray-200 leading-tight">
@@ -38,27 +39,46 @@
             </div>
 
             {{-- Campo: Es alérgeno --}}
-            <fieldset>
+            <fieldset x-data="{ isAllergen: {{ $ingredient->is_allergen ? 'true' : 'false' }} }">
               <legend class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Clasificación alérgeno
               </legend>
               <div class="flex items-center gap-3">
-                <input
-                  type="hidden"
-                  name="is_allergen"
-                  value="0"
-                >
+                <input type="hidden" name="is_allergen" value="0">
                 <input
                   type="checkbox"
                   name="is_allergen"
                   id="is_allergen"
                   value="1"
                   {{ old('is_allergen', $ingredient->is_allergen) ? 'checked' : '' }}
+                  @change="isAllergen = $event.target.checked"
                   class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-green-600 focus:ring-green-500 focus:outline-none focus:ring-2 focus:ring-offset-2"
                 >
                 <label for="is_allergen" class="text-sm text-gray-700 dark:text-gray-300">
                   Marcar como alérgeno
                 </label>
+              </div>
+
+              {{-- Selector de tipo de alérgeno oficial UE — visible solo si is_allergen está marcado --}}
+              <div x-show="isAllergen" x-cloak class="mt-4">
+                <label for="allergen_type" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Tipo de alérgeno oficial (UE)
+                </label>
+                <select
+                  name="allergen_type"
+                  id="allergen_type"
+                  class="w-full rounded-md border-gray-300 dark:bg-gray-900 dark:text-white shadow-sm focus:border-orange-500 focus:ring-orange-500"
+                >
+                  <option value="">— Selecciona el alérgeno oficial —</option>
+                  @foreach(\App\Models\Ingredient::ALLERGEN_TYPES as $slug => $label)
+                    <option value="{{ $slug }}" {{ old('allergen_type', $ingredient->allergen_type) === $slug ? 'selected' : '' }}>
+                      {{ $label }}
+                    </option>
+                  @endforeach
+                </select>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  Según el Reglamento UE 1169/2011 de información alimentaria.
+                </p>
               </div>
             </fieldset>
 

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -208,17 +208,26 @@
                                     @click="toggleAllergen({{ $allergen->id }})"
                                     :aria-pressed="activeAllergens.includes({{ $allergen->id }})"
                                     :class="activeAllergens.includes({{ $allergen->id }})
-                                        ? 'bg-red-500 dark:bg-red-600 text-white border-red-500 dark:border-red-600'
-                                        : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-red-400 hover:text-red-600 dark:hover:text-red-400'"
-                                    class="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full
-                                           text-sm font-medium border transition-colors duration-150
-                                           focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">
-                                <svg x-show="activeAllergens.includes({{ $allergen->id }})"
-                                     aria-hidden="true" class="w-3.5 h-3.5" fill="none"
-                                     stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/>
-                                </svg>
-                                Sin {{ $allergen->name }}
+                                        ? 'ring-2 ring-orange-500 bg-orange-50 dark:bg-orange-900/30'
+                                        : 'bg-white dark:bg-gray-800 opacity-70 hover:opacity-100'"
+                                    class="flex flex-col items-center gap-1 p-2 rounded-lg border border-gray-200
+                                           dark:border-gray-700 transition-all duration-200 cursor-pointer
+                                           focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2
+                                           dark:focus:ring-offset-gray-900"
+                                    aria-label="{{ $allergen->allergenTypeName() ?? $allergen->name }}">
+                                @if($allergen->allergen_type)
+                                    <img src="{{ $allergen->allergenIconPath() }}"
+                                         alt="{{ $allergen->allergenTypeName() }}"
+                                         class="h-10 w-10 rounded-full">
+                                    <span class="text-xs text-gray-600 dark:text-gray-400 text-center leading-tight max-w-[4rem]">
+                                        {{ $allergen->allergenTypeName() }}
+                                    </span>
+                                @else
+                                    <span class="h-10 w-10 flex items-center justify-center bg-yellow-100 dark:bg-yellow-900 rounded-full text-xl" aria-hidden="true">⚠️</span>
+                                    <span class="text-xs text-gray-600 dark:text-gray-400 text-center leading-tight max-w-[4rem]">
+                                        {{ $allergen->name }}
+                                    </span>
+                                @endif
                             </button>
                         @endforeach
                     </div>
@@ -402,14 +411,7 @@
                                                 </p>
                                                 <ul class="flex flex-wrap gap-1" role="list">
                                                     @foreach ($product->ingredients as $allergen)
-                                                        <li>
-                                                            <span class="inline-block text-xs font-semibold
-                                                                         bg-red-600 dark:bg-red-700
-                                                                         text-white
-                                                                         px-2 py-0.5 rounded-full">
-                                                                {{ $allergen->name }}
-                                                            </span>
-                                                        </li>
+                                                        <li><x-allergen-badge :ingredient="$allergen" /></li>
                                                     @endforeach
                                                 </ul>
                                             </div>

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -37,10 +37,10 @@
             <td class="px-4 sm:px-6 py-4 whitespace-nowrap font-medium text-gray-900 text-sm sm:text-base">{{ $product->name }}</td>
             <td class="hidden md:table-cell px-4 sm:px-6 py-4 whitespace-nowrap text-gray-500">{{ number_format($product->price, 2) }} €</td>
             <td class="hidden lg:table-cell px-4 sm:px-6 py-4">
-              @if($product->allergens->isNotEmpty())
+              @if($product->ingredients->where('is_allergen', true)->isNotEmpty())
                 <div class="flex flex-wrap gap-1" role="list" aria-label="Alérgenos de {{ $product->name }}">
-                  @foreach($product->allergens as $allergen)
-                    <x-allergen-badge :allergen="$allergen" />
+                  @foreach($product->ingredients->where('is_allergen', true) as $allergen)
+                    <x-allergen-badge :ingredient="$allergen" />
                   @endforeach
                 </div>
               @else


### PR DESCRIPTION
## Qué se implementa
- 14 SVGs oficiales UE en public/images/allergens/
- allergen-badge actualizado con iconos SVG (sin mapa de keywords)
- Desplegable allergen_type en formularios de ingrediente (Alpine.js x-show)
- Carta pública muestra iconos oficiales en badges de platos y botones de filtro
- Fallback con ⚠️ para alérgenos sin tipo asignado
- Eager load de MenuController incluye allergen_type

## Dependencia
Requiere que feat/allergen-type-db (PR #32) esté mergeado primero.

## Checklist CLAUDE.md
- [x] Rama parte de main actualizado
- [x] Un commit por archivo modificado
- [x] @author según regla (sin duplicados, sin borrar existentes)
- [x] Lógica Alpine.js intacta (toggleAllergen, activeAllergens)
- [x] 14 SVGs con nombres exactos coincidentes con ALLERGEN_TYPES
- [x] php artisan route:list sin errores

## Archivos modificados
- public/images/allergens/ (14 SVGs nuevos)
- resources/views/components/allergen-badge.blade.php
- resources/views/ingredients/create.blade.php
- resources/views/ingredients/edit.blade.php
- resources/views/menu/show.blade.php
- app/Http/Controllers/MenuController.php