### PR TITLE
fix: superadmin login redirect to own panel

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -28,6 +28,10 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
+        if (Auth::user()->isSuperAdmin()) {
+            return redirect()->intended(route('superadmin.dashboard'));
+        }
+
         return redirect()->intended(route('dashboard', absolute: false));
     }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\SuperAdmin\SuperAdminDashboardController;
 use App\Http\Controllers\SuperAdmin\SuperAdminPlanController;
 use App\Http\Controllers\SuperAdmin\SuperAdminBusinessController;
 use App\Http\Controllers\SuperAdmin\SuperAdminMapController;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -28,6 +29,10 @@ Route::get('/carta/{hash}', [MenuController::class, 'show'])
     ->name('menu.show');
 
 Route::get('/dashboard', function () {
+    if (Auth::user()->isSuperAdmin()) {
+        return redirect()->route('superadmin.dashboard');
+    }
+
     return view('dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');
 


### PR DESCRIPTION
## Summary

- `AuthenticatedSessionController::store()` now redirects superadmin to `superadmin.dashboard` instead of the regular admin dashboard
- `/dashboard` route guards against direct URL access by superadmin, redirecting to `/superadmin/dashboard`

## Root cause

Login redirect was unconditional — all roles sent to `route('dashboard')`. Superadmin landed on the gerente panel (categories, ingredients, products, tables visible but irrelevant).

## Test plan

- [ ] Login as `benjamin@zampa.app` (superadmin) → lands on `/superadmin/dashboard`
- [ ] Navigate manually to `/dashboard` as superadmin → redirected to `/superadmin/dashboard`
- [ ] Login as `admin@zampa.app` (gerente) → lands on `/dashboard` as before
- [ ] Login as `camarero@zampa.app` (waiter) → lands on `/dashboard` as before