### PR TITLE
feat: Bloque 4.2 — Panel de cocina en tiempo real

### DIFF
--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Order;
+use App\Models\OrderItem;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+/**
+ * Panel de cocina en tiempo real.
+ *
+ * Muestra las comandas pendientes (status=queued) agrupadas por pedido,
+ * permite marcar ítems como listos y cierra el pedido automáticamente
+ * cuando todos sus ítems han sido preparados.
+ *
+ * @author AyrtonAlania
+ */
+class KitchenController extends Controller
+{
+    /**
+     * Devuelve los pedidos activos con ítems pendientes para la vista principal.
+     *
+     * @return View
+     */
+    public function index(): View
+    {
+        $orders = $this->getActiveOrders();
+
+        return view('kitchen.index', compact('orders'));
+    }
+
+    /**
+     * Endpoint JSON consumido por el polling de Alpine.js cada 5 segundos.
+     *
+     * @return JsonResponse
+     */
+    public function pendingOrders(): JsonResponse
+    {
+        $orders = $this->getActiveOrders()
+            ->map(fn(Order $order) => [
+                'id'         => $order->id,
+                'table_name' => $order->table->name,
+                'created_at' => $order->created_at->format('H:i'),
+                'status'     => $order->status,
+                'items'      => $order->items
+                    ->where('status', 'queued')
+                    ->map(fn(OrderItem $item) => [
+                        'id'            => $item->id,
+                        'product_name'  => $item->product->name,
+                        'quantity'      => $item->quantity,
+                        'modifications' => $item->modifications
+                            ->map(fn($mod) => [
+                                'action'     => $mod->action,
+                                'ingredient' => $mod->ingredient->name,
+                            ])->values(),
+                    ])->values(),
+            ])
+            ->filter(fn($order) => count($order['items']) > 0)
+            ->values();
+
+        $readyCount = Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+            ->where('status', 'ready')
+            ->count();
+
+        return response()->json([
+            'orders'      => $orders,
+            'ready_count' => $readyCount,
+        ]);
+    }
+
+    /**
+     * Marca un ítem como listo y cierra el pedido si todos los ítems están preparados.
+     *
+     * @param  OrderItem  $item
+     * @return JsonResponse
+     */
+    public function markItemReady(OrderItem $item): JsonResponse
+    {
+        $order = $item->order()->with('table')->first();
+
+        abort_if($order->table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+
+        $item->update(['status' => 'ready']);
+
+        $allReady = $order->items()->where('status', 'queued')->doesntExist();
+
+        if ($allReady) {
+            $order->update(['status' => 'ready']);
+        }
+
+        return response()->json([
+            'item_id'      => $item->id,
+            'order_id'     => $order->id,
+            'order_status' => $order->fresh()->status,
+            'all_ready'    => $allReady,
+        ]);
+    }
+
+    /**
+     * Consulta los pedidos activos (cooking o pending) con ítems en cola
+     * pertenecientes al restaurante autenticado.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    private function getActiveOrders(): \Illuminate\Database\Eloquent\Collection
+    {
+        return Order::with([
+            'table',
+            'items' => fn($q) => $q->where('status', 'queued'),
+            'items.product',
+            'items.modifications.ingredient',
+        ])
+        ->whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+        ->whereIn('status', ['pending', 'cooking'])
+        ->orderBy('created_at')
+        ->get();
+    }
+}

--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -108,9 +108,9 @@ class KitchenController extends Controller
     {
         return Order::with([
             'table',
-            'items' => fn($q) => $q->where('status', 'queued'),
-            'items.product',
-            'items.modifications.ingredient',
+            'items' => fn($q) => $q
+                ->where('status', 'queued')
+                ->with(['product', 'modifications.ingredient']),
         ])
         ->whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
         ->whereIn('status', ['pending', 'cooking'])

--- a/app/Http/Middleware/EnsureRole.php
+++ b/app/Http/Middleware/EnsureRole.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Middleware para restringir acceso por rol de usuario.
+ *
+ * Uso en rutas: ->middleware('role:kitchen,admin')
+ *
+ * @author AyrtonAlania
+ */
+class EnsureRole
+{
+    /**
+     * Verifica que el usuario autenticado tenga uno de los roles permitidos.
+     *
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @param  string   ...$roles  Roles permitidos (ej: 'kitchen', 'admin')
+     * @return Response
+     */
+    public function handle(Request $request, Closure $next, string ...$roles): Response
+    {
+        if (! in_array($request->user()?->role, $roles, true)) {
+            abort(403, 'No tienes permiso para acceder a esta sección.');
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,6 +13,7 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->trustProxies(at: '*');
+        $middleware->alias(['role' => \App\Http\Middleware\EnsureRole::class]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/resources/views/kitchen/index.blade.php
+++ b/resources/views/kitchen/index.blade.php
@@ -1,0 +1,206 @@
+{{-- @author AyrtonAlania --}}
+<x-app-layout>
+  <div
+    class="max-w-6xl mx-auto px-4 sm:px-6 py-6 mt-4 sm:mt-10"
+    x-data="kitchenPanel()"
+    x-init="init()"
+  >
+
+    {{-- Cabecera --}}
+    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6">
+      <div>
+        <h2 class="text-xl sm:text-2xl font-bold text-gray-800">Panel de Cocina</h2>
+        <p class="text-sm text-gray-500 mt-1">
+          Actualización automática cada 5 segundos &mdash;
+          <span x-text="lastUpdated" class="font-medium text-indigo-600"></span>
+        </p>
+      </div>
+
+      {{-- Indicador de conexión --}}
+      <div class="flex items-center gap-2 text-sm">
+        <span
+          class="inline-block w-3 h-3 rounded-full"
+          :class="polling ? 'bg-green-500 animate-pulse' : 'bg-red-500'"
+          aria-hidden="true"
+        ></span>
+        <span x-text="polling ? 'En vivo' : 'Sin conexión'" class="text-gray-600"></span>
+      </div>
+    </div>
+
+    {{-- Sin comandas --}}
+    <div x-show="orders.length === 0" class="bg-white shadow rounded-lg p-10 text-center text-gray-400">
+      <svg class="mx-auto mb-4 h-12 w-12 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+          d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+      </svg>
+      <p class="text-lg font-medium">No hay comandas pendientes</p>
+      <p class="text-sm mt-1">Las nuevas comandas aparecerán aquí automáticamente.</p>
+    </div>
+
+    {{-- Grid de comandas --}}
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+      <template x-for="order in orders" :key="order.id">
+        <div class="bg-white shadow-md rounded-lg overflow-hidden border border-gray-200">
+
+          {{-- Cabecera de la comanda --}}
+          <div class="flex items-center justify-between px-4 py-3 bg-indigo-600 text-white">
+            <span class="font-bold text-base" x-text="order.table_name"></span>
+            <span class="text-xs bg-white/20 rounded px-2 py-1" x-text="order.created_at"></span>
+          </div>
+
+          {{-- Ítems pendientes --}}
+          <ul class="divide-y divide-gray-100" role="list">
+            <template x-for="item in order.items" :key="item.id">
+              <li class="px-4 py-3">
+                <div class="flex items-start justify-between gap-2">
+                  <div class="flex-1 min-w-0">
+
+                    {{-- Producto + cantidad --}}
+                    <p class="font-semibold text-gray-800 text-sm">
+                      <span
+                        class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-indigo-100 text-indigo-700 text-xs font-bold mr-1"
+                        x-text="'×' + item.quantity"
+                        aria-label="Cantidad"
+                      ></span>
+                      <span x-text="item.product_name"></span>
+                    </p>
+
+                    {{-- Modificaciones del cliente --}}
+                    <template x-if="item.modifications && item.modifications.length > 0">
+                      <ul class="mt-1 space-y-0.5" aria-label="Modificaciones del cliente">
+                        <template x-for="mod in item.modifications" :key="mod.ingredient">
+                          <li class="flex items-center gap-1 text-xs">
+                            <span
+                              :class="mod.action === 'remove'
+                                ? 'bg-red-100 text-red-700'
+                                : 'bg-green-100 text-green-700'"
+                              class="inline-block px-1.5 py-0.5 rounded font-medium"
+                              x-text="mod.action === 'remove' ? 'Sin' : 'Extra'"
+                            ></span>
+                            <span class="text-gray-600" x-text="mod.ingredient"></span>
+                          </li>
+                        </template>
+                      </ul>
+                    </template>
+
+                  </div>
+
+                  {{-- Botón "Listo" --}}
+                  <button
+                    @click="markReady(item, order)"
+                    :disabled="item.marking"
+                    class="shrink-0 bg-green-500 hover:bg-green-600 disabled:opacity-50 text-white text-xs font-semibold px-3 py-1.5 rounded focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-offset-2 transition"
+                    :aria-label="'Marcar como listo: ' + item.product_name"
+                  >
+                    <span x-show="!item.marking">Listo ✓</span>
+                    <span x-show="item.marking">...</span>
+                  </button>
+
+                </div>
+              </li>
+            </template>
+          </ul>
+
+          {{-- Footer: pedido completo --}}
+          <div
+            x-show="order.all_ready"
+            class="px-4 py-2 bg-green-50 border-t border-green-200 text-green-700 text-xs font-semibold text-center"
+            role="status"
+          >
+            ¡Pedido completo! Listo para servir.
+          </div>
+
+        </div>
+      </template>
+    </div>
+
+  </div>
+
+  @push('scripts')
+  <script>
+    function kitchenPanel() {
+      return {
+        orders: @json($orders->map(fn($o) => [
+          'id'         => $o->id,
+          'table_name' => $o->table->name,
+          'created_at' => $o->created_at->format('H:i'),
+          'status'     => $o->status,
+          'all_ready'  => false,
+          'items'      => $o->items->map(fn($i) => [
+            'id'            => $i->id,
+            'product_name'  => $i->product->name,
+            'quantity'      => $i->quantity,
+            'marking'       => false,
+            'modifications' => $i->modifications->map(fn($m) => [
+              'action'     => $m->action,
+              'ingredient' => $m->ingredient->name,
+            ])->values(),
+          ])->values(),
+        ])->values()),
+
+        polling: true,
+        lastUpdated: '--:--',
+        pollInterval: null,
+
+        init() {
+          this.tick();
+          this.pollInterval = setInterval(() => this.tick(), 5000);
+        },
+
+        async tick() {
+          try {
+            const res  = await fetch('{{ route('kitchen.pending') }}', {
+              headers: { 'X-Requested-With': 'XMLHttpRequest' }
+            });
+            const data = await res.json();
+
+            // Conservar estado 'marking' de ítems que ya están en UI
+            const markingIds = {};
+            this.orders.forEach(o => o.items.forEach(i => { if (i.marking) markingIds[i.id] = true; }));
+
+            this.orders = data.orders.map(o => ({
+              ...o,
+              all_ready: false,
+              items: o.items.map(i => ({ ...i, marking: !!markingIds[i.id] })),
+            }));
+
+            this.polling    = true;
+            this.lastUpdated = new Date().toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+          } catch {
+            this.polling = false;
+          }
+        },
+
+        async markReady(item, order) {
+          item.marking = true;
+          try {
+            const res  = await fetch(`/cocina/items/${item.id}/listo`, {
+              method:  'POST',
+              headers: {
+                'X-CSRF-TOKEN':     document.querySelector('meta[name="csrf-token"]').content,
+                'X-Requested-With': 'XMLHttpRequest',
+                'Accept':           'application/json',
+              },
+            });
+            const data = await res.json();
+
+            // Eliminar ítem marcado
+            order.items = order.items.filter(i => i.id !== item.id);
+
+            if (data.all_ready) {
+              order.all_ready = true;
+              // Retirar la comanda completa tras 2 s
+              setTimeout(() => {
+                this.orders = this.orders.filter(o => o.id !== order.id);
+              }, 2000);
+            }
+          } catch {
+            item.marking = false;
+          }
+        },
+      };
+    }
+  </script>
+  @endpush
+
+</x-app-layout>

--- a/resources/views/kitchen/index.blade.php
+++ b/resources/views/kitchen/index.blade.php
@@ -117,26 +117,29 @@
   </div>
 
   @push('scripts')
+  @php
+    $ordersForJs = $orders->map(fn($o) => [
+      'id'         => $o->id,
+      'table_name' => $o->table->name,
+      'created_at' => $o->created_at->format('H:i'),
+      'status'     => $o->status,
+      'all_ready'  => false,
+      'items'      => $o->items->map(fn($i) => [
+        'id'            => $i->id,
+        'product_name'  => $i->product->name,
+        'quantity'      => $i->quantity,
+        'marking'       => false,
+        'modifications' => $i->modifications->map(fn($m) => [
+          'action'     => $m->action,
+          'ingredient' => $m->ingredient->name,
+        ])->values(),
+      ])->values(),
+    ])->values();
+  @endphp
   <script>
     function kitchenPanel() {
       return {
-        orders: @json($orders->map(fn($o) => [
-          'id'         => $o->id,
-          'table_name' => $o->table->name,
-          'created_at' => $o->created_at->format('H:i'),
-          'status'     => $o->status,
-          'all_ready'  => false,
-          'items'      => $o->items->map(fn($i) => [
-            'id'            => $i->id,
-            'product_name'  => $i->product->name,
-            'quantity'      => $i->quantity,
-            'marking'       => false,
-            'modifications' => $i->modifications->map(fn($m) => [
-              'action'     => $m->action,
-              'ingredient' => $m->ingredient->name,
-            ])->values(),
-          ])->values(),
-        ])->values()),
+        orders: @json($ordersForJs),
 
         polling: true,
         lastUpdated: '--:--',

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -36,5 +36,6 @@
                 {{ $slot }}
             </main>
         </div>
+        @stack('scripts')
     </body>
 </html>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -32,6 +32,21 @@
                     <x-nav-link :href="route('tables.index')" :active="request()->routeIs('tables.*')">
                         {{ __('Mesas QR') }}
                     </x-nav-link>
+                    {{-- Panel de Cocina: visible solo para admin y kitchen --}}
+                    @if(in_array(Auth::user()->role, ['admin', 'kitchen']))
+                    <x-nav-link :href="route('kitchen.index')" :active="request()->routeIs('kitchen.*')" class="relative">
+                        {{ __('Cocina') }}
+                        @php
+                            $readyOrders = \App\Models\Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+                                ->where('status', 'ready')->count();
+                        @endphp
+                        @if($readyOrders > 0)
+                        <span class="absolute -top-1 -right-3 inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-red-500 rounded-full" aria-label="{{ $readyOrders }} pedidos listos para servir">
+                            {{ $readyOrders }}
+                        </span>
+                        @endif
+                    </x-nav-link>
+                    @endif
                 </div>
 
                 <!-- Settings Dropdown -->
@@ -107,6 +122,17 @@
                 <x-responsive-nav-link :href="route('tables.index')" :active="request()->routeIs('tables.*')">
                     {{ __('Mesas QR') }}
                 </x-responsive-nav-link>
+                {{-- Panel de Cocina (Versión Móvil) --}}
+                @if(in_array(Auth::user()->role, ['admin', 'kitchen']))
+                <x-responsive-nav-link :href="route('kitchen.index')" :active="request()->routeIs('kitchen.*')">
+                    {{ __('Cocina') }}
+                    @if(isset($readyOrders) && $readyOrders > 0)
+                    <span class="ml-2 inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-red-500 rounded-full" aria-label="{{ $readyOrders }} pedidos listos">
+                        {{ $readyOrders }}
+                    </span>
+                    @endif
+                </x-responsive-nav-link>
+                @endif
             </div>
 
             <!-- Responsive Settings Options -->

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 use App\Http\Controllers\IngredientController;
 use App\Http\Controllers\CategoryController;
+use App\Http\Controllers\KitchenController;
 use App\Http\Controllers\MenuController;
 use App\Http\Controllers\ProductController;
 use App\Http\Controllers\ProfileController;
@@ -34,6 +35,13 @@ Route::middleware('auth')->group(function () {
     Route::get('/mesas', [TableController::class, 'index'])->name('tables.index');
     Route::get('/mesas/{table}/qr/descargar', [TableController::class, 'downloadQr'])->name('tables.qr.download');
     Route::post('/mesas/{table}/qr/regenerar', [TableController::class, 'regenerateHash'])->name('tables.qr.regenerate');
+
+    // Panel de cocina — accesible para roles admin y kitchen
+    Route::middleware('role:admin,kitchen')->group(function () {
+        Route::get('/cocina', [KitchenController::class, 'index'])->name('kitchen.index');
+        Route::get('/cocina/pendientes', [KitchenController::class, 'pendingOrders'])->name('kitchen.pending');
+        Route::post('/cocina/items/{item}/listo', [KitchenController::class, 'markItemReady'])->name('kitchen.item.ready');
+    });
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Resumen

- Middleware EnsureRole para proteger rutas por rol (admin, kitchen, waiter)
- KitchenController con index(), pendingOrders() (JSON para polling) y markItemReady()
- Polling automatico con Alpine.js cada 5 segundos sin recargar pagina
- Muestra order_items con status=queued agrupados por pedido/mesa
- Boton Listo por item: actualiza order_item.status=ready via POST AJAX
- Marca order.status=ready automaticamente cuando todos sus items estan listos
- Muestra modificaciones del cliente (sin cebolla, extra queso) con badge colorizado
- Badge rojo en nav con conteo de pedidos listos para servir (notificacion al camarero)
- Enlace Cocina visible solo para roles admin y kitchen

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| app/Http/Middleware/EnsureRole.php | Nuevo middleware de rol |
| bootstrap/app.php | Registro del alias role |
| app/Http/Controllers/KitchenController.php | Nuevo controlador |
| routes/web.php | 3 rutas kitchen bajo role:admin,kitchen |
| resources/views/kitchen/index.blade.php | Vista panel cocina con Alpine.js |
| resources/views/layouts/navigation.blade.php | Enlace Cocina + badge pedidos listos |

## Plan de pruebas

- [x] Acceder a /cocina logueado como admin y ver las comandas pendientes
- [x] Verificar que el panel se actualiza solo cada 5 segundos (indicador verde pulsante)
- [x] Crear un pedido con order_items queued y comprobar que aparece en el panel
- [x] Pulsar Listo en un item y verificar que desaparece del panel
- [x] Cuando todos los items de una comanda esten listos, verificar que order.status=ready
- [ ] Verificar badge rojo en nav con el conteo correcto de pedidos listos
- [ ] Acceder a /cocina sin autenticar -> redirige a login
- [ ] Acceder a /cocina con rol waiter -> 403 Acceso denegado

Closes #4.2

Generated with Claude Code