### PR TITLE
feat(bloque6.2): bar panel for waiter with real-time polling

### DIFF
--- a/app/Http/Controllers/BarPanelController.php
+++ b/app/Http/Controllers/BarPanelController.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Order;
+use App\Models\OrderItem;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+/**
+ * Panel de barra en tiempo real.
+ *
+ * Muestra los ítems con destination=bar pendientes (status=queued)
+ * agrupados por pedido, permite marcarlos como listos y cierra
+ * automáticamente el pedido cuando todos sus ítems están preparados.
+ *
+ * @author SebastianBCF
+ */
+class BarPanelController extends Controller
+{
+    /**
+     * Devuelve los pedidos activos con ítems de barra pendientes.
+     *
+     * @return View
+     */
+    public function index(): View
+    {
+        $orders = $this->getActiveOrders();
+
+        return view('bar.index', compact('orders'));
+    }
+
+    /**
+     * Endpoint para el badge del nav: conteo de pedidos con ítems de barra pendientes.
+     *
+     * @return JsonResponse
+     */
+    public function badgeCount(): JsonResponse
+    {
+        $count = Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+            ->whereHas('items', fn($q) => $q->where('destination', 'bar')->where('status', 'queued'))
+            ->whereIn('status', ['pending', 'cooking'])
+            ->count();
+
+        return response()->json(['pending_count' => $count]);
+    }
+
+    /**
+     * Endpoint JSON consumido por el polling de Alpine.js cada 5 segundos.
+     *
+     * @return JsonResponse
+     */
+    public function pendingItems(): JsonResponse
+    {
+        $orders = $this->getActiveOrders()
+            ->map(fn(Order $order) => [
+                'id'         => $order->id,
+                'table_name' => $order->table->name,
+                'created_at' => $order->created_at->format('H:i'),
+                'status'     => $order->status,
+                'items'      => $order->items
+                    ->where('status', 'queued')
+                    ->map(fn(OrderItem $item) => [
+                        'id'           => $item->id,
+                        'product_name' => $item->product->name,
+                        'quantity'     => $item->quantity,
+                    ])->values(),
+            ])
+            ->filter(fn($order) => count($order['items']) > 0)
+            ->values();
+
+        $pendingCount = Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+            ->whereHas('items', fn($q) => $q->where('destination', 'bar')->where('status', 'queued'))
+            ->whereIn('status', ['pending', 'cooking'])
+            ->count();
+
+        return response()->json([
+            'orders'        => $orders,
+            'pending_count' => $pendingCount,
+        ]);
+    }
+
+    /**
+     * Marca un ítem de barra como listo y cierra el pedido si todos
+     * los ítems (cocina + barra) están preparados.
+     *
+     * @param  OrderItem  $item
+     * @return JsonResponse
+     */
+    public function updateItem(OrderItem $item): JsonResponse
+    {
+        $order = $item->order()->with('table')->first();
+
+        abort_if($order->table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($item->destination !== 'bar', 403, 'Este ítem no pertenece a la barra.');
+
+        $item->update(['status' => 'ready']);
+
+        if ($order->status === 'pending') {
+            $order->update(['status' => 'cooking']);
+        }
+
+        $allReady = $order->fresh()->items()->where('status', 'queued')->doesntExist();
+
+        if ($allReady) {
+            $order->update(['status' => 'ready']);
+        }
+
+        return response()->json([
+            'item_id'      => $item->id,
+            'order_id'     => $order->id,
+            'order_status' => $order->fresh()->status,
+            'all_ready'    => $allReady,
+        ]);
+    }
+
+    /**
+     * Consulta los pedidos activos con ítems de barra en cola
+     * pertenecientes al restaurante autenticado.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    private function getActiveOrders(): \Illuminate\Database\Eloquent\Collection
+    {
+        return Order::with([
+            'table',
+            'items' => fn($q) => $q
+                ->where('status', 'queued')
+                ->where('destination', 'bar')
+                ->with(['product']),
+        ])
+        ->whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+        ->whereHas('items', fn($q) => $q->where('destination', 'bar')->where('status', 'queued'))
+        ->whereIn('status', ['pending', 'cooking'])
+        ->orderBy('created_at')
+        ->get();
+    }
+}

--- a/resources/views/bar/index.blade.php
+++ b/resources/views/bar/index.blade.php
@@ -151,7 +151,7 @@
         async markReady(item, order) {
           item.marking = true;
           try {
-            const res = await fetch(`/bar/items/${item.id}`, {
+            const res = await fetch(`{{ url('/bar/items') }}/${item.id}`, {
               method:  'PATCH',
               headers: {
                 'X-CSRF-TOKEN':     document.querySelector('meta[name="csrf-token"]').content,

--- a/resources/views/bar/index.blade.php
+++ b/resources/views/bar/index.blade.php
@@ -1,0 +1,178 @@
+{{-- @author SebastianBCF --}}
+<x-app-layout>
+  <div
+    class="max-w-6xl mx-auto px-4 sm:px-6 py-6 mt-4 sm:mt-10"
+    x-data="barPanel()"
+    x-init="init()"
+  >
+
+    {{-- Cabecera --}}
+    <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6">
+      <div>
+        <h2 class="text-xl sm:text-2xl font-bold text-gray-800">Panel de Barra</h2>
+        <p class="text-sm text-gray-500 mt-1">
+          Actualización automática cada 5 segundos &mdash;
+          <span x-text="lastUpdated" class="font-medium text-amber-600"></span>
+        </p>
+      </div>
+
+      {{-- Indicador de conexión --}}
+      <div class="flex items-center gap-2 text-sm">
+        <span
+          class="inline-block w-3 h-3 rounded-full"
+          :class="polling ? 'bg-green-500 animate-pulse' : 'bg-red-500'"
+          aria-hidden="true"
+        ></span>
+        <span x-text="polling ? 'En vivo' : 'Sin conexión'" class="text-gray-600"></span>
+      </div>
+    </div>
+
+    {{-- Sin ítems pendientes --}}
+    <div x-show="orders.length === 0" class="bg-white shadow rounded-lg p-10 text-center text-gray-400">
+      <svg class="mx-auto mb-4 h-12 w-12 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+          d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+      </svg>
+      <p class="text-lg font-medium">No hay bebidas pendientes</p>
+      <p class="text-sm mt-1">Las nuevas comandas aparecerán aquí automáticamente.</p>
+    </div>
+
+    {{-- Grid de comandas --}}
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+      <template x-for="order in orders" :key="order.id">
+        <div class="bg-white shadow-md rounded-lg overflow-hidden border border-gray-200">
+
+          {{-- Cabecera de la comanda --}}
+          <div class="flex items-center justify-between px-4 py-3 bg-amber-500 text-white">
+            <span class="font-bold text-base" x-text="order.table_name"></span>
+            <span class="text-xs bg-white/20 rounded px-2 py-1" x-text="order.created_at"></span>
+          </div>
+
+          {{-- Ítems pendientes --}}
+          <ul class="divide-y divide-gray-100" role="list">
+            <template x-for="item in order.items" :key="item.id">
+              <li class="px-4 py-3">
+                <div class="flex items-center justify-between gap-2">
+                  <div class="flex-1 min-w-0">
+                    <p class="font-semibold text-gray-800 text-sm">
+                      <span
+                        class="inline-flex items-center justify-center w-6 h-6 rounded-full bg-amber-100 text-amber-700 text-xs font-bold mr-1"
+                        x-text="'×' + item.quantity"
+                        aria-label="Cantidad"
+                      ></span>
+                      <span x-text="item.product_name"></span>
+                    </p>
+                  </div>
+
+                  {{-- Botón "Servido" --}}
+                  <button
+                    @click="markReady(item, order)"
+                    :disabled="item.marking"
+                    class="shrink-0 bg-amber-500 hover:bg-amber-600 disabled:opacity-50 text-white text-xs font-semibold px-3 py-1.5 rounded focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 transition"
+                    :aria-label="'Marcar como servido: ' + item.product_name"
+                  >
+                    <span x-show="!item.marking">Listo ✓</span>
+                    <span x-show="item.marking">...</span>
+                  </button>
+
+                </div>
+              </li>
+            </template>
+          </ul>
+
+          {{-- Footer: comanda completa --}}
+          <div
+            x-show="order.all_ready"
+            class="px-4 py-3 bg-green-50 border-t border-green-200"
+            role="status"
+          >
+            <span class="text-green-700 text-xs font-semibold">¡Pedido completo! Listo para servir.</span>
+          </div>
+
+        </div>
+      </template>
+    </div>
+
+  </div>
+
+  @push('scripts')
+  @php
+    $ordersForJs = $orders->map(fn($o) => [
+      'id'         => $o->id,
+      'table_name' => $o->table->name,
+      'created_at' => $o->created_at->format('H:i'),
+      'status'     => $o->status,
+      'all_ready'  => false,
+      'items'      => $o->items->map(fn($i) => [
+        'id'           => $i->id,
+        'product_name' => $i->product->name,
+        'quantity'     => $i->quantity,
+        'marking'      => false,
+      ])->values(),
+    ])->values();
+  @endphp
+  <script>
+    function barPanel() {
+      return {
+        orders: @json($ordersForJs),
+
+        polling: true,
+        lastUpdated: '--:--',
+        pollInterval: null,
+
+        init() {
+          this.tick();
+          this.pollInterval = setInterval(() => this.tick(), 5000);
+        },
+
+        async tick() {
+          try {
+            const res  = await fetch('{{ route('bar.pending') }}', {
+              headers: { 'X-Requested-With': 'XMLHttpRequest' }
+            });
+            const data = await res.json();
+
+            const markingIds = {};
+            this.orders.forEach(o => o.items.forEach(i => { if (i.marking) markingIds[i.id] = true; }));
+
+            this.orders = data.orders.map(o => ({
+              ...o,
+              all_ready: false,
+              items: o.items.map(i => ({ ...i, marking: !!markingIds[i.id] })),
+            }));
+
+            this.polling     = true;
+            this.lastUpdated = new Date().toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+          } catch {
+            this.polling = false;
+          }
+        },
+
+        async markReady(item, order) {
+          item.marking = true;
+          try {
+            const res = await fetch(`/bar/items/${item.id}`, {
+              method:  'PATCH',
+              headers: {
+                'X-CSRF-TOKEN':     document.querySelector('meta[name="csrf-token"]').content,
+                'X-Requested-With': 'XMLHttpRequest',
+                'Accept':           'application/json',
+              },
+            });
+            const data = await res.json();
+
+            order.items = order.items.filter(i => i.id !== item.id);
+
+            if (data.all_ready) {
+              order.all_ready = true;
+            }
+          } catch {
+            item.marking = false;
+          }
+        },
+      };
+    }
+  </script>
+  @endpush
+
+</x-app-layout>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -54,6 +54,22 @@
                 },
             };
         }
+        function barBadge(url) {
+            return {
+                count: 0,
+                init() {
+                    this.fetch();
+                    setInterval(() => this.fetch(), 10000);
+                },
+                async fetch() {
+                    try {
+                        const res = await fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+                        const data = await res.json();
+                        this.count = data.pending_count ?? 0;
+                    } catch {}
+                },
+            };
+        }
         </script>
     </body>
 </html>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -50,6 +50,24 @@
                         ></span>
                     </span>
                     @endif
+                    {{-- Panel de Barra: visible solo para admin y waiter --}}
+                    @if(in_array(Auth::user()->role, ['admin', 'waiter']))
+                    <span
+                        x-data="barBadge('{{ route('bar.badge') }}')"
+                        x-init="init()"
+                        class="relative inline-flex items-center"
+                    >
+                        <x-nav-link :href="route('bar.index')" :active="request()->routeIs('bar.*')">
+                            {{ __('Barra') }}
+                        </x-nav-link>
+                        <span
+                            x-show="count > 0"
+                            x-text="count"
+                            class="absolute -top-1 right-0 inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-amber-500 rounded-full pointer-events-none"
+                            :aria-label="count + ' bebidas pendientes en barra'"
+                        ></span>
+                    </span>
+                    @endif
                 </div>
 
                 <!-- Settings Dropdown -->
@@ -135,6 +153,20 @@
                             x-text="count"
                             class="ml-2 inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-red-500 rounded-full"
                             :aria-label="count + ' pedidos nuevos sin atender'"
+                        ></span>
+                    </x-responsive-nav-link>
+                </span>
+                @endif
+                {{-- Panel de Barra (Versión Móvil) --}}
+                @if(in_array(Auth::user()->role, ['admin', 'waiter']))
+                <span x-data="barBadge('{{ route('bar.badge') }}')" x-init="init()" class="flex items-center">
+                    <x-responsive-nav-link :href="route('bar.index')" :active="request()->routeIs('bar.*')">
+                        {{ __('Barra') }}
+                        <span
+                            x-show="count > 0"
+                            x-text="count"
+                            class="ml-2 inline-flex items-center justify-center w-5 h-5 text-xs font-bold text-white bg-amber-500 rounded-full"
+                            :aria-label="count + ' bebidas pendientes en barra'"
                         ></span>
                     </x-responsive-nav-link>
                 </span>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 use App\Http\Controllers\IngredientController;
+use App\Http\Controllers\BarPanelController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\KitchenController;
 use App\Http\Controllers\MenuController;
@@ -45,6 +46,14 @@ Route::middleware('auth')->group(function () {
         Route::get('/cocina/pendientes', [KitchenController::class, 'pendingOrders'])->name('kitchen.pending');
         Route::post('/cocina/items/{item}/listo', [KitchenController::class, 'markItemReady'])->name('kitchen.item.ready');
         Route::post('/cocina/orders/{order}/servido', [KitchenController::class, 'markOrderServed'])->name('kitchen.order.served');
+    });
+
+    // Panel de barra — accesible para roles admin y waiter
+    Route::middleware('role:admin,waiter')->group(function () {
+        Route::get('/bar', [BarPanelController::class, 'index'])->name('bar.index');
+        Route::get('/bar/badge', [BarPanelController::class, 'badgeCount'])->name('bar.badge');
+        Route::get('/bar/pendientes', [BarPanelController::class, 'pendingItems'])->name('bar.pending');
+        Route::patch('/bar/items/{item}', [BarPanelController::class, 'updateItem'])->name('bar.items.update');
     });
 });
 

--- a/tests/Feature/Bloque6/BarPanelTest.php
+++ b/tests/Feature/Bloque6/BarPanelTest.php
@@ -1,0 +1,187 @@
+<?php
+
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Models\Table;
+use App\Models\User;
+use Tests\Support\CreatesTenants;
+
+uses(CreatesTenants::class);
+uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->setupTenants();
+});
+
+// ─── Acceso al panel ──────────────────────────────────────────────────────────
+
+it('redirects unauthenticated user away from bar panel', function () {
+    $this->get(route('bar.index'))
+        ->assertRedirect(route('login'));
+});
+
+it('shows bar panel to waiter role', function () {
+    $waiter = User::factory()->create(['role' => 'waiter']);
+
+    $this->actingAs($waiter)
+        ->get(route('bar.index'))
+        ->assertOk()
+        ->assertViewIs('bar.index');
+});
+
+it('shows bar panel to admin role', function () {
+    $admin = User::factory()->create(['role' => 'admin']);
+
+    $this->actingAs($admin)
+        ->get(route('bar.index'))
+        ->assertOk()
+        ->assertViewIs('bar.index');
+});
+
+it('returns 403 for kitchen role on bar panel', function () {
+    $kitchen = User::factory()->create(['role' => 'kitchen']);
+
+    $this->actingAs($kitchen)
+        ->get(route('bar.index'))
+        ->assertForbidden();
+});
+
+// ─── Filtrado de ítems por destination ───────────────────────────────────────
+
+it('shows only bar destination items in bar panel', function () {
+    $waiter     = User::factory()->create(['role' => 'waiter']);
+    $table      = Table::factory()->create(['user_id' => $waiter->id]);
+    $barProduct = Product::factory()->create(['user_id' => $waiter->id]);
+
+    $order   = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    $barItem = OrderItem::factory()->create([
+        'order_id'    => $order->id,
+        'product_id'  => $barProduct->id,
+        'status'      => 'queued',
+        'destination' => 'bar',
+    ]);
+
+    $response = $this->actingAs($waiter)
+        ->get(route('bar.index'))
+        ->assertOk();
+
+    $orders = $response->viewData('orders');
+
+    $allItemIds = $orders->flatMap(fn($o) => $o->items->pluck('id'))->toArray();
+
+    expect($allItemIds)->toContain($barItem->id);
+});
+
+it('does not show kitchen items in bar panel', function () {
+    $waiter         = User::factory()->create(['role' => 'waiter']);
+    $table          = Table::factory()->create(['user_id' => $waiter->id]);
+    $kitchenProduct = Product::factory()->create(['user_id' => $waiter->id]);
+    $barProduct     = Product::factory()->create(['user_id' => $waiter->id]);
+
+    $order          = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    $kitchenItem    = OrderItem::factory()->create([
+        'order_id'    => $order->id,
+        'product_id'  => $kitchenProduct->id,
+        'status'      => 'queued',
+        'destination' => 'kitchen',
+    ]);
+    OrderItem::factory()->create([
+        'order_id'    => $order->id,
+        'product_id'  => $barProduct->id,
+        'status'      => 'queued',
+        'destination' => 'bar',
+    ]);
+
+    $response = $this->actingAs($waiter)
+        ->get(route('bar.index'))
+        ->assertOk();
+
+    $orders = $response->viewData('orders');
+
+    $allItemIds = $orders->flatMap(fn($o) => $o->items->pluck('id'))->toArray();
+
+    expect($allItemIds)->not->toContain($kitchenItem->id);
+});
+
+it('does not show items from other restaurants', function () {
+    $waiter       = User::factory()->create(['role' => 'waiter']);
+    $otherWaiter  = User::factory()->create(['role' => 'waiter']);
+
+    $ownTable   = Table::factory()->create(['user_id' => $waiter->id]);
+    $otherTable = Table::factory()->create(['user_id' => $otherWaiter->id]);
+
+    $ownProduct   = Product::factory()->create(['user_id' => $waiter->id]);
+    $otherProduct = Product::factory()->create(['user_id' => $otherWaiter->id]);
+
+    $ownOrder   = Order::factory()->create(['table_id' => $ownTable->id,   'status' => 'pending']);
+    $otherOrder = Order::factory()->create(['table_id' => $otherTable->id, 'status' => 'pending']);
+
+    OrderItem::factory()->create([
+        'order_id'    => $ownOrder->id,
+        'product_id'  => $ownProduct->id,
+        'status'      => 'queued',
+        'destination' => 'bar',
+    ]);
+    OrderItem::factory()->create([
+        'order_id'    => $otherOrder->id,
+        'product_id'  => $otherProduct->id,
+        'status'      => 'queued',
+        'destination' => 'bar',
+    ]);
+
+    $response = $this->actingAs($waiter)
+        ->get(route('bar.index'))
+        ->assertOk();
+
+    $orders = $response->viewData('orders');
+
+    expect($orders->pluck('id')->toArray())
+        ->toContain($ownOrder->id)
+        ->not->toContain($otherOrder->id);
+});
+
+// ─── Acción markItemReady ─────────────────────────────────────────────────────
+
+it('waiter can mark a bar item as ready', function () {
+    $waiter  = User::factory()->create(['role' => 'waiter']);
+    $table   = Table::factory()->create(['user_id' => $waiter->id]);
+    $product = Product::factory()->create(['user_id' => $waiter->id]);
+
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    $item  = OrderItem::factory()->create([
+        'order_id'    => $order->id,
+        'product_id'  => $product->id,
+        'status'      => 'queued',
+        'destination' => 'bar',
+    ]);
+
+    $this->actingAs($waiter)
+        ->patchJson(route('bar.items.update', $item))
+        ->assertOk()
+        ->assertJsonPath('item_id', $item->id);
+
+    expect($item->fresh()->status)->toBe('ready');
+});
+
+it('returns 403 when waiter tries to update item from another restaurant', function () {
+    $waiter       = User::factory()->create(['role' => 'waiter']);
+    $otherWaiter  = User::factory()->create(['role' => 'waiter']);
+
+    $otherTable   = Table::factory()->create(['user_id' => $otherWaiter->id]);
+    $otherProduct = Product::factory()->create(['user_id' => $otherWaiter->id]);
+
+    $otherOrder = Order::factory()->create(['table_id' => $otherTable->id, 'status' => 'pending']);
+    $otherItem  = OrderItem::factory()->create([
+        'order_id'    => $otherOrder->id,
+        'product_id'  => $otherProduct->id,
+        'status'      => 'queued',
+        'destination' => 'bar',
+    ]);
+
+    $this->actingAs($waiter)
+        ->patchJson(route('bar.items.update', $otherItem))
+        ->assertForbidden();
+
+    expect($otherItem->fresh()->status)->toBe('queued');
+});

--- a/tests/Feature/Bloque6/BarPanelTest.php
+++ b/tests/Feature/Bloque6/BarPanelTest.php
@@ -164,6 +164,26 @@ it('waiter can mark a bar item as ready', function () {
     expect($item->fresh()->status)->toBe('ready');
 });
 
+it('returns 403 when trying to mark a kitchen item as ready via bar endpoint', function () {
+    $waiter         = User::factory()->create(['role' => 'waiter']);
+    $table          = Table::factory()->create(['user_id' => $waiter->id]);
+    $kitchenProduct = Product::factory()->create(['user_id' => $waiter->id]);
+
+    $order       = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    $kitchenItem = OrderItem::factory()->create([
+        'order_id'    => $order->id,
+        'product_id'  => $kitchenProduct->id,
+        'status'      => 'queued',
+        'destination' => 'kitchen',
+    ]);
+
+    $this->actingAs($waiter)
+        ->patchJson(route('bar.items.update', $kitchenItem))
+        ->assertForbidden();
+
+    expect($kitchenItem->fresh()->status)->toBe('queued');
+});
+
 it('returns 403 when waiter tries to update item from another restaurant', function () {
     $waiter       = User::factory()->create(['role' => 'waiter']);
     $otherWaiter  = User::factory()->create(['role' => 'waiter']);


### PR DESCRIPTION
## Resumen

- Nuevo `BarPanelController` que muestra ítems con `destination=bar` pendientes agrupados por pedido
- Panel accesible para roles `admin` y `waiter` (protegido con `role:admin,waiter`)
- Polling Alpine.js cada 5 segundos al endpoint `/bar/pendientes`
- Guard en `updateItem`: rechaza ítems de cocina (403) y de otros restaurantes (403)
- Badge de conteo en la navegación (desktop y móvil) para `admin` y `waiter`
- Función `barBadge()` añadida al layout global

## Archivos

- `app/Http/Controllers/BarPanelController.php` — nuevo controlador
- `routes/web.php` — 4 rutas del panel de barra
- `resources/views/bar/index.blade.php` — vista con Alpine.js polling
- `resources/views/layouts/app.blade.php` — función `barBadge()`
- `resources/views/layouts/navigation.blade.php` — enlace con badge (desktop + móvil)
- `tests/Feature/Bloque6/BarPanelTest.php` — 10 tests

## Tests

- 177/177 pasando (0 regresiones)
- Cubre: redirect sin auth, waiter OK, admin OK, kitchen 403, filtrado bar/kitchen, multitenancy, guard destination, guard user_id

## Plan de prueba

- [ ] `php artisan test tests/Feature/Bloque6/BarPanelTest.php` — 10 tests en verde
- [ ] `php artisan test --parallel` — 177 tests sin fallos
- [ ] Hacer un pedido con productos de categoría bar y verificar que aparecen en `/bar`
- [ ] Verificar que el panel de cocina (`/cocina`) NO muestra esos ítems

> **Nota:** Esta rama parte de `feat/bloque6-kitchen-bar-routing` (PR #100). Mergear el 6.1 primero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)