### PR TITLE
[feat] bloque12 — gestión de personal completo

### DIFF
--- a/tests/Feature/Bloque12/MultitenancyStaffTest.php
+++ b/tests/Feature/Bloque12/MultitenancyStaffTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * @author AyrtonAlania
+ */
+
+use App\Models\Category;
+use App\Models\Ingredient;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->admin      = User::factory()->create(['role' => 'admin']);
+    $this->otherAdmin = User::factory()->create(['role' => 'admin']);
+
+    $this->waiter  = User::factory()->waiter()->staffOf($this->admin)->create();
+    $this->kitchen = User::factory()->kitchen()->staffOf($this->admin)->create();
+
+    // Recursos del admin
+    $this->adminCategory   = Category::factory()->create(['user_id' => $this->admin->id, 'name' => 'Categoría del Admin']);
+    $this->adminIngredient = Ingredient::factory()->create(['user_id' => $this->admin->id, 'name' => 'Ingrediente del Admin']);
+    $this->adminProduct    = Product::factory()->create([
+        'user_id'     => $this->admin->id,
+        'category_id' => $this->adminCategory->id,
+        'name'        => 'Producto del Admin',
+    ]);
+
+    // Recursos de otro admin (no deben ser visibles)
+    $this->otherCategory = Category::factory()->create(['user_id' => $this->otherAdmin->id, 'name' => 'Categoría Ajena']);
+    $this->otherProduct  = Product::factory()->create([
+        'user_id'     => $this->otherAdmin->id,
+        'category_id' => $this->otherCategory->id,
+        'name'        => 'Producto Ajeno',
+    ]);
+});
+
+// ─── CATEGORÍAS ───────────────────────────────────────────────────────────────
+
+it('staff waiter can see their admins categories', function () {
+    $this->actingAs($this->waiter)
+        ->get(route('categories.index'))
+        ->assertOk()
+        ->assertSee('Categoría del Admin');
+});
+
+it('staff kitchen can see their admins categories', function () {
+    $this->actingAs($this->kitchen)
+        ->get(route('categories.index'))
+        ->assertOk()
+        ->assertSee('Categoría del Admin');
+});
+
+it('staff cannot see another admins categories', function () {
+    $this->actingAs($this->waiter)
+        ->get(route('categories.index'))
+        ->assertDontSee('Categoría Ajena');
+});
+
+// ─── INGREDIENTES ─────────────────────────────────────────────────────────────
+
+it('staff waiter can see their admins ingredients', function () {
+    $this->actingAs($this->waiter)
+        ->get(route('ingredients.index'))
+        ->assertOk()
+        ->assertSee('Ingrediente del Admin');
+});
+
+it('staff cannot see another admins ingredients', function () {
+    $otherIngredient = Ingredient::factory()->create([
+        'user_id' => $this->otherAdmin->id,
+        'name'    => 'Ingrediente Ajeno',
+    ]);
+
+    $this->actingAs($this->waiter)
+        ->get(route('ingredients.index'))
+        ->assertDontSee('Ingrediente Ajeno');
+});
+
+// ─── PRODUCTOS ────────────────────────────────────────────────────────────────
+
+it('staff kitchen can see their admins products', function () {
+    $this->actingAs($this->kitchen)
+        ->get(route('products.index'))
+        ->assertOk()
+        ->assertSee('Producto del Admin');
+});
+
+it('staff cannot see another admins products', function () {
+    $this->actingAs($this->waiter)
+        ->get(route('products.index'))
+        ->assertDontSee('Producto Ajeno');
+});
+
+// ─── ownerUserId EN ABORT_IF ──────────────────────────────────────────────────
+
+it('staff waiter can edit their admins category', function () {
+    $this->actingAs($this->waiter)
+        ->get(route('categories.edit', $this->adminCategory))
+        ->assertOk();
+});
+
+it('staff returns 403 editing a category from another admin', function () {
+    $this->actingAs($this->waiter)
+        ->get(route('categories.edit', $this->otherCategory))
+        ->assertForbidden();
+});

--- a/tests/Feature/Bloque12/StaffControllerTest.php
+++ b/tests/Feature/Bloque12/StaffControllerTest.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @author AyrtonAlania
+ */
+
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -38,7 +42,7 @@ it('returns 403 for kitchen trying to access staff index', function () {
         ->assertForbidden();
 });
 
-// ─── SCOPE (solo ve su propio personal) ───────────────────────────────────────
+// ─── LISTADO ──────────────────────────────────────────────────────────────────
 
 it('shows only staff belonging to the authenticated admin', function () {
     $ownStaff = User::factory()->waiter()->staffOf($this->admin)->create(['name' => 'Mi Camarero']);
@@ -54,6 +58,16 @@ it('does not show staff from another admin', function () {
     $this->actingAs($this->admin)
         ->get(route('staff.index'))
         ->assertDontSee('Ajeno Camarero');
+});
+
+it('paginates staff at 15 per page', function () {
+    User::factory()->waiter()->staffOf($this->admin)->count(20)->create();
+
+    $response = $this->actingAs($this->admin)
+        ->get(route('staff.index'));
+
+    $response->assertOk();
+    expect($response->viewData('staff')->count())->toBe(15);
 });
 
 // ─── CREACIÓN ─────────────────────────────────────────────────────────────────
@@ -107,6 +121,32 @@ it('new staff has the admins id as admin_id', function () {
         'email'    => 'staff@test.com',
         'admin_id' => $this->admin->id,
     ]);
+});
+
+it('new staff has the correct role', function () {
+    $this->actingAs($this->admin)
+        ->post(route('staff.store'), [
+            'name'                  => 'Cocinero Correcto',
+            'email'                 => 'cocinero2@test.com',
+            'password'              => 'secret123',
+            'password_confirmation' => 'secret123',
+            'role'                  => 'kitchen',
+        ]);
+
+    $created = User::where('email', 'cocinero2@test.com')->first();
+    expect($created->role)->toBe('kitchen');
+});
+
+it('shows success flash after creating staff', function () {
+    $this->actingAs($this->admin)
+        ->post(route('staff.store'), [
+            'name'                  => 'Flash Test',
+            'email'                 => 'flash@test.com',
+            'password'              => 'secret123',
+            'password_confirmation' => 'secret123',
+            'role'                  => 'waiter',
+        ])
+        ->assertSessionHas('success');
 });
 
 // ─── VALIDACIÓN ───────────────────────────────────────────────────────────────
@@ -171,9 +211,33 @@ it('fails to create staff with role admin', function () {
         ->assertSessionHasErrors('role');
 });
 
+it('fails to create staff without password', function () {
+    $this->actingAs($this->admin)
+        ->post(route('staff.store'), [
+            'name'                  => 'Sin Password',
+            'email'                 => 'sinpass@test.com',
+            'password'              => '',
+            'password_confirmation' => '',
+            'role'                  => 'waiter',
+        ])
+        ->assertSessionHasErrors('password');
+});
+
+it('fails to create staff when passwords do not match', function () {
+    $this->actingAs($this->admin)
+        ->post(route('staff.store'), [
+            'name'                  => 'Mismatch',
+            'email'                 => 'mismatch@test.com',
+            'password'              => 'secret123',
+            'password_confirmation' => 'diferente456',
+            'role'                  => 'waiter',
+        ])
+        ->assertSessionHasErrors('password');
+});
+
 // ─── ELIMINACIÓN ──────────────────────────────────────────────────────────────
 
-it('admin can delete their own staff', function () {
+it('admin can delete their own staff member', function () {
     $this->actingAs($this->admin)
         ->delete(route('staff.destroy', $this->waiterUser))
         ->assertRedirect(route('staff.index'))
@@ -192,14 +256,18 @@ it('returns 403 when admin tries to delete staff from another admin', function (
     $this->assertDatabaseHas('users', ['id' => $foreignStaff->id]);
 });
 
-it('deleted staff cannot login after deletion', function () {
+it('staff member cannot access the system after deletion', function () {
     $email = $this->waiterUser->email;
 
     $this->actingAs($this->admin)
         ->delete(route('staff.destroy', $this->waiterUser));
 
     $this->assertDatabaseMissing('users', ['email' => $email]);
-
-    // El usuario no existe en BD, por lo que cualquier intento de login falla
     $this->assertNull(User::where('email', $email)->first());
+});
+
+it('shows success flash after deleting staff', function () {
+    $this->actingAs($this->admin)
+        ->delete(route('staff.destroy', $this->waiterUser))
+        ->assertSessionHas('success');
 });

--- a/tests/Unit/OwnerUserIdTest.php
+++ b/tests/Unit/OwnerUserIdTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @author AyrtonAlania
+ */
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+// ─── ownerUserId() ────────────────────────────────────────────────────────────
+
+it('returns own id when user is admin (admin_id is null)', function () {
+    $admin = User::factory()->create(['role' => 'admin', 'admin_id' => null]);
+
+    expect($admin->ownerUserId())->toBe($admin->id);
+});
+
+it('returns admin_id when user is staff (admin_id is set)', function () {
+    $admin  = User::factory()->create(['role' => 'admin']);
+    $waiter = User::factory()->waiter()->staffOf($admin)->create();
+
+    expect($waiter->ownerUserId())->toBe($admin->id);
+});
+
+// ─── isAdmin() ────────────────────────────────────────────────────────────────
+
+it('isAdmin returns true for admin role', function () {
+    $admin = User::factory()->create(['role' => 'admin']);
+
+    expect($admin->isAdmin())->toBeTrue();
+});
+
+it('isAdmin returns false for waiter role', function () {
+    $waiter = User::factory()->waiter()->create();
+
+    expect($waiter->isAdmin())->toBeFalse();
+});
+
+it('isAdmin returns false for kitchen role', function () {
+    $kitchen = User::factory()->kitchen()->create();
+
+    expect($kitchen->isAdmin())->toBeFalse();
+});
+
+// ─── isStaff() ────────────────────────────────────────────────────────────────
+
+it('isStaff returns true for waiter role', function () {
+    $waiter = User::factory()->waiter()->create();
+
+    expect($waiter->isStaff())->toBeTrue();
+});
+
+it('isStaff returns true for kitchen role', function () {
+    $kitchen = User::factory()->kitchen()->create();
+
+    expect($kitchen->isStaff())->toBeTrue();
+});
+
+it('isStaff returns false for admin role', function () {
+    $admin = User::factory()->create(['role' => 'admin']);
+
+    expect($admin->isStaff())->toBeFalse();
+});


### PR DESCRIPTION
## Qué se implementa

- **12.1**: Migración `admin_id` nullable FK en `users` (self-referential, `nullOnDelete`)
- **12.2**: Helper `ownerUserId()` en User model + actualización de multitenancy en todos los controladores (Category, Ingredient, Product, Kitchen, BarPanel, Notification, Payment)
- **12.3**: `StaffController` (index, create, store, destroy) + rutas bajo middleware `role:admin` + estados `waiter()`, `kitchen()`, `staffOf()` en UserFactory
- **12.4**: Vistas del panel de staff (tabla responsive + formulario de alta) con accesibilidad WCAG 2.1 AA + enlace "Mi equipo" en navegación solo para admin
- **12.5**: Tests completos — `StaffControllerTest` (23 tests), `MultitenancyStaffTest` (9 tests), `OwnerUserIdTest` (8 tests) — 272 passed, 0 failed

## Test plan

- [x] `php artisan test` — 272 passed, 0 failed
- [x] Happy path: admin crea y elimina staff
- [x] 403: staff no puede acceder a panel, admin no puede eliminar staff ajeno
- [x] Validación: nombre, email, password, rol inválido, duplicado
- [x] Multitenancy: staff ve recursos de su admin, no los de otro admin
- [x] Unit: `ownerUserId()`, `isAdmin()`, `isStaff()` para los tres roles
- [x] Paginación a 15 por página
- [x] Flash messages de éxito en create y destroy