### PR TITLE
Feat/tapas mejoras completas

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -15,21 +15,27 @@ use Illuminate\View\View;
  * No requiere autenticación. Accesible mediante el unique_hash de la mesa.
  *
  * @author Ayrton
+ * @author BenjaminDTS
  */
 class MenuController extends Controller
 {
     /**
      * Muestra la carta digital pública de un restaurante para una mesa concreta.
-     * Carga las categorías activas con sus productos e ingredientes alérgenos.
+     * Filtra las categorías de cocina cuando la cocina está cerrada.
+     * Calcula las variantes de tapa ya usadas y si se debe sugerir tapa al cliente.
      *
      * @param  string  $hash  El unique_hash asignado a la mesa
      * @return View
      */
     public function show(string $hash): View
     {
-        $table = Table::where('unique_hash', $hash)->firstOrFail();
+        $table  = Table::where('unique_hash', $hash)->firstOrFail();
+        $config = $table->user->tapaConfig;
+
+        $kitchenOpen = ! ($config && $config->tapas_enabled) || $config->isKitchenOpen();
 
         $categories = Category::where('user_id', $table->user_id)
+            ->when(! $kitchenOpen, fn ($q) => $q->where('destination', 'bar'))
             ->with([
                 'products' => function ($query) {
                     $query->where('is_active', true)
@@ -51,7 +57,6 @@ class MenuController extends Controller
             ->get()
             ->filter(fn ($category) => $category->products->isNotEmpty());
 
-        // Solo se muestran alérgenos que aparecen en al menos un plato activo.
         $allergens = $categories
             ->flatMap(fn ($c) => $c->products)
             ->flatMap(fn ($p) => $p->ingredients->where('is_allergen', true))
@@ -59,16 +64,38 @@ class MenuController extends Controller
             ->sortBy('name')
             ->values();
 
-        $tapaConfig    = null;
-        $barItemsCount = 0;
+        $tapaConfig        = null;
+        $barItemsCount     = 0;
+        $tapaVariantsUsed  = 0;
+        $tapaProducts      = collect();
+        $shouldSuggest     = false;
 
-        $config = $table->user->tapaConfig;
         if ($config && $config->tapas_enabled) {
             $tapaConfig    = $config;
             $barItemsCount = OrderItem::whereHas('order', fn ($q) =>
                 $q->where('table_id', $table->id)
                   ->where('status', '!=', 'closed')
             )->where('destination', 'bar')->sum('quantity');
+
+            $tapaCategory = Category::where('user_id', $table->user_id)
+                                    ->where('name', 'Tapas')
+                                    ->first();
+
+            if ($tapaCategory) {
+                $tapaVariantsUsed = OrderItem::whereHas('order', fn ($q) =>
+                    $q->where('table_id', $table->id)
+                      ->where('status', '!=', 'closed')
+                )->whereHas('product', fn ($q) =>
+                    $q->where('category_id', $tapaCategory->id)
+                )->distinct('product_id')->count('product_id');
+
+                $tapaProducts = $tapaCategory->products()
+                                             ->where('is_active', true)
+                                             ->orderBy('name')
+                                             ->get(['id', 'name', 'price', 'description']);
+            }
+
+            $shouldSuggest = $config->shouldSuggestTapa((int) $barItemsCount, $tapaVariantsUsed);
         }
 
         $activeOrder = Order::where('table_id', $table->id)
@@ -77,12 +104,17 @@ class MenuController extends Controller
             ->latest()
             ->first();
 
-        $hasActiveOrder    = (bool) $activeOrder;
-        $activeOrderTotal  = $activeOrder?->total ?? 0;
-        $billRequested     = (bool) ($activeOrder?->bill_requested);
+        $hasActiveOrder   = (bool) $activeOrder;
+        $activeOrderTotal = $activeOrder?->total ?? 0;
+        $billRequested    = (bool) ($activeOrder?->bill_requested);
 
         $stripePublicKey = config('services.stripe.key');
 
-        return view('menu.show', compact('table', 'categories', 'allergens', 'tapaConfig', 'barItemsCount', 'hasActiveOrder', 'activeOrderTotal', 'billRequested', 'stripePublicKey'));
+        return view('menu.show', compact(
+            'table', 'categories', 'allergens',
+            'tapaConfig', 'barItemsCount', 'kitchenOpen',
+            'tapaVariantsUsed', 'tapaProducts', 'shouldSuggest',
+            'hasActiveOrder', 'activeOrderTotal', 'billRequested', 'stripePublicKey'
+        ));
     }
 }

--- a/app/Http/Controllers/TapasController.php
+++ b/app/Http/Controllers/TapasController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Category;
 use App\Models\TapaConfig;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -12,7 +13,8 @@ use Illuminate\View\View;
  * Class TapasController
  *
  * Permite al gerente configurar el sistema de tapas del restaurante:
- * activar/desactivar, modo gratuito/de pago, precio y variantes máximas.
+ * activar/desactivar, modo gratuito/de pago, precio, variantes máximas,
+ * tapa extra de pago y horario de apertura de cocina.
  *
  * @author BenjaminDTS
  */
@@ -29,10 +31,14 @@ class TapasController extends Controller
         $tapaConfig = TapaConfig::firstOrCreate(
             ['user_id' => Auth::id()],
             [
-                'tapas_enabled'     => false,
-                'tapas_free'        => true,
-                'max_tapa_variants' => 3,
-                'tapa_price'        => null,
+                'tapas_enabled'      => false,
+                'tapas_free'         => true,
+                'max_tapa_variants'  => 3,
+                'tapa_price'         => null,
+                'extra_tapa_enabled' => false,
+                'extra_tapa_price'   => null,
+                'kitchen_opens_at'   => null,
+                'kitchen_closes_at'  => null,
             ]
         );
 
@@ -41,29 +47,47 @@ class TapasController extends Controller
 
     /**
      * Guarda la configuración de tapas del restaurante.
+     * Al activar tapas crea automáticamente la categoría 'Tapas' con destination=kitchen.
      *
      * @param  Request $request
      * @return RedirectResponse
      */
     public function update(Request $request): RedirectResponse
     {
-        $validated = $request->validate([
-            'tapas_enabled'     => ['sometimes', 'boolean'],
-            'tapas_free'        => ['sometimes', 'boolean'],
-            'max_tapa_variants' => ['required', 'integer', 'min:1', 'max:20'],
-            'tapa_price'        => ['required_if:tapas_free,0', 'nullable', 'numeric', 'min:0', 'max:999.99'],
+        $request->validate([
+            'tapas_enabled'      => ['sometimes', 'boolean'],
+            'tapas_free'         => ['sometimes', 'boolean'],
+            'max_tapa_variants'  => ['required', 'integer', 'min:1', 'max:20'],
+            'tapa_price'         => ['required_if:tapas_free,0', 'nullable', 'numeric', 'min:0', 'max:999.99'],
+            'extra_tapa_enabled' => ['sometimes', 'boolean'],
+            'extra_tapa_price'   => ['required_if:extra_tapa_enabled,1', 'nullable', 'numeric', 'min:0', 'max:999.99'],
+            'kitchen_opens_at'   => ['nullable', 'date_format:H:i', 'required_with:kitchen_closes_at'],
+            'kitchen_closes_at'  => ['nullable', 'date_format:H:i', 'required_with:kitchen_opens_at'],
         ]);
 
-        $tapas_enabled = $request->boolean('tapas_enabled');
+        $userId        = Auth::id();
+        $tapasEnabled  = $request->boolean('tapas_enabled');
         $tapas_free    = $request->boolean('tapas_free');
+        $extraEnabled  = $request->boolean('extra_tapa_enabled');
+
+        if ($tapasEnabled) {
+            Category::firstOrCreate(
+                ['user_id' => $userId, 'name' => 'Tapas'],
+                ['destination' => 'kitchen']
+            );
+        }
 
         TapaConfig::updateOrCreate(
-            ['user_id' => Auth::id()],
+            ['user_id' => $userId],
             [
-                'tapas_enabled'     => $tapas_enabled,
-                'tapas_free'        => $tapas_free,
-                'max_tapa_variants' => $validated['max_tapa_variants'],
-                'tapa_price'        => $tapas_free ? null : ($validated['tapa_price'] ?? null),
+                'tapas_enabled'      => $tapasEnabled,
+                'tapas_free'         => $tapas_free,
+                'max_tapa_variants'  => $request->integer('max_tapa_variants'),
+                'tapa_price'         => $tapas_free ? null : ($request->input('tapa_price') ?? null),
+                'extra_tapa_enabled' => $extraEnabled,
+                'extra_tapa_price'   => $extraEnabled ? ($request->input('extra_tapa_price') ?? null) : null,
+                'kitchen_opens_at'   => $request->input('kitchen_opens_at') ?: null,
+                'kitchen_closes_at'  => $request->input('kitchen_closes_at') ?: null,
             ]
         );
 

--- a/app/Models/TapaConfig.php
+++ b/app/Models/TapaConfig.php
@@ -2,23 +2,29 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
 /**
  * Class TapaConfig
  *
  * Configuración del sistema de tapas de un restaurante (relación 1:1 con User).
  * Permite al gerente activar tapas, definir si son gratuitas o de pago,
- * el precio unitario y el número máximo de variantes distintas por pedido.
+ * el precio unitario, el número máximo de variantes distintas por pedido,
+ * la tapa extra de pago y el horario de apertura de cocina.
  *
  * @package App\Models
- * @property int     $user_id
- * @property bool    $tapas_enabled       Si el sistema de tapas está activo
- * @property bool    $tapas_free          true = gratuitas, false = de pago
- * @property int     $max_tapa_variants   Máximo de variantes distintas por mesa
- * @property float|null $tapa_price       Precio por tapa (solo si tapas_free = false)
+ * @property int        $user_id
+ * @property bool       $tapas_enabled       Si el sistema de tapas está activo
+ * @property bool       $tapas_free          true = gratuitas, false = de pago
+ * @property int        $max_tapa_variants   Máximo de variantes distintas por mesa
+ * @property float|null $tapa_price          Precio por tapa (solo si tapas_free = false)
+ * @property bool       $extra_tapa_enabled  Si se permite pedir una tapa extra de pago
+ * @property float|null $extra_tapa_price    Precio de la tapa extra (obligatorio si extra_tapa_enabled)
+ * @property string|null $kitchen_opens_at   Hora de apertura de cocina (HH:MM:SS, null = siempre abierta)
+ * @property string|null $kitchen_closes_at  Hora de cierre de cocina (HH:MM:SS, null = siempre abierta)
  *
  * @author BenjaminDTS
  */
@@ -35,16 +41,22 @@ class TapaConfig extends Model
         'tapas_free',
         'max_tapa_variants',
         'tapa_price',
+        'extra_tapa_enabled',
+        'extra_tapa_price',
+        'kitchen_opens_at',
+        'kitchen_closes_at',
     ];
 
     /**
      * @var array<string, string>
      */
     protected $casts = [
-        'tapas_enabled'     => 'boolean',
-        'tapas_free'        => 'boolean',
-        'max_tapa_variants' => 'integer',
-        'tapa_price'        => 'decimal:2',
+        'tapas_enabled'      => 'boolean',
+        'tapas_free'         => 'boolean',
+        'max_tapa_variants'  => 'integer',
+        'tapa_price'         => 'decimal:2',
+        'extra_tapa_enabled' => 'boolean',
+        'extra_tapa_price'   => 'decimal:2',
     ];
 
     /**
@@ -55,5 +67,54 @@ class TapaConfig extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Determina si la cocina está abierta en este momento.
+     * Si kitchen_opens_at o kitchen_closes_at son null, se considera siempre abierta.
+     * Soporta rangos que cruzan medianoche (ej: 22:00 – 02:00).
+     *
+     * @return bool
+     */
+    public function isKitchenOpen(): bool
+    {
+        if ($this->kitchen_opens_at === null || $this->kitchen_closes_at === null) {
+            return true;
+        }
+
+        $now    = Carbon::now()->format('H:i:s');
+        $opens  = $this->kitchen_opens_at;
+        $closes = $this->kitchen_closes_at;
+
+        if ($opens <= $closes) {
+            return $now >= $opens && $now <= $closes;
+        }
+
+        // Rango que cruza medianoche (ej: 22:00 – 02:00)
+        return $now >= $opens || $now <= $closes;
+    }
+
+    /**
+     * Determina si se debe mostrar el modal de sugerencia de tapa al cliente.
+     *
+     * @param  int  $barItemsCount     Bebidas de barra en órdenes activas de la mesa
+     * @param  int  $tapaVariantsUsed  Variantes distintas de tapas ya pedidas en la mesa
+     * @return bool
+     */
+    public function shouldSuggestTapa(int $barItemsCount, int $tapaVariantsUsed): bool
+    {
+        if (! $this->tapas_enabled) {
+            return false;
+        }
+
+        if (! $this->isKitchenOpen()) {
+            return false;
+        }
+
+        if ($barItemsCount <= 0) {
+            return false;
+        }
+
+        return $tapaVariantsUsed < $this->max_tapa_variants;
     }
 }

--- a/database/factories/TapaConfigFactory.php
+++ b/database/factories/TapaConfigFactory.php
@@ -18,11 +18,15 @@ class TapaConfigFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id'           => User::factory(),
-            'tapas_enabled'     => false,
-            'tapas_free'        => true,
-            'max_tapa_variants' => 3,
-            'tapa_price'        => null,
+            'user_id'            => User::factory(),
+            'tapas_enabled'      => false,
+            'tapas_free'         => true,
+            'max_tapa_variants'  => 3,
+            'tapa_price'         => null,
+            'extra_tapa_enabled' => false,
+            'extra_tapa_price'   => null,
+            'kitchen_opens_at'   => null,
+            'kitchen_closes_at'  => null,
         ];
     }
 }

--- a/database/migrations/2026_05_03_000001_add_kitchen_schedule_and_extra_tapa_to_tapa_configs_table.php
+++ b/database/migrations/2026_05_03_000001_add_kitchen_schedule_and_extra_tapa_to_tapa_configs_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Añade campos de tapa extra y horario de cocina a tapa_configs.
+ *
+ * @author BenjaminDTS
+ */
+return new class extends Migration
+{
+    /**
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('tapa_configs', function (Blueprint $table) {
+            $table->boolean('extra_tapa_enabled')->default(false)->after('tapa_price');
+            $table->decimal('extra_tapa_price', 8, 2)->nullable()->after('extra_tapa_enabled');
+            $table->time('kitchen_opens_at')->nullable()->after('extra_tapa_price');
+            $table->time('kitchen_closes_at')->nullable()->after('kitchen_opens_at');
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('tapa_configs', function (Blueprint $table) {
+            $table->dropColumn([
+                'extra_tapa_enabled',
+                'extra_tapa_price',
+                'kitchen_opens_at',
+                'kitchen_closes_at',
+            ]);
+        });
+    }
+};

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -35,30 +35,32 @@
                     ->values(),
             ]);
         })->values();
+
+        $tapaProductsForAlpine = $tapaProducts->map(fn ($p) => [
+            'id'    => $p->id,
+            'name'  => $p->name,
+            'price' => (float) $p->price,
+        ])->values();
+
+        $tapaConfigForAlpine = [
+            'enabled'       => $tapaConfig?->tapas_enabled ?? false,
+            'free'          => $tapaConfig?->tapas_free ?? true,
+            'tapaPrice'     => (float) ($tapaConfig?->tapa_price ?? 0),
+            'extraEnabled'  => $tapaConfig?->extra_tapa_enabled ?? false,
+            'extraPrice'    => (float) ($tapaConfig?->extra_tapa_price ?? 0),
+            'maxVariants'   => $tapaConfig?->max_tapa_variants ?? 0,
+            'shouldSuggest' => $shouldSuggest,
+            'variantsUsed'  => $tapaVariantsUsed,
+            'barItemsCount' => (int) $barItemsCount,
+            'kitchenOpen'   => $kitchenOpen,
+        ];
     @endphp
 
     {{-- Los datos se inyectan en un <script> separado para evitar conflictos
          de escapado al pasar JSON como argumento en x-data. --}}
     <script id="menu-products" type="application/json">@json($productsForAlpine)</script>
-    <script id="tapa-config" type="application/json">@json([
-        'enabled'       => $tapaConfig?->tapas_enabled ?? false,
-        'free'          => $tapaConfig?->tapas_free ?? true,
-        'tapaPrice'     => (float) ($tapaConfig?->tapa_price ?? 0),
-        'extraEnabled'  => $tapaConfig?->extra_tapa_enabled ?? false,
-        'extraPrice'    => (float) ($tapaConfig?->extra_tapa_price ?? 0),
-        'maxVariants'   => $tapaConfig?->max_tapa_variants ?? 0,
-        'shouldSuggest' => $shouldSuggest,
-        'variantsUsed'  => $tapaVariantsUsed,
-        'barItemsCount' => (int) $barItemsCount,
-        'kitchenOpen'   => $kitchenOpen,
-    ])</script>
-    <script id="tapa-products" type="application/json">@json(
-        $tapaProducts->map(fn ($p) => [
-            'id'    => $p->id,
-            'name'  => $p->name,
-            'price' => (float) $p->price,
-        ])->values()
-    )</script>
+    <script id="tapa-config" type="application/json">@json($tapaConfigForAlpine)</script>
+    <script id="tapa-products" type="application/json">@json($tapaProductsForAlpine)</script>
 
     <script>
         document.addEventListener('alpine:init', () => {

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -40,11 +40,35 @@
     {{-- Los datos se inyectan en un <script> separado para evitar conflictos
          de escapado al pasar JSON como argumento en x-data. --}}
     <script id="menu-products" type="application/json">@json($productsForAlpine)</script>
+    <script id="tapa-config" type="application/json">@json([
+        'enabled'       => $tapaConfig?->tapas_enabled ?? false,
+        'free'          => $tapaConfig?->tapas_free ?? true,
+        'tapaPrice'     => (float) ($tapaConfig?->tapa_price ?? 0),
+        'extraEnabled'  => $tapaConfig?->extra_tapa_enabled ?? false,
+        'extraPrice'    => (float) ($tapaConfig?->extra_tapa_price ?? 0),
+        'maxVariants'   => $tapaConfig?->max_tapa_variants ?? 0,
+        'shouldSuggest' => $shouldSuggest,
+        'variantsUsed'  => $tapaVariantsUsed,
+        'barItemsCount' => (int) $barItemsCount,
+        'kitchenOpen'   => $kitchenOpen,
+    ])</script>
+    <script id="tapa-products" type="application/json">@json(
+        $tapaProducts->map(fn ($p) => [
+            'id'    => $p->id,
+            'name'  => $p->name,
+            'price' => (float) $p->price,
+        ])->values()
+    )</script>
 
     <script>
         document.addEventListener('alpine:init', () => {
             const raw  = document.getElementById('menu-products');
             const list = raw ? JSON.parse(raw.textContent) : [];
+
+            const rawTapa      = document.getElementById('tapa-config');
+            const tapaConfig   = rawTapa ? JSON.parse(rawTapa.textContent) : {};
+            const rawTapaProd  = document.getElementById('tapa-products');
+            const tapaProdList = rawTapaProd ? JSON.parse(rawTapaProd.textContent) : [];
 
             // ── Carrito global ──────────────────────────────────────────
             Alpine.store('cart', {
@@ -54,6 +78,12 @@
                 sent:    false,
                 error:   null,
                 tableHash: '{{ $table->unique_hash }}',
+
+                showTapaModal:  false,
+                tapaConfig:     tapaConfig,
+                tapaProducts:   tapaProdList,
+                _barItemsCount: tapaConfig.barItemsCount ?? 0,
+                _variantsUsed:  tapaConfig.variantsUsed  ?? 0,
 
                 add(product) {
                     const existing = this.items.find(i => i.productId === product.id);
@@ -70,6 +100,38 @@
                             extras:     product.extras    || [],
                         });
                     }
+                    if (product.destination === 'bar') {
+                        this._barItemsCount++;
+                        this._checkTapaSuggestion();
+                    }
+                },
+
+                _checkTapaSuggestion() {
+                    const cfg = this.tapaConfig;
+                    if (!cfg.enabled)                             return;
+                    if (!cfg.kitchenOpen)                         return;
+                    if (this._barItemsCount <= 0)                 return;
+                    if (this._variantsUsed >= cfg.maxVariants)    return;
+                    if (this.tapaProducts.length === 0)           return;
+                    this.showTapaModal = true;
+                },
+
+                closeTapaModal() {
+                    this.showTapaModal = false;
+                },
+
+                addTapa(tapaProduct) {
+                    const price = this.tapaConfig.free ? 0 : this.tapaConfig.tapaPrice;
+                    this.add({
+                        id:          tapaProduct.id,
+                        name:        tapaProduct.name,
+                        price:       price,
+                        destination: 'kitchen',
+                        removable:   [],
+                        extras:      [],
+                    });
+                    this._variantsUsed++;
+                    this.showTapaModal = false;
                 },
 
                 inc(idx) { this.items[idx].quantity++; },
@@ -1454,6 +1516,26 @@
         {{-- ── Contenido principal ──────────────────────────────────── --}}
         <main id="main-content" class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 space-y-10">
 
+            {{-- ── Banner cocina cerrada ──────────────────────────────── --}}
+            @if(!$kitchenOpen)
+            <div role="status"
+                 class="rounded-xl bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 p-4 sm:p-5 flex flex-col sm:flex-row items-start sm:items-center gap-3">
+                <span aria-hidden="true" class="text-2xl leading-none">🕐</span>
+                <div class="flex-1">
+                    <p class="text-sm font-semibold text-blue-800 dark:text-blue-300">
+                        {{ __('La cocina está cerrada en este momento') }}
+                    </p>
+                    <p class="text-xs text-blue-700 dark:text-blue-400 mt-0.5">
+                        {{ __('Ahora solo se sirven bebidas.') }}
+                        @if($tapaConfig?->kitchen_opens_at)
+                            {{ __('La cocina abre a las') }}
+                            <span class="font-semibold">{{ substr($tapaConfig->kitchen_opens_at, 0, 5) }}</span>.
+                        @endif
+                    </p>
+                </div>
+            </div>
+            @endif
+
             {{-- Estado vacío cuando los filtros excluyen todo --}}
             <div x-show="hasActiveFilters && visibleCount === 0"
                  x-transition
@@ -1625,17 +1707,111 @@
                     </p>
                     <p class="text-xs text-amber-700 dark:text-amber-400 mt-0.5">
                         @if($tapaConfig->tapas_free)
-                            {{ __('Las tapas son gratuitas. Puedes pedirlas indicándolo en tu comanda.') }}
+                            {{ __('Las tapas son gratuitas. Al añadir una bebida te sugeriremos tu tapa.') }}
                         @else
                             {{ __('Precio por tapa:') }}
                             <span class="font-semibold">{{ number_format($tapaConfig->tapa_price ?? 0, 2) }} €</span>
                         @endif
                         &bull; {{ __('Máximo') }} {{ $tapaConfig->max_tapa_variants }} {{ Str::plural('variante', $tapaConfig->max_tapa_variants) }} {{ __('distintas.') }}
+                        @if($tapaConfig->extra_tapa_enabled)
+                            &bull; {{ __('Tapa extra disponible por') }}
+                            <span class="font-semibold">{{ number_format($tapaConfig->extra_tapa_price ?? 0, 2) }} €</span>.
+                        @endif
                     </p>
                 </div>
             </div>
         </section>
         @endif
+
+        {{-- ── Modal sugerencia de tapa ────────────────────────────── --}}
+        <div x-show="$store.cart.showTapaModal"
+             x-transition:enter="transition ease-out duration-300"
+             x-transition:enter-start="opacity-0"
+             x-transition:enter-end="opacity-100"
+             x-transition:leave="transition ease-in duration-200"
+             x-transition:leave-start="opacity-100"
+             x-transition:leave-end="opacity-0"
+             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
+             @click.self="$store.cart.closeTapaModal()"
+             @keydown.escape.window="$store.cart.closeTapaModal()"
+             aria-modal="true"
+             role="dialog"
+             aria-label="Elige tu tapa"
+             style="display:none">
+
+            <div x-show="$store.cart.showTapaModal"
+                 x-transition:enter="transition ease-out duration-300"
+                 x-transition:enter-start="translate-y-full"
+                 x-transition:enter-end="translate-y-0"
+                 x-transition:leave="transition ease-in duration-200"
+                 x-transition:leave-start="translate-y-0"
+                 x-transition:leave-end="translate-y-full"
+                 class="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900
+                        rounded-t-2xl shadow-2xl px-5 pb-8 pt-4 max-h-[85dvh] overflow-y-auto">
+
+                <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-4"></div>
+
+                <h2 class="text-lg font-bold text-gray-900 dark:text-white mb-1">
+                    🍽️ {{ __('¿Quieres una tapa?') }}
+                </h2>
+                <p class="text-sm text-gray-500 dark:text-gray-400 mb-4"
+                   x-text="'Te quedan ' + ($store.cart.tapaConfig.maxVariants - $store.cart._variantsUsed) + ' variante(s) disponible(s).'">
+                </p>
+
+                <ul class="space-y-2 mb-4" aria-label="Tapas disponibles">
+                    <template x-for="tapa in $store.cart.tapaProducts" :key="tapa.id">
+                        <li>
+                            <button type="button"
+                                    @click="$store.cart.addTapa(tapa)"
+                                    class="w-full flex items-center justify-between px-4 py-3 rounded-xl
+                                           bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700
+                                           hover:bg-amber-100 dark:hover:bg-amber-800/30 transition-colors
+                                           focus:outline-none focus:ring-2 focus:ring-amber-500">
+                                <span class="font-medium text-gray-900 dark:text-white" x-text="tapa.name"></span>
+                                <span class="text-sm font-semibold text-amber-700 dark:text-amber-300"
+                                      x-text="$store.cart.tapaConfig.free ? 'Gratis' : ($store.cart.tapaConfig.tapaPrice.toFixed(2).replace('.', ',') + ' €')">
+                                </span>
+                            </button>
+                        </li>
+                    </template>
+                </ul>
+
+                {{-- Tapa extra (si está habilitada) --}}
+                <template x-if="$store.cart.tapaConfig.extraEnabled">
+                    <div class="border-t border-gray-200 dark:border-gray-700 pt-4 mb-4">
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                            {{ __('Tapa extra (no consume variante)') }} —
+                            <span x-text="$store.cart.tapaConfig.extraPrice.toFixed(2).replace('.', ',') + ' €'"></span>
+                        </p>
+                        <template x-for="tapa in $store.cart.tapaProducts" :key="'extra-' + tapa.id">
+                            <button type="button"
+                                    @click="$store.cart.add({
+                                        id: tapa.id,
+                                        name: tapa.name + ' (extra)',
+                                        price: $store.cart.tapaConfig.extraPrice,
+                                        destination: 'kitchen',
+                                        removable: [],
+                                        extras: []
+                                    }); $store.cart.closeTapaModal()"
+                                    class="w-full mb-2 px-4 py-2.5 rounded-xl border border-gray-300 dark:border-gray-600
+                                           text-sm text-left text-gray-700 dark:text-gray-300
+                                           hover:border-indigo-400 hover:text-indigo-600 dark:hover:text-indigo-400
+                                           transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                    x-text="tapa.name + ' (+' + $store.cart.tapaConfig.extraPrice.toFixed(2).replace('.', ',') + ' €)'">
+                            </button>
+                        </template>
+                    </div>
+                </template>
+
+                <button type="button"
+                        @click="$store.cart.closeTapaModal()"
+                        class="w-full py-2.5 rounded-xl text-sm font-medium text-gray-500 dark:text-gray-400
+                               hover:text-gray-700 dark:hover:text-gray-200
+                               focus:outline-none focus:underline transition-colors">
+                    {{ __('Ahora no') }}
+                </button>
+            </div>
+        </div>
 
         {{-- ── Footer ──────────────────────────────────────────────── --}}
         <footer class="mt-12 border-t border-gray-200 dark:border-gray-800 py-6 text-center">

--- a/resources/views/tapas/edit.blade.php
+++ b/resources/views/tapas/edit.blade.php
@@ -1,4 +1,5 @@
 {{-- @author SebastianBCF --}}
+{{-- @author BenjaminDTS --}}
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
@@ -9,7 +10,6 @@
     <div class="py-12">
         <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
 
-            {{-- Flash de éxito --}}
             @if(session('success'))
             <div role="alert" class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-6">
                 {{ session('success') }}
@@ -22,14 +22,15 @@
                     method="POST"
                     action="{{ route('tapas.update') }}"
                     x-data="{
-                        tapas_enabled: {{ $tapaConfig->tapas_enabled ? 'true' : 'false' }},
-                        tapas_free: {{ $tapaConfig->tapas_free ? 'true' : 'false' }}
+                        tapas_enabled:      {{ $tapaConfig->tapas_enabled ? 'true' : 'false' }},
+                        tapas_free:         {{ $tapaConfig->tapas_free ? 'true' : 'false' }},
+                        extra_tapa_enabled: {{ $tapaConfig->extra_tapa_enabled ? 'true' : 'false' }}
                     }"
                 >
                     @csrf
                     @method('PUT')
 
-                    {{-- ── Activar tapas ── --}}
+                    {{-- ── SECCIÓN 1: Tapas básicas ─────────────────────── --}}
                     <div class="flex items-center justify-between mb-6">
                         <div>
                             <label for="tapas_enabled_btn" class="text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -56,7 +57,6 @@
                         <input type="hidden" name="tapas_enabled" :value="tapas_enabled ? '1' : '0'">
                     </div>
 
-                    {{-- ── Configuración detallada (visible solo si tapas activas) ── --}}
                     <div x-show="tapas_enabled" x-transition class="space-y-6 border-t border-gray-200 dark:border-gray-700 pt-6">
 
                         {{-- Gratuitas / de pago --}}
@@ -90,6 +90,7 @@
                         <div x-show="!tapas_free" x-transition>
                             <label for="tapa_price" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                                 {{ __('Precio por tapa (€)') }}
+                                <span aria-hidden="true" class="text-red-500 ml-0.5">*</span>
                             </label>
                             <input
                                 type="number"
@@ -99,22 +100,75 @@
                                 min="0"
                                 max="999.99"
                                 step="0.01"
+                                aria-required="true"
+                                aria-describedby="error-tapa_price"
                                 class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
                                 placeholder="0.00"
-                                aria-describedby="error-tapa_price"
                             >
                             @error('tapa_price')
                                 <p id="error-tapa_price" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                             @enderror
                         </div>
 
-                        {{-- Máximo de variantes distintas --}}
-                        <div>
+                        {{-- ── SECCIÓN 2: Tapa extra ────────────────────── --}}
+                        <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
+                            <div class="flex items-center justify-between mb-4">
+                                <div>
+                                    <label for="extra_tapa_enabled_btn" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                        {{ __('Permitir tapa extra de pago') }}
+                                    </label>
+                                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                        {{ __('El cliente puede pedir una tapa adicional con precio fijo aunque las tapas base sean gratuitas. No consume variante del límite.') }}
+                                    </p>
+                                </div>
+                                <button
+                                    id="extra_tapa_enabled_btn"
+                                    type="button"
+                                    role="switch"
+                                    :aria-checked="extra_tapa_enabled.toString()"
+                                    @click="extra_tapa_enabled = !extra_tapa_enabled"
+                                    :class="extra_tapa_enabled ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+                                    class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                                >
+                                    <span
+                                        :class="extra_tapa_enabled ? 'translate-x-6' : 'translate-x-1'"
+                                        class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform"
+                                    ></span>
+                                </button>
+                                <input type="hidden" name="extra_tapa_enabled" :value="extra_tapa_enabled ? '1' : '0'">
+                            </div>
+
+                            <div x-show="extra_tapa_enabled" x-transition>
+                                <label for="extra_tapa_price" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                    {{ __('Precio de la tapa extra (€)') }}
+                                    <span aria-hidden="true" class="text-red-500 ml-0.5">*</span>
+                                </label>
+                                <input
+                                    type="number"
+                                    id="extra_tapa_price"
+                                    name="extra_tapa_price"
+                                    value="{{ old('extra_tapa_price', $tapaConfig->extra_tapa_price) }}"
+                                    min="0"
+                                    max="999.99"
+                                    step="0.01"
+                                    aria-required="true"
+                                    aria-describedby="error-extra_tapa_price"
+                                    class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                                    placeholder="0.00"
+                                >
+                                @error('extra_tapa_price')
+                                    <p id="error-extra_tapa_price" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                                @enderror
+                            </div>
+                        </div>
+
+                        {{-- ── SECCIÓN 3: Máximo de variantes ──────────── --}}
+                        <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
                             <label for="max_tapa_variants" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                                 {{ __('Máximo de variantes de tapa por mesa') }}
                             </label>
                             <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
-                                {{ __('Número máximo de tapas distintas que se pueden pedir en un mismo pedido (p. ej. 3).') }}
+                                {{ __('Número máximo de tapas distintas que se pueden elegir en los pedidos activos de una mesa (ej. 3 significa que pueden elegir hasta 3 tapas diferentes).') }}
                             </p>
                             <input
                                 type="number"
@@ -132,9 +186,58 @@
                             @enderror
                         </div>
 
+                        {{-- ── SECCIÓN 4: Horario de cocina ─────────────── --}}
+                        <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
+                            <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                {{ __('Horario de cocina') }}
+                            </h3>
+                            <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">
+                                {{ __('Si tu cocina cierra en determinados momentos (por ejemplo, solo sirves bebidas a media tarde), configura aquí su horario. Fuera del horario, los productos de cocina no aparecen en la carta. Deja los campos vacíos si la cocina siempre está disponible.') }}
+                            </p>
+
+                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                <div>
+                                    <label for="kitchen_opens_at" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                        {{ __('Abre a las') }}
+                                    </label>
+                                    <input
+                                        type="time"
+                                        id="kitchen_opens_at"
+                                        name="kitchen_opens_at"
+                                        value="{{ old('kitchen_opens_at', $tapaConfig->kitchen_opens_at ? substr($tapaConfig->kitchen_opens_at, 0, 5) : '') }}"
+                                        aria-describedby="error-kitchen_opens_at"
+                                        class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                                    >
+                                    @error('kitchen_opens_at')
+                                        <p id="error-kitchen_opens_at" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                                    @enderror
+                                </div>
+
+                                <div>
+                                    <label for="kitchen_closes_at" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                        {{ __('Cierra a las') }}
+                                    </label>
+                                    <input
+                                        type="time"
+                                        id="kitchen_closes_at"
+                                        name="kitchen_closes_at"
+                                        value="{{ old('kitchen_closes_at', $tapaConfig->kitchen_closes_at ? substr($tapaConfig->kitchen_closes_at, 0, 5) : '') }}"
+                                        aria-describedby="error-kitchen_closes_at"
+                                        class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                                    >
+                                    @error('kitchen_closes_at')
+                                        <p id="error-kitchen_closes_at" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            <p class="text-xs text-amber-600 dark:text-amber-400 mt-2">
+                                {{ __('Si dejas ambos campos vacíos, la cocina se considera siempre disponible.') }}
+                            </p>
+                        </div>
+
                     </div>
 
-                    {{-- Botón guardar --}}
                     <div class="mt-8 flex justify-end">
                         <button
                             type="submit"

--- a/tests/Feature/Bloque6/TapasTest.php
+++ b/tests/Feature/Bloque6/TapasTest.php
@@ -2,14 +2,18 @@
 
 /**
  * @author AyrtonAlania
+ * @author BenjaminDTS
  */
 
+use App\Models\Category;
 use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\Plan;
+use App\Models\Product;
 use App\Models\Table;
 use App\Models\TapaConfig;
 use App\Models\User;
+use Illuminate\Support\Carbon;
 
 uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
 
@@ -134,6 +138,27 @@ it('tapa_price is cleared when tapas_free is switched to true', function () {
         'user_id'    => $this->user->id,
         'tapa_price' => null,
     ]);
+});
+
+it('fails update when tapas are paid and tapa_price is missing', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '0',
+             'max_tapa_variants' => 3,
+         ])
+         ->assertSessionHasErrors('tapa_price');
+});
+
+it('fails update when tapas are paid and tapa_price is invalid', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '0',
+             'max_tapa_variants' => 3,
+             'tapa_price'        => 'abc',
+         ])
+         ->assertSessionHasErrors('tapa_price');
 });
 
 // ─── Variantes máximas ────────────────────────────────────────────────────────
@@ -275,28 +300,6 @@ it('only counts bar items from active orders excluding closed ones', function ()
     expect($response->viewData('barItemsCount'))->toBe(5);
 });
 
-it('fails update when tapas are paid and tapa_price is missing', function () {
-    $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
-             'tapas_enabled'     => '1',
-             'tapas_free'        => '0',
-             'max_tapa_variants' => 3,
-             // tapa_price intencionalmente ausente
-         ])
-         ->assertSessionHasErrors('tapa_price');
-});
-
-it('fails update when tapas are paid and tapa_price is invalid', function () {
-    $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
-             'tapas_enabled'     => '1',
-             'tapas_free'        => '0',
-             'max_tapa_variants' => 3,
-             'tapa_price'        => 'abc',
-         ])
-         ->assertSessionHasErrors('tapa_price');
-});
-
 it('waiter role cannot access tapas config', function () {
     $waiter = User::factory()->create(['role' => 'waiter']);
 
@@ -321,4 +324,444 @@ it('flash success message shown after saving tapa config', function () {
              'max_tapa_variants' => 3,
          ])
          ->assertSessionHas('success');
+});
+
+// ─── Categoría automática de Tapas ───────────────────────────────────────────
+
+it('creates Tapas category when tapas are enabled for the first time', function () {
+    $this->assertDatabaseMissing('categories', ['user_id' => $this->user->id, 'name' => 'Tapas']);
+
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+         ]);
+
+    $this->assertDatabaseHas('categories', [
+        'user_id' => $this->user->id,
+        'name'    => 'Tapas',
+    ]);
+});
+
+it('creates Tapas category with destination kitchen', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+         ]);
+
+    $this->assertDatabaseHas('categories', [
+        'user_id'     => $this->user->id,
+        'name'        => 'Tapas',
+        'destination' => 'kitchen',
+    ]);
+});
+
+it('does not create duplicate Tapas category if already exists', function () {
+    Category::factory()->create([
+        'user_id'     => $this->user->id,
+        'name'        => 'Tapas',
+        'destination' => 'kitchen',
+    ]);
+
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+         ]);
+
+    expect(Category::where('user_id', $this->user->id)->where('name', 'Tapas')->count())->toBe(1);
+});
+
+it('does not delete Tapas category when tapas are disabled', function () {
+    Category::factory()->create([
+        'user_id'     => $this->user->id,
+        'name'        => 'Tapas',
+        'destination' => 'kitchen',
+    ]);
+
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => true,
+    ]);
+
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '0',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+         ]);
+
+    $this->assertDatabaseHas('categories', [
+        'user_id' => $this->user->id,
+        'name'    => 'Tapas',
+    ]);
+});
+
+// ─── Tapa extra ───────────────────────────────────────────────────────────────
+
+it('fails to save extra tapa enabled without extra tapa price', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'      => '1',
+             'tapas_free'         => '1',
+             'max_tapa_variants'  => 3,
+             'extra_tapa_enabled' => '1',
+             // extra_tapa_price ausente
+         ])
+         ->assertSessionHasErrors('extra_tapa_price');
+});
+
+it('allows saving extra tapa disabled without extra tapa price', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'      => '1',
+             'tapas_free'         => '1',
+             'max_tapa_variants'  => 3,
+             'extra_tapa_enabled' => '0',
+         ])
+         ->assertSessionMissing('errors')
+         ->assertRedirect(route('tapas.edit'));
+});
+
+it('saves extra tapa config correctly', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'      => '1',
+             'tapas_free'         => '1',
+             'max_tapa_variants'  => 3,
+             'extra_tapa_enabled' => '1',
+             'extra_tapa_price'   => '2.50',
+         ]);
+
+    $config = TapaConfig::where('user_id', $this->user->id)->first();
+
+    expect($config->extra_tapa_enabled)->toBeTrue()
+        ->and((float) $config->extra_tapa_price)->toBe(2.50);
+});
+
+it('clears extra tapa price when extra tapa is disabled', function () {
+    TapaConfig::factory()->create([
+        'user_id'            => $this->user->id,
+        'tapas_enabled'      => true,
+        'extra_tapa_enabled' => true,
+        'extra_tapa_price'   => 2.00,
+    ]);
+
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'      => '1',
+             'tapas_free'         => '1',
+             'max_tapa_variants'  => 3,
+             'extra_tapa_enabled' => '0',
+         ]);
+
+    $this->assertDatabaseHas('tapa_configs', [
+        'user_id'          => $this->user->id,
+        'extra_tapa_price' => null,
+    ]);
+});
+
+// ─── Horario de cocina ────────────────────────────────────────────────────────
+
+it('saves kitchen schedule fields correctly', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'      => '1',
+             'tapas_free'         => '1',
+             'max_tapa_variants'  => 3,
+             'kitchen_opens_at'   => '10:00',
+             'kitchen_closes_at'  => '23:00',
+         ]);
+
+    $config = TapaConfig::where('user_id', $this->user->id)->first();
+
+    expect($config->kitchen_opens_at)->toStartWith('10:00')
+        ->and($config->kitchen_closes_at)->toStartWith('23:00');
+});
+
+it('allows null kitchen schedule meaning always open', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+         ])
+         ->assertRedirect(route('tapas.edit'));
+
+    $this->assertDatabaseHas('tapa_configs', [
+        'user_id'          => $this->user->id,
+        'kitchen_opens_at' => null,
+        'kitchen_closes_at' => null,
+    ]);
+});
+
+it('fails when only kitchen_opens_at is provided without kitchen_closes_at', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+             'kitchen_opens_at'  => '10:00',
+             // kitchen_closes_at ausente
+         ])
+         ->assertSessionHasErrors('kitchen_closes_at');
+});
+
+it('fails when only kitchen_closes_at is provided without kitchen_opens_at', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'      => '1',
+             'tapas_free'         => '1',
+             'max_tapa_variants'  => 3,
+             'kitchen_closes_at'  => '23:00',
+             // kitchen_opens_at ausente
+         ])
+         ->assertSessionHasErrors('kitchen_opens_at');
+});
+
+it('menu hides kitchen categories when kitchen is closed', function () {
+    Carbon::setTestNow('2026-05-03 15:00:00');
+
+    TapaConfig::factory()->create([
+        'user_id'           => $this->user->id,
+        'tapas_enabled'     => true,
+        'kitchen_opens_at'  => '17:00',
+        'kitchen_closes_at' => '23:00',
+    ]);
+
+    $table           = Table::factory()->create(['user_id' => $this->user->id]);
+    $kitchenCategory = Category::factory()->create(['user_id' => $this->user->id, 'destination' => 'kitchen']);
+    $barCategory     = Category::factory()->create(['user_id' => $this->user->id, 'destination' => 'bar']);
+
+    Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $kitchenCategory->id, 'is_active' => true]);
+    Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $barCategory->id, 'is_active' => true]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+
+    $response->assertOk();
+    expect($response->viewData('kitchenOpen'))->toBeFalse();
+
+    $categories = $response->viewData('categories');
+    $destinations = $categories->pluck('destination')->unique()->values()->toArray();
+    expect($destinations)->not->toContain('kitchen');
+
+    Carbon::setTestNow();
+});
+
+it('menu shows all categories when no schedule is configured', function () {
+    TapaConfig::factory()->create([
+        'user_id'           => $this->user->id,
+        'tapas_enabled'     => true,
+        'kitchen_opens_at'  => null,
+        'kitchen_closes_at' => null,
+    ]);
+
+    $table           = Table::factory()->create(['user_id' => $this->user->id]);
+    $kitchenCategory = Category::factory()->create(['user_id' => $this->user->id, 'destination' => 'kitchen']);
+    $barCategory     = Category::factory()->create(['user_id' => $this->user->id, 'destination' => 'bar']);
+
+    Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $kitchenCategory->id, 'is_active' => true]);
+    Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $barCategory->id, 'is_active' => true]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+
+    $response->assertOk();
+    expect($response->viewData('kitchenOpen'))->toBeTrue();
+
+    $categories   = $response->viewData('categories');
+    $destinations = $categories->pluck('destination')->unique()->sort()->values()->toArray();
+    expect($destinations)->toContain('kitchen')
+        ->and($destinations)->toContain('bar');
+});
+
+// ─── Sugerencia de tapa ───────────────────────────────────────────────────────
+
+it('shouldSuggest is true when conditions are met', function () {
+    Carbon::setTestNow('2026-05-03 12:00:00');
+
+    TapaConfig::factory()->create([
+        'user_id'           => $this->user->id,
+        'tapas_enabled'     => true,
+        'max_tapa_variants' => 3,
+        'kitchen_opens_at'  => '10:00',
+        'kitchen_closes_at' => '23:00',
+    ]);
+
+    $table        = Table::factory()->create(['user_id' => $this->user->id]);
+    $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
+    Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $tapaCategory->id, 'is_active' => true]);
+
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    OrderItem::factory()->create(['order_id' => $order->id, 'destination' => 'bar', 'quantity' => 1]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+    $response->assertOk();
+    expect($response->viewData('shouldSuggest'))->toBeTrue();
+
+    Carbon::setTestNow();
+});
+
+it('shouldSuggest is false when tapas are disabled', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => false,
+    ]);
+
+    $table = Table::factory()->create(['user_id' => $this->user->id]);
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    OrderItem::factory()->create(['order_id' => $order->id, 'destination' => 'bar', 'quantity' => 2]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+    $response->assertOk();
+    expect($response->viewData('shouldSuggest'))->toBeFalse();
+});
+
+it('shouldSuggest is false when kitchen is closed', function () {
+    Carbon::setTestNow('2026-05-03 15:00:00');
+
+    TapaConfig::factory()->create([
+        'user_id'           => $this->user->id,
+        'tapas_enabled'     => true,
+        'max_tapa_variants' => 3,
+        'kitchen_opens_at'  => '17:00',
+        'kitchen_closes_at' => '23:00',
+    ]);
+
+    $table        = Table::factory()->create(['user_id' => $this->user->id]);
+    $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
+    Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $tapaCategory->id, 'is_active' => true]);
+
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    OrderItem::factory()->create(['order_id' => $order->id, 'destination' => 'bar', 'quantity' => 1]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+    $response->assertOk();
+    expect($response->viewData('shouldSuggest'))->toBeFalse();
+
+    Carbon::setTestNow();
+});
+
+it('shouldSuggest is false when max variants already reached', function () {
+    Carbon::setTestNow('2026-05-03 12:00:00');
+
+    TapaConfig::factory()->create([
+        'user_id'           => $this->user->id,
+        'tapas_enabled'     => true,
+        'max_tapa_variants' => 2,
+        'kitchen_opens_at'  => '10:00',
+        'kitchen_closes_at' => '23:00',
+    ]);
+
+    $table        = Table::factory()->create(['user_id' => $this->user->id]);
+    $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
+    $product1     = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $tapaCategory->id, 'is_active' => true]);
+    $product2     = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $tapaCategory->id, 'is_active' => true]);
+    Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $tapaCategory->id, 'is_active' => true]);
+
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    OrderItem::factory()->create(['order_id' => $order->id, 'destination' => 'bar', 'quantity' => 3]);
+    // 2 variantes distintas de tapa ya pedidas (igual al max)
+    OrderItem::factory()->create(['order_id' => $order->id, 'destination' => 'kitchen', 'product_id' => $product1->id, 'quantity' => 1]);
+    OrderItem::factory()->create(['order_id' => $order->id, 'destination' => 'kitchen', 'product_id' => $product2->id, 'quantity' => 1]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+    $response->assertOk();
+    expect($response->viewData('shouldSuggest'))->toBeFalse();
+
+    Carbon::setTestNow();
+});
+
+it('tapa products in view are limited to products from Tapas category', function () {
+    Carbon::setTestNow('2026-05-03 12:00:00');
+
+    TapaConfig::factory()->create([
+        'user_id'           => $this->user->id,
+        'tapas_enabled'     => true,
+        'max_tapa_variants' => 5,
+        'kitchen_opens_at'  => '10:00',
+        'kitchen_closes_at' => '23:00',
+    ]);
+
+    $table        = Table::factory()->create(['user_id' => $this->user->id]);
+    $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
+    $otherCat     = Category::factory()->create(['user_id' => $this->user->id, 'destination' => 'kitchen']);
+
+    $tapaProduct  = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $tapaCategory->id, 'is_active' => true]);
+    Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $otherCat->id, 'is_active' => true]);
+
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    OrderItem::factory()->create(['order_id' => $order->id, 'destination' => 'bar', 'quantity' => 1]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+    $response->assertOk();
+
+    $tapaProducts = $response->viewData('tapaProducts');
+    expect($tapaProducts)->toHaveCount(1)
+        ->and($tapaProducts->first()->id)->toBe($tapaProduct->id);
+
+    Carbon::setTestNow();
+});
+
+it('tapa products only include active products from Tapas category', function () {
+    Carbon::setTestNow('2026-05-03 12:00:00');
+
+    TapaConfig::factory()->create([
+        'user_id'           => $this->user->id,
+        'tapas_enabled'     => true,
+        'max_tapa_variants' => 5,
+        'kitchen_opens_at'  => '10:00',
+        'kitchen_closes_at' => '23:00',
+    ]);
+
+    $table        = Table::factory()->create(['user_id' => $this->user->id]);
+    $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
+
+    $active   = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $tapaCategory->id, 'is_active' => true]);
+    Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $tapaCategory->id, 'is_active' => false]);
+
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    OrderItem::factory()->create(['order_id' => $order->id, 'destination' => 'bar', 'quantity' => 1]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+    $response->assertOk();
+
+    $tapaProducts = $response->viewData('tapaProducts');
+    expect($tapaProducts)->toHaveCount(1)
+        ->and($tapaProducts->first()->id)->toBe($active->id);
+
+    Carbon::setTestNow();
+});
+
+it('tapaVariantsUsed counts distinct tapa products in active orders', function () {
+    Carbon::setTestNow('2026-05-03 12:00:00');
+
+    TapaConfig::factory()->create([
+        'user_id'           => $this->user->id,
+        'tapas_enabled'     => true,
+        'max_tapa_variants' => 5,
+        'kitchen_opens_at'  => '10:00',
+        'kitchen_closes_at' => '23:00',
+    ]);
+
+    $table        = Table::factory()->create(['user_id' => $this->user->id]);
+    $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
+    $product1     = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $tapaCategory->id, 'is_active' => true]);
+    $product2     = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $tapaCategory->id, 'is_active' => true]);
+    Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $tapaCategory->id, 'is_active' => true]);
+
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    // Misma variante pedida 2 veces: solo cuenta como 1
+    OrderItem::factory()->create(['order_id' => $order->id, 'destination' => 'kitchen', 'product_id' => $product1->id, 'quantity' => 2]);
+    OrderItem::factory()->create(['order_id' => $order->id, 'destination' => 'kitchen', 'product_id' => $product2->id, 'quantity' => 1]);
+    OrderItem::factory()->create(['order_id' => $order->id, 'destination' => 'bar', 'quantity' => 3]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+    $response->assertOk();
+    expect($response->viewData('tapaVariantsUsed'))->toBe(2);
+
+    Carbon::setTestNow();
 });

--- a/tests/Unit/TapasCalculatorTest.php
+++ b/tests/Unit/TapasCalculatorTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * Unit tests para los helpers de TapaConfig:
+ * isKitchenOpen() y shouldSuggestTapa().
+ *
+ * @author BenjaminDTS
+ */
+
+use App\Models\TapaConfig;
+use Illuminate\Support\Carbon;
+
+// ─── isKitchenOpen ────────────────────────────────────────────────────────────
+
+it('isKitchenOpen returns true with null schedule', function () {
+    $config = new TapaConfig([
+        'kitchen_opens_at'  => null,
+        'kitchen_closes_at' => null,
+    ]);
+
+    expect($config->isKitchenOpen())->toBeTrue();
+});
+
+it('isKitchenOpen returns true when current time is within schedule', function () {
+    Carbon::setTestNow('2026-05-03 12:00:00');
+
+    $config = new TapaConfig([
+        'kitchen_opens_at'  => '10:00:00',
+        'kitchen_closes_at' => '23:00:00',
+    ]);
+
+    expect($config->isKitchenOpen())->toBeTrue();
+
+    Carbon::setTestNow();
+});
+
+it('isKitchenOpen returns false when current time is outside schedule', function () {
+    Carbon::setTestNow('2026-05-03 09:00:00');
+
+    $config = new TapaConfig([
+        'kitchen_opens_at'  => '10:00:00',
+        'kitchen_closes_at' => '23:00:00',
+    ]);
+
+    expect($config->isKitchenOpen())->toBeFalse();
+
+    Carbon::setTestNow();
+});
+
+it('isKitchenOpen supports ranges crossing midnight', function () {
+    Carbon::setTestNow('2026-05-03 01:00:00');
+
+    $config = new TapaConfig([
+        'kitchen_opens_at'  => '22:00:00',
+        'kitchen_closes_at' => '02:00:00',
+    ]);
+
+    expect($config->isKitchenOpen())->toBeTrue();
+
+    Carbon::setTestNow();
+});
+
+it('isKitchenOpen returns false at midday when range crosses midnight', function () {
+    Carbon::setTestNow('2026-05-03 12:00:00');
+
+    $config = new TapaConfig([
+        'kitchen_opens_at'  => '22:00:00',
+        'kitchen_closes_at' => '02:00:00',
+    ]);
+
+    expect($config->isKitchenOpen())->toBeFalse();
+
+    Carbon::setTestNow();
+});
+
+it('isKitchenOpen returns false when only opens_at is null', function () {
+    $config = new TapaConfig([
+        'kitchen_opens_at'  => null,
+        'kitchen_closes_at' => '23:00:00',
+    ]);
+
+    // Un solo campo null = sin horario = siempre abierta
+    expect($config->isKitchenOpen())->toBeTrue();
+});
+
+// ─── shouldSuggestTapa ────────────────────────────────────────────────────────
+
+it('shouldSuggestTapa returns false when tapas disabled even if kitchen is open', function () {
+    Carbon::setTestNow('2026-05-03 12:00:00');
+
+    $config = new TapaConfig([
+        'tapas_enabled'     => false,
+        'max_tapa_variants' => 3,
+        'kitchen_opens_at'  => '10:00:00',
+        'kitchen_closes_at' => '23:00:00',
+    ]);
+
+    expect($config->shouldSuggestTapa(2, 0))->toBeFalse();
+
+    Carbon::setTestNow();
+});
+
+it('shouldSuggestTapa returns false when kitchen closed even if tapas enabled', function () {
+    Carbon::setTestNow('2026-05-03 09:00:00');
+
+    $config = new TapaConfig([
+        'tapas_enabled'     => true,
+        'max_tapa_variants' => 3,
+        'kitchen_opens_at'  => '10:00:00',
+        'kitchen_closes_at' => '23:00:00',
+    ]);
+
+    expect($config->shouldSuggestTapa(2, 0))->toBeFalse();
+
+    Carbon::setTestNow();
+});
+
+it('shouldSuggestTapa returns false when barItemsCount is zero', function () {
+    $config = new TapaConfig([
+        'tapas_enabled'     => true,
+        'max_tapa_variants' => 3,
+        'kitchen_opens_at'  => null,
+        'kitchen_closes_at' => null,
+    ]);
+
+    expect($config->shouldSuggestTapa(0, 0))->toBeFalse();
+});
+
+it('shouldSuggestTapa returns false when max variants already reached', function () {
+    $config = new TapaConfig([
+        'tapas_enabled'     => true,
+        'max_tapa_variants' => 2,
+        'kitchen_opens_at'  => null,
+        'kitchen_closes_at' => null,
+    ]);
+
+    expect($config->shouldSuggestTapa(3, 2))->toBeFalse();
+});
+
+it('shouldSuggestTapa returns true when all conditions are met', function () {
+    $config = new TapaConfig([
+        'tapas_enabled'     => true,
+        'max_tapa_variants' => 3,
+        'kitchen_opens_at'  => null,
+        'kitchen_closes_at' => null,
+    ]);
+
+    expect($config->shouldSuggestTapa(2, 1))->toBeTrue();
+});


### PR DESCRIPTION
## 📝 Descripción
<!-- Resumen claro de los cambios introducidos en este PR -->


## 🔗 Issue Relacionado
<!-- Enlaza el issue o tarea que resuelve este PR -->
Closes #...

## 🔢 Bloque del Roadmap
<!-- Indica el bloque al que pertenece, ej: Bloque 1.6 -->
**Bloque:** X.X

## 🧩 Tipo de Cambio
- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Refactorización sin cambio de comportamiento
- [ ] `style` — Cambios visuales sin lógica
- [ ] `docs` — Solo documentación
- [ ] `test` — Pruebas

---

## ✅ Checklist — Backend (BenjaminDTS)
- [ ] La rama parte de `main` actualizado
- [ ] Un commit por acción concreta (rutas, controlador, vista por separado)
- [ ] Todos los métodos tienen PHPDoc completo (`@param`, `@return`)
- [ ] `@author` solo en la cabecera de la clase, nunca en los métodos
- [ ] `abort_if($model->user_id !== Auth::id(), 403)` en `edit`, `update` y `destroy`
- [ ] Validaciones con `$request->validate([...])` en `store` y `update`
- [ ] Mensajes flash implementados (`->with('success', '...')`)
- [ ] Si hay imágenes: se borra la vieja antes de guardar la nueva
- [ ] Migraciones documentadas si hay cambios en BBDD
- [ ] La aplicación arranca sin errores (`php artisan serve`)

## ✅ Checklist — Frontend (SebastianBCF)
- [ ] `npm run build` ejecutado con los cambios de Tailwind
- [ ] Vistas muestran correctamente los mensajes flash (`@if(session('success'))`)
- [ ] HTML5 semántico y Mobile-First
- [ ] Sin `console.log` en el código

## ✅ Checklist — QA (Ayrton)
- [ ] Happy path probado y funciona correctamente
- [ ] Validaciones del formulario verificadas (campos requeridos, formatos)
- [ ] Multitenancy verificado: un usuario no accede a datos de otro
- [ ] Mensajes flash de éxito y error aparecen correctamente
- [ ] No hay regresiones en funcionalidades existentes

---

## 📸 Capturas de Pantalla
<!-- Si aplica, añade capturas antes/después de los cambios visuales -->

## 🔗 Contexto Adicional
<!-- Cualquier información relevante para el revisor -->
