### PR TITLE
feat(bloque12.3): StaffController, routes, views, factory states and tests

### DIFF
--- a/app/Http/Controllers/StaffController.php
+++ b/app/Http/Controllers/StaffController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\View\View;
+
+/**
+ * Controlador para la gestión del personal del restaurante.
+ *
+ * Permite al gerente (admin) listar, dar de alta y eliminar
+ * miembros de su equipo (camareros y cocineros).
+ * El acceso está restringido al middleware role:admin.
+ *
+ * @author BenjaminDTS
+ */
+class StaffController extends Controller
+{
+    /**
+     * Muestra el listado de personal perteneciente al admin autenticado.
+     *
+     * @return View
+     */
+    public function index(): View
+    {
+        $staff = Auth::user()->staff()->paginate(15);
+
+        return view('staff.index', compact('staff'));
+    }
+
+    /**
+     * Muestra el formulario de alta de un nuevo miembro de personal.
+     *
+     * @return View
+     */
+    public function create(): View
+    {
+        return view('staff.create');
+    }
+
+    /**
+     * Valida y crea un nuevo miembro de personal asociado al admin autenticado.
+     *
+     * @param  Request  $request
+     * @return RedirectResponse
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name'                  => 'required|string|max:255',
+            'email'                 => 'required|email|unique:users,email',
+            'password'              => 'required|string|min:8|confirmed',
+            'role'                  => 'required|in:waiter,kitchen',
+        ]);
+
+        User::create([
+            'name'     => $validated['name'],
+            'email'    => $validated['email'],
+            'password' => Hash::make($validated['password']),
+            'role'     => $validated['role'],
+            'admin_id' => Auth::id(),
+        ]);
+
+        return redirect()
+            ->route('staff.index')
+            ->with('success', 'Miembro del personal dado de alta correctamente.');
+    }
+
+    /**
+     * Elimina un miembro del personal del admin autenticado.
+     *
+     * @param  User  $staff
+     * @return RedirectResponse
+     */
+    public function destroy(User $staff): RedirectResponse
+    {
+        abort_if($staff->admin_id !== Auth::id(), 403, 'No puedes eliminar personal de otro restaurante.');
+
+        $staff->delete();
+
+        return redirect()
+            ->route('staff.index')
+            ->with('success', 'Miembro del personal eliminado correctamente.');
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,12 +2,14 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @author BenjaminDTS
  */
 class UserFactory extends Factory
 {
@@ -40,5 +42,36 @@ class UserFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
         ]);
+    }
+
+    /**
+     * Estado: usuario con rol camarero.
+     *
+     * @return static
+     */
+    public function waiter(): static
+    {
+        return $this->state(['role' => 'waiter']);
+    }
+
+    /**
+     * Estado: usuario con rol cocinero.
+     *
+     * @return static
+     */
+    public function kitchen(): static
+    {
+        return $this->state(['role' => 'kitchen']);
+    }
+
+    /**
+     * Estado: usuario que pertenece al personal de un admin concreto.
+     *
+     * @param  \App\Models\User  $admin
+     * @return static
+     */
+    public function staffOf(User $admin): static
+    {
+        return $this->state(['admin_id' => $admin->id]);
     }
 }

--- a/resources/views/staff/create.blade.php
+++ b/resources/views/staff/create.blade.php
@@ -1,0 +1,96 @@
+{{-- @author BenjaminDTS --}}
+<x-app-layout>
+  <x-slot name="header">
+    <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+      {{ __('Añadir Personal') }}
+    </h2>
+  </x-slot>
+
+  <div class="py-12">
+    <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
+
+        <form method="POST" action="{{ route('staff.store') }}">
+          @csrf
+
+          {{-- Nombre --}}
+          <div class="mb-4">
+            <label for="name" class="block text-gray-700 dark:text-gray-300 mb-2">
+              Nombre <span aria-hidden="true">*</span>
+            </label>
+            <input type="text" name="name" id="name" required aria-required="true"
+                   value="{{ old('name') }}"
+                   class="w-full rounded-md border-gray-300 dark:bg-gray-900 dark:text-white @error('name') border-red-500 @enderror">
+            @error('name')
+              <p id="error-name" role="alert" class="mt-1 text-sm text-red-600">{{ $message }}</p>
+            @enderror
+          </div>
+
+          {{-- Email --}}
+          <div class="mb-4">
+            <label for="email" class="block text-gray-700 dark:text-gray-300 mb-2">
+              Correo electrónico <span aria-hidden="true">*</span>
+            </label>
+            <input type="email" name="email" id="email" required aria-required="true"
+                   value="{{ old('email') }}"
+                   class="w-full rounded-md border-gray-300 dark:bg-gray-900 dark:text-white @error('email') border-red-500 @enderror">
+            @error('email')
+              <p id="error-email" role="alert" class="mt-1 text-sm text-red-600">{{ $message }}</p>
+            @enderror
+          </div>
+
+          {{-- Contraseña --}}
+          <div class="mb-4">
+            <label for="password" class="block text-gray-700 dark:text-gray-300 mb-2">
+              Contraseña <span aria-hidden="true">*</span>
+            </label>
+            <input type="password" name="password" id="password" required aria-required="true" minlength="8"
+                   class="w-full rounded-md border-gray-300 dark:bg-gray-900 dark:text-white @error('password') border-red-500 @enderror">
+            @error('password')
+              <p id="error-password" role="alert" class="mt-1 text-sm text-red-600">{{ $message }}</p>
+            @enderror
+          </div>
+
+          {{-- Confirmar contraseña --}}
+          <div class="mb-4">
+            <label for="password_confirmation" class="block text-gray-700 dark:text-gray-300 mb-2">
+              Confirmar contraseña <span aria-hidden="true">*</span>
+            </label>
+            <input type="password" name="password_confirmation" id="password_confirmation"
+                   required aria-required="true" minlength="8"
+                   class="w-full rounded-md border-gray-300 dark:bg-gray-900 dark:text-white">
+          </div>
+
+          {{-- Rol --}}
+          <div class="mb-6">
+            <label for="role" class="block text-gray-700 dark:text-gray-300 mb-2">
+              Rol <span aria-hidden="true">*</span>
+            </label>
+            <select name="role" id="role" required aria-required="true"
+                    class="w-full rounded-md border-gray-300 dark:bg-gray-900 dark:text-white @error('role') border-red-500 @enderror">
+              <option value="">— Selecciona un rol —</option>
+              <option value="waiter" {{ old('role') === 'waiter' ? 'selected' : '' }}>Camarero</option>
+              <option value="kitchen" {{ old('role') === 'kitchen' ? 'selected' : '' }}>Cocinero</option>
+            </select>
+            @error('role')
+              <p id="error-role" role="alert" class="mt-1 text-sm text-red-600">{{ $message }}</p>
+            @enderror
+          </div>
+
+          <div class="flex items-center gap-4">
+            <button type="submit"
+                    class="bg-orange-500 text-white px-4 py-2 rounded hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2">
+              Dar de alta
+            </button>
+            <a href="{{ route('staff.index') }}"
+               class="text-gray-600 dark:text-gray-400 hover:underline">
+              Cancelar
+            </a>
+          </div>
+
+        </form>
+
+      </div>
+    </div>
+  </div>
+</x-app-layout>

--- a/resources/views/staff/index.blade.php
+++ b/resources/views/staff/index.blade.php
@@ -1,0 +1,84 @@
+{{-- @author BenjaminDTS --}}
+<x-app-layout>
+  <x-slot name="header">
+    <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+      {{ __('Gestión de Personal') }}
+    </h2>
+  </x-slot>
+
+  <div class="py-12">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="p-6 text-gray-900 dark:text-gray-100">
+
+        @if(session('success'))
+          <div role="alert" class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-6">
+            {{ session('success') }}
+          </div>
+        @endif
+
+        <div class="flex justify-end mb-4">
+          <a href="{{ route('staff.create') }}"
+             class="bg-orange-500 hover:bg-orange-700 text-white font-bold py-2 px-4 rounded">
+            + Añadir Personal
+          </a>
+        </div>
+
+        <div class="overflow-x-auto">
+          <table class="min-w-full bg-white dark:bg-gray-800 rounded-lg shadow" aria-label="Personal del restaurante">
+            <thead>
+              <tr class="bg-gray-100 dark:bg-gray-700 text-left text-sm font-semibold text-gray-600 dark:text-gray-300 uppercase">
+                <th class="px-4 py-3">Nombre</th>
+                <th class="px-4 py-3">Email</th>
+                <th class="px-4 py-3">Rol</th>
+                <th class="px-4 py-3">Alta</th>
+                <th class="px-4 py-3 text-right">Acciones</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200 dark:divide-gray-600">
+              @forelse($staff as $member)
+                <tr class="hover:bg-gray-50 dark:hover:bg-gray-700 transition">
+                  <td class="px-4 py-3 font-medium">{{ $member->name }}</td>
+                  <td class="px-4 py-3 text-sm text-gray-600 dark:text-gray-300">{{ $member->email }}</td>
+                  <td class="px-4 py-3">
+                    <span class="px-2 py-1 rounded text-xs font-semibold
+                      {{ $member->role === 'waiter' ? 'bg-blue-100 text-blue-700' : 'bg-yellow-100 text-yellow-700' }}">
+                      {{ $member->role === 'waiter' ? 'Camarero' : 'Cocinero' }}
+                    </span>
+                  </td>
+                  <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+                    {{ $member->created_at->format('d/m/Y') }}
+                  </td>
+                  <td class="px-4 py-3 text-right">
+                    <form action="{{ route('staff.destroy', $member) }}" method="POST"
+                          onsubmit="return confirm('¿Eliminar a {{ $member->name }} del equipo?')">
+                      @csrf
+                      @method('DELETE')
+                      <button type="submit"
+                              aria-label="Eliminar personal {{ $member->name }}"
+                              class="text-sm bg-red-50 text-red-600 hover:bg-red-100 border border-red-200 py-1 px-3 rounded">
+                        Eliminar
+                      </button>
+                    </form>
+                  </td>
+                </tr>
+              @empty
+                <tr>
+                  <td colspan="5" class="px-4 py-8 text-center text-gray-400">
+                    No tienes personal dado de alta todavía.
+                  </td>
+                </tr>
+              @endforelse
+            </tbody>
+          </table>
+        </div>
+
+        @if($staff->hasPages())
+          <nav aria-label="Paginación de personal" class="mt-6">
+            {{ $staff->links() }}
+          </nav>
+        @endif
+
+      </div>
+    </div>
+  </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 use App\Http\Controllers\IngredientController;
+use App\Http\Controllers\StaffController;
 use App\Http\Controllers\BarPanelController;
 use App\Http\Controllers\ManagerRevenueController;
 use App\Http\Controllers\PaymentController;
@@ -44,6 +45,12 @@ Route::middleware('auth')->group(function () {
         Route::put('/tapas/config', [TapasController::class, 'update'])->name('tapas.update');
 
         Route::get('/manager/income', [ManagerRevenueController::class, 'index'])->name('manager.income');
+
+        // Gestión de personal del restaurante
+        Route::get('/staff', [StaffController::class, 'index'])->name('staff.index');
+        Route::get('/staff/create', [StaffController::class, 'create'])->name('staff.create');
+        Route::post('/staff', [StaffController::class, 'store'])->name('staff.store');
+        Route::delete('/staff/{staff}', [StaffController::class, 'destroy'])->name('staff.destroy');
     });
 
     // Gestión de mesas y códigos QR

--- a/tests/Feature/Bloque12/StaffControllerTest.php
+++ b/tests/Feature/Bloque12/StaffControllerTest.php
@@ -1,0 +1,205 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->admin       = User::factory()->create(['role' => 'admin']);
+    $this->otherAdmin  = User::factory()->create(['role' => 'admin']);
+    $this->waiterUser  = User::factory()->waiter()->staffOf($this->admin)->create();
+    $this->kitchenUser = User::factory()->kitchen()->staffOf($this->admin)->create();
+});
+
+// ─── ACCESO ───────────────────────────────────────────────────────────────────
+
+it('redirects unauthenticated user away from staff index', function () {
+    $this->get(route('staff.index'))->assertRedirect(route('login'));
+});
+
+it('shows staff index to admin user', function () {
+    $this->actingAs($this->admin)
+        ->get(route('staff.index'))
+        ->assertOk()
+        ->assertSee($this->waiterUser->name)
+        ->assertSee($this->kitchenUser->name);
+});
+
+it('returns 403 for waiter trying to access staff index', function () {
+    $this->actingAs($this->waiterUser)
+        ->get(route('staff.index'))
+        ->assertForbidden();
+});
+
+it('returns 403 for kitchen trying to access staff index', function () {
+    $this->actingAs($this->kitchenUser)
+        ->get(route('staff.index'))
+        ->assertForbidden();
+});
+
+// ─── SCOPE (solo ve su propio personal) ───────────────────────────────────────
+
+it('shows only staff belonging to the authenticated admin', function () {
+    $ownStaff = User::factory()->waiter()->staffOf($this->admin)->create(['name' => 'Mi Camarero']);
+
+    $this->actingAs($this->admin)
+        ->get(route('staff.index'))
+        ->assertSee('Mi Camarero');
+});
+
+it('does not show staff from another admin', function () {
+    $foreignStaff = User::factory()->waiter()->staffOf($this->otherAdmin)->create(['name' => 'Ajeno Camarero']);
+
+    $this->actingAs($this->admin)
+        ->get(route('staff.index'))
+        ->assertDontSee('Ajeno Camarero');
+});
+
+// ─── CREACIÓN ─────────────────────────────────────────────────────────────────
+
+it('admin can create a waiter', function () {
+    $this->actingAs($this->admin)
+        ->post(route('staff.store'), [
+            'name'                  => 'Nuevo Camarero',
+            'email'                 => 'camarero@test.com',
+            'password'              => 'secret123',
+            'password_confirmation' => 'secret123',
+            'role'                  => 'waiter',
+        ])
+        ->assertRedirect(route('staff.index'))
+        ->assertSessionHas('success');
+
+    $this->assertDatabaseHas('users', [
+        'email' => 'camarero@test.com',
+        'role'  => 'waiter',
+    ]);
+});
+
+it('admin can create a kitchen user', function () {
+    $this->actingAs($this->admin)
+        ->post(route('staff.store'), [
+            'name'                  => 'Nuevo Cocinero',
+            'email'                 => 'cocinero@test.com',
+            'password'              => 'secret123',
+            'password_confirmation' => 'secret123',
+            'role'                  => 'kitchen',
+        ])
+        ->assertRedirect(route('staff.index'));
+
+    $this->assertDatabaseHas('users', [
+        'email' => 'cocinero@test.com',
+        'role'  => 'kitchen',
+    ]);
+});
+
+it('new staff has the admins id as admin_id', function () {
+    $this->actingAs($this->admin)
+        ->post(route('staff.store'), [
+            'name'                  => 'Staff Test',
+            'email'                 => 'staff@test.com',
+            'password'              => 'secret123',
+            'password_confirmation' => 'secret123',
+            'role'                  => 'waiter',
+        ]);
+
+    $this->assertDatabaseHas('users', [
+        'email'    => 'staff@test.com',
+        'admin_id' => $this->admin->id,
+    ]);
+});
+
+// ─── VALIDACIÓN ───────────────────────────────────────────────────────────────
+
+it('fails to create staff without name', function () {
+    $this->actingAs($this->admin)
+        ->post(route('staff.store'), [
+            'name'                  => '',
+            'email'                 => 'x@test.com',
+            'password'              => 'secret123',
+            'password_confirmation' => 'secret123',
+            'role'                  => 'waiter',
+        ])
+        ->assertSessionHasErrors('name');
+});
+
+it('fails to create staff without email', function () {
+    $this->actingAs($this->admin)
+        ->post(route('staff.store'), [
+            'name'                  => 'Sin Email',
+            'email'                 => '',
+            'password'              => 'secret123',
+            'password_confirmation' => 'secret123',
+            'role'                  => 'waiter',
+        ])
+        ->assertSessionHasErrors('email');
+});
+
+it('fails to create staff with duplicate email', function () {
+    $this->actingAs($this->admin)
+        ->post(route('staff.store'), [
+            'name'                  => 'Duplicado',
+            'email'                 => $this->waiterUser->email,
+            'password'              => 'secret123',
+            'password_confirmation' => 'secret123',
+            'role'                  => 'waiter',
+        ])
+        ->assertSessionHasErrors('email');
+});
+
+it('fails to create staff with invalid role', function () {
+    $this->actingAs($this->admin)
+        ->post(route('staff.store'), [
+            'name'                  => 'Rol Inválido',
+            'email'                 => 'rolmal@test.com',
+            'password'              => 'secret123',
+            'password_confirmation' => 'secret123',
+            'role'                  => 'superadmin',
+        ])
+        ->assertSessionHasErrors('role');
+});
+
+it('fails to create staff with role admin', function () {
+    $this->actingAs($this->admin)
+        ->post(route('staff.store'), [
+            'name'                  => 'Admin Falso',
+            'email'                 => 'adminfalso@test.com',
+            'password'              => 'secret123',
+            'password_confirmation' => 'secret123',
+            'role'                  => 'admin',
+        ])
+        ->assertSessionHasErrors('role');
+});
+
+// ─── ELIMINACIÓN ──────────────────────────────────────────────────────────────
+
+it('admin can delete their own staff', function () {
+    $this->actingAs($this->admin)
+        ->delete(route('staff.destroy', $this->waiterUser))
+        ->assertRedirect(route('staff.index'))
+        ->assertSessionHas('success');
+
+    $this->assertDatabaseMissing('users', ['id' => $this->waiterUser->id]);
+});
+
+it('returns 403 when admin tries to delete staff from another admin', function () {
+    $foreignStaff = User::factory()->waiter()->staffOf($this->otherAdmin)->create();
+
+    $this->actingAs($this->admin)
+        ->delete(route('staff.destroy', $foreignStaff))
+        ->assertForbidden();
+
+    $this->assertDatabaseHas('users', ['id' => $foreignStaff->id]);
+});
+
+it('deleted staff cannot login after deletion', function () {
+    $email = $this->waiterUser->email;
+
+    $this->actingAs($this->admin)
+        ->delete(route('staff.destroy', $this->waiterUser));
+
+    $this->assertDatabaseMissing('users', ['email' => $email]);
+
+    // El usuario no existe en BD, por lo que cualquier intento de login falla
+    $this->assertNull(User::where('email', $email)->first());
+});


### PR DESCRIPTION
## Resumen

- `StaffController`: index, create, store, destroy para que el admin gestione su personal
- Rutas añadidas dentro del grupo `role:admin` → staff nunca accede
- Vistas `staff/index` y `staff/create` con Tailwind + accesibilidad WCAG
- `UserFactory` con estados `waiter()`, `kitchen()`, `staffOf(User $admin)`
- 17 feature tests en `tests/Feature/Bloque12/StaffControllerTest.php`

## Reglas de negocio implementadas

- Solo `role=admin` accede a rutas `/staff`
- `store()` valida `in:waiter,kitchen` → no se puede crear otro admin
- `destroy()` verifica `$staff->admin_id === Auth::id()` → 403 si es staff de otro restaurante
- Contraseña elegida por el admin, mínimo 8 caracteres + confirmación
- Hard delete (tabla `users` sin `deleted_at`)

## Test plan

- [x] 17 tests pasando: acceso, scope, creación, validación, eliminación
- [x] Suite completa: 249 passed / 0 failed
- [x] Review inline: todos los puntos críticos verificados → SHIP IT