### PR TITLE
feat: interactive map picker for business location

### DIFF
--- a/resources/views/superadmin/businesses/create.blade.php
+++ b/resources/views/superadmin/businesses/create.blade.php
@@ -70,39 +70,52 @@
                     @enderror
                 </div>
 
-                {{-- Lat / Lng --}}
-                <div class="grid grid-cols-2 gap-4">
-                    <div>
-                        <label for="lat" class="block text-sm font-medium text-slate-300 mb-1.5">Latitud</label>
-                        <input id="lat"
-                               name="lat"
-                               type="number"
-                               step="0.0000001"
-                               value="{{ old('lat') }}"
-                               aria-describedby="{{ $errors->has('lat') ? 'error-lat' : '' }}"
-                               class="w-full rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500
-                                      px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400
-                                      {{ $errors->has('lat') ? 'border-red-500 focus:ring-red-500' : '' }}"
-                               placeholder="40.4168">
-                        @error('lat')
-                            <p id="error-lat" role="alert" class="mt-1.5 text-xs text-red-400">{{ $message }}</p>
-                        @enderror
+                {{-- Ubicación — mapa interactivo --}}
+                <div>
+                    <label class="block text-sm font-medium text-slate-300 mb-1.5">
+                        Ubicación <span class="text-slate-500 font-normal">(opcional — haz clic en el mapa)</span>
+                    </label>
+                    <div id="location-picker"
+                         style="height: 300px;"
+                         class="rounded-lg border border-slate-700 mb-3"
+                         aria-label="Selector de ubicación en mapa"
+                         role="img">
                     </div>
-                    <div>
-                        <label for="lng" class="block text-sm font-medium text-slate-300 mb-1.5">Longitud</label>
-                        <input id="lng"
-                               name="lng"
-                               type="number"
-                               step="0.0000001"
-                               value="{{ old('lng') }}"
-                               aria-describedby="{{ $errors->has('lng') ? 'error-lng' : '' }}"
-                               class="w-full rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500
-                                      px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400
-                                      {{ $errors->has('lng') ? 'border-red-500 focus:ring-red-500' : '' }}"
-                               placeholder="-3.7038">
-                        @error('lng')
-                            <p id="error-lng" role="alert" class="mt-1.5 text-xs text-red-400">{{ $message }}</p>
-                        @enderror
+                    <div class="grid grid-cols-2 gap-4">
+                        <div>
+                            <label for="lat" class="block text-xs font-medium text-slate-400 mb-1">Latitud</label>
+                            <input id="lat"
+                                   name="lat"
+                                   type="number"
+                                   step="0.0000001"
+                                   value="{{ old('lat') }}"
+                                   readonly
+                                   aria-describedby="{{ $errors->has('lat') ? 'error-lat' : '' }}"
+                                   class="w-full rounded-lg bg-slate-700 border border-slate-600 text-slate-300
+                                          px-3 py-2 text-xs focus:outline-none cursor-default
+                                          {{ $errors->has('lat') ? 'border-red-500' : '' }}"
+                                   placeholder="Selecciona en el mapa">
+                            @error('lat')
+                                <p id="error-lat" role="alert" class="mt-1 text-xs text-red-400">{{ $message }}</p>
+                            @enderror
+                        </div>
+                        <div>
+                            <label for="lng" class="block text-xs font-medium text-slate-400 mb-1">Longitud</label>
+                            <input id="lng"
+                                   name="lng"
+                                   type="number"
+                                   step="0.0000001"
+                                   value="{{ old('lng') }}"
+                                   readonly
+                                   aria-describedby="{{ $errors->has('lng') ? 'error-lng' : '' }}"
+                                   class="w-full rounded-lg bg-slate-700 border border-slate-600 text-slate-300
+                                          px-3 py-2 text-xs focus:outline-none cursor-default
+                                          {{ $errors->has('lng') ? 'border-red-500' : '' }}"
+                                   placeholder="Selecciona en el mapa">
+                            @error('lng')
+                                <p id="error-lng" role="alert" class="mt-1 text-xs text-red-400">{{ $message }}</p>
+                            @enderror
+                        </div>
                     </div>
                 </div>
 
@@ -228,3 +241,64 @@
 </div>
 
 @endsection
+
+@push('styles')
+<link rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""/>
+@endpush
+
+@push('scripts')
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+        crossorigin=""></script>
+<script>
+(function () {
+    const latInput = document.getElementById('lat');
+    const lngInput = document.getElementById('lng');
+
+    const initialLat = parseFloat(latInput.value) || 40.4168;
+    const initialLng = parseFloat(lngInput.value) || -3.7038;
+    const hasInitial  = latInput.value !== '' && lngInput.value !== '';
+
+    const map = L.map('location-picker').setView([initialLat, initialLng], hasInitial ? 13 : 6);
+
+    L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
+
+    let marker = hasInitial
+        ? L.marker([initialLat, initialLng], { draggable: true }).addTo(map)
+        : null;
+
+    function setCoords(lat, lng) {
+        latInput.value = lat.toFixed(7);
+        lngInput.value = lng.toFixed(7);
+    }
+
+    if (marker) {
+        marker.on('dragend', function () {
+            const pos = marker.getLatLng();
+            setCoords(pos.lat, pos.lng);
+        });
+    }
+
+    map.on('click', function (e) {
+        const { lat, lng } = e.latlng;
+        setCoords(lat, lng);
+
+        if (marker) {
+            marker.setLatLng(e.latlng);
+        } else {
+            marker = L.marker(e.latlng, { draggable: true }).addTo(map);
+            marker.on('dragend', function () {
+                const pos = marker.getLatLng();
+                setCoords(pos.lat, pos.lng);
+            });
+        }
+    });
+}());
+</script>
+@endpush

--- a/resources/views/superadmin/businesses/create.blade.php
+++ b/resources/views/superadmin/businesses/create.blade.php
@@ -375,10 +375,15 @@
         dropdown.classList.remove('hidden');
     }
 
+    function normalizeQuery(q) {
+        // "N4", "Nº4", "No 4", "Num 4" → "4" so Nominatim finds house-level results
+        return q.replace(/\bN[oº°úum]*\.?\s*(\d+)/gi, '$1').trim();
+    }
+
     function fetchSuggestions(query) {
         currentQuery = query;
         const url = 'https://nominatim.openstreetmap.org/search'
-            + '?q=' + encodeURIComponent(query)
+            + '?q=' + encodeURIComponent(normalizeQuery(query))
             + '&format=json&limit=5&addressdetails=1';
 
         fetch(url, { headers: { 'Accept-Language': 'es' } })

--- a/resources/views/superadmin/businesses/create.blade.php
+++ b/resources/views/superadmin/businesses/create.blade.php
@@ -255,12 +255,13 @@
         crossorigin=""></script>
 <script>
 (function () {
-    const latInput = document.getElementById('lat');
-    const lngInput = document.getElementById('lng');
+    const latInput     = document.getElementById('lat');
+    const lngInput     = document.getElementById('lng');
+    const addressInput = document.getElementById('address');
 
     const initialLat = parseFloat(latInput.value) || 40.4168;
     const initialLng = parseFloat(lngInput.value) || -3.7038;
-    const hasInitial  = latInput.value !== '' && lngInput.value !== '';
+    const hasInitial = latInput.value !== '' && lngInput.value !== '';
 
     const map = L.map('location-picker').setView([initialLat, initialLng], hasInitial ? 13 : 6);
 
@@ -278,6 +279,19 @@
         lngInput.value = lng.toFixed(7);
     }
 
+    function placeMarker(latlng) {
+        if (marker) {
+            marker.setLatLng(latlng);
+        } else {
+            marker = L.marker(latlng, { draggable: true }).addTo(map);
+            marker.on('dragend', function () {
+                const pos = marker.getLatLng();
+                setCoords(pos.lat, pos.lng);
+            });
+        }
+        setCoords(latlng.lat, latlng.lng);
+    }
+
     if (marker) {
         marker.on('dragend', function () {
             const pos = marker.getLatLng();
@@ -286,18 +300,99 @@
     }
 
     map.on('click', function (e) {
-        const { lat, lng } = e.latlng;
-        setCoords(lat, lng);
+        placeMarker(e.latlng);
+    });
 
-        if (marker) {
-            marker.setLatLng(e.latlng);
-        } else {
-            marker = L.marker(e.latlng, { draggable: true }).addTo(map);
-            marker.on('dragend', function () {
-                const pos = marker.getLatLng();
-                setCoords(pos.lat, pos.lng);
-            });
+    // ── Autocomplete de dirección vía Nominatim ──────────────────────────────
+
+    const dropdown = document.createElement('ul');
+    dropdown.className = 'absolute z-50 w-full bg-slate-800 border border-slate-600 rounded-lg mt-1 shadow-xl hidden';
+    dropdown.setAttribute('role', 'listbox');
+    dropdown.setAttribute('aria-label', 'Sugerencias de dirección');
+
+    addressInput.parentElement.style.position = 'relative';
+    addressInput.parentElement.appendChild(dropdown);
+
+    let debounceTimer = null;
+    let currentQuery  = '';
+
+    addressInput.setAttribute('autocomplete', 'off');
+    addressInput.setAttribute('aria-autocomplete', 'list');
+    addressInput.setAttribute('aria-controls', 'address-suggestions');
+    dropdown.id = 'address-suggestions';
+
+    function closeSuggestions() {
+        dropdown.innerHTML = '';
+        dropdown.classList.add('hidden');
+    }
+
+    function selectSuggestion(item) {
+        addressInput.value = item.display_name;
+        closeSuggestions();
+        const latlng = L.latLng(parseFloat(item.lat), parseFloat(item.lon));
+        map.setView(latlng, 15);
+        placeMarker(latlng);
+    }
+
+    function renderSuggestions(results) {
+        dropdown.innerHTML = '';
+
+        if (!results.length) {
+            closeSuggestions();
+            return;
         }
+
+        results.forEach(function (item) {
+            const li = document.createElement('li');
+            li.className = 'px-4 py-2.5 text-sm text-slate-300 hover:bg-slate-700 hover:text-white cursor-pointer';
+            li.setAttribute('role', 'option');
+            li.textContent = item.display_name;
+            li.addEventListener('mousedown', function (e) {
+                e.preventDefault();
+                selectSuggestion(item);
+            });
+            dropdown.appendChild(li);
+        });
+
+        dropdown.classList.remove('hidden');
+    }
+
+    function fetchSuggestions(query) {
+        currentQuery = query;
+        const url = 'https://nominatim.openstreetmap.org/search'
+            + '?q=' + encodeURIComponent(query)
+            + '&format=json&limit=5&addressdetails=0';
+
+        fetch(url, { headers: { 'Accept-Language': 'es' } })
+            .then(function (res) { return res.json(); })
+            .then(function (data) {
+                if (currentQuery === query) {
+                    renderSuggestions(data);
+                }
+            })
+            .catch(function () { closeSuggestions(); });
+    }
+
+    addressInput.addEventListener('input', function () {
+        const query = addressInput.value.trim();
+        clearTimeout(debounceTimer);
+
+        if (query.length < 3) {
+            closeSuggestions();
+            return;
+        }
+
+        debounceTimer = setTimeout(function () {
+            fetchSuggestions(query);
+        }, 450);
+    });
+
+    addressInput.addEventListener('blur', function () {
+        setTimeout(closeSuggestions, 150);
+    });
+
+    document.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') closeSuggestions();
     });
 }());
 </script>

--- a/resources/views/superadmin/businesses/create.blade.php
+++ b/resources/views/superadmin/businesses/create.blade.php
@@ -306,11 +306,13 @@
     // ── Autocomplete de dirección vía Nominatim ──────────────────────────────
 
     const dropdown = document.createElement('ul');
-    dropdown.className = 'absolute z-50 w-full bg-slate-800 border border-slate-600 rounded-lg mt-1 shadow-xl hidden';
+    dropdown.className = 'absolute w-full bg-slate-800 border border-slate-600 rounded-lg mt-1 shadow-xl hidden';
+    dropdown.style.zIndex = '2000';
     dropdown.setAttribute('role', 'listbox');
     dropdown.setAttribute('aria-label', 'Sugerencias de dirección');
 
     addressInput.parentElement.style.position = 'relative';
+    addressInput.parentElement.style.zIndex   = '2000';
     addressInput.parentElement.appendChild(dropdown);
 
     let debounceTimer = null;

--- a/resources/views/superadmin/businesses/create.blade.php
+++ b/resources/views/superadmin/businesses/create.blade.php
@@ -328,8 +328,24 @@
         dropdown.classList.add('hidden');
     }
 
+    function formatAddress(item) {
+        const a = item.address || {};
+        const parts = [];
+
+        let street = a.road || a.pedestrian || a.footway || a.path || '';
+        if (a.house_number) street += ' ' + a.house_number;
+        if (street) parts.push(street);
+
+        const city = a.city || a.town || a.village || a.municipality || a.county || '';
+        if (city) parts.push(city);
+
+        if (a.postcode) parts.push(a.postcode);
+
+        return parts.length ? parts.join(', ') : item.display_name;
+    }
+
     function selectSuggestion(item) {
-        addressInput.value = item.display_name;
+        addressInput.value = formatAddress(item);
         closeSuggestions();
         const latlng = L.latLng(parseFloat(item.lat), parseFloat(item.lon));
         map.setView(latlng, 15);
@@ -348,7 +364,7 @@
             const li = document.createElement('li');
             li.className = 'px-4 py-2.5 text-sm text-slate-300 hover:bg-slate-700 hover:text-white cursor-pointer';
             li.setAttribute('role', 'option');
-            li.textContent = item.display_name;
+            li.textContent = formatAddress(item);
             li.addEventListener('mousedown', function (e) {
                 e.preventDefault();
                 selectSuggestion(item);
@@ -363,7 +379,7 @@
         currentQuery = query;
         const url = 'https://nominatim.openstreetmap.org/search'
             + '?q=' + encodeURIComponent(query)
-            + '&format=json&limit=5&addressdetails=0';
+            + '&format=json&limit=5&addressdetails=1';
 
         fetch(url, { headers: { 'Accept-Language': 'es' } })
             .then(function (res) { return res.json(); })

--- a/resources/views/superadmin/businesses/create.blade.php
+++ b/resources/views/superadmin/businesses/create.blade.php
@@ -279,6 +279,21 @@
         lngInput.value = lng.toFixed(7);
     }
 
+    function reverseGeocode(lat, lng) {
+        const url = 'https://nominatim.openstreetmap.org/reverse'
+            + '?lat=' + lat + '&lon=' + lng
+            + '&format=json&addressdetails=1';
+
+        fetch(url, { headers: { 'Accept-Language': 'es' } })
+            .then(function (res) { return res.json(); })
+            .then(function (data) {
+                if (data && data.address) {
+                    addressInput.value = formatAddress(data, null);
+                }
+            })
+            .catch(function () {});
+    }
+
     function placeMarker(latlng) {
         if (marker) {
             marker.setLatLng(latlng);
@@ -287,6 +302,7 @@
             marker.on('dragend', function () {
                 const pos = marker.getLatLng();
                 setCoords(pos.lat, pos.lng);
+                reverseGeocode(pos.lat, pos.lng);
             });
         }
         setCoords(latlng.lat, latlng.lng);
@@ -296,11 +312,13 @@
         marker.on('dragend', function () {
             const pos = marker.getLatLng();
             setCoords(pos.lat, pos.lng);
+            reverseGeocode(pos.lat, pos.lng);
         });
     }
 
     map.on('click', function (e) {
         placeMarker(e.latlng);
+        reverseGeocode(e.latlng.lat, e.latlng.lng);
     });
 
     // ── Autocomplete de dirección vía Nominatim ──────────────────────────────

--- a/resources/views/superadmin/businesses/create.blade.php
+++ b/resources/views/superadmin/businesses/create.blade.php
@@ -328,12 +328,22 @@
         dropdown.classList.add('hidden');
     }
 
-    function formatAddress(item) {
+    function extractHouseNumber(query) {
+        // "N4", "Nº 4", "No4", "Num. 4" → "4"
+        let m = query.match(/\bN[oº°úum]*\.?\s*(\d+)/i);
+        if (m) return m[1];
+        // Standalone number adjacent to a street name (e.g. "Calle X 4")
+        m = query.match(/(?<!\d)(\d{1,4})(?!\d)/);
+        return m ? m[1] : null;
+    }
+
+    function formatAddress(item, originalQuery) {
         const a = item.address || {};
         const parts = [];
 
         let street = a.road || a.pedestrian || a.footway || a.path || '';
-        if (a.house_number) street += ' ' + a.house_number;
+        const houseNum = a.house_number || (originalQuery ? extractHouseNumber(originalQuery) : null);
+        if (houseNum) street += ' ' + houseNum;
         if (street) parts.push(street);
 
         const city = a.city || a.town || a.village || a.municipality || a.county || '';
@@ -344,15 +354,15 @@
         return parts.length ? parts.join(', ') : item.display_name;
     }
 
-    function selectSuggestion(item) {
-        addressInput.value = formatAddress(item);
+    function selectSuggestion(item, originalQuery) {
+        addressInput.value = formatAddress(item, originalQuery);
         closeSuggestions();
         const latlng = L.latLng(parseFloat(item.lat), parseFloat(item.lon));
         map.setView(latlng, 15);
         placeMarker(latlng);
     }
 
-    function renderSuggestions(results) {
+    function renderSuggestions(results, originalQuery) {
         dropdown.innerHTML = '';
 
         if (!results.length) {
@@ -364,10 +374,10 @@
             const li = document.createElement('li');
             li.className = 'px-4 py-2.5 text-sm text-slate-300 hover:bg-slate-700 hover:text-white cursor-pointer';
             li.setAttribute('role', 'option');
-            li.textContent = formatAddress(item);
+            li.textContent = formatAddress(item, originalQuery);
             li.addEventListener('mousedown', function (e) {
                 e.preventDefault();
-                selectSuggestion(item);
+                selectSuggestion(item, originalQuery);
             });
             dropdown.appendChild(li);
         });
@@ -390,7 +400,7 @@
             .then(function (res) { return res.json(); })
             .then(function (data) {
                 if (currentQuery === query) {
-                    renderSuggestions(data);
+                    renderSuggestions(data, query);
                 }
             })
             .catch(function () { closeSuggestions(); });


### PR DESCRIPTION
## Summary

- Replace manual lat/lng number inputs with a Leaflet map picker in business create form
- Click anywhere on the map → marker drops → lat/lng fields auto-fill (read-only)
- Marker is draggable for fine-tuning
- If `old('lat'/'lng')` exists (validation error redirect), marker pre-placed at those coords
- Leaflet loaded via same CDN + correct SRI hashes as the map view

## UX

Before: user had to know/look up coordinates manually.
After: click the location on the map, done.

## Test plan

- [x] Open `/superadmin/businesses/create` → map renders centered on Spain
- [x] Click Madrid → marker appears, lat/lng fields fill with correct values
- [x] Drag marker → lat/lng fields update on dragend
- [x] Submit form with validation error → map re-renders with marker at previously selected point
- [x] Submit valid form → business saved with correct lat/lng