### PR TITLE
fix: badge de cocina en tiempo real con conteo correcto de pedidos pendientes

### DIFF
--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -87,7 +87,7 @@ class KitchenController extends Controller
         $allReady = $order->items()->where('status', 'queued')->doesntExist();
 
         if ($allReady) {
-            $order->update(['status' => 'ready']);
+            $order->update(['status' => 'served']);
         }
 
         return response()->json([

--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -32,6 +32,20 @@ class KitchenController extends Controller
     }
 
     /**
+     * Endpoint ligero para el badge del nav: devuelve el conteo de pedidos pendientes.
+     *
+     * @return JsonResponse
+     */
+    public function badgeCount(): JsonResponse
+    {
+        $count = Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+            ->where('status', 'pending')
+            ->count();
+
+        return response()->json(['pending_count' => $count]);
+    }
+
+    /**
      * Endpoint JSON consumido por el polling de Alpine.js cada 5 segundos.
      *
      * @return JsonResponse

--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -87,7 +87,7 @@ class KitchenController extends Controller
         $allReady = $order->items()->where('status', 'queued')->doesntExist();
 
         if ($allReady) {
-            $order->update(['status' => 'served']);
+            $order->update(['status' => 'ready']);
         }
 
         return response()->json([
@@ -96,6 +96,22 @@ class KitchenController extends Controller
             'order_status' => $order->fresh()->status,
             'all_ready'    => $allReady,
         ]);
+    }
+
+    /**
+     * Marca un pedido completo como servido, limpiando la notificación del badge.
+     *
+     * @param  Order  $order
+     * @return JsonResponse
+     */
+    public function markOrderServed(Order $order): JsonResponse
+    {
+        abort_if($order->table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($order->status !== 'ready', 422, 'El pedido no está listo para servir.');
+
+        $order->update(['status' => 'served']);
+
+        return response()->json(['order_id' => $order->id, 'status' => 'served']);
     }
 
     /**

--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -60,13 +60,13 @@ class KitchenController extends Controller
             ->filter(fn($order) => count($order['items']) > 0)
             ->values();
 
-        $readyCount = Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
-            ->where('status', 'ready')
+        $pendingCount = Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+            ->where('status', 'pending')
             ->count();
 
         return response()->json([
-            'orders'      => $orders,
-            'ready_count' => $readyCount,
+            'orders'        => $orders,
+            'pending_count' => $pendingCount,
         ]);
     }
 
@@ -84,7 +84,11 @@ class KitchenController extends Controller
 
         $item->update(['status' => 'ready']);
 
-        $allReady = $order->items()->where('status', 'queued')->doesntExist();
+        if ($order->status === 'pending') {
+            $order->update(['status' => 'cooking']);
+        }
+
+        $allReady = $order->fresh()->items()->where('status', 'queued')->doesntExist();
 
         if ($allReady) {
             $order->update(['status' => 'ready']);

--- a/resources/views/kitchen/index.blade.php
+++ b/resources/views/kitchen/index.blade.php
@@ -104,10 +104,19 @@
           {{-- Footer: pedido completo --}}
           <div
             x-show="order.all_ready"
-            class="px-4 py-2 bg-green-50 border-t border-green-200 text-green-700 text-xs font-semibold text-center"
+            class="px-4 py-3 bg-green-50 border-t border-green-200 flex items-center justify-between gap-3"
             role="status"
           >
-            ¡Pedido completo! Listo para servir.
+            <span class="text-green-700 text-xs font-semibold">¡Pedido completo! Listo para servir.</span>
+            <button
+              @click="markServed(order)"
+              :disabled="order.serving"
+              class="text-xs font-semibold px-3 py-1 rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-1"
+              aria-label="Marcar pedido como servido"
+            >
+              <span x-show="!order.serving">Servido ✓</span>
+              <span x-show="order.serving">...</span>
+            </button>
           </div>
 
         </div>
@@ -124,6 +133,7 @@
       'created_at' => $o->created_at->format('H:i'),
       'status'     => $o->status,
       'all_ready'  => false,
+      'serving'    => false,
       'items'      => $o->items->map(fn($i) => [
         'id'            => $i->id,
         'product_name'  => $i->product->name,
@@ -164,6 +174,7 @@
             this.orders = data.orders.map(o => ({
               ...o,
               all_ready: false,
+              serving: false,
               items: o.items.map(i => ({ ...i, marking: !!markingIds[i.id] })),
             }));
 
@@ -192,13 +203,26 @@
 
             if (data.all_ready) {
               order.all_ready = true;
-              // Retirar la comanda completa tras 2 s
-              setTimeout(() => {
-                this.orders = this.orders.filter(o => o.id !== order.id);
-              }, 2000);
             }
           } catch {
             item.marking = false;
+          }
+        },
+
+        async markServed(order) {
+          order.serving = true;
+          try {
+            await fetch(`/cocina/orders/${order.id}/servido`, {
+              method:  'POST',
+              headers: {
+                'X-CSRF-TOKEN':     document.querySelector('meta[name="csrf-token"]').content,
+                'X-Requested-With': 'XMLHttpRequest',
+                'Accept':           'application/json',
+              },
+            });
+            this.orders = this.orders.filter(o => o.id !== order.id);
+          } catch {
+            order.serving = false;
           }
         },
       };

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -37,5 +37,23 @@
             </main>
         </div>
         @stack('scripts')
+        <script>
+        function kitchenBadge(url) {
+            return {
+                count: 0,
+                init() {
+                    this.fetch();
+                    setInterval(() => this.fetch(), 10000);
+                },
+                async fetch() {
+                    try {
+                        const res = await fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+                        const data = await res.json();
+                        this.count = data.pending_count ?? 0;
+                    } catch {}
+                },
+            };
+        }
+        </script>
     </body>
 </html>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -37,12 +37,12 @@
                     <x-nav-link :href="route('kitchen.index')" :active="request()->routeIs('kitchen.*')" class="relative">
                         {{ __('Cocina') }}
                         @php
-                            $readyOrders = \App\Models\Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
-                                ->where('status', 'ready')->count();
+                            $pendingOrders = \App\Models\Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+                                ->where('status', 'pending')->count();
                         @endphp
-                        @if($readyOrders > 0)
-                        <span class="absolute -top-1 -right-3 inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-red-500 rounded-full" aria-label="{{ $readyOrders }} pedidos listos para servir">
-                            {{ $readyOrders }}
+                        @if($pendingOrders > 0)
+                        <span class="absolute -top-1 -right-3 inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-red-500 rounded-full" aria-label="{{ $pendingOrders }} pedidos nuevos sin atender">
+                            {{ $pendingOrders }}
                         </span>
                         @endif
                     </x-nav-link>
@@ -126,9 +126,9 @@
                 @if(in_array(Auth::user()->role, ['admin', 'kitchen']))
                 <x-responsive-nav-link :href="route('kitchen.index')" :active="request()->routeIs('kitchen.*')">
                     {{ __('Cocina') }}
-                    @if(isset($readyOrders) && $readyOrders > 0)
-                    <span class="ml-2 inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-red-500 rounded-full" aria-label="{{ $readyOrders }} pedidos listos">
-                        {{ $readyOrders }}
+                    @if(isset($pendingOrders) && $pendingOrders > 0)
+                    <span class="ml-2 inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-red-500 rounded-full" aria-label="{{ $pendingOrders }} pedidos nuevos sin atender">
+                        {{ $pendingOrders }}
                     </span>
                     @endif
                 </x-responsive-nav-link>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -34,18 +34,21 @@
                     </x-nav-link>
                     {{-- Panel de Cocina: visible solo para admin y kitchen --}}
                     @if(in_array(Auth::user()->role, ['admin', 'kitchen']))
-                    <x-nav-link :href="route('kitchen.index')" :active="request()->routeIs('kitchen.*')" class="relative">
-                        {{ __('Cocina') }}
-                        @php
-                            $pendingOrders = \App\Models\Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
-                                ->where('status', 'pending')->count();
-                        @endphp
-                        @if($pendingOrders > 0)
-                        <span class="absolute -top-1 -right-3 inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-red-500 rounded-full" aria-label="{{ $pendingOrders }} pedidos nuevos sin atender">
-                            {{ $pendingOrders }}
-                        </span>
-                        @endif
-                    </x-nav-link>
+                    <span
+                        x-data="kitchenBadge('{{ route('kitchen.badge') }}')"
+                        x-init="init()"
+                        class="relative inline-flex items-center"
+                    >
+                        <x-nav-link :href="route('kitchen.index')" :active="request()->routeIs('kitchen.*')">
+                            {{ __('Cocina') }}
+                        </x-nav-link>
+                        <span
+                            x-show="count > 0"
+                            x-text="count"
+                            class="absolute -top-1 right-0 inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-red-500 rounded-full pointer-events-none"
+                            :aria-label="count + ' pedidos nuevos sin atender'"
+                        ></span>
+                    </span>
                     @endif
                 </div>
 
@@ -124,14 +127,17 @@
                 </x-responsive-nav-link>
                 {{-- Panel de Cocina (Versión Móvil) --}}
                 @if(in_array(Auth::user()->role, ['admin', 'kitchen']))
-                <x-responsive-nav-link :href="route('kitchen.index')" :active="request()->routeIs('kitchen.*')">
-                    {{ __('Cocina') }}
-                    @if(isset($pendingOrders) && $pendingOrders > 0)
-                    <span class="ml-2 inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-red-500 rounded-full" aria-label="{{ $pendingOrders }} pedidos nuevos sin atender">
-                        {{ $pendingOrders }}
-                    </span>
-                    @endif
-                </x-responsive-nav-link>
+                <span x-data="kitchenBadge('{{ route('kitchen.badge') }}')" x-init="init()" class="flex items-center">
+                    <x-responsive-nav-link :href="route('kitchen.index')" :active="request()->routeIs('kitchen.*')">
+                        {{ __('Cocina') }}
+                        <span
+                            x-show="count > 0"
+                            x-text="count"
+                            class="ml-2 inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-red-500 rounded-full"
+                            :aria-label="count + ' pedidos nuevos sin atender'"
+                        ></span>
+                    </x-responsive-nav-link>
+                </span>
                 @endif
             </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,7 @@ Route::middleware('auth')->group(function () {
         Route::get('/cocina', [KitchenController::class, 'index'])->name('kitchen.index');
         Route::get('/cocina/pendientes', [KitchenController::class, 'pendingOrders'])->name('kitchen.pending');
         Route::post('/cocina/items/{item}/listo', [KitchenController::class, 'markItemReady'])->name('kitchen.item.ready');
+        Route::post('/cocina/orders/{order}/servido', [KitchenController::class, 'markOrderServed'])->name('kitchen.order.served');
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,6 +39,7 @@ Route::middleware('auth')->group(function () {
     // Panel de cocina — accesible para roles admin y kitchen
     Route::middleware('role:admin,kitchen')->group(function () {
         Route::get('/cocina', [KitchenController::class, 'index'])->name('kitchen.index');
+        Route::get('/cocina/badge', [KitchenController::class, 'badgeCount'])->name('kitchen.badge');
         Route::get('/cocina/pendientes', [KitchenController::class, 'pendingOrders'])->name('kitchen.pending');
         Route::post('/cocina/items/{item}/listo', [KitchenController::class, 'markItemReady'])->name('kitchen.item.ready');
         Route::post('/cocina/orders/{order}/servido', [KitchenController::class, 'markOrderServed'])->name('kitchen.order.served');


### PR DESCRIPTION
## Summary
- Badge del nav ahora cuenta pedidos `pending` (nuevos sin atender) en lugar de `ready`
- Al marcar el primer ítem como listo, el pedido transiciona `pending → cooking` y el badge se decrementa
- Badge se actualiza en tiempo real cada 10s via polling Alpine.js sin recargar página
- Añadido endpoint `GET /cocina/badge` ligero para el polling del nav
- Añadido botón "Servido ✓" en panel de cocina para transicionar pedidos `ready → served`

## Test plan
- [x] Realizar un pedido desde la carta pública
- [x] Verificar que el badge aparece en el nav en ≤10s sin recargar
- [x] En panel de cocina, marcar un ítem como listo → badge desaparece en ≤10s
- [x] Verificar que pedidos completados no incrementan el badge