### PR TITLE
feat(bloque6.4): Sistema de Tapas configurable por el gerente

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -66,7 +66,7 @@ class MenuController extends Controller
             $tapaConfig    = $config;
             $barItemsCount = OrderItem::whereHas('order', fn ($q) =>
                 $q->where('table_id', $table->id)
-                  ->whereNotIn('status', ['closed', 'cancelled'])
+                  ->where('status', '!=', 'closed')
             )->where('destination', 'bar')->sum('quantity');
         }
 

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Category;
+use App\Models\OrderItem;
 use App\Models\Table;
 use Illuminate\View\View;
 
@@ -57,6 +58,18 @@ class MenuController extends Controller
             ->sortBy('name')
             ->values();
 
-        return view('menu.show', compact('table', 'categories', 'allergens'));
+        $tapaConfig    = null;
+        $barItemsCount = 0;
+
+        $config = $table->user->tapaConfig;
+        if ($config && $config->tapas_enabled) {
+            $tapaConfig    = $config;
+            $barItemsCount = OrderItem::whereHas('order', fn ($q) =>
+                $q->where('table_id', $table->id)
+                  ->whereNotIn('status', ['closed', 'cancelled'])
+            )->where('destination', 'bar')->sum('quantity');
+        }
+
+        return view('menu.show', compact('table', 'categories', 'allergens', 'tapaConfig', 'barItemsCount'));
     }
 }

--- a/app/Http/Controllers/TapasController.php
+++ b/app/Http/Controllers/TapasController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TapaConfig;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+/**
+ * Class TapasController
+ *
+ * Permite al gerente configurar el sistema de tapas del restaurante:
+ * activar/desactivar, modo gratuito/de pago, precio y variantes máximas.
+ *
+ * @author BenjaminDTS
+ */
+class TapasController extends Controller
+{
+    /**
+     * Muestra el formulario de configuración de tapas.
+     * Crea la configuración con valores por defecto si aún no existe.
+     *
+     * @return View
+     */
+    public function edit(): View
+    {
+        $tapaConfig = TapaConfig::firstOrCreate(
+            ['user_id' => Auth::id()],
+            [
+                'tapas_enabled'     => false,
+                'tapas_free'        => true,
+                'max_tapa_variants' => 3,
+                'tapa_price'        => null,
+            ]
+        );
+
+        return view('tapas.edit', compact('tapaConfig'));
+    }
+
+    /**
+     * Guarda la configuración de tapas del restaurante.
+     *
+     * @param  Request $request
+     * @return RedirectResponse
+     */
+    public function update(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'tapas_enabled'     => ['sometimes', 'boolean'],
+            'tapas_free'        => ['sometimes', 'boolean'],
+            'max_tapa_variants' => ['required', 'integer', 'min:1', 'max:20'],
+            'tapa_price'        => ['nullable', 'numeric', 'min:0', 'max:999.99'],
+        ]);
+
+        $tapas_enabled = $request->boolean('tapas_enabled');
+        $tapas_free    = $request->boolean('tapas_free');
+
+        TapaConfig::updateOrCreate(
+            ['user_id' => Auth::id()],
+            [
+                'tapas_enabled'     => $tapas_enabled,
+                'tapas_free'        => $tapas_free,
+                'max_tapa_variants' => $validated['max_tapa_variants'],
+                'tapa_price'        => $tapas_free ? null : ($validated['tapa_price'] ?? null),
+            ]
+        );
+
+        return redirect()->route('tapas.edit')
+                         ->with('success', 'Configuración de tapas guardada correctamente.');
+    }
+}

--- a/app/Http/Controllers/TapasController.php
+++ b/app/Http/Controllers/TapasController.php
@@ -51,7 +51,7 @@ class TapasController extends Controller
             'tapas_enabled'     => ['sometimes', 'boolean'],
             'tapas_free'        => ['sometimes', 'boolean'],
             'max_tapa_variants' => ['required', 'integer', 'min:1', 'max:20'],
-            'tapa_price'        => ['nullable', 'numeric', 'min:0', 'max:999.99'],
+            'tapa_price'        => ['required_if:tapas_free,0', 'nullable', 'numeric', 'min:0', 'max:999.99'],
         ]);
 
         $tapas_enabled = $request->boolean('tapas_enabled');

--- a/app/Models/TapaConfig.php
+++ b/app/Models/TapaConfig.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Class TapaConfig
+ *
+ * Configuración del sistema de tapas de un restaurante (relación 1:1 con User).
+ * Permite al gerente activar tapas, definir si son gratuitas o de pago,
+ * el precio unitario y el número máximo de variantes distintas por pedido.
+ *
+ * @package App\Models
+ * @property int     $user_id
+ * @property bool    $tapas_enabled       Si el sistema de tapas está activo
+ * @property bool    $tapas_free          true = gratuitas, false = de pago
+ * @property int     $max_tapa_variants   Máximo de variantes distintas por mesa
+ * @property float|null $tapa_price       Precio por tapa (solo si tapas_free = false)
+ *
+ * @author BenjaminDTS
+ */
+class TapaConfig extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'user_id',
+        'tapas_enabled',
+        'tapas_free',
+        'max_tapa_variants',
+        'tapa_price',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'tapas_enabled'     => 'boolean',
+        'tapas_free'        => 'boolean',
+        'max_tapa_variants' => 'integer',
+        'tapa_price'        => 'decimal:2',
+    ];
+
+    /**
+     * El restaurante (usuario) al que pertenece esta configuración.
+     *
+     * @return BelongsTo
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
  * Class User
@@ -115,5 +116,15 @@ class User extends Authenticatable
     public function ingredients(): HasMany
     {
         return $this->hasMany(Ingredient::class);
+    }
+
+    /**
+     * Obtiene la configuración de tapas del restaurante.
+     *
+     * @return HasOne
+     */
+    public function tapaConfig(): HasOne
+    {
+        return $this->hasOne(TapaConfig::class);
     }
 }

--- a/database/factories/TapaConfigFactory.php
+++ b/database/factories/TapaConfigFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\TapaConfig>
+ *
+ * @author BenjaminDTS
+ */
+class TapaConfigFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id'           => User::factory(),
+            'tapas_enabled'     => false,
+            'tapas_free'        => true,
+            'max_tapa_variants' => 3,
+            'tapa_price'        => null,
+        ];
+    }
+}

--- a/database/migrations/2026_04_25_000001_create_tapa_configs_table.php
+++ b/database/migrations/2026_04_25_000001_create_tapa_configs_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Crea la tabla tapa_configs para configuración de tapas por restaurante.
+ *
+ * @author BenjaminDTS
+ */
+return new class extends Migration
+{
+    /**
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::create('tapa_configs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->onDelete('cascade');
+            $table->boolean('tapas_enabled')->default(false);
+            $table->boolean('tapas_free')->default(true);
+            $table->unsignedInteger('max_tapa_variants')->default(3);
+            $table->decimal('tapa_price', 8, 2)->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tapa_configs');
+    }
+};

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -32,6 +32,12 @@
                     <x-nav-link :href="route('tables.index')" :active="request()->routeIs('tables.*')">
                         {{ __('Mesas QR') }}
                     </x-nav-link>
+                    {{-- Configuración de tapas: visible solo para admin --}}
+                    @if(Auth::user()->role === 'admin')
+                    <x-nav-link :href="route('tapas.edit')" :active="request()->routeIs('tapas.*')">
+                        {{ __('Tapas') }}
+                    </x-nav-link>
+                    @endif
                     {{-- Panel de Cocina: visible solo para admin y kitchen --}}
                     @if(in_array(Auth::user()->role, ['admin', 'kitchen']))
                     <span
@@ -143,6 +149,12 @@
                 <x-responsive-nav-link :href="route('tables.index')" :active="request()->routeIs('tables.*')">
                     {{ __('Mesas QR') }}
                 </x-responsive-nav-link>
+                {{-- Configuración de tapas (Versión Móvil) --}}
+                @if(Auth::user()->role === 'admin')
+                <x-responsive-nav-link :href="route('tapas.edit')" :active="request()->routeIs('tapas.*')">
+                    {{ __('Tapas') }}
+                </x-responsive-nav-link>
+                @endif
                 {{-- Panel de Cocina (Versión Móvil) --}}
                 @if(in_array(Auth::user()->role, ['admin', 'kitchen']))
                 <span x-data="kitchenBadge('{{ route('kitchen.badge') }}')" x-init="init()" class="flex items-center">

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1033,7 +1033,7 @@
                             {{ __('Las tapas son gratuitas. Puedes pedirlas indicándolo en tu comanda.') }}
                         @else
                             {{ __('Precio por tapa:') }}
-                            <span class="font-semibold">{{ number_format($tapaConfig->tapa_price, 2) }} €</span>
+                            <span class="font-semibold">{{ number_format($tapaConfig->tapa_price ?? 0, 2) }} €</span>
                         @endif
                         &bull; {{ __('Máximo') }} {{ $tapaConfig->max_tapa_variants }} {{ Str::plural('variante', $tapaConfig->max_tapa_variants) }} {{ __('distintas.') }}
                     </p>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1014,6 +1014,34 @@
 
         </main>
 
+        {{-- ── Banner de Tapas disponibles ─────────────────────────── --}}
+        @if($tapaConfig && $barItemsCount > 0)
+        <section
+            aria-label="Tapas disponibles"
+            class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 mb-8"
+        >
+            <div class="rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 p-4 sm:p-5 flex flex-col sm:flex-row items-start sm:items-center gap-3">
+                <span aria-hidden="true" class="text-2xl leading-none">🍽️</span>
+                <div class="flex-1">
+                    <p class="text-sm font-semibold text-amber-800 dark:text-amber-300">
+                        {{ __('¡Tienes') }}
+                        <span class="font-bold text-base">{{ $barItemsCount }}</span>
+                        {{ Str::plural('tapa', $barItemsCount) }} {{ __('disponible') }}{{ $barItemsCount > 1 ? 's' : '' }}
+                    </p>
+                    <p class="text-xs text-amber-700 dark:text-amber-400 mt-0.5">
+                        @if($tapaConfig->tapas_free)
+                            {{ __('Las tapas son gratuitas. Puedes pedirlas indicándolo en tu comanda.') }}
+                        @else
+                            {{ __('Precio por tapa:') }}
+                            <span class="font-semibold">{{ number_format($tapaConfig->tapa_price, 2) }} €</span>
+                        @endif
+                        &bull; {{ __('Máximo') }} {{ $tapaConfig->max_tapa_variants }} {{ Str::plural('variante', $tapaConfig->max_tapa_variants) }} {{ __('distintas.') }}
+                    </p>
+                </div>
+            </div>
+        </section>
+        @endif
+
         {{-- ── Footer ──────────────────────────────────────────────── --}}
         <footer class="mt-12 border-t border-gray-200 dark:border-gray-800 py-6 text-center">
             <p class="text-xs text-gray-400 dark:text-gray-600">

--- a/resources/views/tapas/edit.blade.php
+++ b/resources/views/tapas/edit.blade.php
@@ -1,0 +1,152 @@
+{{-- @author SebastianBCF --}}
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Configuración de Tapas') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
+
+            {{-- Flash de éxito --}}
+            @if(session('success'))
+            <div role="alert" class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-6">
+                {{ session('success') }}
+            </div>
+            @endif
+
+            <div class="bg-white dark:bg-gray-800 shadow sm:rounded-lg p-6 sm:p-8">
+
+                <form
+                    method="POST"
+                    action="{{ route('tapas.update') }}"
+                    x-data="{
+                        tapas_enabled: {{ $tapaConfig->tapas_enabled ? 'true' : 'false' }},
+                        tapas_free: {{ $tapaConfig->tapas_free ? 'true' : 'false' }}
+                    }"
+                >
+                    @csrf
+                    @method('PUT')
+
+                    {{-- ── Activar tapas ── --}}
+                    <div class="flex items-center justify-between mb-6">
+                        <div>
+                            <label for="tapas_enabled_btn" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                {{ __('Activar sistema de tapas') }}
+                            </label>
+                            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                {{ __('Cuando está activo, los clientes pueden elegir tapas según las bebidas consumidas.') }}
+                            </p>
+                        </div>
+                        <button
+                            id="tapas_enabled_btn"
+                            type="button"
+                            role="switch"
+                            :aria-checked="tapas_enabled.toString()"
+                            @click="tapas_enabled = !tapas_enabled"
+                            :class="tapas_enabled ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+                            class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                        >
+                            <span
+                                :class="tapas_enabled ? 'translate-x-6' : 'translate-x-1'"
+                                class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform"
+                            ></span>
+                        </button>
+                        <input type="hidden" name="tapas_enabled" :value="tapas_enabled ? '1' : '0'">
+                    </div>
+
+                    {{-- ── Configuración detallada (visible solo si tapas activas) ── --}}
+                    <div x-show="tapas_enabled" x-transition class="space-y-6 border-t border-gray-200 dark:border-gray-700 pt-6">
+
+                        {{-- Gratuitas / de pago --}}
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <label for="tapas_free_btn" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                    {{ __('Tapas gratuitas') }}
+                                </label>
+                                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                    {{ __('Desactiva para cobrar un precio fijo por tapa.') }}
+                                </p>
+                            </div>
+                            <button
+                                id="tapas_free_btn"
+                                type="button"
+                                role="switch"
+                                :aria-checked="tapas_free.toString()"
+                                @click="tapas_free = !tapas_free"
+                                :class="tapas_free ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+                                class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                            >
+                                <span
+                                    :class="tapas_free ? 'translate-x-6' : 'translate-x-1'"
+                                    class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform"
+                                ></span>
+                            </button>
+                            <input type="hidden" name="tapas_free" :value="tapas_free ? '1' : '0'">
+                        </div>
+
+                        {{-- Precio por tapa (solo si de pago) --}}
+                        <div x-show="!tapas_free" x-transition>
+                            <label for="tapa_price" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                {{ __('Precio por tapa (€)') }}
+                            </label>
+                            <input
+                                type="number"
+                                id="tapa_price"
+                                name="tapa_price"
+                                value="{{ old('tapa_price', $tapaConfig->tapa_price) }}"
+                                min="0"
+                                max="999.99"
+                                step="0.01"
+                                class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                                placeholder="0.00"
+                                aria-describedby="error-tapa_price"
+                            >
+                            @error('tapa_price')
+                                <p id="error-tapa_price" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                        {{-- Máximo de variantes distintas --}}
+                        <div>
+                            <label for="max_tapa_variants" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                {{ __('Máximo de variantes de tapa por mesa') }}
+                            </label>
+                            <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                                {{ __('Número máximo de tapas distintas que se pueden pedir en un mismo pedido (p. ej. 3).') }}
+                            </p>
+                            <input
+                                type="number"
+                                id="max_tapa_variants"
+                                name="max_tapa_variants"
+                                value="{{ old('max_tapa_variants', $tapaConfig->max_tapa_variants) }}"
+                                min="1"
+                                max="20"
+                                aria-required="true"
+                                aria-describedby="error-max_tapa_variants"
+                                class="mt-1 block w-32 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                            >
+                            @error('max_tapa_variants')
+                                <p id="error-max_tapa_variants" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                    </div>
+
+                    {{-- Botón guardar --}}
+                    <div class="mt-8 flex justify-end">
+                        <button
+                            type="submit"
+                            class="inline-flex items-center px-5 py-2 bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 text-white text-sm font-medium rounded-md transition-colors"
+                        >
+                            {{ __('Guardar configuración') }}
+                        </button>
+                    </div>
+
+                </form>
+            </div>
+
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,9 +36,11 @@ Route::middleware('auth')->group(function () {
     Route::post('/productos/{product}/ingredientes', [ProductController::class, 'syncIngredients'])
          ->name('products.ingredients.sync');
 
-    // Configuración de tapas — accesible para el gerente (admin)
-    Route::get('/tapas/config', [TapasController::class, 'edit'])->name('tapas.edit');
-    Route::put('/tapas/config', [TapasController::class, 'update'])->name('tapas.update');
+    // Configuración de tapas — solo accesible para el gerente (admin)
+    Route::middleware('role:admin')->group(function () {
+        Route::get('/tapas/config', [TapasController::class, 'edit'])->name('tapas.edit');
+        Route::put('/tapas/config', [TapasController::class, 'update'])->name('tapas.update');
+    });
 
     // Gestión de mesas y códigos QR
     Route::get('/mesas', [TableController::class, 'index'])->name('tables.index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 use App\Http\Controllers\IngredientController;
 use App\Http\Controllers\BarPanelController;
+use App\Http\Controllers\TapasController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\KitchenController;
 use App\Http\Controllers\MenuController;
@@ -34,6 +35,10 @@ Route::middleware('auth')->group(function () {
          ->name('products.ingredients.edit');
     Route::post('/productos/{product}/ingredientes', [ProductController::class, 'syncIngredients'])
          ->name('products.ingredients.sync');
+
+    // Configuración de tapas — accesible para el gerente (admin)
+    Route::get('/tapas/config', [TapasController::class, 'edit'])->name('tapas.edit');
+    Route::put('/tapas/config', [TapasController::class, 'update'])->name('tapas.update');
 
     // Gestión de mesas y códigos QR
     Route::get('/mesas', [TableController::class, 'index'])->name('tables.index');

--- a/tests/Feature/Bloque6/TapasTest.php
+++ b/tests/Feature/Bloque6/TapasTest.php
@@ -2,16 +2,17 @@
 
 use App\Models\Order;
 use App\Models\OrderItem;
+use App\Models\Plan;
 use App\Models\Table;
 use App\Models\TapaConfig;
 use App\Models\User;
-use Tests\Support\CreatesTenants;
 
-uses(CreatesTenants::class);
 uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
 
 beforeEach(function () {
-    $this->setupTenants();
+    $plan        = \App\Models\Plan::factory()->create();
+    $this->user  = User::factory()->create(['plan_id' => $plan->id, 'role' => 'admin']);
+    $this->other = User::factory()->create(['plan_id' => $plan->id, 'role' => 'admin']);
 });
 
 // ─── Acceso y autenticación ───────────────────────────────────────────────────
@@ -268,6 +269,44 @@ it('only counts bar items from active orders excluding closed ones', function ()
 
     // served orders still count; only closed is excluded
     expect($response->viewData('barItemsCount'))->toBe(5);
+});
+
+it('fails update when tapas are paid and tapa_price is missing', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '0',
+             'max_tapa_variants' => 3,
+             // tapa_price intencionalmente ausente
+         ])
+         ->assertSessionHasErrors('tapa_price');
+});
+
+it('fails update when tapas are paid and tapa_price is invalid', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '0',
+             'max_tapa_variants' => 3,
+             'tapa_price'        => 'abc',
+         ])
+         ->assertSessionHasErrors('tapa_price');
+});
+
+it('waiter role cannot access tapas config', function () {
+    $waiter = User::factory()->create(['role' => 'waiter']);
+
+    $this->actingAs($waiter)
+         ->get(route('tapas.edit'))
+         ->assertForbidden();
+});
+
+it('kitchen role cannot access tapas config', function () {
+    $kitchen = User::factory()->create(['role' => 'kitchen']);
+
+    $this->actingAs($kitchen)
+         ->get(route('tapas.edit'))
+         ->assertForbidden();
 });
 
 it('flash success message shown after saving tapa config', function () {

--- a/tests/Feature/Bloque6/TapasTest.php
+++ b/tests/Feature/Bloque6/TapasTest.php
@@ -1,0 +1,281 @@
+<?php
+
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Table;
+use App\Models\TapaConfig;
+use App\Models\User;
+use Tests\Support\CreatesTenants;
+
+uses(CreatesTenants::class);
+uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->setupTenants();
+});
+
+// ─── Acceso y autenticación ───────────────────────────────────────────────────
+
+it('redirects unauthenticated user away from tapas config', function () {
+    $this->get(route('tapas.edit'))
+         ->assertRedirect(route('login'));
+});
+
+it('gerente can access tapas configuration page', function () {
+    $this->actingAs($this->user)
+         ->get(route('tapas.edit'))
+         ->assertOk()
+         ->assertViewIs('tapas.edit');
+});
+
+it('creates a default TapaConfig on first visit', function () {
+    $this->assertDatabaseMissing('tapa_configs', ['user_id' => $this->user->id]);
+
+    $this->actingAs($this->user)
+         ->get(route('tapas.edit'));
+
+    $this->assertDatabaseHas('tapa_configs', [
+        'user_id'        => $this->user->id,
+        'tapas_enabled'  => 0,
+        'tapas_free'     => 1,
+        'max_tapa_variants' => 3,
+    ]);
+});
+
+// ─── Activar / desactivar tapas ───────────────────────────────────────────────
+
+it('gerente can enable tapas', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+         ])
+         ->assertRedirect(route('tapas.edit'));
+
+    $this->assertDatabaseHas('tapa_configs', [
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => 1,
+    ]);
+});
+
+it('gerente can disable tapas', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => true,
+    ]);
+
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '0',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+         ])
+         ->assertRedirect(route('tapas.edit'));
+
+    $this->assertDatabaseHas('tapa_configs', [
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => 0,
+    ]);
+});
+
+// ─── Gratuitas / de pago ──────────────────────────────────────────────────────
+
+it('gerente can set tapas as free', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 2,
+         ]);
+
+    $config = TapaConfig::where('user_id', $this->user->id)->first();
+
+    expect($config->tapas_free)->toBeTrue()
+        ->and($config->tapa_price)->toBeNull();
+});
+
+it('gerente can set tapas with price', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '0',
+             'max_tapa_variants' => 2,
+             'tapa_price'        => '1.50',
+         ]);
+
+    $config = TapaConfig::where('user_id', $this->user->id)->first();
+
+    expect($config->tapas_free)->toBeFalse()
+        ->and((float) $config->tapa_price)->toBe(1.50);
+});
+
+it('tapa_price is cleared when tapas_free is switched to true', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => true,
+        'tapas_free'    => false,
+        'tapa_price'    => 2.00,
+    ]);
+
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+         ]);
+
+    $this->assertDatabaseHas('tapa_configs', [
+        'user_id'    => $this->user->id,
+        'tapa_price' => null,
+    ]);
+});
+
+// ─── Variantes máximas ────────────────────────────────────────────────────────
+
+it('max tapa variants limit is respected in update', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 5,
+         ]);
+
+    $this->assertDatabaseHas('tapa_configs', [
+        'user_id'           => $this->user->id,
+        'max_tapa_variants' => 5,
+    ]);
+});
+
+it('fails update when max_tapa_variants exceeds 20', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 99,
+         ])
+         ->assertSessionHasErrors('max_tapa_variants');
+});
+
+it('fails update when max_tapa_variants is below 1', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 0,
+         ])
+         ->assertSessionHasErrors('max_tapa_variants');
+});
+
+// ─── Multitenancy ─────────────────────────────────────────────────────────────
+
+it('each restaurant has its own independent tapa config', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 4,
+         ]);
+
+    $this->actingAs($this->other)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '0',
+             'tapas_free'        => '0',
+             'max_tapa_variants' => 2,
+             'tapa_price'        => '2.00',
+         ]);
+
+    $userConfig  = TapaConfig::where('user_id', $this->user->id)->first();
+    $otherConfig = TapaConfig::where('user_id', $this->other->id)->first();
+
+    expect($userConfig->tapas_enabled)->toBeTrue()
+        ->and($otherConfig->tapas_enabled)->toBeFalse();
+});
+
+// ─── Recuento de bebidas / tapas disponibles ──────────────────────────────────
+
+it('tapas count equals total bar item quantity ordered at that table', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => true,
+    ]);
+
+    $table = Table::factory()->create(['user_id' => $this->user->id]);
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+
+    OrderItem::factory()->create([
+        'order_id'    => $order->id,
+        'destination' => 'bar',
+        'quantity'    => 3,
+    ]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+
+    $response->assertOk();
+    expect($response->viewData('barItemsCount'))->toBe(3);
+});
+
+it('no tapas shown when tapas are disabled', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => false,
+    ]);
+
+    $table = Table::factory()->create(['user_id' => $this->user->id]);
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    OrderItem::factory()->create(['order_id' => $order->id, 'destination' => 'bar', 'quantity' => 2]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+
+    $response->assertOk();
+    expect($response->viewData('tapaConfig'))->toBeNull()
+        ->and($response->viewData('barItemsCount'))->toBe(0);
+});
+
+it('no tapas shown when zero bar items ordered', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => true,
+    ]);
+
+    $table = Table::factory()->create(['user_id' => $this->user->id]);
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    OrderItem::factory()->create(['order_id' => $order->id, 'destination' => 'kitchen', 'quantity' => 2]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+
+    $response->assertOk();
+    expect($response->viewData('barItemsCount'))->toBe(0);
+});
+
+it('only counts bar items from active orders excluding closed ones', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => true,
+    ]);
+
+    $table  = Table::factory()->create(['user_id' => $this->user->id]);
+
+    $active = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    $closed = Order::factory()->create(['table_id' => $table->id, 'status' => 'closed']);
+    $served = Order::factory()->create(['table_id' => $table->id, 'status' => 'served']);
+
+    OrderItem::factory()->create(['order_id' => $active->id, 'destination' => 'bar', 'quantity' => 2]);
+    OrderItem::factory()->create(['order_id' => $closed->id, 'destination' => 'bar', 'quantity' => 5]);
+    OrderItem::factory()->create(['order_id' => $served->id, 'destination' => 'bar', 'quantity' => 3]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+
+    // served orders still count; only closed is excluded
+    expect($response->viewData('barItemsCount'))->toBe(5);
+});
+
+it('flash success message shown after saving tapa config', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+         ])
+         ->assertSessionHas('success');
+});


### PR DESCRIPTION
## Resumen

- Tabla `tapa_configs` (1:1 con `users`) para configuración por restaurante
- El gerente activa/desactiva tapas, elige gratuitas o de pago, fija precio y máximo de variantes distintas por mesa
- La carta pública muestra un banner con las tapas disponibles (= suma de bebidas `destination=bar` en pedidos activos de esa mesa)
- Enlace "Tapas" en la navegación visible solo para `role=admin`

## Archivos clave

| Archivo | Acción |
|---|---|
| `database/migrations/2026_04_25_000001_create_tapa_configs_table.php` | Migración |
| `app/Models/TapaConfig.php` | Modelo con casts boolean |
| `app/Models/User.php` | Relación `tapaConfig(): HasOne` |
| `app/Http/Controllers/TapasController.php` | `edit()` + `update()` con `firstOrCreate` |
| `routes/web.php` | Rutas bajo `middleware('role:admin')` |
| `resources/views/tapas/edit.blade.php` | Formulario Alpine.js con toggles |
| `app/Http/Controllers/MenuController.php` | Pasa `$tapaConfig` y `$barItemsCount` |
| `resources/views/menu/show.blade.php` | Banner de tapas disponibles |
| `resources/views/layouts/navigation.blade.php` | Enlace "Tapas" solo para admin |
| `database/factories/TapaConfigFactory.php` | Factory para tests |
| `tests/Feature/Bloque6/TapasTest.php` | 21 tests |

## Test plan

- [x] `php artisan test tests/Feature/Bloque6/TapasTest.php` → 21/21 passed
- [x] `php artisan test` → 204/204 passed (sin regresiones)
- [x] Acceso a `/tapas/config` → 403 para waiter y kitchen, 200 para admin
- [x] `firstOrCreate` crea config por defecto en primera visita
- [x] `required_if:tapas_free,0` obliga a introducir precio cuando tapas son de pago
- [x] Banner de tapas solo aparece si `tapas_enabled=true` y hay bebidas en pedidos activos
- [x] Pedidos cerrados no cuentan para el recuento de tapas
- [x] Cada restaurante tiene su propia config (multitenancy aislado)
