### PR TITLE
feat(bloque12.2): add ownerUserId helper and update all multitenancy controllers

### DIFF
--- a/app/Http/Controllers/BarPanelController.php
+++ b/app/Http/Controllers/BarPanelController.php
@@ -39,7 +39,8 @@ class BarPanelController extends Controller
      */
     public function badgeCount(): JsonResponse
     {
-        $count = Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+        $ownerId = Auth::user()->ownerUserId();
+        $count   = Order::whereHas('table', fn($q) => $q->where('user_id', $ownerId))
             ->whereHas('items', fn($q) => $q->where('destination', 'bar')->where('status', 'queued'))
             ->whereIn('status', ['pending', 'cooking'])
             ->count();
@@ -71,7 +72,8 @@ class BarPanelController extends Controller
             ->filter(fn($order) => count($order['items']) > 0)
             ->values();
 
-        $pendingCount = Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+        $ownerId      = Auth::user()->ownerUserId();
+        $pendingCount = Order::whereHas('table', fn($q) => $q->where('user_id', $ownerId))
             ->whereHas('items', fn($q) => $q->where('destination', 'bar')->where('status', 'queued'))
             ->whereIn('status', ['pending', 'cooking'])
             ->count();
@@ -93,7 +95,7 @@ class BarPanelController extends Controller
     {
         $order = $item->order()->with('table')->first();
 
-        abort_if($order->table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($order->table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
         abort_if($item->destination !== 'bar', 403, 'Este ítem no pertenece a la barra.');
 
         $item->update(['status' => 'ready']);
@@ -133,7 +135,7 @@ class BarPanelController extends Controller
                 ->where('destination', 'bar')
                 ->with(['product']),
         ])
-        ->whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+        ->whereHas('table', fn($q) => $q->where('user_id', Auth::user()->ownerUserId()))
         ->whereHas('items', fn($q) => $q->where('destination', 'bar')->where('status', 'queued'))
         ->whereIn('status', ['pending', 'cooking'])
         ->orderBy('created_at')

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -26,11 +26,8 @@ class CategoryController extends Controller
      */
     public function index(): View
     {
-        // Obtener el usuario actual
-        $user = Auth::user();
-
-        // Obtener sus categorías mediante la relación definida en el modelo User
-        $categories = $user->categories()->paginate(15);
+        $ownerId    = Auth::user()->ownerUserId();
+        $categories = Category::where('user_id', $ownerId)->paginate(15);
 
         return view('categories.index', compact('categories'));
     }
@@ -59,8 +56,9 @@ class CategoryController extends Controller
             'destination' => 'required|in:kitchen,bar', // Solo acepta 'kitchen' o 'bar'
         ]);
 
-        // 2. Crear la categoría asociada al usuario
-        $request->user()->categories()->create($validated);
+        // 2. Crear la categoría bajo el propietario del restaurante
+        $ownerId = Auth::user()->ownerUserId();
+        Category::create(array_merge($validated, ['user_id' => $ownerId]));
 
         // 3. Redirigir al listado con mensaje de éxito
         return redirect()->route('categories.index')->with('success', 'Categoría creada correctamente.');
@@ -86,7 +84,7 @@ class CategoryController extends Controller
     public function edit(Category $category): View
     {
         // Protección Multitenancy: solo el dueño puede editar su categoría
-        abort_if($category->user_id !== Auth::id(), 403, 'No tienes permiso para editar esta categoría.');
+        abort_if($category->user_id !== Auth::user()->ownerUserId(), 403, 'No tienes permiso para editar esta categoría.');
 
         return view('categories.edit', compact('category'));
     }
@@ -100,7 +98,7 @@ class CategoryController extends Controller
      */
     public function update(Request $request, Category $category): RedirectResponse
     {
-        abort_if($category->user_id !== Auth::id(), 403);
+        abort_if($category->user_id !== Auth::user()->ownerUserId(), 403);
 
         $validated = $request->validate([
             'name' => 'required|string|max:255',
@@ -120,7 +118,7 @@ class CategoryController extends Controller
      */
     public function destroy(Category $category): RedirectResponse
     {
-        abort_if($category->user_id !== Auth::id(), 403);
+        abort_if($category->user_id !== Auth::user()->ownerUserId(), 403);
 
         $category->delete();
 

--- a/app/Http/Controllers/IngredientController.php
+++ b/app/Http/Controllers/IngredientController.php
@@ -26,8 +26,8 @@ class IngredientController extends Controller
      */
     public function index(): \Illuminate\View\View
     {
-        $user = Auth::user();
-        $ingredients = $user->ingredients()->paginate(15); // Usamos la relación del modelo User
+        $ownerId     = Auth::user()->ownerUserId();
+        $ingredients = Ingredient::where('user_id', $ownerId)->paginate(15);
 
         return view('ingredients.index', compact('ingredients'));
     }
@@ -56,7 +56,8 @@ class IngredientController extends Controller
             'allergen_type' => ['nullable', 'string', Rule::in(array_keys(Ingredient::ALLERGEN_TYPES))],
         ]);
 
-        $request->user()->ingredients()->create($validated);
+        $ownerId = Auth::user()->ownerUserId();
+        Ingredient::create(array_merge($validated, ['user_id' => $ownerId]));
 
         return redirect()->route('ingredients.index')->with('success', 'Ingrediente creado correctamente.');
     }
@@ -77,7 +78,7 @@ class IngredientController extends Controller
      */
     public function edit(Ingredient $ingredient): \Illuminate\View\View
     {
-        abort_if($ingredient->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($ingredient->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         return view('ingredients.edit', compact('ingredient'));
     }
@@ -91,7 +92,7 @@ class IngredientController extends Controller
      */
     public function update(Request $request, Ingredient $ingredient): \Illuminate\Http\RedirectResponse
     {
-        abort_if($ingredient->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($ingredient->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $validated = $request->validate([
             'name'         => 'required|string|max:255',
@@ -112,7 +113,7 @@ class IngredientController extends Controller
      */
     public function destroy(Ingredient $ingredient): \Illuminate\Http\RedirectResponse
     {
-        abort_if($ingredient->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($ingredient->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $ingredient->delete();
 

--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -39,7 +39,8 @@ class KitchenController extends Controller
      */
     public function badgeCount(): JsonResponse
     {
-        $count = Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+        $ownerId = Auth::user()->ownerUserId();
+        $count   = Order::whereHas('table', fn($q) => $q->where('user_id', $ownerId))
             ->whereHas('items', fn($q) => $q->where('destination', 'kitchen')->where('status', 'queued'))
             ->whereIn('status', ['pending', 'cooking'])
             ->count();
@@ -76,7 +77,8 @@ class KitchenController extends Controller
             ->filter(fn($order) => count($order['items']) > 0)
             ->values();
 
-        $pendingCount = Order::whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+        $ownerId      = Auth::user()->ownerUserId();
+        $pendingCount = Order::whereHas('table', fn($q) => $q->where('user_id', $ownerId))
             ->where('status', 'pending')
             ->count();
 
@@ -96,7 +98,7 @@ class KitchenController extends Controller
     {
         $order = $item->order()->with('table')->first();
 
-        abort_if($order->table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($order->table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
         abort_if($item->destination !== 'kitchen', 403, 'Este ítem no pertenece a cocina.');
 
         $item->update(['status' => 'ready']);
@@ -129,7 +131,7 @@ class KitchenController extends Controller
      */
     public function markOrderServed(Order $order): JsonResponse
     {
-        abort_if($order->table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($order->table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
         abort_if($order->status !== 'ready', 422, 'El pedido no está listo para servir.');
 
         $order->update(['status' => 'served', 'notification_ready' => false]);
@@ -152,7 +154,7 @@ class KitchenController extends Controller
                 ->where('destination', 'kitchen')
                 ->with(['product', 'modifications.ingredient']),
         ])
-        ->whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+        ->whereHas('table', fn($q) => $q->where('user_id', Auth::user()->ownerUserId()))
         ->whereHas('items', fn($q) => $q->where('destination', 'kitchen')->where('status', 'queued'))
         ->whereIn('status', ['pending', 'cooking'])
         ->orderBy('created_at')

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -28,7 +28,7 @@ class NotificationController extends Controller
     {
         $orders = Order::with('table')
             ->where('notification_ready', true)
-            ->whereHas('table', fn($q) => $q->where('user_id', Auth::id()))
+            ->whereHas('table', fn($q) => $q->where('user_id', Auth::user()->ownerUserId()))
             ->get()
             ->map(fn(Order $order) => [
                 'id'    => $order->id,
@@ -47,7 +47,7 @@ class NotificationController extends Controller
      */
     public function dismiss(Order $order): JsonResponse
     {
-        abort_if($order->table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($order->table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $order->update(['notification_ready' => false]);
 
@@ -83,7 +83,7 @@ class NotificationController extends Controller
      */
     public function dismissBillRequest(Order $order): JsonResponse
     {
-        abort_if($order->table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($order->table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $order->update(['bill_requested' => false]);
 

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -63,7 +63,7 @@ class NotificationController extends Controller
     {
         $orders = Order::with('table')
             ->where('bill_requested', true)
-            ->whereHas('table', fn ($q) => $q->where('user_id', Auth::id()))
+            ->whereHas('table', fn ($q) => $q->where('user_id', Auth::user()->ownerUserId()))
             ->get()
             ->map(fn (Order $order) => [
                 'id'              => $order->id,

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Auth;
  * Gestiona los flujos de pago desde el panel del camarero.
  *
  * @author SebastianBCF
+ * @author BenjaminDTS
  */
 class PaymentController extends Controller
 {
@@ -23,7 +24,7 @@ class PaymentController extends Controller
      */
     public function cashPayment(Order $order): JsonResponse
     {
-        abort_if($order->table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($order->table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
         abort_if($order->status === 'closed', 422, 'Este pedido ya está cerrado.');
 
         $order->update([

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -28,7 +28,8 @@ class ProductController extends Controller
    */
   public function index(): View
   {
-    $products = Product::where('user_id', Auth::id())->with('allergens')->paginate(15);
+    $ownerId  = Auth::user()->ownerUserId();
+    $products = Product::where('user_id', $ownerId)->with('allergens')->paginate(15);
     return view('products.index', compact('products'));
   }
 
@@ -40,7 +41,8 @@ class ProductController extends Controller
    */
   public function create(): View
   {
-    $categories = Category::where('user_id', Auth::id())->get();
+    $ownerId    = Auth::user()->ownerUserId();
+    $categories = Category::where('user_id', $ownerId)->get();
     return view('products.create', compact('categories'));
   }
 
@@ -57,11 +59,11 @@ class ProductController extends Controller
       'name'        => 'required|string|max:255',
       'description' => 'nullable|string',
       'price'       => 'required|numeric|min:0',
-      'category_id' => ['required', Rule::exists('categories', 'id')->where('user_id', Auth::id())],
+      'category_id' => ['required', Rule::exists('categories', 'id')->where('user_id', Auth::user()->ownerUserId())],
       'image'       => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
     ]);
 
-    $validatedData['user_id'] = Auth::id();
+    $validatedData['user_id'] = Auth::user()->ownerUserId();
 
     if ($request->hasFile('image')) {
       /** @var string $path Ruta donde se almacena temporalmente la imagen */
@@ -97,11 +99,12 @@ class ProductController extends Controller
 
     {
 
-        abort_if($product->user_id !== Auth::id(), 403, 'No tienes permiso para editar este plato.');
- 
+        $ownerId = Auth::user()->ownerUserId();
+        abort_if($product->user_id !== $ownerId, 403, 'No tienes permiso para editar este plato.');
+
         $product->load('allergens');
 
-        $categories = Category::where('user_id', Auth::id())->get();
+        $categories = Category::where('user_id', $ownerId)->get();
 
         return view('products.edit', compact('product', 'categories'));
 
@@ -125,8 +128,8 @@ class ProductController extends Controller
 
     {
 
-        abort_if($product->user_id !== Auth::id(), 403);
- 
+        abort_if($product->user_id !== Auth::user()->ownerUserId(), 403);
+
         $validatedData = $request->validate([
 
             'name'        => 'required|string|max:255',
@@ -177,7 +180,7 @@ class ProductController extends Controller
 
     {
 
-        abort_if($product->user_id !== Auth::id(), 403);
+        abort_if($product->user_id !== Auth::user()->ownerUserId(), 403);
 
         $product->delete();
 
@@ -193,11 +196,12 @@ class ProductController extends Controller
      */
     public function editIngredients(Product $product): View
     {
-        abort_if($product->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        $ownerId = Auth::user()->ownerUserId();
+        abort_if($product->user_id !== $ownerId, 403, 'Acceso denegado.');
 
         $product->load('ingredients');
 
-        $ingredients = Ingredient::where('user_id', Auth::id())
+        $ingredients = Ingredient::where('user_id', $ownerId)
                                  ->orderBy('name')
                                  ->get();
 
@@ -213,7 +217,7 @@ class ProductController extends Controller
      */
     public function syncIngredients(Request $request, Product $product): RedirectResponse
     {
-        abort_if($product->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($product->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $validated = $request->validate([
             'ingredients'                     => 'nullable|array',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -174,4 +174,16 @@ class User extends Authenticatable
     {
         return in_array($this->role, ['waiter', 'kitchen'], true);
     }
+
+    /**
+     * Devuelve el user_id del propietario real de los recursos del restaurante.
+     * Si el usuario es admin: devuelve su propio id.
+     * Si el usuario es staff: devuelve el id de su gerente (admin_id).
+     *
+     * @return int
+     */
+    public function ownerUserId(): int
+    {
+        return $this->admin_id ?? $this->id;
+    }
 }


### PR DESCRIPTION
## Resumen

- `User::ownerUserId()`: nuevo helper que devuelve el `id` del propietario real de los recursos. Si el usuario es admin → su propio `id`. Si es staff → el `admin_id` de su gerente.
- Todos los controladores accesibles por staff actualizados: `CategoryController`, `IngredientController`, `ProductController`, `KitchenController`, `BarPanelController`, `NotificationController`, `PaymentController`.
- `MenuController`: sin cambios (accede vía `table->user_id` desde hash público, no usa `Auth::id()`).
- `TapasController`, `ManagerRevenueController`, `TableController`: sin cambios (rutas `role:admin` exclusivas).

## Controladores modificados

| Controlador | Cambios |
|---|---|
| `CategoryController` | `index`, `store`, `edit`, `update`, `destroy` |
| `IngredientController` | `index`, `store`, `edit`, `update`, `destroy` |
| `ProductController` | `index`, `create`, `store`, `edit`, `update`, `destroy`, `editIngredients`, `syncIngredients` |
| `KitchenController` | `badgeCount`, `pendingOrders`, `markItemReady`, `markOrderServed`, `getActiveOrders` |
| `BarPanelController` | `badgeCount`, `pendingItems`, `updateItem`, `getActiveOrders` |
| `NotificationController` | `ready`, `dismiss`, `billRequests`, `dismissBillRequest` |
| `PaymentController` | `cashPayment` |

## Test plan

- [x] `php artisan migrate:fresh --seed` sin errores
- [x] `php artisan test` — 232 passed / 0 failed
- [x] Revisión por sub-agente reviewer — blocker detectado y corregido antes del push
- [x] Segunda revisión post-fix — SHIP IT confirmado