### PR TITLE
feat(bloque12.1): add admin_id nullable FK and staff relations to User

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -17,12 +17,14 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  *
  * @package App\Models
  * @property int $id
- * @property int|null $plan_id  ID del plan de suscripción (si aplica)
- * @property string $name       Nombre completo del usuario
- * @property string $email      Correo electrónico (login)
- * @property string $role       Rol: 'admin', 'waiter', 'kitchen'
+ * @property int|null $plan_id   ID del plan de suscripción (si aplica)
+ * @property int|null $admin_id  ID del gerente propietario (null si es admin)
+ * @property string $name        Nombre completo del usuario
+ * @property string $email       Correo electrónico (login)
+ * @property string $role        Rol: 'admin', 'waiter', 'kitchen'
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @author BenjaminDTS
  */
 class User extends Authenticatable
 {
@@ -39,6 +41,7 @@ class User extends Authenticatable
         'email',
         'password',
         'role',
+        'admin_id',
     ];
 
     /**
@@ -126,5 +129,49 @@ class User extends Authenticatable
     public function tapaConfig(): HasOne
     {
         return $this->hasOne(TapaConfig::class);
+    }
+
+    /**
+     * Obtiene el gerente (admin) al que pertenece este miembro de staff.
+     *
+     * @return BelongsTo
+     */
+    public function admin(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'admin_id');
+    }
+
+    /**
+     * Obtiene los miembros de staff (camareros y cocineros) gestionados por este admin.
+     *
+     * @return HasMany
+     */
+    public function staff(): HasMany
+    {
+        return $this->hasMany(User::class, 'admin_id');
+    }
+
+    /* -------------------------------------------------------------------------- */
+    /* HELPERS DE ROL                               */
+    /* -------------------------------------------------------------------------- */
+
+    /**
+     * Indica si el usuario es un gerente (admin del restaurante).
+     *
+     * @return bool
+     */
+    public function isAdmin(): bool
+    {
+        return $this->role === 'admin';
+    }
+
+    /**
+     * Indica si el usuario es personal del restaurante (waiter o kitchen).
+     *
+     * @return bool
+     */
+    public function isStaff(): bool
+    {
+        return in_array($this->role, ['waiter', 'kitchen'], true);
     }
 }

--- a/database/migrations/2026_04_29_144602_add_admin_id_to_users_table.php
+++ b/database/migrations/2026_04_29_144602_add_admin_id_to_users_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('admin_id')
+                ->nullable()
+                ->after('role')
+                ->constrained('users')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropForeign(['admin_id']);
+            $table->dropColumn('admin_id');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -11,6 +11,9 @@ use App\Models\Category;
 use App\Models\Product;
 use App\Models\Ingredient;
 
+/**
+ * @author BenjaminDTS
+ */
 class DatabaseSeeder extends Seeder
 {
     /**
@@ -39,6 +42,7 @@ class DatabaseSeeder extends Seeder
             'password' => bcrypt('password'),
             'role' => 'admin',
             'plan_id' => $plan->id,
+            'admin_id' => null,
         ]);
 
         // 3. Crear 10 Mesas para este usuario


### PR DESCRIPTION
## Resumen

- Migración `add_admin_id_to_users_table`: añade `admin_id` como FK nullable auto-referenciada a `users`, con `nullOnDelete` para proteger al staff si se elimina un admin.
- `User` model: `admin_id` en `$fillable`, relaciones `admin()` / `staff()`, helpers `isAdmin()` / `isStaff()`, `@author BenjaminDTS`.
- `DatabaseSeeder`: `admin_id => null` explícito en el usuario de prueba.

## Test plan

- [x] `php artisan migrate:fresh --seed` sin errores
- [x] `php artisan test` — 232 passed / 0 failed
- [x] FK auto-referenciada verificada (nullable + nullOnDelete + constrained('users'))
- [x] Relaciones y helpers revisados por sub-agente reviewer → SHIP IT