### PR TITLE
feat(bloque13.2): middleware superadmin, rutas /superadmin/ y layout propio

### DIFF
--- a/app/Http/Controllers/SuperAdmin/SuperAdminBusinessController.php
+++ b/app/Http/Controllers/SuperAdmin/SuperAdminBusinessController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers\SuperAdmin;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Response;
+
+/**
+ * Gestión de negocios registrados en la plataforma (stub — implementado en Bloque 13.4).
+ *
+ * @author BenjaminDTS
+ */
+class SuperAdminBusinessController extends Controller
+{
+    /**
+     * @return Response
+     */
+    public function index(): Response
+    {
+        abort(501, 'Bloque 13.4 pendiente de implementación.');
+    }
+
+    /**
+     * @return Response
+     */
+    public function create(): Response
+    {
+        abort(501, 'Bloque 13.4 pendiente de implementación.');
+    }
+
+    /**
+     * @return Response
+     */
+    public function store(): Response
+    {
+        abort(501, 'Bloque 13.4 pendiente de implementación.');
+    }
+
+    /**
+     * @param  User  $business
+     * @return Response
+     */
+    public function destroy(User $business): Response
+    {
+        abort(501, 'Bloque 13.4 pendiente de implementación.');
+    }
+
+    /**
+     * @param  User  $business
+     * @return Response
+     */
+    public function toggle(User $business): Response
+    {
+        abort(501, 'Bloque 13.4 pendiente de implementación.');
+    }
+}

--- a/app/Http/Controllers/SuperAdmin/SuperAdminDashboardController.php
+++ b/app/Http/Controllers/SuperAdmin/SuperAdminDashboardController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\SuperAdmin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\View\View;
+
+/**
+ * Dashboard principal del panel de superadministración.
+ *
+ * @author BenjaminDTS
+ */
+class SuperAdminDashboardController extends Controller
+{
+    /**
+     * @return View
+     */
+    public function index(): View
+    {
+        return view('superadmin.dashboard');
+    }
+}

--- a/app/Http/Controllers/SuperAdmin/SuperAdminMapController.php
+++ b/app/Http/Controllers/SuperAdmin/SuperAdminMapController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\SuperAdmin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Response;
+
+/**
+ * Mapa de negocios con Leaflet.js (stub — implementado en Bloque 13.5).
+ *
+ * @author BenjaminDTS
+ */
+class SuperAdminMapController extends Controller
+{
+    /**
+     * @return Response
+     */
+    public function index(): Response
+    {
+        abort(501, 'Bloque 13.5 pendiente de implementación.');
+    }
+}

--- a/app/Http/Controllers/SuperAdmin/SuperAdminPlanController.php
+++ b/app/Http/Controllers/SuperAdmin/SuperAdminPlanController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\SuperAdmin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Response;
+
+/**
+ * Gestión de planes SaaS (stub — implementado en Bloque 13.3).
+ *
+ * @author BenjaminDTS
+ */
+class SuperAdminPlanController extends Controller
+{
+    /**
+     * @return Response
+     */
+    public function index(): Response
+    {
+        abort(501, 'Bloque 13.3 pendiente de implementación.');
+    }
+}

--- a/app/Http/Middleware/EnsureSuperAdmin.php
+++ b/app/Http/Middleware/EnsureSuperAdmin.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Restringe acceso exclusivamente a usuarios con rol superadmin.
+ *
+ * @author BenjaminDTS
+ */
+class EnsureSuperAdmin
+{
+    /**
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @return Response
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!Auth::check() || !Auth::user()->isSuperAdmin()) {
+            abort(403, 'Acceso restringido al superadmin.');
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,7 +13,10 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->trustProxies(at: '*');
-        $middleware->alias(['role' => \App\Http\Middleware\EnsureRole::class]);
+        $middleware->alias([
+            'role'           => \App\Http\Middleware\EnsureRole::class,
+            'role.superadmin' => \App\Http\Middleware\EnsureSuperAdmin::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/resources/views/layouts/superadmin.blade.php
+++ b/resources/views/layouts/superadmin.blade.php
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="es" class="h-full bg-slate-950">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>{{ config('app.name', 'Zampa') }} — Superadmin</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="h-full font-sans antialiased">
+
+    {{-- Skip to content --}}
+    <a href="#main-content"
+       class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4
+              bg-amber-400 text-slate-900 px-4 py-2 rounded font-semibold z-50">
+        Saltar al contenido principal
+    </a>
+
+    <div class="flex h-full min-h-screen">
+
+        {{-- Sidebar --}}
+        <aside class="w-64 flex-shrink-0 bg-slate-900 border-r border-slate-800 flex flex-col">
+
+            {{-- Logo / Branding --}}
+            <div class="flex items-center gap-3 px-6 py-5 border-b border-slate-800">
+                <span class="inline-flex items-center justify-center w-9 h-9 rounded-lg bg-amber-400 text-slate-900 font-black text-sm select-none">
+                    SA
+                </span>
+                <div class="leading-tight">
+                    <p class="text-white font-bold text-sm">Zampa</p>
+                    <p class="text-amber-400 text-xs font-medium uppercase tracking-widest">Superadmin</p>
+                </div>
+            </div>
+
+            {{-- Navigation --}}
+            <nav aria-label="Navegación superadmin" class="flex-1 px-4 py-6 space-y-1">
+
+                <a href="{{ route('superadmin.dashboard') }}"
+                   class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors
+                          {{ request()->routeIs('superadmin.dashboard')
+                              ? 'bg-amber-400 text-slate-900'
+                              : 'text-slate-300 hover:bg-slate-800 hover:text-white' }}">
+                    <svg class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>
+                    </svg>
+                    Panel principal
+                </a>
+
+                <a href="{{ route('superadmin.plans.index') }}"
+                   class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors
+                          {{ request()->routeIs('superadmin.plans.*')
+                              ? 'bg-amber-400 text-slate-900'
+                              : 'text-slate-300 hover:bg-slate-800 hover:text-white' }}">
+                    <svg class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+                    </svg>
+                    Planes
+                </a>
+
+                <a href="{{ route('superadmin.businesses.index') }}"
+                   class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors
+                          {{ request()->routeIs('superadmin.businesses.*')
+                              ? 'bg-amber-400 text-slate-900'
+                              : 'text-slate-300 hover:bg-slate-800 hover:text-white' }}">
+                    <svg class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
+                    </svg>
+                    Negocios
+                </a>
+
+                <a href="{{ route('superadmin.map') }}"
+                   class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors
+                          {{ request()->routeIs('superadmin.map')
+                              ? 'bg-amber-400 text-slate-900'
+                              : 'text-slate-300 hover:bg-slate-800 hover:text-white' }}">
+                    <svg class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"/>
+                    </svg>
+                    Mapa
+                </a>
+
+            </nav>
+
+            {{-- User info + logout --}}
+            <div class="px-4 py-4 border-t border-slate-800">
+                <div class="flex items-center gap-3 px-3 py-2 mb-2">
+                    <div class="w-8 h-8 rounded-full bg-amber-400 flex items-center justify-center flex-shrink-0">
+                        <span class="text-slate-900 font-bold text-xs">
+                            {{ strtoupper(substr(Auth::user()->name, 0, 2)) }}
+                        </span>
+                    </div>
+                    <div class="min-w-0">
+                        <p class="text-white text-sm font-medium truncate">{{ Auth::user()->name }}</p>
+                        <p class="text-amber-400 text-xs font-medium">Superadmin</p>
+                    </div>
+                </div>
+                <form method="POST" action="{{ route('logout') }}">
+                    @csrf
+                    <button type="submit"
+                            class="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-slate-400
+                                   hover:bg-slate-800 hover:text-white transition-colors">
+                        <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                  d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
+                        </svg>
+                        Cerrar sesión
+                    </button>
+                </form>
+            </div>
+
+        </aside>
+
+        {{-- Main content --}}
+        <div class="flex-1 flex flex-col min-w-0 bg-slate-950">
+
+            {{-- Top bar --}}
+            <header class="bg-slate-900 border-b border-slate-800 px-6 py-4 flex items-center justify-between flex-shrink-0">
+                <div>
+                    @isset($header)
+                        <div class="text-white font-semibold text-lg">{{ $header }}</div>
+                    @endisset
+                </div>
+                <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold
+                             bg-amber-400/10 text-amber-400 ring-1 ring-amber-400/30">
+                    SUPERADMIN
+                </span>
+            </header>
+
+            <main id="main-content" class="flex-1 overflow-auto p-6 sm:p-8">
+                {{ $slot }}
+            </main>
+
+        </div>
+
+    </div>
+
+</body>
+</html>

--- a/resources/views/layouts/superadmin.blade.php
+++ b/resources/views/layouts/superadmin.blade.php
@@ -119,10 +119,8 @@
 
             {{-- Top bar --}}
             <header class="bg-slate-900 border-b border-slate-800 px-6 py-4 flex items-center justify-between flex-shrink-0">
-                <div>
-                    @isset($header)
-                        <div class="text-white font-semibold text-lg">{{ $header }}</div>
-                    @endisset
+                <div class="text-white font-semibold text-lg">
+                    @yield('header')
                 </div>
                 <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold
                              bg-amber-400/10 text-amber-400 ring-1 ring-amber-400/30">
@@ -131,7 +129,7 @@
             </header>
 
             <main id="main-content" class="flex-1 overflow-auto p-6 sm:p-8">
-                {{ $slot }}
+                @yield('content')
             </main>
 
         </div>

--- a/resources/views/superadmin/dashboard.blade.php
+++ b/resources/views/superadmin/dashboard.blade.php
@@ -1,0 +1,103 @@
+@extends('layouts.superadmin')
+
+@section('header', 'Panel principal')
+
+@section('content')
+<div class="max-w-7xl mx-auto space-y-8">
+
+    {{-- Bienvenida --}}
+    <section aria-labelledby="bienvenida-title">
+        <h1 id="bienvenida-title" class="text-2xl font-bold text-white mb-1">
+            Bienvenido, {{ Auth::user()->name }}
+        </h1>
+        <p class="text-slate-400 text-sm">Panel de superadministración de Zampa</p>
+    </section>
+
+    {{-- Cards de acceso rápido --}}
+    <section aria-labelledby="accesos-title">
+        <h2 id="accesos-title" class="text-sm font-semibold text-slate-400 uppercase tracking-widest mb-4">
+            Accesos rápidos
+        </h2>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+
+            {{-- Planes --}}
+            <a href="{{ route('superadmin.plans.index') }}"
+               class="group flex items-center gap-4 p-5 rounded-xl bg-slate-900 border border-slate-800
+                      hover:border-amber-400/50 hover:bg-slate-800 transition-all">
+                <span class="w-12 h-12 rounded-lg bg-amber-400/10 flex items-center justify-center flex-shrink-0
+                             group-hover:bg-amber-400/20 transition-colors">
+                    <svg class="w-6 h-6 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+                    </svg>
+                </span>
+                <div>
+                    <p class="text-white font-semibold">Planes</p>
+                    <p class="text-slate-400 text-sm">Gestión de planes SaaS</p>
+                </div>
+            </a>
+
+            {{-- Negocios --}}
+            <a href="{{ route('superadmin.businesses.index') }}"
+               class="group flex items-center gap-4 p-5 rounded-xl bg-slate-900 border border-slate-800
+                      hover:border-amber-400/50 hover:bg-slate-800 transition-all">
+                <span class="w-12 h-12 rounded-lg bg-amber-400/10 flex items-center justify-center flex-shrink-0
+                             group-hover:bg-amber-400/20 transition-colors">
+                    <svg class="w-6 h-6 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
+                    </svg>
+                </span>
+                <div>
+                    <p class="text-white font-semibold">Negocios</p>
+                    <p class="text-slate-400 text-sm">Administrar restaurantes</p>
+                </div>
+            </a>
+
+            {{-- Mapa --}}
+            <a href="{{ route('superadmin.map') }}"
+               class="group flex items-center gap-4 p-5 rounded-xl bg-slate-900 border border-slate-800
+                      hover:border-amber-400/50 hover:bg-slate-800 transition-all">
+                <span class="w-12 h-12 rounded-lg bg-amber-400/10 flex items-center justify-center flex-shrink-0
+                             group-hover:bg-amber-400/20 transition-colors">
+                    <svg class="w-6 h-6 text-amber-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"/>
+                    </svg>
+                </span>
+                <div>
+                    <p class="text-white font-semibold">Mapa</p>
+                    <p class="text-slate-400 text-sm">Distribución geográfica</p>
+                </div>
+            </a>
+
+        </div>
+    </section>
+
+    {{-- Placeholder estadísticas (B13.3 y B13.4 las poblan con datos reales) --}}
+    <section aria-labelledby="stats-title">
+        <h2 id="stats-title" class="text-sm font-semibold text-slate-400 uppercase tracking-widest mb-4">
+            Estadísticas globales
+        </h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            <div class="p-5 rounded-xl bg-slate-900 border border-slate-800">
+                <p class="text-slate-400 text-xs uppercase tracking-widest mb-1">Negocios registrados</p>
+                <p class="text-3xl font-bold text-white">—</p>
+                <p class="text-slate-500 text-sm mt-1">Disponible en B13.4</p>
+            </div>
+            <div class="p-5 rounded-xl bg-slate-900 border border-slate-800">
+                <p class="text-slate-400 text-xs uppercase tracking-widest mb-1">Planes activos</p>
+                <p class="text-3xl font-bold text-white">—</p>
+                <p class="text-slate-500 text-sm mt-1">Disponible en B13.3</p>
+            </div>
+            <div class="p-5 rounded-xl bg-slate-900 border border-slate-800">
+                <p class="text-slate-400 text-xs uppercase tracking-widest mb-1">Negocios activos</p>
+                <p class="text-3xl font-bold text-white">—</p>
+                <p class="text-slate-500 text-sm mt-1">Disponible en B13.4</p>
+            </div>
+        </div>
+    </section>
+
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,10 @@ use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\ProductController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\TableController;
+use App\Http\Controllers\SuperAdmin\SuperAdminDashboardController;
+use App\Http\Controllers\SuperAdmin\SuperAdminPlanController;
+use App\Http\Controllers\SuperAdmin\SuperAdminBusinessController;
+use App\Http\Controllers\SuperAdmin\SuperAdminMapController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -88,6 +92,31 @@ Route::middleware('auth')->group(function () {
         Route::post('/payments/{order}/cash', [PaymentController::class, 'cashPayment'])
              ->name('payments.cash');
     });
+});
+
+// Panel de superadministración — acceso exclusivo a rol superadmin
+Route::middleware(['auth', 'role.superadmin'])
+     ->prefix('superadmin')
+     ->name('superadmin.')
+     ->group(function () {
+
+    Route::get('/', fn () => redirect()->route('superadmin.dashboard'));
+
+    Route::get('/dashboard', [SuperAdminDashboardController::class, 'index'])
+         ->name('dashboard');
+
+    // Gestión de planes (Bloque 13.3)
+    Route::resource('plans', SuperAdminPlanController::class);
+
+    // Gestión de negocios (Bloque 13.4)
+    Route::resource('businesses', SuperAdminBusinessController::class)
+         ->only(['index', 'create', 'store', 'destroy']);
+    Route::patch('businesses/{business}/toggle', [SuperAdminBusinessController::class, 'toggle'])
+         ->name('businesses.toggle');
+
+    // Mapa de negocios (Bloque 13.5)
+    Route::get('map', [SuperAdminMapController::class, 'index'])
+         ->name('map');
 });
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/Bloque13/SuperAdminAccessTest.php
+++ b/tests/Feature/Bloque13/SuperAdminAccessTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->superadmin = User::factory()->create(['role' => 'superadmin']);
+    $this->admin      = User::factory()->create(['role' => 'admin']);
+    $this->waiter     = User::factory()->create(['role' => 'waiter']);
+    $this->kitchen    = User::factory()->create(['role' => 'kitchen']);
+});
+
+it('redirects unauthenticated user from superadmin panel', function () {
+    $this->get(route('superadmin.dashboard'))
+         ->assertRedirect(route('login'));
+});
+
+it('returns 403 for admin role trying to access superadmin', function () {
+    $this->actingAs($this->admin)
+         ->get(route('superadmin.dashboard'))
+         ->assertForbidden();
+});
+
+it('returns 403 for waiter role trying to access superadmin', function () {
+    $this->actingAs($this->waiter)
+         ->get(route('superadmin.dashboard'))
+         ->assertForbidden();
+});
+
+it('returns 403 for kitchen role trying to access superadmin', function () {
+    $this->actingAs($this->kitchen)
+         ->get(route('superadmin.dashboard'))
+         ->assertForbidden();
+});
+
+it('shows superadmin dashboard to superadmin role', function () {
+    $this->actingAs($this->superadmin)
+         ->get(route('superadmin.dashboard'))
+         ->assertOk()
+         ->assertViewIs('superadmin.dashboard');
+});
+
+it('superadmin cannot access routes protected by role:admin middleware', function () {
+    $this->actingAs($this->superadmin)
+         ->get(route('tapas.edit'))
+         ->assertForbidden();
+});


### PR DESCRIPTION
## Summary

- Middleware `EnsureSuperAdmin` que aborta 403 si el usuario no tiene rol `superadmin`
- Alias `role.superadmin` registrado en `bootstrap/app.php`
- Grupo de rutas `/superadmin/` con doble middleware `auth` + `role.superadmin` (dashboard, planes, negocios, mapa)
- Controladores stub para B13.3–B13.5 (`SuperAdminPlanController`, `SuperAdminBusinessController`, `SuperAdminMapController`)
- Layout `layouts/superadmin.blade.php` visualmente distinto del panel admin (sidebar slate-900, badge SA, acento amber-400)
- Vista `superadmin/dashboard.blade.php` con accesos rápidos y placeholders de estadísticas

## Test plan

- [x] `php artisan test tests/Feature/Bloque13/SuperAdminAccessTest.php` → 6/6 pasando
- [x] Suite completa `php artisan test` → 278/278 pasando, sin regresiones
- [x] Unauthenticated → redirect a login
- [x] Roles admin, waiter, kitchen → 403
- [x] Rol superadmin → 200 en dashboard
- [x] Superadmin bloqueado por `role:admin` en rutas del panel gerente