### PR TITLE
feat(bloque6.1): order item routing by destination (kitchen/bar)

### DIFF
--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\DB;
 
 /**
  * @author SebastianBCF
+ * @author BenjaminDTS
  */
 class OrderController extends Controller
 {
@@ -49,7 +50,7 @@ class OrderController extends Controller
             $total = 0;
 
             foreach ($validated['items'] as $itemData) {
-                $product = Product::findOrFail($itemData['product_id']);
+                $product = Product::with('category')->findOrFail($itemData['product_id']);
 
                 $extraCharge = collect($itemData['modifications'] ?? [])
                     ->where('action', 'add')
@@ -59,11 +60,12 @@ class OrderController extends Controller
                 $total    += $unitPrice * $itemData['quantity'];
 
                 $orderItem = OrderItem::create([
-                    'order_id'   => $order->id,
-                    'product_id' => $product->id,
-                    'quantity'   => $itemData['quantity'],
-                    'price'      => $product->price,
-                    'status'     => 'queued',
+                    'order_id'    => $order->id,
+                    'product_id'  => $product->id,
+                    'quantity'    => $itemData['quantity'],
+                    'price'       => $product->price,
+                    'status'      => 'queued',
+                    'destination' => $product->category->destination,
                 ]);
 
                 foreach ($itemData['modifications'] ?? [] as $mod) {

--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -16,6 +16,7 @@ use Illuminate\View\View;
  * cuando todos sus ítems han sido preparados.
  *
  * @author AyrtonAlania
+ * @author BenjaminDTS
  */
 class KitchenController extends Controller
 {
@@ -144,9 +145,11 @@ class KitchenController extends Controller
             'table',
             'items' => fn($q) => $q
                 ->where('status', 'queued')
+                ->where('destination', 'kitchen')
                 ->with(['product', 'modifications.ingredient']),
         ])
         ->whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+        ->whereHas('items', fn($q) => $q->where('destination', 'kitchen')->where('status', 'queued'))
         ->whereIn('status', ['pending', 'cooking'])
         ->orderBy('created_at')
         ->get();

--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -96,6 +96,7 @@ class KitchenController extends Controller
         $order = $item->order()->with('table')->first();
 
         abort_if($order->table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($item->destination !== 'kitchen', 403, 'Este ítem no pertenece a cocina.');
 
         $item->update(['status' => 'ready']);
 

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -13,15 +13,18 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * Una línea de detalle dentro de un pedido.
  * Ej: "2 Hamburguesas de la Casa".
  *
- * @property int $quantity      Cantidad solicitada
- * @property float $price     Precio unitario en el momento del pedido
- * @property string $status     'queued' (en cola), 'ready' (listo para servir)
+ * @property int    $quantity      Cantidad solicitada
+ * @property float  $price         Precio unitario en el momento del pedido
+ * @property string $status        'queued' (en cola), 'ready' (listo para servir)
+ * @property string $destination   'kitchen' o 'bar', copiado de la categoría del producto
+ *
+ * @author BenjaminDTS
  */
 class OrderItem extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['order_id', 'product_id', 'quantity', 'price', 'status'];
+    protected $fillable = ['order_id', 'product_id', 'quantity', 'price', 'status', 'destination'];
 
     /**
      * El pedido general al que pertenece esta línea.

--- a/database/factories/OrderItemFactory.php
+++ b/database/factories/OrderItemFactory.php
@@ -17,11 +17,12 @@ class OrderItemFactory extends Factory
     public function definition(): array
     {
         return [
-            'order_id'   => Order::factory(),
-            'product_id' => Product::factory(),
-            'quantity'   => fake()->numberBetween(1, 5),
-            'price'      => fake()->randomFloat(2, 3, 30),
-            'status'     => 'queued',
+            'order_id'    => Order::factory(),
+            'product_id'  => Product::factory(),
+            'quantity'    => fake()->numberBetween(1, 5),
+            'price'       => fake()->randomFloat(2, 3, 30),
+            'status'      => 'queued',
+            'destination' => 'kitchen',
         ];
     }
 }

--- a/database/migrations/2026_04_24_000001_add_destination_to_order_items_table.php
+++ b/database/migrations/2026_04_24_000001_add_destination_to_order_items_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->enum('destination', ['kitchen', 'bar'])
+                ->default('kitchen')
+                ->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->dropColumn('destination');
+        });
+    }
+};

--- a/tests/Feature/Bloque6/OrderRoutingTest.php
+++ b/tests/Feature/Bloque6/OrderRoutingTest.php
@@ -159,3 +159,52 @@ it('bar items do not appear among kitchen panel items', function () {
 
     expect($allItemIds)->not->toContain($barItem->id);
 });
+
+// ─── Guard: cocina no puede marcar ítems de barra ─────────────────────────────
+
+it('kitchen panel returns 403 when trying to mark a bar item as ready', function () {
+    $kitchenUser = User::factory()->create(['role' => 'kitchen']);
+    $table       = Table::factory()->create(['user_id' => $kitchenUser->id]);
+    $barProduct  = Product::factory()->create(['user_id' => $kitchenUser->id]);
+
+    $order   = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    $barItem = OrderItem::factory()->create([
+        'order_id'    => $order->id,
+        'product_id'  => $barProduct->id,
+        'status'      => 'queued',
+        'destination' => 'bar',
+    ]);
+
+    $this->actingAs($kitchenUser)
+        ->postJson(route('kitchen.item.ready', $barItem))
+        ->assertForbidden();
+
+    expect($barItem->fresh()->status)->toBe('queued');
+});
+
+it('mixed order does not become ready while bar items are still queued', function () {
+    $kitchenUser     = User::factory()->create(['role' => 'kitchen']);
+    $table           = Table::factory()->create(['user_id' => $kitchenUser->id]);
+    $kitchenProduct  = Product::factory()->create(['user_id' => $kitchenUser->id]);
+
+    $order       = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    $kitchenItem = OrderItem::factory()->create([
+        'order_id'    => $order->id,
+        'product_id'  => $kitchenProduct->id,
+        'status'      => 'queued',
+        'destination' => 'kitchen',
+    ]);
+    OrderItem::factory()->create([
+        'order_id'    => $order->id,
+        'product_id'  => $kitchenProduct->id,
+        'status'      => 'queued',
+        'destination' => 'bar',
+    ]);
+
+    $this->actingAs($kitchenUser)
+        ->postJson(route('kitchen.item.ready', $kitchenItem))
+        ->assertOk()
+        ->assertJsonPath('all_ready', false);
+
+    expect($order->fresh()->status)->not->toBe('ready');
+});

--- a/tests/Feature/Bloque6/OrderRoutingTest.php
+++ b/tests/Feature/Bloque6/OrderRoutingTest.php
@@ -1,0 +1,161 @@
+<?php
+
+use App\Models\Category;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Models\Table;
+use App\Models\User;
+use Tests\Support\CreatesTenants;
+
+uses(CreatesTenants::class);
+uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->setupTenants();
+});
+
+// ─── Enrutado al crear el pedido ─────────────────────────────────────────────
+
+it('assigns kitchen destination to items of kitchen category', function () {
+    $table    = Table::factory()->for($this->user)->create();
+    $category = Category::factory()->for($this->user)->create(['destination' => 'kitchen']);
+    $product  = Product::factory()->for($category)->for($this->user)->create();
+
+    $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items'      => [
+            ['product_id' => $product->id, 'quantity' => 1],
+        ],
+    ])->assertCreated();
+
+    $this->assertDatabaseHas('order_items', [
+        'product_id'  => $product->id,
+        'destination' => 'kitchen',
+    ]);
+});
+
+it('assigns bar destination to items of bar category', function () {
+    $table    = Table::factory()->for($this->user)->create();
+    $category = Category::factory()->for($this->user)->create(['destination' => 'bar']);
+    $product  = Product::factory()->for($category)->for($this->user)->create();
+
+    $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items'      => [
+            ['product_id' => $product->id, 'quantity' => 1],
+        ],
+    ])->assertCreated();
+
+    $this->assertDatabaseHas('order_items', [
+        'product_id'  => $product->id,
+        'destination' => 'bar',
+    ]);
+});
+
+it('assigns correct destination when order has mixed kitchen and bar items', function () {
+    $table           = Table::factory()->for($this->user)->create();
+    $kitchenCategory = Category::factory()->for($this->user)->create(['destination' => 'kitchen']);
+    $barCategory     = Category::factory()->for($this->user)->create(['destination' => 'bar']);
+    $kitchenProduct  = Product::factory()->for($kitchenCategory)->for($this->user)->create();
+    $barProduct      = Product::factory()->for($barCategory)->for($this->user)->create();
+
+    $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items'      => [
+            ['product_id' => $kitchenProduct->id, 'quantity' => 1],
+            ['product_id' => $barProduct->id,     'quantity' => 2],
+        ],
+    ])->assertCreated();
+
+    $this->assertDatabaseHas('order_items', [
+        'product_id'  => $kitchenProduct->id,
+        'destination' => 'kitchen',
+    ]);
+
+    $this->assertDatabaseHas('order_items', [
+        'product_id'  => $barProduct->id,
+        'destination' => 'bar',
+    ]);
+});
+
+// ─── Panel de cocina — filtrado por destination ───────────────────────────────
+
+it('kitchen panel only shows orders with kitchen destination items', function () {
+    $kitchenUser     = User::factory()->create(['role' => 'kitchen']);
+    $table           = Table::factory()->create(['user_id' => $kitchenUser->id]);
+    $kitchenCategory = Category::factory()->create(['user_id' => $kitchenUser->id, 'destination' => 'kitchen']);
+    $kitchenProduct  = Product::factory()->create(['user_id' => $kitchenUser->id, 'category_id' => $kitchenCategory->id]);
+
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    OrderItem::factory()->create([
+        'order_id'    => $order->id,
+        'product_id'  => $kitchenProduct->id,
+        'status'      => 'queued',
+        'destination' => 'kitchen',
+    ]);
+
+    $response = $this->actingAs($kitchenUser)
+        ->get(route('kitchen.index'))
+        ->assertOk();
+
+    $orders = $response->viewData('orders');
+
+    expect($orders->pluck('id')->toArray())->toContain($order->id);
+});
+
+it('kitchen panel does not show orders with only bar destination items', function () {
+    $kitchenUser = User::factory()->create(['role' => 'kitchen']);
+    $table       = Table::factory()->create(['user_id' => $kitchenUser->id]);
+    $barCategory = Category::factory()->create(['user_id' => $kitchenUser->id, 'destination' => 'bar']);
+    $barProduct  = Product::factory()->create(['user_id' => $kitchenUser->id, 'category_id' => $barCategory->id]);
+
+    $barOrder = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    OrderItem::factory()->create([
+        'order_id'    => $barOrder->id,
+        'product_id'  => $barProduct->id,
+        'status'      => 'queued',
+        'destination' => 'bar',
+    ]);
+
+    $response = $this->actingAs($kitchenUser)
+        ->get(route('kitchen.index'))
+        ->assertOk();
+
+    $orders = $response->viewData('orders');
+
+    expect($orders->pluck('id')->toArray())->not->toContain($barOrder->id);
+});
+
+it('bar items do not appear among kitchen panel items', function () {
+    $kitchenUser     = User::factory()->create(['role' => 'kitchen']);
+    $table           = Table::factory()->create(['user_id' => $kitchenUser->id]);
+    $kitchenCategory = Category::factory()->create(['user_id' => $kitchenUser->id, 'destination' => 'kitchen']);
+    $barCategory     = Category::factory()->create(['user_id' => $kitchenUser->id, 'destination' => 'bar']);
+    $kitchenProduct  = Product::factory()->create(['user_id' => $kitchenUser->id, 'category_id' => $kitchenCategory->id]);
+    $barProduct      = Product::factory()->create(['user_id' => $kitchenUser->id, 'category_id' => $barCategory->id]);
+
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    OrderItem::factory()->create([
+        'order_id'    => $order->id,
+        'product_id'  => $kitchenProduct->id,
+        'status'      => 'queued',
+        'destination' => 'kitchen',
+    ]);
+    $barItem = OrderItem::factory()->create([
+        'order_id'    => $order->id,
+        'product_id'  => $barProduct->id,
+        'status'      => 'queued',
+        'destination' => 'bar',
+    ]);
+
+    $response = $this->actingAs($kitchenUser)
+        ->get(route('kitchen.index'))
+        ->assertOk();
+
+    $orders = $response->viewData('orders');
+
+    $allItemIds = $orders->flatMap(fn($o) => $o->items->pluck('id'))->toArray();
+
+    expect($allItemIds)->not->toContain($barItem->id);
+});


### PR DESCRIPTION
## Resumen

- Añade columna `destination enum(kitchen|bar)` a `order_items`, copiada de `category.destination` al crear el pedido
- El panel de cocina filtra y muestra únicamente ítems con `destination = kitchen`
- Guard en `markItemReady`: cocina no puede marcar ítems de barra como listos (403)
- Un pedido mixto no pasa a `ready` mientras queden ítems de barra en cola

## Archivos modificados

- `database/migrations/2026_04_24_000001_add_destination_to_order_items_table.php` — nueva migración
- `app/Models/OrderItem.php` — `destination` en `$fillable`
- `app/Http/Controllers/Api/OrderController.php` — eager load de category + asignación de destination
- `app/Http/Controllers/KitchenController.php` — filtro por destination + guard en markItemReady
- `database/factories/OrderItemFactory.php` — default `destination = kitchen`
- `tests/Feature/Bloque6/OrderRoutingTest.php` — 8 tests nuevos

## Tests

- 167/167 pasando (0 regresiones)
- Cubre: asignación kitchen, asignación bar, pedido mixto, filtrado del panel, guard 403, orden no-ready con bar pendiente

## Plan de prueba

- [ ] `php artisan test tests/Feature/Bloque6/OrderRoutingTest.php` — 8 tests en verde
- [ ] `php artisan test --parallel` — 167 tests sin fallos
- [ ] Hacer un pedido desde la carta con productos de categoría kitchen y bar, verificar que el panel de cocina solo muestra los kitchen

🤖 Generated with [Claude Code](https://claude.com/claude-code)