### PR TITLE
[feat] bloque13 — panel superadmin completo

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ npm run dev              # Vite HMR en <http://localhost:5173> (solo desarrollo)
 
 ## Progreso del desarrollo
 
-**Progreso global: 60%** (35/58 sub-bloques completados)
+**Progreso global: 71%** (41/58 sub-bloques completados)
 
 | Sub-bloque | Descripción | Estado |
 | ---------- | ----------- | ------ |
@@ -114,17 +114,17 @@ npm run dev              # Vite HMR en <http://localhost:5173> (solo desarrollo)
 | 7.4 | Pantalla de propina antes de pagar con tarjeta | ✅ Completado |
 | 7.5 | Desglose de ingresos para el gerente | ✅ Completado |
 | 7.6 | Tests del Bloque 7 | ✅ Completado |
-| 12.1 | Migración `admin_id` nullable FK en `users` | 🔒 Pendiente |
-| 12.2 | Helper `ownerUserId()` en User model + actualizar controllers multitenancy | 🔒 Pendiente |
-| 12.3 | `StaffController` — listar, crear y eliminar staff | 🔒 Pendiente |
-| 12.4 | Vistas del panel de staff (tabla + formulario de alta) | 🔒 Pendiente |
-| 12.5 | Tests del Bloque 12 | 🔒 Pendiente |
-| 13.1 | Migración `superadmin` + campos negocio en `users` + seeder equipo | 🔒 Pendiente |
-| 13.2 | Middleware `role:superadmin` + rutas `/superadmin/` + layout propio | 🔒 Pendiente |
-| 13.3 | Gestión de planes — CRUD completo | 🔒 Pendiente |
-| 13.4 | Gestión de negocios — crear admins, asignar plan, ver stats | 🔒 Pendiente |
-| 13.5 | Mapa de negocios — Leaflet.js con pin por negocio | 🔒 Pendiente |
-| 13.6 | Tests del Bloque 13 | 🔒 Pendiente |
+| 12.1 | Migración `admin_id` nullable FK en `users` | ✅ Completado |
+| 12.2 | Helper `ownerUserId()` en User model + actualizar controllers multitenancy | ✅ Completado |
+| 12.3 | `StaffController` — listar, crear y eliminar staff | ✅ Completado |
+| 12.4 | Vistas del panel de staff (tabla + formulario de alta) | ✅ Completado |
+| 12.5 | Tests del Bloque 12 | ✅ Completado |
+| 13.1 | Migración `superadmin` + campos negocio en `users` + seeder equipo | ✅ Completado |
+| 13.2 | Middleware `role:superadmin` + rutas `/superadmin/` + layout propio | ✅ Completado |
+| 13.3 | Gestión de planes — CRUD completo | ✅ Completado |
+| 13.4 | Gestión de negocios — crear admins, asignar plan, ver stats | ✅ Completado |
+| 13.5 | Mapa de negocios — Leaflet.js con pin por negocio | ✅ Completado |
+| 13.6 | Tests del Bloque 13 | ✅ Completado |
 | 8.1 | Interfaz drag & drop para crear, mover y eliminar mesas | 🔒 Pendiente |
 | 8.2 | Límite de mesas según plan del gerente | 🔒 Pendiente |
 | 8.3 | Formas de mesa (cuadrada, redonda, rectangular) | 🔒 Pendiente |
@@ -148,8 +148,8 @@ npm run dev              # Vite HMR en <http://localhost:5173> (solo desarrollo)
 
 | Tabla | Relación clave |
 | ----- | -------------- |
-| plans | 1:N con users |
-| users | Centro del Multitenancy (user_id en todo) |
+| plans | 1:N con users — campos: `name`, `price`, `max_tables` |
+| users | Centro del Multitenancy — campos nuevos B12/B13: `admin_id` (FK nullable, nullOnDelete), `role` (admin/waiter/kitchen/superadmin), `active` (boolean), `plan_id` (FK nullable), `business_name`, `address`, `lat`, `lng` |
 | categories | user_id FK — campo `destination`: kitchen / bar |
 | ingredients | user_id FK — campo `is_allergen` (boolean) |
 | products | user_id FK, category_id FK, image (string) |

--- a/tests/Feature/Bloque13/BusinessManagementTest.php
+++ b/tests/Feature/Bloque13/BusinessManagementTest.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @author AyrtonAlania
+ */
+
 use App\Models\Plan;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -25,6 +29,14 @@ it('shows businesses index to superadmin', function () {
 
 it('returns 403 for admin trying to access business management', function () {
     $this->actingAs($this->admin)
+         ->get(route('superadmin.businesses.index'))
+         ->assertForbidden();
+});
+
+it('returns 403 for waiter trying to access business management', function () {
+    $waiter = User::factory()->waiter()->create();
+
+    $this->actingAs($waiter)
          ->get(route('superadmin.businesses.index'))
          ->assertForbidden();
 });
@@ -69,6 +81,22 @@ it('superadmin can create a new admin business', function () {
     ]);
 });
 
+it('new business has null admin_id', function () {
+    $this->actingAs($this->superadmin)
+         ->post(route('superadmin.businesses.store'), [
+             'name'                  => 'Test Admin',
+             'email'                 => 'test@nulladmin.es',
+             'password'              => 'secret123',
+             'password_confirmation' => 'secret123',
+             'business_name'         => 'Negocio Null',
+             'address'               => 'Calle Nula 1',
+             'plan_id'               => $this->plan->id,
+         ]);
+
+    $created = User::where('email', 'test@nulladmin.es')->first();
+    expect($created->admin_id)->toBeNull();
+});
+
 it('new business has role admin and active true', function () {
     $this->actingAs($this->superadmin)
          ->post(route('superadmin.businesses.store'), [
@@ -86,6 +114,34 @@ it('new business has role admin and active true', function () {
     expect($created->role)->toBe('admin')
         ->and($created->active)->toBeTrue()
         ->and($created->plan_id)->toBe($this->plan->id);
+});
+
+it('fails to create business without email', function () {
+    $this->actingAs($this->superadmin)
+         ->post(route('superadmin.businesses.store'), [
+             'name'                  => 'Juan García',
+             'email'                 => '',
+             'password'              => 'secret123',
+             'password_confirmation' => 'secret123',
+             'business_name'         => 'El Rincón',
+             'address'               => 'Calle Mayor 1',
+             'plan_id'               => $this->plan->id,
+         ])
+         ->assertSessionHasErrors('email');
+});
+
+it('fails to create business without business name', function () {
+    $this->actingAs($this->superadmin)
+         ->post(route('superadmin.businesses.store'), [
+             'name'                  => 'Juan García',
+             'email'                 => 'juan3@rincon.es',
+             'password'              => 'secret123',
+             'password_confirmation' => 'secret123',
+             'business_name'         => '',
+             'address'               => 'Calle Mayor 1',
+             'plan_id'               => $this->plan->id,
+         ])
+         ->assertSessionHasErrors('business_name');
 });
 
 it('fails to create business without plan', function () {
@@ -179,6 +235,26 @@ it('superadmin can delete a business', function () {
          ->assertSessionHas('success');
 
     $this->assertDatabaseMissing('users', ['id' => $toDelete->id]);
+});
+
+it('after hard delete staff of deleted admin has null admin_id', function () {
+    $toDelete = User::factory()->admin()->withBusiness()->create(['plan_id' => $this->plan->id]);
+    $staff    = User::factory()->waiter()->create(['admin_id' => $toDelete->id]);
+
+    $this->actingAs($this->superadmin)
+         ->delete(route('superadmin.businesses.destroy', $toDelete));
+
+    expect($staff->fresh()->admin_id)->toBeNull();
+});
+
+it('after hard delete staff is not also deleted', function () {
+    $toDelete = User::factory()->admin()->withBusiness()->create(['plan_id' => $this->plan->id]);
+    $staff    = User::factory()->waiter()->create(['admin_id' => $toDelete->id]);
+
+    $this->actingAs($this->superadmin)
+         ->delete(route('superadmin.businesses.destroy', $toDelete));
+
+    $this->assertDatabaseHas('users', ['id' => $staff->id]);
 });
 
 it('returns 403 when trying to toggle a non-admin user', function () {

--- a/tests/Feature/Bloque13/MapTest.php
+++ b/tests/Feature/Bloque13/MapTest.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @author AyrtonAlania
+ */
+
 use App\Models\Plan;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -104,6 +108,18 @@ it('businesses without coordinates are counted in withoutCoords', function () {
     $withoutCoords = $response->viewData('withoutCoords');
 
     expect($withoutCoords)->toBe(2);
+});
+
+it('withoutCoords only counts admins not all users', function () {
+    // 1 admin sin coords
+    User::factory()->admin()->create(['lat' => null, 'lng' => null]);
+    // staff huérfano sin coords — no debe inflar el contador
+    User::factory()->waiter()->create(['lat' => null, 'lng' => null]);
+
+    $response      = $this->actingAs($this->superadmin)->get(route('superadmin.map'));
+    $withoutCoords = $response->viewData('withoutCoords');
+
+    expect($withoutCoords)->toBe(1);
 });
 
 // ──────────────────────────────────────────────

--- a/tests/Feature/Bloque13/PlanManagementTest.php
+++ b/tests/Feature/Bloque13/PlanManagementTest.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @author AyrtonAlania
+ */
+
 use App\Models\Plan;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -26,6 +30,14 @@ it('shows plans index to superadmin', function () {
 
 it('returns 403 for admin trying to access plans management', function () {
     $this->actingAs($this->admin)
+         ->get(route('superadmin.plans.index'))
+         ->assertForbidden();
+});
+
+it('returns 403 for waiter trying to manage plans', function () {
+    $waiter = User::factory()->waiter()->create();
+
+    $this->actingAs($waiter)
          ->get(route('superadmin.plans.index'))
          ->assertForbidden();
 });

--- a/tests/Feature/Bloque13/SuperAdminAccessTest.php
+++ b/tests/Feature/Bloque13/SuperAdminAccessTest.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @author AyrtonAlania
+ */
+
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 

--- a/tests/Unit/UserRoleTest.php
+++ b/tests/Unit/UserRoleTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * @author AyrtonAlania
+ */
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+// ─── isSuperAdmin() ───────────────────────────────────────────────────────────
+
+it('isSuperAdmin returns true for superadmin role', function () {
+    $user = User::factory()->superadmin()->create();
+    expect($user->isSuperAdmin())->toBeTrue();
+});
+
+it('isSuperAdmin returns false for admin role', function () {
+    $user = User::factory()->admin()->create();
+    expect($user->isSuperAdmin())->toBeFalse();
+});
+
+it('isSuperAdmin returns false for waiter role', function () {
+    $user = User::factory()->waiter()->create();
+    expect($user->isSuperAdmin())->toBeFalse();
+});
+
+it('isSuperAdmin returns false for kitchen role', function () {
+    $user = User::factory()->kitchen()->create();
+    expect($user->isSuperAdmin())->toBeFalse();
+});
+
+// ─── isAdmin() ────────────────────────────────────────────────────────────────
+
+it('isAdmin returns true for admin role', function () {
+    $user = User::factory()->admin()->create();
+    expect($user->isAdmin())->toBeTrue();
+});
+
+it('isAdmin returns false for superadmin role', function () {
+    $user = User::factory()->superadmin()->create();
+    expect($user->isAdmin())->toBeFalse();
+});
+
+it('isAdmin returns false for waiter role', function () {
+    $user = User::factory()->waiter()->create();
+    expect($user->isAdmin())->toBeFalse();
+});
+
+// ─── isStaff() ────────────────────────────────────────────────────────────────
+
+it('isStaff returns true for waiter role', function () {
+    $user = User::factory()->waiter()->create();
+    expect($user->isStaff())->toBeTrue();
+});
+
+it('isStaff returns true for kitchen role', function () {
+    $user = User::factory()->kitchen()->create();
+    expect($user->isStaff())->toBeTrue();
+});
+
+it('isStaff returns false for admin role', function () {
+    $user = User::factory()->admin()->create();
+    expect($user->isStaff())->toBeFalse();
+});
+
+it('isStaff returns false for superadmin role', function () {
+    $user = User::factory()->superadmin()->create();
+    expect($user->isStaff())->toBeFalse();
+});
+
+// ─── isActive() ───────────────────────────────────────────────────────────────
+
+it('isActive returns true when active is true', function () {
+    $user = User::factory()->create(['active' => true]);
+    expect($user->isActive())->toBeTrue();
+});
+
+it('isActive returns false when active is false', function () {
+    $user = User::factory()->inactive()->create();
+    expect($user->isActive())->toBeFalse();
+});
+
+// ─── ownerUserId() ────────────────────────────────────────────────────────────
+
+it('ownerUserId returns own id when admin_id is null', function () {
+    $admin = User::factory()->admin()->create(['admin_id' => null]);
+    expect($admin->ownerUserId())->toBe($admin->id);
+});
+
+it('ownerUserId returns admin_id when admin_id is set', function () {
+    $admin = User::factory()->admin()->create();
+    $staff = User::factory()->waiter()->staffOf($admin)->create();
+    expect($staff->ownerUserId())->toBe($admin->id);
+});


### PR DESCRIPTION
## Qué se implementa

- 13.1: Rol superadmin + campos negocio en users + seeder con BenjaminDTS, SebastianBCF y Ayrton
- 13.2: Middleware role:superadmin + rutas /superadmin/ + layout propio del panel superadmin
- 13.3: CRUD de planes SaaS (nombre, precio, límite mesas)
- 13.4: Gestión de negocios — crear, activar/desactivar, eliminar (hard delete con nullOnDelete en admin_id)
- 13.5: Mapa interactivo de negocios con Leaflet.js (pins verde/rojo, filtro role=admin, staff huérfano excluido por diseño)
- 13.6: Tests completos del Bloque 13

## Impacto en el sistema existente

- Se añaden plan_id y active a la tabla users
- Se añaden business_name, address, lat, lng a users
- Los admins inactivos son redirigidos al hacer login
- El seeder crea 3 superadmins adicionales (equipo Zampa)
- Hard delete de un negocio deja su staff con admin_id = null (el staff huérfano no se borra — se refinará si hace falta)
- No hay breaking changes para admins activos existentes

## Comportamiento del hard delete (decisión B13.4)

Al borrar un negocio (admin):
- El admin se borra físicamente de la tabla users
- Su staff queda con admin_id = null (nullOnDelete en FK)
- El staff huérfano sigue existiendo pero sin restaurante
- Tables, orders y demás dependen de sus propias FK; si tienen cascadeDelete se propagan, si tienen restrict el delete puede fallar — a refinar en bloque posterior

## Tests — 341 passing (693 assertions)

| Archivo | Tests |
|---------|-------|
| SuperAdminAccessTest.php | 6 — acceso por rol (unauthenticated/admin/waiter/kitchen/superadmin + bidireccional) |
| PlanManagementTest.php | 13 — CRUD planes, validaciones, unicidad, negocios asignados |
| BusinessManagementTest.php | 21 — CRUD negocios, toggle, hard delete + null admin_id staff + staff no borrado |
| MapTest.php | 15 — filtros, staff huérfano excluido, withoutCoords solo admins, shape de datos |
| UserRoleTest.php | 15 — unit tests isSuperAdmin/isAdmin/isStaff/isActive/ownerUserId |

## Checklist CLAUDE.md

- [x] php artisan test pasa al 100% (341/341)
- [x] Un commit por archivo
- [x] Middleware con doble protección (auth + role.superadmin)
- [x] abort_if() en operaciones sensibles de los controladores
- [x] @author AyrtonAlania en cabeceras de todos los archivos de test del Bloque 13
- [x] README actualizado con progreso al 71%