### PR TITLE
feat: desglose de ingresos para el gerente (Bloque 7.5)

### DIFF
--- a/app/Http/Controllers/ManagerRevenueController.php
+++ b/app/Http/Controllers/ManagerRevenueController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Order;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+/**
+ * Desglose de ingresos para el gerente.
+ * Muestra totales por método de pago filtrados por período.
+ *
+ * @author SebastianBCF
+ */
+class ManagerRevenueController extends Controller
+{
+    /**
+     * @param  Request  $request
+     * @return View
+     */
+    public function index(Request $request): View
+    {
+        $period = $request->query('period', 'month');
+
+        $start = match ($period) {
+            'today' => now()->startOfDay(),
+            'week'  => now()->startOfWeek(),
+            default => now()->startOfMonth(),
+        };
+
+        // JOIN en lugar de whereHas para evitar N+1 y garantizar multitenancy en una sola query
+        $base = Order::query()
+            ->join('tables', 'orders.table_id', '=', 'tables.id')
+            ->where('tables.user_id', Auth::id())
+            ->where('orders.payment_status', 'paid')
+            ->where('orders.updated_at', '>=', $start->toDateTimeString());
+
+        $summary = (clone $base)
+            ->selectRaw("
+                COALESCE(SUM(CASE WHEN orders.payment_method = 'cash' THEN orders.total ELSE 0 END), 0) as cash_revenue,
+                COALESCE(SUM(CASE WHEN orders.payment_method = 'card' THEN orders.total ELSE 0 END), 0) as card_revenue,
+                COALESCE(SUM(orders.tip), 0)                                                             as tip_revenue,
+                SUM(CASE WHEN orders.payment_method = 'cash' THEN 1 ELSE 0 END)                         as cash_count,
+                SUM(CASE WHEN orders.payment_method = 'card' THEN 1 ELSE 0 END)                         as card_count,
+                COUNT(*)                                                                                 as total_count
+            ")
+            ->first();
+
+        $orders = (clone $base)
+            ->select(
+                'orders.id',
+                'orders.total',
+                'orders.tip',
+                'orders.payment_method',
+                'orders.updated_at',
+                'tables.name as table_name',
+            )
+            ->orderByDesc('orders.updated_at')
+            ->paginate(15)
+            ->withQueryString();
+
+        return view('manager.income', compact('period', 'summary', 'orders'));
+    }
+}

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -38,6 +38,12 @@
                         {{ __('Tapas') }}
                     </x-nav-link>
                     @endif
+                    {{-- Desglose de ingresos: visible solo para admin --}}
+                    @if(Auth::user()->role === 'admin')
+                    <x-nav-link :href="route('manager.income')" :active="request()->routeIs('manager.*')">
+                        {{ __('Ingresos') }}
+                    </x-nav-link>
+                    @endif
                     {{-- Panel de Cocina: visible solo para admin y kitchen --}}
                     @if(in_array(Auth::user()->role, ['admin', 'kitchen']))
                     <span
@@ -153,6 +159,12 @@
                 @if(Auth::user()->role === 'admin')
                 <x-responsive-nav-link :href="route('tapas.edit')" :active="request()->routeIs('tapas.*')">
                     {{ __('Tapas') }}
+                </x-responsive-nav-link>
+                @endif
+                {{-- Desglose de ingresos (Versión Móvil) --}}
+                @if(Auth::user()->role === 'admin')
+                <x-responsive-nav-link :href="route('manager.income')" :active="request()->routeIs('manager.*')">
+                    {{ __('Ingresos') }}
                 </x-responsive-nav-link>
                 @endif
                 {{-- Panel de Cocina (Versión Móvil) --}}

--- a/resources/views/manager/income.blade.php
+++ b/resources/views/manager/income.blade.php
@@ -1,0 +1,220 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <h1 class="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
+                Desglose de ingresos
+            </h1>
+
+            {{-- Filtros de período --}}
+            <nav aria-label="Filtro de período"
+                 class="flex gap-1 bg-gray-100 dark:bg-gray-700 rounded-xl p-1 self-start sm:self-auto">
+                @foreach(['today' => 'Hoy', 'week' => 'Esta semana', 'month' => 'Este mes'] as $value => $label)
+                    <a href="{{ route('manager.income', ['period' => $value]) }}"
+                       aria-current="{{ $period === $value ? 'page' : 'false' }}"
+                       class="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors
+                              focus:outline-none focus:ring-2 focus:ring-indigo-500
+                              {{ $period === $value
+                                  ? 'bg-white dark:bg-gray-800 text-indigo-600 dark:text-indigo-400 shadow-sm'
+                                  : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white' }}">
+                        {{ $label }}
+                    </a>
+                @endforeach
+            </nav>
+        </div>
+    </x-slot>
+
+    <main id="main-content" class="py-6">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
+
+            {{-- Tarjetas de resumen --}}
+            <section aria-labelledby="summary-heading">
+                <h2 id="summary-heading" class="sr-only">Resumen de ingresos</h2>
+                <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+
+                    {{-- Efectivo --}}
+                    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">💵</span>
+                            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Efectivo</span>
+                        </div>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                            {{ number_format($summary->cash_revenue, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                            {{ $summary->cash_count }}
+                            pedido{{ $summary->cash_count != 1 ? 's' : '' }}
+                        </p>
+                    </div>
+
+                    {{-- Tarjeta --}}
+                    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">💳</span>
+                            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Tarjeta</span>
+                        </div>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                            {{ number_format($summary->card_revenue, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                            {{ $summary->card_count }}
+                            pedido{{ $summary->card_count != 1 ? 's' : '' }}
+                        </p>
+                    </div>
+
+                    {{-- Propinas --}}
+                    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">🎁</span>
+                            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Propinas</span>
+                        </div>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                            {{ number_format($summary->tip_revenue, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Solo pagos con tarjeta</p>
+                    </div>
+
+                    {{-- Total cobrado --}}
+                    @php $grand = $summary->cash_revenue + $summary->card_revenue + $summary->tip_revenue; @endphp
+                    <div class="bg-indigo-600 dark:bg-indigo-700 rounded-2xl shadow-sm p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">💰</span>
+                            <span class="text-sm font-medium text-indigo-200">Total cobrado</span>
+                        </div>
+                        <p class="text-2xl font-bold text-white">
+                            {{ number_format($grand, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-indigo-300">
+                            {{ $summary->total_count }}
+                            pedido{{ $summary->total_count != 1 ? 's' : '' }}
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            {{-- Tabla de pedidos cobrados --}}
+            <section aria-labelledby="orders-heading">
+                <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                            border border-gray-200 dark:border-gray-700">
+
+                    <div class="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+                        <h2 id="orders-heading"
+                            class="text-base font-semibold text-gray-900 dark:text-white">
+                            Pedidos cobrados
+                        </h2>
+                    </div>
+
+                    @if($orders->isEmpty())
+                        <div class="px-5 py-14 text-center">
+                            <p class="text-gray-400 dark:text-gray-500 text-sm">
+                                No hay pedidos cobrados en este período.
+                            </p>
+                        </div>
+                    @else
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700"
+                                   aria-label="Listado de pedidos cobrados">
+                                <thead class="bg-gray-50 dark:bg-gray-700/50">
+                                    <tr>
+                                        <th scope="col"
+                                            class="px-5 py-3 text-left text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Fecha y hora
+                                        </th>
+                                        <th scope="col"
+                                            class="px-5 py-3 text-left text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Mesa
+                                        </th>
+                                        <th scope="col"
+                                            class="px-5 py-3 text-left text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Método
+                                        </th>
+                                        <th scope="col"
+                                            class="px-5 py-3 text-right text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Pedido
+                                        </th>
+                                        <th scope="col"
+                                            class="hidden sm:table-cell px-5 py-3 text-right text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Propina
+                                        </th>
+                                        <th scope="col"
+                                            class="px-5 py-3 text-right text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Total cobrado
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-gray-100 dark:divide-gray-700/60">
+                                    @foreach($orders as $order)
+                                        <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/30 transition-colors">
+                                            <td class="px-5 py-4 text-sm text-gray-600 dark:text-gray-300 whitespace-nowrap">
+                                                <time datetime="{{ $order->updated_at->toIso8601String() }}">
+                                                    {{ $order->updated_at->format('d/m/Y H:i') }}
+                                                </time>
+                                            </td>
+                                            <td class="px-5 py-4 text-sm font-medium
+                                                       text-gray-900 dark:text-white whitespace-nowrap">
+                                                {{ $order->table_name }}
+                                            </td>
+                                            <td class="px-5 py-4 whitespace-nowrap">
+                                                @if($order->payment_method === 'card')
+                                                    <span class="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full
+                                                                 text-xs font-medium
+                                                                 bg-indigo-100 dark:bg-indigo-900/40
+                                                                 text-indigo-700 dark:text-indigo-300">
+                                                        <span aria-hidden="true">💳</span> Tarjeta
+                                                    </span>
+                                                @else
+                                                    <span class="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full
+                                                                 text-xs font-medium
+                                                                 bg-green-100 dark:bg-green-900/40
+                                                                 text-green-700 dark:text-green-300">
+                                                        <span aria-hidden="true">💵</span> Efectivo
+                                                    </span>
+                                                @endif
+                                            </td>
+                                            <td class="px-5 py-4 text-sm text-right
+                                                       text-gray-700 dark:text-gray-300 whitespace-nowrap tabular-nums">
+                                                {{ number_format($order->total, 2, ',', '.') }}&nbsp;€
+                                            </td>
+                                            <td class="hidden sm:table-cell px-5 py-4 text-sm text-right
+                                                       whitespace-nowrap tabular-nums">
+                                                @if($order->tip > 0)
+                                                    <span class="text-indigo-600 dark:text-indigo-400">
+                                                        +{{ number_format($order->tip, 2, ',', '.') }}&nbsp;€
+                                                    </span>
+                                                @else
+                                                    <span class="text-gray-300 dark:text-gray-600"
+                                                          aria-label="Sin propina">—</span>
+                                                @endif
+                                            </td>
+                                            <td class="px-5 py-4 text-sm text-right font-semibold
+                                                       text-gray-900 dark:text-white whitespace-nowrap tabular-nums">
+                                                {{ number_format($order->total + $order->tip, 2, ',', '.') }}&nbsp;€
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+
+                        @if($orders->hasPages())
+                            <div class="px-5 py-4 border-t border-gray-200 dark:border-gray-700">
+                                <nav aria-label="Paginación de pedidos cobrados">
+                                    {{ $orders->links() }}
+                                </nav>
+                            </div>
+                        @endif
+                    @endif
+                </div>
+            </section>
+
+        </div>
+    </main>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 use App\Http\Controllers\IngredientController;
 use App\Http\Controllers\BarPanelController;
+use App\Http\Controllers\ManagerRevenueController;
 use App\Http\Controllers\PaymentController;
 use App\Http\Controllers\TapasController;
 use App\Http\Controllers\CategoryController;
@@ -37,10 +38,12 @@ Route::middleware('auth')->group(function () {
     Route::post('/productos/{product}/ingredientes', [ProductController::class, 'syncIngredients'])
          ->name('products.ingredients.sync');
 
-    // Configuración de tapas — solo accesible para el gerente (admin)
+    // Rutas exclusivas del gerente (admin)
     Route::middleware('role:admin')->group(function () {
         Route::get('/tapas/config', [TapasController::class, 'edit'])->name('tapas.edit');
         Route::put('/tapas/config', [TapasController::class, 'update'])->name('tapas.update');
+
+        Route::get('/manager/income', [ManagerRevenueController::class, 'index'])->name('manager.income');
     });
 
     // Gestión de mesas y códigos QR


### PR DESCRIPTION
## Bloque 7.5 — Desglose de ingresos para el gerente

Vista en el panel del gerente con el resumen de ingresos cobrados, desglosados por metodo de pago y filtrables por periodo.

## Cambios

### Backend
- `ManagerRevenueController@index` — query con `JOIN` en lugar de `whereHas` para evitar N+1; una sola query de resumen con `CASE WHEN` condicionales; `paginate(15)` con `withQueryString()` para conservar el filtro en la paginacion
- `routes/web.php` — `GET /manager/income` dentro del grupo `role:admin`; import de `ManagerRevenueController`

### Frontend
- `resources/views/manager/income.blade.php` — tabs de periodo (Hoy / Esta semana / Este mes), 4 tarjetas KPI (Efectivo, Tarjeta, Propinas, Total cobrado), tabla responsive con columna Propina oculta en movil (`hidden sm:table-cell`), estado vacio, paginacion con `aria-label`; numeros con `tabular-nums`; `<time datetime>` en fechas
- `resources/views/layouts/navigation.blade.php` — enlace «Ingresos» visible solo para `admin` en desktop y mobile

## Criterios de aceptacion cumplidos
- [x] Muestra ingresos totales desglosados: efectivo / tarjeta / propinas
- [x] Filtrable por periodo (hoy / semana / mes)
- [x] Queries optimizadas sin N+1 (JOIN + CASE WHEN en una sola pasada)

## Checklist
- [x] Un commit por archivo modificado
- [x] PHPDoc completo en todos los metodos
- [x] `@author` solo en cabecera de clase
- [x] Rutas con `route()`, sin URLs hardcodeadas
- [x] `paginate(15)` con `withQueryString()`
- [x] Accesibilidad WCAG: `aria-label`, `<time datetime>`, `<nav aria-label>`, `scope=col`
- [x] Responsive mobile-first
