### PR TITLE
fix: corregir SVGs de alérgenos con atributo fill duplicado

### DIFF
--- a/public/images/allergens/cacahuetes.svg
+++ b/public/images/allergens/cacahuetes.svg
@@ -1,5 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-cacahuetes">
   <title id="title-cacahuetes">Cacahuetes</title>
   <circle cx="32" cy="32" r="32" fill="#8B4513"/>
-  <path fill="white" d="M32 14 C26 14 22 18 22 23 C22 26 24 29 26 30 C24 31 22 34 22 37 C22 42 26 46 32 46 C38 46 42 42 42 37 C42 34 40 31 38 30 C40 29 42 26 42 23 C42 18 38 14 32 14 Z M26 30 Q32 28 38 30" stroke="white" stroke-width="1.5" fill="none"/>
+  <path fill="white" d="M32 14 C26 14 22 18 22 23 C22 26 24 29 26 30 C24 31 22 34 22 37 C22 42 26 46 32 46 C38 46 42 42 42 37 C42 34 40 31 38 30 C40 29 42 26 42 23 C42 18 38 14 32 14 Z"/>
+  <path stroke="white" stroke-width="1.5" fill="none" d="M26 30 Q32 28 38 30"/>
 </svg>

--- a/public/images/allergens/frutos-cascara.svg
+++ b/public/images/allergens/frutos-cascara.svg
@@ -1,5 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-frutos-cascara">
   <title id="title-frutos-cascara">Frutos de cáscara</title>
   <circle cx="32" cy="32" r="32" fill="#A0522D"/>
-  <path fill="white" d="M32 16 C24 16 18 22 18 30 C18 38 24 48 32 50 C40 48 46 38 46 30 C46 22 40 16 32 16 Z M18 30 Q32 26 46 30 M26 20 Q32 28 38 20" stroke="white" stroke-width="1.5" fill="none"/>
+  <path fill="white" d="M32 16 C24 16 18 22 18 30 C18 38 24 48 32 50 C40 48 46 38 46 30 C46 22 40 16 32 16 Z"/>
+  <path stroke="#A0522D" stroke-width="1.5" fill="none" d="M18 30 Q32 26 46 30 M26 20 Q32 28 38 20"/>
 </svg>

--- a/public/images/allergens/moluscos.svg
+++ b/public/images/allergens/moluscos.svg
@@ -1,6 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-moluscos">
   <title id="title-moluscos">Moluscos</title>
   <circle cx="32" cy="32" r="32" fill="#1A3A5C"/>
-  <path fill="white" d="M32 48 C20 48 14 40 14 32 C14 22 22 16 32 16 C42 16 50 22 50 32 C50 40 44 48 32 48 Z M32 16 L32 48 M14 32 Q32 28 50 32 M18 22 Q32 36 46 22 M20 42 Q32 38 44 42" fill="none" stroke="white" stroke-width="2"/>
+  <path fill="white" d="M32 48 C20 48 14 40 14 32 C14 22 22 16 32 16 C42 16 50 22 50 32 C50 40 44 48 32 48 Z"/>
+  <path stroke="#1A3A5C" stroke-width="2" fill="none" d="M32 16 L32 48 M14 32 Q32 28 50 32 M18 22 Q32 36 46 22 M20 42 Q32 38 44 42"/>
   <path fill="white" d="M32 48 L26 56 L32 52 L38 56 Z"/>
 </svg>


### PR DESCRIPTION
## Summary

- Corrige los SVGs de **cacahuetes**, **frutos-cascara** y **moluscos** que no renderizaban correctamente
- El bug era un atributo `fill` duplicado en el mismo `<path>` (`fill="white"` y `fill="none"`), lo cual es XML inválido y produce comportamiento impredecible entre navegadores
- Solución: separar cada `<path>` problemático en dos elementos independientes, uno para el relleno y otro para el trazo

## Test plan

- [ ] Verificar que los tres iconos se renderizan visualmente en la carta pública (`/menu/{hash}`)
- [ ] Verificar que los iconos aparecen en la vista de productos del panel de administración
- [ ] Comprobar que el `alt` y los atributos ARIA (`role="img"`, `aria-labelledby`) siguen presentes