### PR TITLE
feat: Bloque 5.3 — ChatController y rutas publicas de la API

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Conversation;
+use App\Models\Table;
+use App\Services\ChatService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Gestiona los endpoints públicos del chatbot IA.
+ *
+ * Los endpoints son accesibles sin autenticación porque la carta digital
+ * es pública. El multitenancy se garantiza implícitamente a través de
+ * table_hash → table → user_id.
+ *
+ * @author AyrtonAlania
+ */
+class ChatController extends Controller
+{
+    /**
+     * @param  ChatService  $chatService
+     */
+    public function __construct(protected ChatService $chatService) {}
+
+    /**
+     * Inicia una nueva conversación para la mesa identificada por su unique_hash.
+     *
+     * @param  string  $tableHash  Hash único de la mesa (desde la URL del QR)
+     * @return JsonResponse
+     */
+    public function start(string $tableHash): JsonResponse
+    {
+        $table = Table::where('unique_hash', $tableHash)->firstOrFail();
+
+        $conversation = Conversation::create([
+            'table_id' => $table->id,
+            'status'   => 'active',
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'data'    => ['conversation_id' => $conversation->id],
+            'message' => 'Conversación iniciada.',
+        ], 201);
+    }
+
+    /**
+     * Envía un mensaje del cliente y devuelve la respuesta del asistente IA.
+     *
+     * @param  Request       $request
+     * @param  Conversation  $conversation
+     * @return JsonResponse
+     */
+    public function send(Request $request, Conversation $conversation): JsonResponse
+    {
+        $validated = $request->validate([
+            'message' => 'required|string|max:500',
+        ]);
+
+        if ($conversation->status === 'closed') {
+            return response()->json([
+                'success' => false,
+                'data'    => null,
+                'message' => 'Esta conversación ya está cerrada. Inicia una nueva.',
+            ], 422);
+        }
+
+        $result = $this->chatService->handleMessage($conversation, $validated['message']);
+
+        return response()->json([
+            'success' => ! $result['error'],
+            'data'    => ['reply' => $result['message'], 'closed' => $result['closed']],
+            'message' => $result['error'] ? 'Error en el asistente.' : 'OK',
+        ]);
+    }
+
+    /**
+     * Cierra manualmente una conversación activa.
+     *
+     * @param  Conversation  $conversation
+     * @return JsonResponse
+     */
+    public function close(Conversation $conversation): JsonResponse
+    {
+        $conversation->update(['status' => 'closed']);
+
+        return response()->json([
+            'success' => true,
+            'data'    => null,
+            'message' => 'Conversación cerrada.',
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,12 @@
 <?php
 
 use App\Http\Controllers\Api\OrderController;
+use App\Http\Controllers\ChatController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/v1/orders', [OrderController::class, 'store'])->name('api.orders.store');
+
+// Chatbot IA — rutas públicas (sin autenticación, contexto por table_hash)
+Route::post('/v1/chat/{tableHash}/start',      [ChatController::class, 'start'])->name('api.chat.start');
+Route::post('/v1/chat/{conversation}/message', [ChatController::class, 'send'])->name('api.chat.send');
+Route::delete('/v1/chat/{conversation}',       [ChatController::class, 'close'])->name('api.chat.close');


### PR DESCRIPTION
## Resumen

Implementa la capa HTTP del chatbot IA (sub-tarea 3/5 de la épica #41).

- `ChatController` con 3 métodos: `start()` (crea conversación), `send()` (envía mensaje y recibe respuesta IA), `close()` (cierre manual)
- Respuestas JSON estándar `{ success, data, message }` en todos los endpoints
- Validación de request en `send()`: campo `message` requerido, máximo 500 caracteres
- Control de conversación cerrada: devuelve 422 si se intenta enviar mensaje a conversación `closed`
- 3 rutas públicas registradas en `routes/api.php` bajo `/api/v1/chat/`

## Archivos

| Archivo | Acción |
|---------|--------|
| `app/Http/Controllers/ChatController.php` | Nuevo controlador |
| `routes/api.php` | 3 rutas nuevas bajo `/api/v1/chat/` |

## Rutas registradas

| Método | Ruta | Acción |
|--------|------|--------|
| POST | `/api/v1/chat/{tableHash}/start` | Inicia conversación |
| POST | `/api/v1/chat/{conversation}/message` | Envía mensaje |
| DELETE | `/api/v1/chat/{conversation}` | Cierra conversación |

## Plan de pruebas

- [ ] `POST /api/v1/chat/{hash_valido}/start` → 201 con `conversation_id`
- [ ] `POST /api/v1/chat/{hash_invalido}/start` → 404
- [ ] `POST /api/v1/chat/{conv_id}/message` con mensaje válido → respuesta de la IA
- [ ] `POST /api/v1/chat/{conv_id}/message` sin campo `message` → 422
- [ ] `POST /api/v1/chat/{conv_id}/message` en conversación `closed` → 422
- [ ] `DELETE /api/v1/chat/{conv_id}` → 200 y `status=closed` en BD

Closes #44
Sub-tarea de épica #41 — depende de #42 (modelos) y #43 (servicios)

Generated with Claude Code