### PR TITLE
feat: Bloque 5.1 — Migraciones y modelos Conversation y Message

### DIFF
--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Representa una sesión de chat del chatbot IA ligada a una mesa.
+ *
+ * Una mesa puede tener varias conversaciones a lo largo del tiempo.
+ * Se cierra (status=closed) al finalizar la sesión o al pagar.
+ * Los mensajes se eliminan en cascada al borrar la conversación.
+ *
+ * @author AyrtonAlania
+ *
+ * @property int    $id
+ * @property int    $table_id     Mesa a la que pertenece la conversación
+ * @property string $status       'active' o 'closed'
+ * @property int    $tokens_used  Tokens acumulados consumidos en la API de IA
+ */
+class Conversation extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'table_id',
+        'status',
+        'tokens_used',
+    ];
+
+    /**
+     * Mesa física a la que pertenece esta conversación.
+     *
+     * @return BelongsTo
+     */
+    public function table(): BelongsTo
+    {
+        return $this->belongsTo(Table::class);
+    }
+
+    /**
+     * Mensajes intercambiados en esta conversación (user, assistant, system).
+     *
+     * @return HasMany
+     */
+    public function messages(): HasMany
+    {
+        return $this->hasMany(Message::class);
+    }
+}

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Representa un mensaje individual dentro de una conversación del chatbot.
+ *
+ * El rol indica el origen del mensaje: 'user' (cliente), 'assistant' (IA)
+ * o 'system' (prompt de contexto del restaurante).
+ *
+ * @author AyrtonAlania
+ *
+ * @property int    $id
+ * @property int    $conversation_id  Conversación a la que pertenece
+ * @property string $role             'user', 'assistant' o 'system'
+ * @property string $content          Texto del mensaje
+ * @property int|null $tokens_used    Tokens consumidos en este mensaje
+ */
+class Message extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'conversation_id',
+        'role',
+        'content',
+        'tokens_used',
+    ];
+
+    /**
+     * Conversación a la que pertenece este mensaje.
+     *
+     * @return BelongsTo
+     */
+    public function conversation(): BelongsTo
+    {
+        return $this->belongsTo(Conversation::class);
+    }
+}

--- a/database/migrations/2026_04_18_152553_create_conversations_table.php
+++ b/database/migrations/2026_04_18_152553_create_conversations_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Crea la tabla conversations para persistir sesiones del chatbot por mesa.
+ *
+ * Cada conversación queda ligada a una mesa (table_id) y almacena
+ * el estado de la sesión y los tokens consumidos en la API de IA.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('conversations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('table_id')->constrained('tables')->onDelete('cascade');
+            $table->enum('status', ['active', 'closed'])->default('active');
+            $table->integer('tokens_used')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('conversations');
+    }
+};

--- a/database/migrations/2026_04_18_152601_create_messages_table.php
+++ b/database/migrations/2026_04_18_152601_create_messages_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Crea la tabla messages para almacenar cada mensaje del chatbot.
+ *
+ * Cada mensaje pertenece a una conversación y guarda el rol
+ * (user, assistant, system), el contenido y los tokens consumidos.
+ * Se elimina en cascada al borrar la conversación.
+ */
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('conversation_id')->constrained()->onDelete('cascade');
+            $table->enum('role', ['user', 'assistant', 'system']);
+            $table->text('content');
+            $table->integer('tokens_used')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};


### PR DESCRIPTION
## Resumen

Implementa la capa de persistencia del chatbot IA (sub-tarea 1/5 de la épica #41).

- Migración `conversations`: tabla ligada a `tables` via `table_id` (FK cascade), con campos `status` (active/closed) y `tokens_used`
- Migración `messages`: tabla ligada a `conversations` via `conversation_id` (FK cascade), con `role` enum (user/assistant/system), `content` y `tokens_used`
- Modelo `Conversation`: relaciones `table()` (BelongsTo) y `messages()` (HasMany)
- Modelo `Message`: relación `conversation()` (BelongsTo)

## Archivos

| Archivo | Acción |
|---------|--------|
| `database/migrations/2026_04_18_152553_create_conversations_table.php` | Nueva migración |
| `database/migrations/2026_04_18_152601_create_messages_table.php` | Nueva migración |
| `app/Models/Conversation.php` | Nuevo modelo |
| `app/Models/Message.php` | Nuevo modelo |

## Plan de pruebas

- [ ] Ejecutar `php artisan migrate` sin errores
- [ ] Verificar que `conversations` tiene FK hacia `tables` con cascade
- [ ] Verificar que `messages` tiene FK hacia `conversations` con cascade
- [ ] Borrar una conversación y confirmar que sus mensajes se eliminan en cascada
- [ ] Crear una `Conversation` via tinker y asociarle `Message` correctamente

Closes #42
Sub-tarea de épica #41

Generated with Claude Code