### PR TITLE
fix: kitchen badge counting bar orders

### DIFF
--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -40,7 +40,8 @@ class KitchenController extends Controller
     public function badgeCount(): JsonResponse
     {
         $count = Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
-            ->where('status', 'pending')
+            ->whereHas('items', fn($q) => $q->where('destination', 'kitchen')->where('status', 'queued'))
+            ->whereIn('status', ['pending', 'cooking'])
             ->count();
 
         return response()->json(['pending_count' => $count]);


### PR DESCRIPTION
## Problema

El badge de **Cocina** en el nav mostraba el mismo número que el de **Barra** cuando había pedidos mixtos, porque contaba todos los `Order` con `status='pending'` sin filtrar por destino de los ítems.

## Causa

`KitchenController::badgeCount()` usaba `->where('status', 'pending')` a nivel de `Order`, ignorando el campo `destination` de los `OrderItem`.

## Solución

Se alinea con `BarPanelController::badgeCount()`: ahora filtra por órdenes que tengan al menos un ítem con `destination='kitchen'` y `status='queued'`, y cuyo estado sea `pending` o `cooking`.

## Archivos

- `app/Http/Controllers/KitchenController.php`

## Test plan

- [x] Crear un pedido solo de barra → badge Cocina = 0, badge Barra = 1
- [x] Crear un pedido solo de cocina → badge Cocina = 1, badge Barra = 0
- [x] Crear un pedido mixto → ambos badges = 1