### PR TITLE
feat(bloque13.3): CRUD de planes SaaS en panel superadmin

### DIFF
--- a/app/Http/Controllers/SuperAdmin/SuperAdminPlanController.php
+++ b/app/Http/Controllers/SuperAdmin/SuperAdminPlanController.php
@@ -3,20 +3,109 @@
 namespace App\Http\Controllers\SuperAdmin;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Http\Response;
+use App\Models\Plan;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
 
 /**
- * Gestión de planes SaaS (stub — implementado en Bloque 13.3).
+ * Gestión de planes SaaS desde el panel del superadmin.
  *
  * @author BenjaminDTS
  */
 class SuperAdminPlanController extends Controller
 {
     /**
-     * @return Response
+     * @return View
      */
-    public function index(): Response
+    public function index(): View
     {
-        abort(501, 'Bloque 13.3 pendiente de implementación.');
+        abort_if(!Auth::user()->isSuperAdmin(), 403);
+
+        $plans = Plan::withCount('users')->paginate(15);
+
+        return view('superadmin.plans.index', compact('plans'));
+    }
+
+    /**
+     * @return View
+     */
+    public function create(): View
+    {
+        abort_if(!Auth::user()->isSuperAdmin(), 403);
+
+        return view('superadmin.plans.create');
+    }
+
+    /**
+     * @param Request $request
+     * @return RedirectResponse
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        abort_if(!Auth::user()->isSuperAdmin(), 403);
+
+        $request->validate([
+            'name'       => 'required|string|max:255|unique:plans,name',
+            'price'      => 'required|numeric|min:0',
+            'max_tables' => 'required|integer|min:1|max:500',
+        ]);
+
+        Plan::create($request->only('name', 'price', 'max_tables'));
+
+        return redirect()->route('superadmin.plans.index')
+                         ->with('success', 'Plan creado correctamente.');
+    }
+
+    /**
+     * @param Plan $plan
+     * @return View
+     */
+    public function edit(Plan $plan): View
+    {
+        abort_if(!Auth::user()->isSuperAdmin(), 403);
+
+        return view('superadmin.plans.edit', compact('plan'));
+    }
+
+    /**
+     * @param Request $request
+     * @param Plan $plan
+     * @return RedirectResponse
+     */
+    public function update(Request $request, Plan $plan): RedirectResponse
+    {
+        abort_if(!Auth::user()->isSuperAdmin(), 403);
+
+        $request->validate([
+            'name'       => 'required|string|max:255|unique:plans,name,' . $plan->id,
+            'price'      => 'required|numeric|min:0',
+            'max_tables' => 'required|integer|min:1|max:500',
+        ]);
+
+        $plan->update($request->only('name', 'price', 'max_tables'));
+
+        return redirect()->route('superadmin.plans.index')
+                         ->with('success', 'Plan actualizado correctamente.');
+    }
+
+    /**
+     * @param Plan $plan
+     * @return RedirectResponse
+     */
+    public function destroy(Plan $plan): RedirectResponse
+    {
+        abort_if(!Auth::user()->isSuperAdmin(), 403);
+
+        if ($plan->hasActiveBusinesses()) {
+            return redirect()->route('superadmin.plans.index')
+                             ->with('error', 'No se puede eliminar un plan con negocios asignados.');
+        }
+
+        $plan->delete();
+
+        return redirect()->route('superadmin.plans.index')
+                         ->with('success', 'Plan eliminado correctamente.');
     }
 }

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -15,6 +15,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string $name       Nombre del plan
  * @property float $price     Coste mensual
  * @property int $max_tables    Límite de mesas permitidas
+ *
+ * @author BenjaminDTS
  */
 class Plan extends Model
 {
@@ -22,11 +24,28 @@ class Plan extends Model
 
     protected $fillable = ['name', 'price', 'max_tables'];
 
+    protected $casts = [
+        'price'      => 'decimal:2',
+        'max_tables' => 'integer',
+    ];
+
     /**
      * Usuarios (Restaurantes) que tienen contratado este plan.
+     *
+     * @return HasMany
      */
     public function users(): HasMany
     {
         return $this->hasMany(User::class);
+    }
+
+    /**
+     * Indica si hay negocios asignados a este plan.
+     *
+     * @return bool
+     */
+    public function hasActiveBusinesses(): bool
+    {
+        return $this->users()->exists();
     }
 }

--- a/resources/views/superadmin/plans/create.blade.php
+++ b/resources/views/superadmin/plans/create.blade.php
@@ -1,0 +1,110 @@
+@extends('layouts.superadmin')
+
+@section('header', 'Nuevo plan')
+
+@section('content')
+
+<div class="max-w-xl mx-auto">
+
+    <div class="mb-6">
+        <a href="{{ route('superadmin.plans.index') }}"
+           class="inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
+            </svg>
+            Volver a planes
+        </a>
+        <h1 class="text-xl sm:text-2xl font-bold text-white mt-2">Nuevo plan SaaS</h1>
+    </div>
+
+    <section class="bg-slate-900 rounded-xl ring-1 ring-slate-800 p-6">
+
+        <form method="POST" action="{{ route('superadmin.plans.store') }}" novalidate>
+            @csrf
+
+            <div class="space-y-5">
+
+                {{-- Nombre --}}
+                <div>
+                    <label for="name" class="block text-sm font-medium text-slate-300 mb-1.5">
+                        Nombre del plan <span class="text-red-400" aria-hidden="true">*</span>
+                    </label>
+                    <input id="name"
+                           name="name"
+                           type="text"
+                           value="{{ old('name') }}"
+                           aria-required="true"
+                           aria-describedby="{{ $errors->has('name') ? 'error-name' : '' }}"
+                           class="w-full rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500
+                                  px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400
+                                  {{ $errors->has('name') ? 'border-red-500 focus:ring-red-500' : '' }}"
+                           placeholder="Ej: Plan Básico">
+                    @error('name')
+                        <p id="error-name" role="alert" class="mt-1.5 text-xs text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                {{-- Precio --}}
+                <div>
+                    <label for="price" class="block text-sm font-medium text-slate-300 mb-1.5">
+                        Precio mensual (€) <span class="text-red-400" aria-hidden="true">*</span>
+                    </label>
+                    <input id="price"
+                           name="price"
+                           type="number"
+                           min="0"
+                           step="0.01"
+                           value="{{ old('price') }}"
+                           aria-required="true"
+                           aria-describedby="{{ $errors->has('price') ? 'error-price' : '' }}"
+                           class="w-full rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500
+                                  px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400
+                                  {{ $errors->has('price') ? 'border-red-500 focus:ring-red-500' : '' }}"
+                           placeholder="0.00">
+                    @error('price')
+                        <p id="error-price" role="alert" class="mt-1.5 text-xs text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                {{-- Límite de mesas --}}
+                <div>
+                    <label for="max_tables" class="block text-sm font-medium text-slate-300 mb-1.5">
+                        Límite de mesas <span class="text-red-400" aria-hidden="true">*</span>
+                    </label>
+                    <input id="max_tables"
+                           name="max_tables"
+                           type="number"
+                           min="1"
+                           max="500"
+                           value="{{ old('max_tables') }}"
+                           aria-required="true"
+                           aria-describedby="{{ $errors->has('max_tables') ? 'error-max_tables' : '' }}"
+                           class="w-full rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500
+                                  px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400
+                                  {{ $errors->has('max_tables') ? 'border-red-500 focus:ring-red-500' : '' }}"
+                           placeholder="Ej: 10">
+                    @error('max_tables')
+                        <p id="error-max_tables" role="alert" class="mt-1.5 text-xs text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+            </div>
+
+            <div class="flex items-center justify-end gap-3 mt-8 pt-5 border-t border-slate-800">
+                <a href="{{ route('superadmin.plans.index') }}"
+                   class="px-4 py-2 rounded-lg text-sm font-medium text-slate-400 hover:text-white hover:bg-slate-800 transition-colors focus:outline-none focus:ring-2 focus:ring-slate-600">
+                    Cancelar
+                </a>
+                <button type="submit"
+                        class="px-5 py-2 rounded-lg bg-amber-400 text-slate-900 text-sm font-semibold hover:bg-amber-300 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 focus:ring-offset-slate-900">
+                    Crear plan
+                </button>
+            </div>
+
+        </form>
+
+    </section>
+
+</div>
+
+@endsection

--- a/resources/views/superadmin/plans/edit.blade.php
+++ b/resources/views/superadmin/plans/edit.blade.php
@@ -1,0 +1,111 @@
+@extends('layouts.superadmin')
+
+@section('header', 'Editar plan')
+
+@section('content')
+
+<div class="max-w-xl mx-auto">
+
+    <div class="mb-6">
+        <a href="{{ route('superadmin.plans.index') }}"
+           class="inline-flex items-center gap-1.5 text-sm text-slate-400 hover:text-white transition-colors">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
+            </svg>
+            Volver a planes
+        </a>
+        <h1 class="text-xl sm:text-2xl font-bold text-white mt-2">Editar plan: {{ $plan->name }}</h1>
+    </div>
+
+    <section class="bg-slate-900 rounded-xl ring-1 ring-slate-800 p-6">
+
+        <form method="POST" action="{{ route('superadmin.plans.update', $plan) }}" novalidate>
+            @csrf
+            @method('PUT')
+
+            <div class="space-y-5">
+
+                {{-- Nombre --}}
+                <div>
+                    <label for="name" class="block text-sm font-medium text-slate-300 mb-1.5">
+                        Nombre del plan <span class="text-red-400" aria-hidden="true">*</span>
+                    </label>
+                    <input id="name"
+                           name="name"
+                           type="text"
+                           value="{{ old('name', $plan->name) }}"
+                           aria-required="true"
+                           aria-describedby="{{ $errors->has('name') ? 'error-name' : '' }}"
+                           class="w-full rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500
+                                  px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400
+                                  {{ $errors->has('name') ? 'border-red-500 focus:ring-red-500' : '' }}"
+                           placeholder="Ej: Plan Básico">
+                    @error('name')
+                        <p id="error-name" role="alert" class="mt-1.5 text-xs text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                {{-- Precio --}}
+                <div>
+                    <label for="price" class="block text-sm font-medium text-slate-300 mb-1.5">
+                        Precio mensual (€) <span class="text-red-400" aria-hidden="true">*</span>
+                    </label>
+                    <input id="price"
+                           name="price"
+                           type="number"
+                           min="0"
+                           step="0.01"
+                           value="{{ old('price', $plan->price) }}"
+                           aria-required="true"
+                           aria-describedby="{{ $errors->has('price') ? 'error-price' : '' }}"
+                           class="w-full rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500
+                                  px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400
+                                  {{ $errors->has('price') ? 'border-red-500 focus:ring-red-500' : '' }}"
+                           placeholder="0.00">
+                    @error('price')
+                        <p id="error-price" role="alert" class="mt-1.5 text-xs text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                {{-- Límite de mesas --}}
+                <div>
+                    <label for="max_tables" class="block text-sm font-medium text-slate-300 mb-1.5">
+                        Límite de mesas <span class="text-red-400" aria-hidden="true">*</span>
+                    </label>
+                    <input id="max_tables"
+                           name="max_tables"
+                           type="number"
+                           min="1"
+                           max="500"
+                           value="{{ old('max_tables', $plan->max_tables) }}"
+                           aria-required="true"
+                           aria-describedby="{{ $errors->has('max_tables') ? 'error-max_tables' : '' }}"
+                           class="w-full rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500
+                                  px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400
+                                  {{ $errors->has('max_tables') ? 'border-red-500 focus:ring-red-500' : '' }}"
+                           placeholder="Ej: 10">
+                    @error('max_tables')
+                        <p id="error-max_tables" role="alert" class="mt-1.5 text-xs text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+
+            </div>
+
+            <div class="flex items-center justify-end gap-3 mt-8 pt-5 border-t border-slate-800">
+                <a href="{{ route('superadmin.plans.index') }}"
+                   class="px-4 py-2 rounded-lg text-sm font-medium text-slate-400 hover:text-white hover:bg-slate-800 transition-colors focus:outline-none focus:ring-2 focus:ring-slate-600">
+                    Cancelar
+                </a>
+                <button type="submit"
+                        class="px-5 py-2 rounded-lg bg-amber-400 text-slate-900 text-sm font-semibold hover:bg-amber-300 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 focus:ring-offset-slate-900">
+                    Guardar cambios
+                </button>
+            </div>
+
+        </form>
+
+    </section>
+
+</div>
+
+@endsection

--- a/resources/views/superadmin/plans/index.blade.php
+++ b/resources/views/superadmin/plans/index.blade.php
@@ -1,0 +1,132 @@
+@extends('layouts.superadmin')
+
+@section('header', 'Planes SaaS')
+
+@section('content')
+
+<div class="max-w-5xl mx-auto space-y-6">
+
+    {{-- Flash messages --}}
+    @if(session('success'))
+        <div role="alert" class="flex items-center gap-3 px-4 py-3 rounded-lg bg-emerald-500/10 text-emerald-400 ring-1 ring-emerald-500/30 text-sm">
+            <svg class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+            </svg>
+            {{ session('success') }}
+        </div>
+    @endif
+
+    @if(session('error'))
+        <div role="alert" class="flex items-center gap-3 px-4 py-3 rounded-lg bg-red-500/10 text-red-400 ring-1 ring-red-500/30 text-sm">
+            <svg class="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+            </svg>
+            {{ session('error') }}
+        </div>
+    @endif
+
+    {{-- Header row --}}
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+            <h1 class="text-xl sm:text-2xl font-bold text-white">Planes SaaS</h1>
+            <p class="text-slate-400 text-sm mt-1">Gestiona los planes de suscripción disponibles para los negocios.</p>
+        </div>
+        <a href="{{ route('superadmin.plans.create') }}"
+           class="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-amber-400 text-slate-900 text-sm font-semibold hover:bg-amber-300 transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 focus:ring-offset-slate-950">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+            </svg>
+            Nuevo plan
+        </a>
+    </div>
+
+    {{-- Table --}}
+    <section aria-labelledby="planes-heading" class="bg-slate-900 rounded-xl ring-1 ring-slate-800 overflow-hidden">
+        <h2 id="planes-heading" class="sr-only">Listado de planes</h2>
+
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-slate-800" aria-label="Planes SaaS">
+                <thead class="bg-slate-800/50">
+                    <tr>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider">Nombre</th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider">Precio / mes</th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider">Límite mesas</th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider">Negocios</th>
+                        <th scope="col" class="px-6 py-3 text-right text-xs font-semibold text-slate-400 uppercase tracking-wider">Acciones</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-800">
+                    @forelse($plans as $plan)
+                        <tr class="hover:bg-slate-800/30 transition-colors">
+                            <td class="px-6 py-4 text-sm font-medium text-white">{{ $plan->name }}</td>
+                            <td class="px-6 py-4 text-sm text-slate-300">{{ number_format($plan->price, 2, ',', '.') }} €</td>
+                            <td class="px-6 py-4 text-sm text-slate-300">{{ $plan->max_tables }}</td>
+                            <td class="px-6 py-4 text-sm">
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium
+                                             {{ $plan->users_count > 0 ? 'bg-amber-400/10 text-amber-400' : 'bg-slate-700 text-slate-400' }}">
+                                    {{ $plan->users_count }}
+                                </span>
+                            </td>
+                            <td class="px-6 py-4 text-right">
+                                <div class="flex items-center justify-end gap-2">
+                                    <a href="{{ route('superadmin.plans.edit', $plan) }}"
+                                       class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium text-slate-300 bg-slate-800 hover:bg-slate-700 hover:text-white transition-colors focus:outline-none focus:ring-2 focus:ring-amber-400"
+                                       aria-label="Editar plan {{ $plan->name }}">
+                                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+                                        </svg>
+                                        Editar
+                                    </a>
+
+                                    @if($plan->users_count > 0)
+                                        <span class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium
+                                                     text-slate-600 bg-slate-800/50 cursor-not-allowed"
+                                              title="No se puede eliminar: tiene {{ $plan->users_count }} negocio(s) asignado(s)"
+                                              aria-disabled="true">
+                                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                                            </svg>
+                                            Eliminar
+                                        </span>
+                                    @else
+                                        <form method="POST" action="{{ route('superadmin.plans.destroy', $plan) }}"
+                                              onsubmit="return confirm('¿Eliminar el plan «{{ $plan->name }}»? Esta acción no se puede deshacer.')">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit"
+                                                    class="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium text-red-400 bg-red-500/10 hover:bg-red-500/20 transition-colors focus:outline-none focus:ring-2 focus:ring-red-500"
+                                                    aria-label="Eliminar plan {{ $plan->name }}">
+                                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                                                </svg>
+                                                Eliminar
+                                            </button>
+                                        </form>
+                                    @endif
+                                </div>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="5" class="px-6 py-12 text-center text-slate-500 text-sm">
+                                No hay planes creados todavía.
+                                <a href="{{ route('superadmin.plans.create') }}" class="text-amber-400 hover:text-amber-300 ml-1">Crear el primero</a>.
+                            </td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        @if($plans->hasPages())
+            <div class="px-6 py-4 border-t border-slate-800">
+                <nav aria-label="Paginación de planes">
+                    {{ $plans->links() }}
+                </nav>
+            </div>
+        @endif
+    </section>
+
+</div>
+
+@endsection

--- a/tests/Feature/Bloque13/PlanManagementTest.php
+++ b/tests/Feature/Bloque13/PlanManagementTest.php
@@ -1,0 +1,170 @@
+<?php
+
+use App\Models\Plan;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->superadmin = User::factory()->create(['role' => 'superadmin']);
+    $this->admin      = User::factory()->create(['role' => 'admin']);
+});
+
+// ──────────────────────────────────────────────
+// INDEX
+// ──────────────────────────────────────────────
+
+it('shows plans index to superadmin', function () {
+    Plan::factory()->count(3)->create();
+
+    $this->actingAs($this->superadmin)
+         ->get(route('superadmin.plans.index'))
+         ->assertOk()
+         ->assertViewIs('superadmin.plans.index');
+});
+
+it('returns 403 for admin trying to access plans management', function () {
+    $this->actingAs($this->admin)
+         ->get(route('superadmin.plans.index'))
+         ->assertForbidden();
+});
+
+it('plans index shows number of businesses per plan', function () {
+    $plan = Plan::factory()->create();
+    User::factory()->count(2)->create(['role' => 'admin', 'plan_id' => $plan->id]);
+
+    $response = $this->actingAs($this->superadmin)
+                     ->get(route('superadmin.plans.index'))
+                     ->assertOk();
+
+    $plans = $response->viewData('plans');
+    $found = $plans->firstWhere('id', $plan->id);
+
+    expect($found->users_count)->toBe(2);
+});
+
+// ──────────────────────────────────────────────
+// CREATE
+// ──────────────────────────────────────────────
+
+it('superadmin can create a plan with valid data', function () {
+    $this->actingAs($this->superadmin)
+         ->post(route('superadmin.plans.store'), [
+             'name'       => 'Plan Premium',
+             'price'      => 29.99,
+             'max_tables' => 20,
+         ])
+         ->assertRedirect(route('superadmin.plans.index'))
+         ->assertSessionHas('success');
+
+    $this->assertDatabaseHas('plans', [
+        'name'       => 'Plan Premium',
+        'max_tables' => 20,
+    ]);
+});
+
+it('fails to create plan without name', function () {
+    $this->actingAs($this->superadmin)
+         ->post(route('superadmin.plans.store'), [
+             'name'       => '',
+             'price'      => 9.99,
+             'max_tables' => 5,
+         ])
+         ->assertSessionHasErrors('name');
+});
+
+it('fails to create plan with negative price', function () {
+    $this->actingAs($this->superadmin)
+         ->post(route('superadmin.plans.store'), [
+             'name'       => 'Plan X',
+             'price'      => -5,
+             'max_tables' => 5,
+         ])
+         ->assertSessionHasErrors('price');
+});
+
+it('fails to create plan with zero max_tables', function () {
+    $this->actingAs($this->superadmin)
+         ->post(route('superadmin.plans.store'), [
+             'name'       => 'Plan X',
+             'price'      => 9.99,
+             'max_tables' => 0,
+         ])
+         ->assertSessionHasErrors('max_tables');
+});
+
+it('fails to create plan with duplicate name', function () {
+    Plan::factory()->create(['name' => 'Plan Básico']);
+
+    $this->actingAs($this->superadmin)
+         ->post(route('superadmin.plans.store'), [
+             'name'       => 'Plan Básico',
+             'price'      => 19.99,
+             'max_tables' => 10,
+         ])
+         ->assertSessionHasErrors('name');
+});
+
+// ──────────────────────────────────────────────
+// UPDATE
+// ──────────────────────────────────────────────
+
+it('superadmin can update a plan', function () {
+    $plan = Plan::factory()->create(['name' => 'Plan Viejo', 'price' => 9.99, 'max_tables' => 5]);
+
+    $this->actingAs($this->superadmin)
+         ->put(route('superadmin.plans.update', $plan), [
+             'name'       => 'Plan Nuevo',
+             'price'      => 19.99,
+             'max_tables' => 15,
+         ])
+         ->assertRedirect(route('superadmin.plans.index'))
+         ->assertSessionHas('success');
+
+    $this->assertDatabaseHas('plans', [
+        'id'         => $plan->id,
+        'name'       => 'Plan Nuevo',
+        'max_tables' => 15,
+    ]);
+});
+
+it('update allows keeping the same name on the same plan', function () {
+    $plan = Plan::factory()->create(['name' => 'Plan Único']);
+
+    $this->actingAs($this->superadmin)
+         ->put(route('superadmin.plans.update', $plan), [
+             'name'       => 'Plan Único',
+             'price'      => 49.99,
+             'max_tables' => 30,
+         ])
+         ->assertRedirect(route('superadmin.plans.index'))
+         ->assertSessionHas('success');
+});
+
+// ──────────────────────────────────────────────
+// DESTROY
+// ──────────────────────────────────────────────
+
+it('superadmin can delete a plan with no businesses', function () {
+    $plan = Plan::factory()->create();
+
+    $this->actingAs($this->superadmin)
+         ->delete(route('superadmin.plans.destroy', $plan))
+         ->assertRedirect(route('superadmin.plans.index'))
+         ->assertSessionHas('success');
+
+    $this->assertDatabaseMissing('plans', ['id' => $plan->id]);
+});
+
+it('cannot delete a plan that has businesses assigned', function () {
+    $plan = Plan::factory()->create();
+    User::factory()->create(['role' => 'admin', 'plan_id' => $plan->id]);
+
+    $this->actingAs($this->superadmin)
+         ->delete(route('superadmin.plans.destroy', $plan))
+         ->assertRedirect(route('superadmin.plans.index'))
+         ->assertSessionHas('error');
+
+    $this->assertDatabaseHas('plans', ['id' => $plan->id]);
+});


### PR DESCRIPTION
## Resumen

- Actualiza `Plan` model con `casts`, relación `users()` y helper `hasActiveBusinesses()`
- Implementa `SuperAdminPlanController` con CRUD completo (index, create, store, edit, update, destroy)
- Crea vistas `superadmin/plans/` (index, create, edit) extendiendo el layout superadmin
- Protege `destroy` para no eliminar planes con negocios asignados
- Incluye 12 feature tests, 32 assertions, 100% verde

## Archivos

| Archivo | Acción |
|---|---|
| `app/Models/Plan.php` | casts, hasActiveBusinesses(), @author |
| `app/Http/Controllers/SuperAdmin/SuperAdminPlanController.php` | CRUD completo |
| `resources/views/superadmin/plans/index.blade.php` | Tabla con users_count |
| `resources/views/superadmin/plans/create.blade.php` | Formulario nuevo plan |
| `resources/views/superadmin/plans/edit.blade.php` | Formulario edición |
| `tests/Feature/Bloque13/PlanManagementTest.php` | 12 tests |

## Plan de pruebas

- [x] `php artisan test tests/Feature/Bloque13/PlanManagementTest.php` → 12/12 pass
- [x] Superadmin ve el índice de planes con conteo de negocios
- [x] Admin recibe 403 al intentar acceder
- [x] Validaciones: nombre requerido, precio mínimo 0, max_tables mínimo 1, nombre único
- [x] Update ignora el plan actual en la validación unique
- [x] Destroy bloqueado si el plan tiene negocios asignados
