### PR TITLE
feat: pantalla de propina antes del pago con tarjeta (Bloque 7.4)

### DIFF
--- a/app/Http/Controllers/Api/CardPaymentController.php
+++ b/app/Http/Controllers/Api/CardPaymentController.php
@@ -20,13 +20,13 @@ class CardPaymentController extends Controller
     public function __construct(private readonly StripeService $stripe) {}
 
     /**
-     * Crea un PaymentIntent de Stripe para el pedido activo de la mesa.
-     * Devuelve el client_secret que necesita Stripe.js en el cliente.
+     * Devuelve el total del pedido activo para calcular porcentajes de propina.
+     * No crea ningún PaymentIntent en Stripe.
      *
-     * @param  string  $hash  El unique_hash de la mesa
+     * @param  string  $hash
      * @return JsonResponse
      */
-    public function intent(string $hash): JsonResponse
+    public function total(string $hash): JsonResponse
     {
         $table = Table::where('unique_hash', $hash)->firstOrFail();
 
@@ -42,16 +42,54 @@ class CardPaymentController extends Controller
             ], 404);
         }
 
+        return response()->json(['success' => true, 'total' => $order->total]);
+    }
+
+    /**
+     * Crea un PaymentIntent de Stripe para el pedido activo de la mesa.
+     * Acepta una propina opcional que se suma al total del pedido.
+     * Devuelve el client_secret que necesita Stripe.js en el cliente.
+     *
+     * @param  Request  $request
+     * @param  string   $hash
+     * @return JsonResponse
+     */
+    public function intent(Request $request, string $hash): JsonResponse
+    {
+        $validated = $request->validate([
+            'tip' => 'nullable|numeric|min:0|max:500',
+        ]);
+
+        $tip = (float) ($validated['tip'] ?? 0);
+
+        $table = Table::where('unique_hash', $hash)->firstOrFail();
+
+        $order = Order::where('table_id', $table->id)
+            ->whereIn('status', ['pending', 'cooking', 'ready'])
+            ->latest()
+            ->first();
+
+        if (! $order) {
+            return response()->json([
+                'success' => false,
+                'message' => 'No hay un pedido activo en esta mesa.',
+            ], 404);
+        }
+
+        $grandTotal = $order->total + $tip;
+
         $result = $this->stripe->createPaymentIntent(
-            amount:   (int) round($order->total * 100),
+            amount:   (int) round($grandTotal * 100),
             currency: 'eur',
-            metadata: ['order_id' => $order->id, 'table_name' => $table->name],
+            metadata: ['order_id' => $order->id, 'table_name' => $table->name, 'tip' => $tip],
         );
 
         return response()->json([
             'success'       => true,
             'client_secret' => $result['client_secret'],
             'total'         => $order->total,
+            'tip'           => $tip,
+            'grand_total'   => $grandTotal,
         ]);
     }
 
@@ -67,6 +105,7 @@ class CardPaymentController extends Controller
     {
         $validated = $request->validate([
             'payment_intent_id' => 'required|string',
+            'tip'               => 'nullable|numeric|min:0|max:500',
         ]);
 
         $table = Table::where('unique_hash', $hash)->firstOrFail();
@@ -97,6 +136,7 @@ class CardPaymentController extends Controller
             'payment_status' => 'paid',
             'status'         => 'closed',
             'bill_requested' => false,
+            'tip'            => $validated['tip'] ?? 0,
         ]);
 
         return response()->json(['success' => true]);

--- a/app/Http/Controllers/ManagerRevenueController.php
+++ b/app/Http/Controllers/ManagerRevenueController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Order;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+/**
+ * Desglose de ingresos para el gerente.
+ * Muestra totales por método de pago filtrados por período.
+ *
+ * @author SebastianBCF
+ */
+class ManagerRevenueController extends Controller
+{
+    /**
+     * @param  Request  $request
+     * @return View
+     */
+    public function index(Request $request): View
+    {
+        $period = $request->query('period', 'month');
+
+        $start = match ($period) {
+            'today' => now()->startOfDay(),
+            'week'  => now()->startOfWeek(),
+            default => now()->startOfMonth(),
+        };
+
+        // JOIN en lugar de whereHas para evitar N+1 y garantizar multitenancy en una sola query
+        $base = Order::query()
+            ->join('tables', 'orders.table_id', '=', 'tables.id')
+            ->where('tables.user_id', Auth::id())
+            ->where('orders.payment_status', 'paid')
+            ->where('orders.updated_at', '>=', $start->toDateTimeString());
+
+        $summary = (clone $base)
+            ->selectRaw("
+                COALESCE(SUM(CASE WHEN orders.payment_method = 'cash' THEN orders.total ELSE 0 END), 0) as cash_revenue,
+                COALESCE(SUM(CASE WHEN orders.payment_method = 'card' THEN orders.total ELSE 0 END), 0) as card_revenue,
+                COALESCE(SUM(orders.tip), 0)                                                             as tip_revenue,
+                SUM(CASE WHEN orders.payment_method = 'cash' THEN 1 ELSE 0 END)                         as cash_count,
+                SUM(CASE WHEN orders.payment_method = 'card' THEN 1 ELSE 0 END)                         as card_count,
+                COUNT(*)                                                                                 as total_count
+            ")
+            ->first();
+
+        $orders = (clone $base)
+            ->select(
+                'orders.id',
+                'orders.total',
+                'orders.tip',
+                'orders.payment_method',
+                'orders.updated_at',
+                'tables.name as table_name',
+            )
+            ->orderByDesc('orders.updated_at')
+            ->paginate(15)
+            ->withQueryString();
+
+        return view('manager.income', compact('period', 'summary', 'orders'));
+    }
+}

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -71,12 +71,16 @@ class MenuController extends Controller
             )->where('destination', 'bar')->sum('quantity');
         }
 
-        $hasActiveOrder  = Order::where('table_id', $table->id)
+        $activeOrder = Order::where('table_id', $table->id)
             ->whereIn('status', ['pending', 'cooking', 'ready'])
-            ->exists();
+            ->latest()
+            ->first();
+
+        $hasActiveOrder    = (bool) $activeOrder;
+        $activeOrderTotal  = $activeOrder?->total ?? 0;
 
         $stripePublicKey = config('services.stripe.key');
 
-        return view('menu.show', compact('table', 'categories', 'allergens', 'tapaConfig', 'barItemsCount', 'hasActiveOrder', 'stripePublicKey'));
+        return view('menu.show', compact('table', 'categories', 'allergens', 'tapaConfig', 'barItemsCount', 'hasActiveOrder', 'activeOrderTotal', 'stripePublicKey'));
     }
 }

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -38,6 +38,12 @@
                         {{ __('Tapas') }}
                     </x-nav-link>
                     @endif
+                    {{-- Desglose de ingresos: visible solo para admin --}}
+                    @if(Auth::user()->role === 'admin')
+                    <x-nav-link :href="route('manager.income')" :active="request()->routeIs('manager.*')">
+                        {{ __('Ingresos') }}
+                    </x-nav-link>
+                    @endif
                     {{-- Panel de Cocina: visible solo para admin y kitchen --}}
                     @if(in_array(Auth::user()->role, ['admin', 'kitchen']))
                     <span
@@ -153,6 +159,12 @@
                 @if(Auth::user()->role === 'admin')
                 <x-responsive-nav-link :href="route('tapas.edit')" :active="request()->routeIs('tapas.*')">
                     {{ __('Tapas') }}
+                </x-responsive-nav-link>
+                @endif
+                {{-- Desglose de ingresos (Versión Móvil) --}}
+                @if(Auth::user()->role === 'admin')
+                <x-responsive-nav-link :href="route('manager.income')" :active="request()->routeIs('manager.*')">
+                    {{ __('Ingresos') }}
                 </x-responsive-nav-link>
                 @endif
                 {{-- Panel de Cocina (Versión Móvil) --}}

--- a/resources/views/manager/income.blade.php
+++ b/resources/views/manager/income.blade.php
@@ -1,0 +1,220 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <h1 class="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
+                Desglose de ingresos
+            </h1>
+
+            {{-- Filtros de período --}}
+            <nav aria-label="Filtro de período"
+                 class="flex gap-1 bg-gray-100 dark:bg-gray-700 rounded-xl p-1 self-start sm:self-auto">
+                @foreach(['today' => 'Hoy', 'week' => 'Esta semana', 'month' => 'Este mes'] as $value => $label)
+                    <a href="{{ route('manager.income', ['period' => $value]) }}"
+                       aria-current="{{ $period === $value ? 'page' : 'false' }}"
+                       class="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors
+                              focus:outline-none focus:ring-2 focus:ring-indigo-500
+                              {{ $period === $value
+                                  ? 'bg-white dark:bg-gray-800 text-indigo-600 dark:text-indigo-400 shadow-sm'
+                                  : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white' }}">
+                        {{ $label }}
+                    </a>
+                @endforeach
+            </nav>
+        </div>
+    </x-slot>
+
+    <main id="main-content" class="py-6">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
+
+            {{-- Tarjetas de resumen --}}
+            <section aria-labelledby="summary-heading">
+                <h2 id="summary-heading" class="sr-only">Resumen de ingresos</h2>
+                <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+
+                    {{-- Efectivo --}}
+                    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">💵</span>
+                            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Efectivo</span>
+                        </div>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                            {{ number_format($summary->cash_revenue, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                            {{ $summary->cash_count }}
+                            pedido{{ $summary->cash_count != 1 ? 's' : '' }}
+                        </p>
+                    </div>
+
+                    {{-- Tarjeta --}}
+                    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">💳</span>
+                            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Tarjeta</span>
+                        </div>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                            {{ number_format($summary->card_revenue, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                            {{ $summary->card_count }}
+                            pedido{{ $summary->card_count != 1 ? 's' : '' }}
+                        </p>
+                    </div>
+
+                    {{-- Propinas --}}
+                    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">🎁</span>
+                            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Propinas</span>
+                        </div>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                            {{ number_format($summary->tip_revenue, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Solo pagos con tarjeta</p>
+                    </div>
+
+                    {{-- Total cobrado --}}
+                    @php $grand = $summary->cash_revenue + $summary->card_revenue + $summary->tip_revenue; @endphp
+                    <div class="bg-indigo-600 dark:bg-indigo-700 rounded-2xl shadow-sm p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">💰</span>
+                            <span class="text-sm font-medium text-indigo-200">Total cobrado</span>
+                        </div>
+                        <p class="text-2xl font-bold text-white">
+                            {{ number_format($grand, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-indigo-300">
+                            {{ $summary->total_count }}
+                            pedido{{ $summary->total_count != 1 ? 's' : '' }}
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            {{-- Tabla de pedidos cobrados --}}
+            <section aria-labelledby="orders-heading">
+                <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                            border border-gray-200 dark:border-gray-700">
+
+                    <div class="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+                        <h2 id="orders-heading"
+                            class="text-base font-semibold text-gray-900 dark:text-white">
+                            Pedidos cobrados
+                        </h2>
+                    </div>
+
+                    @if($orders->isEmpty())
+                        <div class="px-5 py-14 text-center">
+                            <p class="text-gray-400 dark:text-gray-500 text-sm">
+                                No hay pedidos cobrados en este período.
+                            </p>
+                        </div>
+                    @else
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700"
+                                   aria-label="Listado de pedidos cobrados">
+                                <thead class="bg-gray-50 dark:bg-gray-700/50">
+                                    <tr>
+                                        <th scope="col"
+                                            class="px-5 py-3 text-left text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Fecha y hora
+                                        </th>
+                                        <th scope="col"
+                                            class="px-5 py-3 text-left text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Mesa
+                                        </th>
+                                        <th scope="col"
+                                            class="px-5 py-3 text-left text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Método
+                                        </th>
+                                        <th scope="col"
+                                            class="px-5 py-3 text-right text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Pedido
+                                        </th>
+                                        <th scope="col"
+                                            class="hidden sm:table-cell px-5 py-3 text-right text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Propina
+                                        </th>
+                                        <th scope="col"
+                                            class="px-5 py-3 text-right text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Total cobrado
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-gray-100 dark:divide-gray-700/60">
+                                    @foreach($orders as $order)
+                                        <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/30 transition-colors">
+                                            <td class="px-5 py-4 text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                                                <time datetime="{{ $order->updated_at->toIso8601String() }}">
+                                                    {{ $order->updated_at->format('d/m/Y H:i') }}
+                                                </time>
+                                            </td>
+                                            <td class="px-5 py-4 text-sm font-medium
+                                                       text-gray-900 dark:text-white whitespace-nowrap">
+                                                {{ $order->table_name }}
+                                            </td>
+                                            <td class="px-5 py-4 whitespace-nowrap">
+                                                @if($order->payment_method === 'card')
+                                                    <span class="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full
+                                                                 text-xs font-medium
+                                                                 bg-indigo-100 dark:bg-indigo-900/40
+                                                                 text-indigo-700 dark:text-indigo-300">
+                                                        <span aria-hidden="true">💳</span> Tarjeta
+                                                    </span>
+                                                @else
+                                                    <span class="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full
+                                                                 text-xs font-medium
+                                                                 bg-green-100 dark:bg-green-900/40
+                                                                 text-green-700 dark:text-green-300">
+                                                        <span aria-hidden="true">💵</span> Efectivo
+                                                    </span>
+                                                @endif
+                                            </td>
+                                            <td class="px-5 py-4 text-sm text-right
+                                                       text-gray-700 dark:text-gray-300 whitespace-nowrap tabular-nums">
+                                                {{ number_format($order->total, 2, ',', '.') }}&nbsp;€
+                                            </td>
+                                            <td class="hidden sm:table-cell px-5 py-4 text-sm text-right
+                                                       whitespace-nowrap tabular-nums">
+                                                @if($order->tip > 0)
+                                                    <span class="text-indigo-600 dark:text-indigo-400">
+                                                        +{{ number_format($order->tip, 2, ',', '.') }}&nbsp;€
+                                                    </span>
+                                                @else
+                                                    <span class="text-gray-300 dark:text-gray-600"
+                                                          aria-label="Sin propina">—</span>
+                                                @endif
+                                            </td>
+                                            <td class="px-5 py-4 text-sm text-right font-semibold
+                                                       text-gray-900 dark:text-white whitespace-nowrap tabular-nums">
+                                                {{ number_format($order->total + $order->tip, 2, ',', '.') }}&nbsp;€
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+
+                        @if($orders->hasPages())
+                            <div class="px-5 py-4 border-t border-gray-200 dark:border-gray-700">
+                                <nav aria-label="Paginación de pedidos cobrados">
+                                    {{ $orders->links() }}
+                                </nav>
+                            </div>
+                        @endif
+                    @endif
+                </div>
+            </section>
+
+        </div>
+    </main>
+</x-app-layout>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -243,8 +243,8 @@
                 showingTip:  false,
                 tipAmount:   0,
                 tipPercent:  null,
-                orderTotal:  0,
-                grandTotal:  0,
+                orderTotal:  @json((float) $activeOrderTotal),
+                grandTotal:  @json((float) $activeOrderTotal),
 
                 // Estado de pago con tarjeta
                 payingCard:   false,
@@ -295,32 +295,13 @@
                     }
                 },
 
-                // Paso 1 — Pago con tarjeta: obtiene el total y abre la pantalla de propina
-                async openCardPayment() {
+                // Paso 1 — Pago con tarjeta: abre la pantalla de propina
+                openCardPayment() {
                     this.choosing   = false;
-                    this.sending    = true;
-                    this.error      = null;
-                    try {
-                        const res = await fetch('/api/v1/payment/' + this.tableHash + '/total', {
-                            headers: { 'Accept': 'application/json' },
-                        });
-                        const data = await res.json();
-                        if (!res.ok) {
-                            this.error = data.message ?? 'No se pudo iniciar el pago.';
-                            this.choosing = true;
-                            return;
-                        }
-                        this.orderTotal = data.total;
-                        this.grandTotal = data.total;
-                        this.tipAmount  = 0;
-                        this.tipPercent = null;
-                        this.showingTip = true;
-                    } catch {
-                        this.error    = 'Error de conexión. Inténtalo de nuevo.';
-                        this.choosing = true;
-                    } finally {
-                        this.sending = false;
-                    }
+                    this.tipAmount  = 0;
+                    this.tipPercent = null;
+                    this.grandTotal = this.orderTotal;
+                    this.showingTip = true;
                 },
 
                 // Selecciona un porcentaje de propina predefinido

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -239,6 +239,13 @@
                 method:      null,
                 tableHash:   '{{ $table->unique_hash }}',
 
+                // Estado de la pantalla de propina
+                showingTip:  false,
+                tipAmount:   0,
+                tipPercent:  null,
+                orderTotal:  0,
+                grandTotal:  0,
+
                 // Estado de pago con tarjeta
                 payingCard:   false,
                 stripeReady:  false,
@@ -288,12 +295,64 @@
                     }
                 },
 
-                // Pago con tarjeta: abre el sheet de Stripe y crea el PaymentIntent
+                // Paso 1 — Pago con tarjeta: obtiene el total y abre la pantalla de propina
                 async openCardPayment() {
-                    this.choosing    = false;
+                    this.choosing   = false;
+                    this.sending    = true;
+                    this.error      = null;
+                    try {
+                        const res = await fetch('/api/v1/payment/' + this.tableHash + '/total', {
+                            headers: { 'Accept': 'application/json' },
+                        });
+                        const data = await res.json();
+                        if (!res.ok) {
+                            this.error = data.message ?? 'No se pudo iniciar el pago.';
+                            this.choosing = true;
+                            return;
+                        }
+                        this.orderTotal = data.total;
+                        this.grandTotal = data.total;
+                        this.tipAmount  = 0;
+                        this.tipPercent = null;
+                        this.showingTip = true;
+                    } catch {
+                        this.error    = 'Error de conexión. Inténtalo de nuevo.';
+                        this.choosing = true;
+                    } finally {
+                        this.sending = false;
+                    }
+                },
+
+                // Selecciona un porcentaje de propina predefinido
+                setTipPercent(pct) {
+                    this.tipPercent = pct;
+                    this.tipAmount  = Math.round(this.orderTotal * pct) / 100;
+                    this.grandTotal = this.orderTotal + this.tipAmount;
+                },
+
+                // Actualiza la propina desde el input personalizado
+                updateCustomTip(value) {
+                    this.tipPercent = null;
+                    const parsed    = parseFloat(value) || 0;
+                    this.tipAmount  = Math.max(0, Math.round(parsed * 100) / 100);
+                    this.grandTotal = this.orderTotal + this.tipAmount;
+                },
+
+                // Cierra la pantalla de propina y vuelve a elegir método de pago
+                closeTip() {
+                    this.showingTip = false;
+                    this.tipAmount  = 0;
+                    this.tipPercent = null;
+                    this.choosing   = true;
+                },
+
+                // Paso 2 — Crea el PaymentIntent con la propina y abre Stripe Elements
+                async proceedToStripe() {
+                    this.showingTip  = false;
                     this.payingCard  = true;
                     this.stripeReady = false;
                     this.stripeError = null;
+                    this.sending     = true;
                     try {
                         const res = await fetch('/api/v1/payment/' + this.tableHash + '/intent', {
                             method:  'POST',
@@ -302,6 +361,7 @@
                                 'Accept':       'application/json',
                                 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content ?? '',
                             },
+                            body: JSON.stringify({ tip: this.tipAmount }),
                         });
                         const data = await res.json();
                         if (!res.ok) {
@@ -309,12 +369,14 @@
                             this.payingCard  = false;
                             return;
                         }
-                        this.stripeTotal = data.total;
-                        // Montar Stripe Elements tras actualizar el DOM
+                        this.stripeTotal = data.grand_total;
+                        this.grandTotal  = data.grand_total;
                         setTimeout(() => this._mountStripe(data.client_secret), 80);
                     } catch {
                         this.stripeError = 'Error de conexión al iniciar el pago.';
                         this.payingCard  = false;
+                    } finally {
+                        this.sending = false;
                     }
                 },
 
@@ -360,7 +422,7 @@
                                     'Accept':       'application/json',
                                     'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content ?? '',
                                 },
-                                body: JSON.stringify({ payment_intent_id: paymentIntent.id }),
+                                body: JSON.stringify({ payment_intent_id: paymentIntent.id, tip: this.tipAmount }),
                             });
                             const data = await res.json();
                             if (res.ok && data.success) {
@@ -766,6 +828,132 @@
             </div>
         </div>{{-- /sheet --}}
 
+        {{-- ── Sheet: propina (antes del pago con tarjeta) ───────── --}}
+        <div x-show="$store.bill.showingTip"
+             x-transition:enter="transition ease-out duration-300"
+             x-transition:enter-start="opacity-0"
+             x-transition:enter-end="opacity-100"
+             x-transition:leave="transition ease-in duration-200"
+             x-transition:leave-start="opacity-100"
+             x-transition:leave-end="opacity-0"
+             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
+             @click.self="$store.bill.closeTip()"
+             @keydown.escape.window="$store.bill.closeTip()"
+             aria-modal="true" role="dialog" aria-label="Añadir propina">
+
+            <div x-show="$store.bill.showingTip"
+                 x-transition:enter="transition ease-out duration-300"
+                 x-transition:enter-start="translate-y-full"
+                 x-transition:enter-end="translate-y-0"
+                 x-transition:leave="transition ease-in duration-200"
+                 x-transition:leave-start="translate-y-0"
+                 x-transition:leave-end="translate-y-full"
+                 class="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900
+                        rounded-t-2xl shadow-2xl px-5 pb-8 pt-4">
+
+                <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-5"></div>
+
+                {{-- Cabecera --}}
+                <div class="flex items-center justify-between mb-5">
+                    <div>
+                        <h2 class="text-lg font-bold text-gray-900 dark:text-white">¿Quieres dejar propina?</h2>
+                        <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">La propina es completamente opcional</p>
+                    </div>
+                    <button type="button"
+                            @click="$store.bill.closeTip()"
+                            aria-label="Cancelar propina"
+                            class="p-1.5 rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100
+                                   dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-400">
+                        <svg aria-hidden="true" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                        </svg>
+                    </button>
+                </div>
+
+                {{-- Resumen del pedido --}}
+                <div class="bg-gray-50 dark:bg-gray-800 rounded-xl px-4 py-3 mb-5 flex justify-between items-center">
+                    <span class="text-sm text-gray-500 dark:text-gray-400">Total del pedido</span>
+                    <span class="text-lg font-bold text-gray-900 dark:text-white"
+                          x-text="$store.bill.orderTotal.toFixed(2).replace('.', ',') + ' €'"></span>
+                </div>
+
+                {{-- Botones de porcentaje --}}
+                <div class="grid grid-cols-4 gap-2 mb-4" role="group" aria-label="Porcentaje de propina">
+                    <template x-for="pct in [5, 10, 15, 20]" :key="pct">
+                        <button type="button"
+                                @click="$store.bill.setTipPercent(pct)"
+                                :aria-pressed="$store.bill.tipPercent === pct"
+                                :class="$store.bill.tipPercent === pct
+                                    ? 'ring-2 ring-indigo-500 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 border-indigo-400'
+                                    : 'bg-gray-50 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-700'"
+                                class="flex flex-col items-center py-3 rounded-xl border-2 font-semibold text-sm
+                                       transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                            <span x-text="pct + '%'"></span>
+                            <span class="text-xs font-normal mt-0.5 text-gray-500 dark:text-gray-400"
+                                  x-text="(Math.round($store.bill.orderTotal * pct) / 100).toFixed(2).replace('.', ',') + ' €'"></span>
+                        </button>
+                    </template>
+                </div>
+
+                {{-- Input de propina personalizada --}}
+                <div class="relative mb-5">
+                    <label for="custom-tip-input" class="sr-only">Propina personalizada en euros</label>
+                    <input type="number"
+                           id="custom-tip-input"
+                           min="0"
+                           step="0.50"
+                           placeholder="Otro importe"
+                           @input="$store.bill.updateCustomTip($event.target.value)"
+                           :value="$store.bill.tipPercent === null && $store.bill.tipAmount > 0 ? $store.bill.tipAmount : ''"
+                           aria-describedby="custom-tip-hint"
+                           class="w-full rounded-xl border border-gray-300 dark:border-gray-600
+                                  bg-white dark:bg-gray-800 text-gray-900 dark:text-white
+                                  px-4 py-3 pr-10 text-right placeholder-gray-400
+                                  focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+                    <span class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 font-medium pointer-events-none"
+                          aria-hidden="true">€</span>
+                </div>
+                <p id="custom-tip-hint" class="sr-only">Escribe un importe personalizado en euros</p>
+
+                {{-- Desglose total + propina --}}
+                <div class="space-y-1 mb-5">
+                    <template x-if="$store.bill.tipAmount > 0">
+                        <div class="flex justify-between text-sm">
+                            <span class="text-gray-500 dark:text-gray-400">Propina</span>
+                            <span class="font-medium text-gray-700 dark:text-gray-300"
+                                  x-text="'+ ' + $store.bill.tipAmount.toFixed(2).replace('.', ',') + ' €'"></span>
+                        </div>
+                    </template>
+                    <div class="flex justify-between text-base font-bold border-t border-gray-200 dark:border-gray-700 pt-2">
+                        <span class="text-gray-900 dark:text-white">Total a pagar</span>
+                        <span class="text-indigo-600 dark:text-indigo-400"
+                              x-text="$store.bill.grandTotal.toFixed(2).replace('.', ',') + ' €'"></span>
+                    </div>
+                </div>
+
+                {{-- Botón continuar --}}
+                <button type="button"
+                        @click="$store.bill.proceedToStripe()"
+                        class="w-full py-3.5 rounded-xl bg-indigo-600 hover:bg-indigo-700
+                               text-white font-bold text-base shadow-sm transition-colors
+                               focus:outline-none focus:ring-4 focus:ring-indigo-400">
+                    <span x-show="$store.bill.tipAmount > 0">
+                        💳 Pagar <span x-text="$store.bill.grandTotal.toFixed(2).replace('.', ',') + ' €'"></span> con propina
+                    </span>
+                    <span x-show="$store.bill.tipAmount <= 0">
+                        💳 Pagar sin propina
+                    </span>
+                </button>
+
+                <button type="button"
+                        @click="$store.bill.closeTip()"
+                        class="w-full mt-3 py-2.5 rounded-xl text-sm font-medium text-gray-500 dark:text-gray-400
+                               hover:text-gray-700 dark:hover:text-gray-200 focus:outline-none focus:underline transition-colors">
+                    Cancelar
+                </button>
+            </div>
+        </div>{{-- /tip sheet --}}
+
         {{-- ── Sheet: pago con tarjeta (Stripe Elements) ──────────── --}}
         <div x-show="$store.bill.payingCard"
              x-transition:enter="transition ease-out duration-300"
@@ -799,6 +987,12 @@
                             <span class="font-semibold text-gray-900 dark:text-white"
                                   x-text="$store.bill.stripeTotal.toFixed(2).replace('.', ',') + ' €'"></span>
                         </p>
+                        <template x-if="$store.bill.tipAmount > 0">
+                            <p class="text-xs text-indigo-500 dark:text-indigo-400 mt-0.5">
+                                Incluye propina de
+                                <span x-text="$store.bill.tipAmount.toFixed(2).replace('.', ',') + ' €'"></span>
+                            </p>
+                        </template>
                     </div>
                     <button type="button"
                             @click="$store.bill.closeCardPayment()"

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,9 @@ Route::post('/v1/bill-request/{hash}', [BillRequestController::class, 'store'])
     ->name('api.bill.request');
 
 // Pago con tarjeta — rutas públicas (sin autenticación, contexto por table_hash)
+Route::get('/v1/payment/{hash}/total',    [CardPaymentController::class, 'total'])
+    ->middleware('throttle:30,1')
+    ->name('api.payment.total');
 Route::post('/v1/payment/{hash}/intent',  [CardPaymentController::class, 'intent'])
     ->middleware('throttle:10,1')
     ->name('api.payment.intent');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 use App\Http\Controllers\IngredientController;
 use App\Http\Controllers\BarPanelController;
+use App\Http\Controllers\ManagerRevenueController;
 use App\Http\Controllers\PaymentController;
 use App\Http\Controllers\TapasController;
 use App\Http\Controllers\CategoryController;
@@ -37,10 +38,12 @@ Route::middleware('auth')->group(function () {
     Route::post('/productos/{product}/ingredientes', [ProductController::class, 'syncIngredients'])
          ->name('products.ingredients.sync');
 
-    // Configuración de tapas — solo accesible para el gerente (admin)
+    // Rutas exclusivas del gerente (admin)
     Route::middleware('role:admin')->group(function () {
         Route::get('/tapas/config', [TapasController::class, 'edit'])->name('tapas.edit');
         Route::put('/tapas/config', [TapasController::class, 'update'])->name('tapas.update');
+
+        Route::get('/manager/income', [ManagerRevenueController::class, 'index'])->name('manager.income');
     });
 
     // Gestión de mesas y códigos QR

--- a/tests/Feature/Bloque7/PaymentTest.php
+++ b/tests/Feature/Bloque7/PaymentTest.php
@@ -1,0 +1,415 @@
+<?php
+
+/**
+ * @author AyrtonAlania
+ */
+
+use App\Models\Conversation;
+use App\Models\Order;
+use App\Models\Table;
+use App\Models\User;
+use App\Services\StripeService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\CreatesTenants;
+
+uses(RefreshDatabase::class);
+uses(CreatesTenants::class);
+
+beforeEach(function () {
+    $this->setupTenants();
+});
+
+// ─── Solicitud de cuenta (BillRequestController) ─────────────────────────────
+
+it('bill request marks order as bill_requested and stores preferred payment method', function () {
+    $table = Table::factory()->for($this->user)->create();
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+
+    $this->postJson("/api/v1/bill-request/{$table->unique_hash}", [
+        'payment_method' => 'cash',
+    ])->assertOk()->assertJson(['success' => true]);
+
+    $this->assertDatabaseHas('orders', [
+        'id'                       => $order->id,
+        'bill_requested'           => true,
+        'requested_payment_method' => 'cash',
+    ]);
+});
+
+it('bill request accepts card as preferred payment method', function () {
+    $table = Table::factory()->for($this->user)->create();
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+
+    $this->postJson("/api/v1/bill-request/{$table->unique_hash}", [
+        'payment_method' => 'card',
+    ])->assertOk();
+
+    $this->assertDatabaseHas('orders', [
+        'id'                       => $order->id,
+        'bill_requested'           => true,
+        'requested_payment_method' => 'card',
+    ]);
+});
+
+it('bill request returns 404 when no active order exists for the table', function () {
+    $table = Table::factory()->for($this->user)->create();
+
+    $this->postJson("/api/v1/bill-request/{$table->unique_hash}", [
+        'payment_method' => 'cash',
+    ])->assertNotFound();
+});
+
+it('bill request returns 404 with invalid table hash', function () {
+    $this->postJson('/api/v1/bill-request/invalid-hash-xyz', [
+        'payment_method' => 'cash',
+    ])->assertNotFound();
+});
+
+it('bill request returns 422 when payment_method is missing', function () {
+    $table = Table::factory()->for($this->user)->create();
+    Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+
+    $this->postJson("/api/v1/bill-request/{$table->unique_hash}", [])
+        ->assertUnprocessable();
+});
+
+it('bill request returns 422 when payment_method is invalid', function () {
+    $table = Table::factory()->for($this->user)->create();
+    Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+
+    $this->postJson("/api/v1/bill-request/{$table->unique_hash}", [
+        'payment_method' => 'bitcoin',
+    ])->assertUnprocessable();
+});
+
+it('bill request does not find a closed order', function () {
+    $table = Table::factory()->for($this->user)->create();
+    Order::factory()->create(['table_id' => $table->id, 'status' => 'closed']);
+
+    $this->postJson("/api/v1/bill-request/{$table->unique_hash}", [
+        'payment_method' => 'cash',
+    ])->assertNotFound();
+});
+
+// ─── Pago en efectivo (PaymentController) ────────────────────────────────────
+
+it('cash payment closes the order with payment_method cash', function () {
+    $admin = User::factory()->create(['role' => 'admin']);
+    $table = Table::factory()->create(['user_id' => $admin->id]);
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+
+    $this->actingAs($admin)
+        ->postJson(route('payments.cash', $order))
+        ->assertOk()
+        ->assertJson(['success' => true]);
+
+    $this->assertDatabaseHas('orders', [
+        'id'             => $order->id,
+        'status'         => 'closed',
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'bill_requested' => false,
+    ]);
+});
+
+it('cash payment returns 403 when order belongs to another user', function () {
+    $admin      = User::factory()->create(['role' => 'admin']);
+    $otherAdmin = User::factory()->create(['role' => 'admin']);
+    $table      = Table::factory()->create(['user_id' => $otherAdmin->id]);
+    $order      = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+
+    $this->actingAs($admin)
+        ->postJson(route('payments.cash', $order))
+        ->assertForbidden();
+});
+
+it('cash payment returns 422 when order is already closed', function () {
+    $admin = User::factory()->create(['role' => 'admin']);
+    $table = Table::factory()->create(['user_id' => $admin->id]);
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'closed']);
+
+    $this->actingAs($admin)
+        ->postJson(route('payments.cash', $order))
+        ->assertUnprocessable();
+});
+
+it('cash payment redirects unauthenticated user to login', function () {
+    $table = Table::factory()->for($this->user)->create();
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+
+    $this->postJson(route('payments.cash', $order))
+        ->assertUnauthorized();
+});
+
+// ─── Total del pedido (CardPaymentController::total) ─────────────────────────
+// CardPaymentController injects StripeService in its constructor, so every test
+// that hits these routes must mock it to avoid the null-config Stripe exception.
+
+it('total endpoint returns the order total for an active order', function () {
+    $this->mock(StripeService::class)->shouldNotReceive('createPaymentIntent', 'confirmPayment');
+
+    $table = Table::factory()->for($this->user)->create();
+    $order = Order::factory()->create([
+        'table_id' => $table->id,
+        'status'   => 'pending',
+        'total'    => 42.50,
+    ]);
+
+    $this->getJson("/api/v1/payment/{$table->unique_hash}/total")
+        ->assertOk()
+        ->assertJson(['success' => true, 'total' => 42.50]);
+});
+
+it('total endpoint returns 404 when no active order exists', function () {
+    $this->mock(StripeService::class)->shouldNotReceive('createPaymentIntent', 'confirmPayment');
+
+    $table = Table::factory()->for($this->user)->create();
+
+    $this->getJson("/api/v1/payment/{$table->unique_hash}/total")
+        ->assertNotFound();
+});
+
+it('total endpoint returns 404 with invalid hash', function () {
+    $this->mock(StripeService::class)->shouldNotReceive('createPaymentIntent', 'confirmPayment');
+
+    $this->getJson('/api/v1/payment/nonexistent-hash/total')
+        ->assertNotFound();
+});
+
+// ─── Pago con tarjeta — intent (CardPaymentController::intent) ───────────────
+
+it('intent endpoint creates a PaymentIntent via Stripe and returns client_secret', function () {
+    $table = Table::factory()->for($this->user)->create();
+    $order = Order::factory()->create([
+        'table_id' => $table->id,
+        'status'   => 'pending',
+        'total'    => 20.00,
+    ]);
+
+    $this->mock(StripeService::class)
+        ->shouldReceive('createPaymentIntent')
+        ->once()
+        ->withArgs(fn (int $amount) => $amount === 2000)
+        ->andReturn([
+            'id'            => 'pi_test_123',
+            'client_secret' => 'secret_test',
+            'status'        => 'requires_payment_method',
+        ]);
+
+    $this->postJson("/api/v1/payment/{$table->unique_hash}/intent", ['tip' => 0])
+        ->assertOk()
+        ->assertJson([
+            'success'       => true,
+            'client_secret' => 'secret_test',
+            'total'         => 20.00,
+        ]);
+});
+
+it('intent endpoint includes tip in the grand total sent to Stripe', function () {
+    $table = Table::factory()->for($this->user)->create();
+    $order = Order::factory()->create([
+        'table_id' => $table->id,
+        'status'   => 'pending',
+        'total'    => 20.00,
+    ]);
+
+    $this->mock(StripeService::class)
+        ->shouldReceive('createPaymentIntent')
+        ->once()
+        ->withArgs(fn (int $amount) => $amount === 2500) // 20 + 5 = 25 €
+        ->andReturn([
+            'id'            => 'pi_test_456',
+            'client_secret' => 'secret_tip',
+            'status'        => 'requires_payment_method',
+        ]);
+
+    $this->postJson("/api/v1/payment/{$table->unique_hash}/intent", ['tip' => 5.00])
+        ->assertOk()
+        ->assertJson([
+            'tip'         => 5.00,
+            'grand_total' => 25.00,
+        ]);
+});
+
+it('intent endpoint returns 404 when no active order exists', function () {
+    $table = Table::factory()->for($this->user)->create();
+
+    $this->mock(StripeService::class)
+        ->shouldNotReceive('createPaymentIntent');
+
+    $this->postJson("/api/v1/payment/{$table->unique_hash}/intent", [])
+        ->assertNotFound();
+});
+
+it('intent endpoint returns 422 when tip is negative', function () {
+    $table = Table::factory()->for($this->user)->create();
+    Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+
+    $this->mock(StripeService::class)
+        ->shouldNotReceive('createPaymentIntent');
+
+    $this->postJson("/api/v1/payment/{$table->unique_hash}/intent", ['tip' => -1])
+        ->assertUnprocessable();
+});
+
+it('intent endpoint returns 404 with invalid hash', function () {
+    $this->mock(StripeService::class)
+        ->shouldNotReceive('createPaymentIntent');
+
+    $this->postJson('/api/v1/payment/bad-hash/intent', [])
+        ->assertNotFound();
+});
+
+// ─── Pago con tarjeta — confirm (CardPaymentController::confirm) ──────────────
+
+it('confirm endpoint closes the order with payment_method card when Stripe succeeds', function () {
+    $table = Table::factory()->for($this->user)->create();
+    $order = Order::factory()->create([
+        'table_id' => $table->id,
+        'status'   => 'pending',
+        'total'    => 30.00,
+    ]);
+
+    $this->mock(StripeService::class)
+        ->shouldReceive('confirmPayment')
+        ->once()
+        ->with('pi_test_789')
+        ->andReturn(['id' => 'pi_test_789', 'status' => 'succeeded']);
+
+    $this->postJson("/api/v1/payment/{$table->unique_hash}/confirm", [
+        'payment_intent_id' => 'pi_test_789',
+        'tip'               => 0,
+    ])->assertOk()->assertJson(['success' => true]);
+
+    $this->assertDatabaseHas('orders', [
+        'id'             => $order->id,
+        'status'         => 'closed',
+        'payment_method' => 'card',
+        'payment_status' => 'paid',
+        'tip'            => 0,
+    ]);
+});
+
+it('tip is stored separately in orders.tip after card payment', function () {
+    $table = Table::factory()->for($this->user)->create();
+    $order = Order::factory()->create([
+        'table_id' => $table->id,
+        'status'   => 'pending',
+        'total'    => 18.00,
+    ]);
+
+    $this->mock(StripeService::class)
+        ->shouldReceive('confirmPayment')
+        ->andReturn(['id' => 'pi_test_tip', 'status' => 'succeeded']);
+
+    $this->postJson("/api/v1/payment/{$table->unique_hash}/confirm", [
+        'payment_intent_id' => 'pi_test_tip',
+        'tip'               => 3.50,
+    ])->assertOk();
+
+    $this->assertDatabaseHas('orders', [
+        'id'    => $order->id,
+        'tip'   => 3.50,
+        'total' => 18.00,
+    ]);
+});
+
+it('confirm endpoint returns 422 and does not close the order when Stripe status is not succeeded', function () {
+    $table = Table::factory()->for($this->user)->create();
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+
+    $this->mock(StripeService::class)
+        ->shouldReceive('confirmPayment')
+        ->andReturn(['id' => 'pi_failed', 'status' => 'requires_payment_method']);
+
+    $this->postJson("/api/v1/payment/{$table->unique_hash}/confirm", [
+        'payment_intent_id' => 'pi_failed',
+    ])->assertUnprocessable()->assertJson(['success' => false]);
+
+    expect($order->fresh()->status)->not->toBe('closed');
+});
+
+it('confirm endpoint returns 422 when payment_intent_id is missing', function () {
+    $table = Table::factory()->for($this->user)->create();
+    Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+
+    $this->mock(StripeService::class)
+        ->shouldNotReceive('confirmPayment');
+
+    $this->postJson("/api/v1/payment/{$table->unique_hash}/confirm", [])
+        ->assertUnprocessable();
+});
+
+it('confirm endpoint returns 404 when no active order exists', function () {
+    $table = Table::factory()->for($this->user)->create();
+
+    $this->mock(StripeService::class)
+        ->shouldNotReceive('confirmPayment');
+
+    $this->postJson("/api/v1/payment/{$table->unique_hash}/confirm", [
+        'payment_intent_id' => 'pi_test_no_order',
+    ])->assertNotFound();
+});
+
+it('confirm endpoint returns 404 with invalid hash', function () {
+    $this->mock(StripeService::class)
+        ->shouldNotReceive('confirmPayment');
+
+    $this->postJson('/api/v1/payment/bad-hash/confirm', [
+        'payment_intent_id' => 'pi_test_xyz',
+    ])->assertNotFound();
+});
+
+// ─── Cierre de conversaciones al cerrar pedido ────────────────────────────────
+
+it('closing a card payment closes active conversations on the table', function () {
+    $table        = Table::factory()->for($this->user)->create();
+    $order        = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    $conversation = Conversation::factory()->create(['table_id' => $table->id, 'status' => 'active']);
+
+    $this->mock(StripeService::class)
+        ->shouldReceive('confirmPayment')
+        ->andReturn(['id' => 'pi_conv_close', 'status' => 'succeeded']);
+
+    $this->postJson("/api/v1/payment/{$table->unique_hash}/confirm", [
+        'payment_intent_id' => 'pi_conv_close',
+        'tip'               => 0,
+    ])->assertOk();
+
+    $this->assertDatabaseHas('conversations', [
+        'id'     => $conversation->id,
+        'status' => 'closed',
+    ]);
+});
+
+it('closing a cash payment closes active conversations on the table', function () {
+    $admin        = User::factory()->create(['role' => 'admin']);
+    $table        = Table::factory()->create(['user_id' => $admin->id]);
+    $order        = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    $conversation = Conversation::factory()->create(['table_id' => $table->id, 'status' => 'active']);
+
+    $this->actingAs($admin)
+        ->postJson(route('payments.cash', $order))
+        ->assertOk();
+
+    $this->assertDatabaseHas('conversations', [
+        'id'     => $conversation->id,
+        'status' => 'closed',
+    ]);
+});
+
+// ─── Stripe nunca se llama sin mock ──────────────────────────────────────────
+
+it('StripeService is never instantiated during bill request (no real calls)', function () {
+    $table = Table::factory()->for($this->user)->create();
+    Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+
+    // BillRequestController no inyecta StripeService — verificamos que no explota
+    $this->mock(StripeService::class)
+        ->shouldNotReceive('createPaymentIntent')
+        ->shouldNotReceive('confirmPayment');
+
+    $this->postJson("/api/v1/bill-request/{$table->unique_hash}", [
+        'payment_method' => 'card',
+    ])->assertOk();
+});


### PR DESCRIPTION
  Descripción:
  ## Bloque 7.4 — Pantalla de propina antes del pago con tarjeta

  Pantalla intermedia entre la selección de método de pago y el formulario de Stripe que permite al cliente añadir una propina opcional antes de confirmar el cobro.

  ## Cambios

  ### Backend
  - `MenuController`: pasa `$activeOrderTotal` a la vista (elimina fetch extra en el cliente)
  - `CardPaymentController`: nuevo método `total()` (GET), acepta `tip` opcional en `intent()` sumándolo al PaymentIntent, y guarda `tip` en BD desde `confirm()`
  - `routes/api.php`: nueva ruta `GET /api/v1/payment/{hash}/total`

  ### Frontend (`menu/show.blade.php`)
  - Nuevo sheet de propina con botones rápidos (5 %, 10 %, 15 %, 20 %), input libre y desglose en tiempo real
  - El total se inicializa desde PHP (`@json($activeOrderTotal)`), sin petición API extra
  - `openCardPayment()` abre el sheet de propina de forma síncrona (sin fetch)
  - `proceedToStripe()` crea el PaymentIntent con `total + propina`
  - `submitCardPayment()` envía `tip` al endpoint `/confirm`
  - El sheet de Stripe muestra «Incluye propina de X €» cuando aplica

  ## Criterios de aceptación
  - [x] Se muestra antes de confirmar el pago con tarjeta
  - [x] La propina es opcional (botón «Pagar sin propina»)
  - [x] La propina se registra en `orders.tip` separada del total
  - [x] El importe del PaymentIntent incluye propina + total