### PR TITLE
[test] bloque6.5 — @author AyrtonAlania en tests del Bloque 6

### DIFF
--- a/tests/Feature/Bloque6/BarPanelTest.php
+++ b/tests/Feature/Bloque6/BarPanelTest.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @author AyrtonAlania
+ */
+
 use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\Product;

--- a/tests/Feature/Bloque6/OrderRoutingTest.php
+++ b/tests/Feature/Bloque6/OrderRoutingTest.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @author AyrtonAlania
+ */
+
 use App\Models\Category;
 use App\Models\Order;
 use App\Models\OrderItem;

--- a/tests/Feature/Bloque6/TapasTest.php
+++ b/tests/Feature/Bloque6/TapasTest.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @author AyrtonAlania
+ */
+
 use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\Plan;


### PR DESCRIPTION
## Qué se incluye

Añade el docblock `@author AyrtonAlania` al inicio de los tres archivos de test del Bloque 6, cumpliendo la Regla Global de Autoría (CASO A: sin `@author` previo).

- `tests/Feature/Bloque6/OrderRoutingTest.php`
- `tests/Feature/Bloque6/BarPanelTest.php`
- `tests/Feature/Bloque6/TapasTest.php`

## Checklist CLAUDE.md

- [x] `php artisan test` pasa al 100% — 204 passed (92 assertions en Bloque 6)
- [x] Un commit por archivo
- [x] `RefreshDatabase` en todos los Feature tests
- [x] Sin credenciales hardcodeadas
- [x] Sin llamadas a OpenAI sin `Http::fake()`
- [x] Commits en formato Conventional Commits (`test(bloque6.5): ...`)
- [x] `@author AyrtonAlania` presente en los tres archivos