### PR TITLE
fix: superadmin dashboard real stats

### DIFF
--- a/app/Http/Controllers/SuperAdmin/SuperAdminDashboardController.php
+++ b/app/Http/Controllers/SuperAdmin/SuperAdminDashboardController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\SuperAdmin;
 
 use App\Http\Controllers\Controller;
+use App\Models\Plan;
+use App\Models\User;
 use Illuminate\View\View;
 
 /**
@@ -17,6 +19,14 @@ class SuperAdminDashboardController extends Controller
      */
     public function index(): View
     {
-        return view('superadmin.dashboard');
+        $totalBusinesses  = User::where('role', 'admin')->count();
+        $activeBusinesses = User::where('role', 'admin')->where('active', true)->count();
+        $totalPlans       = Plan::count();
+
+        return view('superadmin.dashboard', compact(
+            'totalBusinesses',
+            'activeBusinesses',
+            'totalPlans',
+        ));
     }
 }

--- a/resources/views/superadmin/dashboard.blade.php
+++ b/resources/views/superadmin/dashboard.blade.php
@@ -83,18 +83,15 @@
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             <div class="p-5 rounded-xl bg-slate-900 border border-slate-800">
                 <p class="text-slate-400 text-xs uppercase tracking-widest mb-1">Negocios registrados</p>
-                <p class="text-3xl font-bold text-white">—</p>
-                <p class="text-slate-500 text-sm mt-1">Disponible en B13.4</p>
+                <p class="text-3xl font-bold text-white">{{ $totalBusinesses }}</p>
             </div>
             <div class="p-5 rounded-xl bg-slate-900 border border-slate-800">
-                <p class="text-slate-400 text-xs uppercase tracking-widest mb-1">Planes activos</p>
-                <p class="text-3xl font-bold text-white">—</p>
-                <p class="text-slate-500 text-sm mt-1">Disponible en B13.3</p>
+                <p class="text-slate-400 text-xs uppercase tracking-widest mb-1">Planes disponibles</p>
+                <p class="text-3xl font-bold text-white">{{ $totalPlans }}</p>
             </div>
             <div class="p-5 rounded-xl bg-slate-900 border border-slate-800">
                 <p class="text-slate-400 text-xs uppercase tracking-widest mb-1">Negocios activos</p>
-                <p class="text-3xl font-bold text-white">—</p>
-                <p class="text-slate-500 text-sm mt-1">Disponible en B13.4</p>
+                <p class="text-3xl font-bold text-white">{{ $activeBusinesses }}</p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary

- `SuperAdminDashboardController::index()` now queries real counts and passes them to the view
- Dashboard view replaces hardcoded `—` / `Disponible en B13.X` placeholders with actual data

## Stats shown

| Card | Query |
|------|-------|
| Negocios registrados | `User where role=admin count()` |
| Planes disponibles | `Plan count()` |
| Negocios activos | `User where role=admin and active=true count()` |

## Root cause

Controller was created as a stub in B13.2 and never updated when B13.3 and B13.4 landed.

## Test plan

- [x] Login as superadmin → dashboard shows numeric values, no `—` or placeholder text
- [x] Create a new business → "Negocios registrados" increments
- [x] Deactivate a business → "Negocios activos" decrements