### PR TITLE
feat(tapas): multi-slot kitchen schedule and improved tapas system

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -32,7 +32,12 @@ class MenuController extends Controller
         $table  = Table::where('unique_hash', $hash)->firstOrFail();
         $config = $table->user->tapaConfig;
 
-        $kitchenOpen = ! ($config && $config->tapas_enabled) || $config->isKitchenOpen();
+        if ($config) {
+            $config->load('schedules');
+        }
+
+        $kitchenOpen     = ! ($config && $config->tapas_enabled) || $config->isKitchenOpen();
+        $nextOpeningTime = ($config && ! $kitchenOpen) ? $config->nextOpeningTime() : null;
 
         $categories = Category::where('user_id', $table->user_id)
             ->when(! $kitchenOpen, fn ($q) => $q->where('destination', 'bar'))
@@ -112,7 +117,7 @@ class MenuController extends Controller
 
         return view('menu.show', compact(
             'table', 'categories', 'allergens',
-            'tapaConfig', 'barItemsCount', 'kitchenOpen',
+            'tapaConfig', 'barItemsCount', 'kitchenOpen', 'nextOpeningTime',
             'tapaVariantsUsed', 'tapaProducts', 'shouldSuggest',
             'hasActiveOrder', 'activeOrderTotal', 'billRequested', 'stripePublicKey'
         ));

--- a/app/Http/Controllers/TapasController.php
+++ b/app/Http/Controllers/TapasController.php
@@ -14,7 +14,7 @@ use Illuminate\View\View;
  *
  * Permite al gerente configurar el sistema de tapas del restaurante:
  * activar/desactivar, modo gratuito/de pago, precio, variantes máximas,
- * tapa extra de pago y horario de apertura de cocina.
+ * tapa extra de pago y tramos horarios de apertura de cocina.
  *
  * @author BenjaminDTS
  */
@@ -37,10 +37,10 @@ class TapasController extends Controller
                 'tapa_price'         => null,
                 'extra_tapa_enabled' => false,
                 'extra_tapa_price'   => null,
-                'kitchen_opens_at'   => null,
-                'kitchen_closes_at'  => null,
             ]
         );
+
+        $tapaConfig->load('schedules');
 
         return view('tapas.edit', compact('tapaConfig'));
     }
@@ -48,6 +48,7 @@ class TapasController extends Controller
     /**
      * Guarda la configuración de tapas del restaurante.
      * Al activar tapas crea automáticamente la categoría 'Tapas' con destination=kitchen.
+     * Reemplaza los tramos horarios de cocina por los enviados en el formulario.
      *
      * @param  Request $request
      * @return RedirectResponse
@@ -55,20 +56,21 @@ class TapasController extends Controller
     public function update(Request $request): RedirectResponse
     {
         $request->validate([
-            'tapas_enabled'      => ['sometimes', 'boolean'],
-            'tapas_free'         => ['sometimes', 'boolean'],
-            'max_tapa_variants'  => ['required', 'integer', 'min:1', 'max:20'],
-            'tapa_price'         => ['required_if:tapas_free,0', 'nullable', 'numeric', 'min:0', 'max:999.99'],
-            'extra_tapa_enabled' => ['sometimes', 'boolean'],
-            'extra_tapa_price'   => ['required_if:extra_tapa_enabled,1', 'nullable', 'numeric', 'min:0', 'max:999.99'],
-            'kitchen_opens_at'   => ['nullable', 'date_format:H:i', 'required_with:kitchen_closes_at'],
-            'kitchen_closes_at'  => ['nullable', 'date_format:H:i', 'required_with:kitchen_opens_at'],
+            'tapas_enabled'            => ['sometimes', 'boolean'],
+            'tapas_free'               => ['sometimes', 'boolean'],
+            'max_tapa_variants'        => ['required', 'integer', 'min:1', 'max:20'],
+            'tapa_price'               => ['required_if:tapas_free,0', 'nullable', 'numeric', 'min:0', 'max:999.99'],
+            'extra_tapa_enabled'       => ['sometimes', 'boolean'],
+            'extra_tapa_price'         => ['required_if:extra_tapa_enabled,1', 'nullable', 'numeric', 'min:0', 'max:999.99'],
+            'schedules'                => ['nullable', 'array', 'max:10'],
+            'schedules.*.opens_at'     => ['required', 'date_format:H:i'],
+            'schedules.*.closes_at'    => ['required', 'date_format:H:i'],
         ]);
 
-        $userId        = Auth::id();
-        $tapasEnabled  = $request->boolean('tapas_enabled');
-        $tapas_free    = $request->boolean('tapas_free');
-        $extraEnabled  = $request->boolean('extra_tapa_enabled');
+        $userId       = Auth::id();
+        $tapasEnabled = $request->boolean('tapas_enabled');
+        $tapasFree    = $request->boolean('tapas_free');
+        $extraEnabled = $request->boolean('extra_tapa_enabled');
 
         if ($tapasEnabled) {
             Category::firstOrCreate(
@@ -77,19 +79,26 @@ class TapasController extends Controller
             );
         }
 
-        TapaConfig::updateOrCreate(
+        $config = TapaConfig::updateOrCreate(
             ['user_id' => $userId],
             [
                 'tapas_enabled'      => $tapasEnabled,
-                'tapas_free'         => $tapas_free,
+                'tapas_free'         => $tapasFree,
                 'max_tapa_variants'  => $request->integer('max_tapa_variants'),
-                'tapa_price'         => $tapas_free ? null : ($request->input('tapa_price') ?? null),
+                'tapa_price'         => $tapasFree ? null : ($request->input('tapa_price') ?? null),
                 'extra_tapa_enabled' => $extraEnabled,
                 'extra_tapa_price'   => $extraEnabled ? ($request->input('extra_tapa_price') ?? null) : null,
-                'kitchen_opens_at'   => $request->input('kitchen_opens_at') ?: null,
-                'kitchen_closes_at'  => $request->input('kitchen_closes_at') ?: null,
             ]
         );
+
+        $config->schedules()->delete();
+
+        foreach ($request->input('schedules', []) as $slot) {
+            $config->schedules()->create([
+                'opens_at'  => $slot['opens_at'],
+                'closes_at' => $slot['closes_at'],
+            ]);
+        }
 
         return redirect()->route('tapas.edit')
                          ->with('success', 'Configuración de tapas guardada correctamente.');

--- a/app/Models/KitchenSchedule.php
+++ b/app/Models/KitchenSchedule.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Class KitchenSchedule
+ *
+ * Representa un tramo horario de apertura de cocina asociado a una TapaConfig.
+ * Un restaurante puede tener varios tramos (ej: mediodía y noche).
+ *
+ * @package App\Models
+ * @property string $opens_at   Hora de apertura (HH:MM:SS)
+ * @property string $closes_at  Hora de cierre  (HH:MM:SS)
+ *
+ * @author BenjaminDTS
+ */
+class KitchenSchedule extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'tapa_config_id',
+        'opens_at',
+        'closes_at',
+    ];
+
+    /**
+     * @return BelongsTo
+     */
+    public function tapaConfig(): BelongsTo
+    {
+        return $this->belongsTo(TapaConfig::class);
+    }
+}

--- a/app/Models/TapaConfig.php
+++ b/app/Models/TapaConfig.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 
 /**
@@ -13,7 +14,7 @@ use Illuminate\Support\Carbon;
  * Configuración del sistema de tapas de un restaurante (relación 1:1 con User).
  * Permite al gerente activar tapas, definir si son gratuitas o de pago,
  * el precio unitario, el número máximo de variantes distintas por pedido,
- * la tapa extra de pago y el horario de apertura de cocina.
+ * la tapa extra de pago y los tramos horarios de apertura de cocina.
  *
  * @package App\Models
  * @property int        $user_id
@@ -23,8 +24,6 @@ use Illuminate\Support\Carbon;
  * @property float|null $tapa_price          Precio por tapa (solo si tapas_free = false)
  * @property bool       $extra_tapa_enabled  Si se permite pedir una tapa extra de pago
  * @property float|null $extra_tapa_price    Precio de la tapa extra (obligatorio si extra_tapa_enabled)
- * @property string|null $kitchen_opens_at   Hora de apertura de cocina (HH:MM:SS, null = siempre abierta)
- * @property string|null $kitchen_closes_at  Hora de cierre de cocina (HH:MM:SS, null = siempre abierta)
  *
  * @author BenjaminDTS
  */
@@ -43,8 +42,6 @@ class TapaConfig extends Model
         'tapa_price',
         'extra_tapa_enabled',
         'extra_tapa_price',
-        'kitchen_opens_at',
-        'kitchen_closes_at',
     ];
 
     /**
@@ -70,28 +67,72 @@ class TapaConfig extends Model
     }
 
     /**
+     * Tramos horarios de apertura de cocina configurados por el gerente.
+     *
+     * @return HasMany
+     */
+    public function schedules(): HasMany
+    {
+        return $this->hasMany(KitchenSchedule::class)->orderBy('opens_at');
+    }
+
+    /**
      * Determina si la cocina está abierta en este momento.
-     * Si kitchen_opens_at o kitchen_closes_at son null, se considera siempre abierta.
+     * Sin tramos configurados se considera siempre abierta.
      * Soporta rangos que cruzan medianoche (ej: 22:00 – 02:00).
      *
      * @return bool
      */
     public function isKitchenOpen(): bool
     {
-        if ($this->kitchen_opens_at === null || $this->kitchen_closes_at === null) {
+        $schedules = $this->schedules;
+
+        if ($schedules->isEmpty()) {
             return true;
         }
 
-        $now    = Carbon::now()->format('H:i:s');
-        $opens  = $this->kitchen_opens_at;
-        $closes = $this->kitchen_closes_at;
+        $now = Carbon::now()->format('H:i:s');
 
-        if ($opens <= $closes) {
-            return $now >= $opens && $now <= $closes;
+        foreach ($schedules as $schedule) {
+            $opens  = $schedule->opens_at;
+            $closes = $schedule->closes_at;
+
+            if ($opens <= $closes) {
+                if ($now >= $opens && $now <= $closes) {
+                    return true;
+                }
+            } else {
+                // Tramo que cruza medianoche (ej: 22:00 – 02:00)
+                if ($now >= $opens || $now <= $closes) {
+                    return true;
+                }
+            }
         }
 
-        // Rango que cruza medianoche (ej: 22:00 – 02:00)
-        return $now >= $opens || $now <= $closes;
+        return false;
+    }
+
+    /**
+     * Devuelve la hora de apertura del próximo tramo (HH:MM) para mostrarlo
+     * en el aviso de cocina cerrada. Null si no hay tramos configurados.
+     *
+     * @return string|null
+     */
+    public function nextOpeningTime(): ?string
+    {
+        $schedules = $this->schedules;
+
+        if ($schedules->isEmpty()) {
+            return null;
+        }
+
+        $now  = Carbon::now()->format('H:i:s');
+        $next = $schedules->first(fn ($s) => $s->opens_at > $now);
+
+        // Si no hay tramo posterior hoy, el primero de mañana
+        $schedule = $next ?? $schedules->first();
+
+        return substr($schedule->opens_at, 0, 5);
     }
 
     /**

--- a/database/factories/KitchenScheduleFactory.php
+++ b/database/factories/KitchenScheduleFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\TapaConfig;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\KitchenSchedule>
+ *
+ * @author BenjaminDTS
+ */
+class KitchenScheduleFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'tapa_config_id' => TapaConfig::factory(),
+            'opens_at'       => '10:00:00',
+            'closes_at'      => '23:00:00',
+        ];
+    }
+}

--- a/database/factories/TapaConfigFactory.php
+++ b/database/factories/TapaConfigFactory.php
@@ -25,8 +25,6 @@ class TapaConfigFactory extends Factory
             'tapa_price'         => null,
             'extra_tapa_enabled' => false,
             'extra_tapa_price'   => null,
-            'kitchen_opens_at'   => null,
-            'kitchen_closes_at'  => null,
         ];
     }
 }

--- a/database/migrations/2026_05_03_000002_create_kitchen_schedules_table.php
+++ b/database/migrations/2026_05_03_000002_create_kitchen_schedules_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Reemplaza los campos de horario planos en tapa_configs por una tabla
+ * kitchen_schedules que permite N tramos de apertura de cocina por restaurante.
+ *
+ * @author BenjaminDTS
+ */
+return new class extends Migration
+{
+    /**
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::create('kitchen_schedules', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tapa_config_id')->constrained()->onDelete('cascade');
+            $table->time('opens_at');
+            $table->time('closes_at');
+            $table->timestamps();
+        });
+
+        Schema::table('tapa_configs', function (Blueprint $table) {
+            $table->dropColumn(['kitchen_opens_at', 'kitchen_closes_at']);
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('kitchen_schedules');
+
+        Schema::table('tapa_configs', function (Blueprint $table) {
+            $table->time('kitchen_opens_at')->nullable();
+            $table->time('kitchen_closes_at')->nullable();
+        });
+    }
+};

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1529,9 +1529,9 @@
                     </p>
                     <p class="text-xs text-blue-700 dark:text-blue-400 mt-0.5">
                         {{ __('Ahora solo se sirven bebidas.') }}
-                        @if($tapaConfig?->kitchen_opens_at)
+                        @if($nextOpeningTime)
                             {{ __('La cocina abre a las') }}
-                            <span class="font-semibold">{{ substr($tapaConfig->kitchen_opens_at, 0, 5) }}</span>.
+                            <span class="font-semibold">{{ $nextOpeningTime }}</span>.
                         @endif
                     </p>
                 </div>

--- a/resources/views/tapas/edit.blade.php
+++ b/resources/views/tapas/edit.blade.php
@@ -18,6 +18,12 @@
 
             <div class="bg-white dark:bg-gray-800 shadow sm:rounded-lg p-6 sm:p-8">
 
+                @php
+                    $schedulesForAlpine = $tapaConfig->schedules->map(function ($s) {
+                        return ['opens_at' => substr($s->opens_at, 0, 5), 'closes_at' => substr($s->closes_at, 0, 5)];
+                    })->values();
+                @endphp
+
                 <form
                     method="POST"
                     action="{{ route('tapas.update') }}"
@@ -25,7 +31,7 @@
                         tapas_enabled:      {{ $tapaConfig->tapas_enabled ? 'true' : 'false' }},
                         tapas_free:         {{ $tapaConfig->tapas_free ? 'true' : 'false' }},
                         extra_tapa_enabled: {{ $tapaConfig->extra_tapa_enabled ? 'true' : 'false' }},
-                        schedules: @json($tapaConfig->schedules->map(fn ($s) => ['opens_at' => substr($s->opens_at, 0, 5), 'closes_at' => substr($s->closes_at, 0, 5)])->values()),
+                        schedules: @json($schedulesForAlpine),
                         addSchedule()    { this.schedules.push({ opens_at: '', closes_at: '' }); },
                         removeSchedule(i){ this.schedules.splice(i, 1); }
                     }"

--- a/resources/views/tapas/edit.blade.php
+++ b/resources/views/tapas/edit.blade.php
@@ -24,7 +24,10 @@
                     x-data="{
                         tapas_enabled:      {{ $tapaConfig->tapas_enabled ? 'true' : 'false' }},
                         tapas_free:         {{ $tapaConfig->tapas_free ? 'true' : 'false' }},
-                        extra_tapa_enabled: {{ $tapaConfig->extra_tapa_enabled ? 'true' : 'false' }}
+                        extra_tapa_enabled: {{ $tapaConfig->extra_tapa_enabled ? 'true' : 'false' }},
+                        schedules: @json($tapaConfig->schedules->map(fn ($s) => ['opens_at' => substr($s->opens_at, 0, 5), 'closes_at' => substr($s->closes_at, 0, 5)])->values()),
+                        addSchedule()    { this.schedules.push({ opens_at: '', closes_at: '' }); },
+                        removeSchedule(i){ this.schedules.splice(i, 1); }
                     }"
                 >
                     @csrf
@@ -186,53 +189,85 @@
                             @enderror
                         </div>
 
-                        {{-- ── SECCIÓN 4: Horario de cocina ─────────────── --}}
+                        {{-- ── SECCIÓN 4: Horario de cocina (tramos) ────── --}}
                         <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
                             <h3 class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                                 {{ __('Horario de cocina') }}
                             </h3>
                             <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">
-                                {{ __('Si tu cocina cierra en determinados momentos (por ejemplo, solo sirves bebidas a media tarde), configura aquí su horario. Fuera del horario, los productos de cocina no aparecen en la carta. Deja los campos vacíos si la cocina siempre está disponible.') }}
+                                {{ __('Añade los tramos en los que la cocina está abierta (ej: mediodía 13:00–16:00 y noche 20:00–23:30). Fuera de estos tramos la carta solo muestra bebidas. Sin tramos configurados la cocina se considera siempre disponible.') }}
                             </p>
 
-                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                                <div>
-                                    <label for="kitchen_opens_at" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                                        {{ __('Abre a las') }}
-                                    </label>
-                                    <input
-                                        type="time"
-                                        id="kitchen_opens_at"
-                                        name="kitchen_opens_at"
-                                        value="{{ old('kitchen_opens_at', $tapaConfig->kitchen_opens_at ? substr($tapaConfig->kitchen_opens_at, 0, 5) : '') }}"
-                                        aria-describedby="error-kitchen_opens_at"
-                                        class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                                    >
-                                    @error('kitchen_opens_at')
-                                        <p id="error-kitchen_opens_at" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
-                                    @enderror
-                                </div>
+                            {{-- Errores de validación de tramos --}}
+                            @error('schedules')
+                                <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                            @enderror
+                            @error('schedules.*.opens_at')
+                                <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                            @enderror
+                            @error('schedules.*.closes_at')
+                                <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                            @enderror
 
-                                <div>
-                                    <label for="kitchen_closes_at" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                                        {{ __('Cierra a las') }}
-                                    </label>
-                                    <input
-                                        type="time"
-                                        id="kitchen_closes_at"
-                                        name="kitchen_closes_at"
-                                        value="{{ old('kitchen_closes_at', $tapaConfig->kitchen_closes_at ? substr($tapaConfig->kitchen_closes_at, 0, 5) : '') }}"
-                                        aria-describedby="error-kitchen_closes_at"
-                                        class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                                    >
-                                    @error('kitchen_closes_at')
-                                        <p id="error-kitchen_closes_at" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
-                                    @enderror
-                                </div>
+                            {{-- Lista dinámica de tramos --}}
+                            <div class="space-y-3 mb-4" role="list" aria-label="Tramos horarios de cocina">
+                                <template x-for="(slot, i) in schedules" :key="i">
+                                    <div class="flex items-end gap-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-600"
+                                         role="listitem">
+                                        <div class="flex-1">
+                                            <label :for="'opens_at_' + i"
+                                                   class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                                                {{ __('Abre') }}
+                                            </label>
+                                            <input type="time"
+                                                   :id="'opens_at_' + i"
+                                                   :name="'schedules[' + i + '][opens_at]'"
+                                                   x-model="slot.opens_at"
+                                                   aria-required="true"
+                                                   class="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                        </div>
+                                        <div class="flex-1">
+                                            <label :for="'closes_at_' + i"
+                                                   class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                                                {{ __('Cierra') }}
+                                            </label>
+                                            <input type="time"
+                                                   :id="'closes_at_' + i"
+                                                   :name="'schedules[' + i + '][closes_at]'"
+                                                   x-model="slot.closes_at"
+                                                   aria-required="true"
+                                                   class="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                        </div>
+                                        <button type="button"
+                                                @click="removeSchedule(i)"
+                                                :aria-label="'Eliminar tramo ' + (i + 1)"
+                                                class="mb-0.5 flex-shrink-0 p-1.5 rounded-md text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20
+                                                       focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors">
+                                            <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </template>
                             </div>
 
-                            <p class="text-xs text-amber-600 dark:text-amber-400 mt-2">
-                                {{ __('Si dejas ambos campos vacíos, la cocina se considera siempre disponible.') }}
+                            <button type="button"
+                                    @click="addSchedule()"
+                                    :disabled="schedules.length >= 10"
+                                    class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium
+                                           border border-indigo-300 dark:border-indigo-600 text-indigo-700 dark:text-indigo-300
+                                           hover:bg-indigo-50 dark:hover:bg-indigo-900/20
+                                           focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-colors
+                                           disabled:opacity-40 disabled:cursor-not-allowed">
+                                <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
+                                </svg>
+                                {{ __('Añadir tramo') }}
+                            </button>
+
+                            <p x-show="schedules.length === 0"
+                               class="text-xs text-amber-600 dark:text-amber-400 mt-2">
+                                {{ __('Sin tramos: la cocina se considera siempre disponible.') }}
                             </p>
                         </div>
 

--- a/tests/Feature/Bloque6/TapasTest.php
+++ b/tests/Feature/Bloque6/TapasTest.php
@@ -465,25 +465,62 @@ it('clears extra tapa price when extra tapa is disabled', function () {
     ]);
 });
 
-// ─── Horario de cocina ────────────────────────────────────────────────────────
+// ─── Horario de cocina (multi-tramo) ─────────────────────────────────────────
 
-it('saves kitchen schedule fields correctly', function () {
+it('saves a single kitchen schedule slot correctly', function () {
     $this->actingAs($this->user)
          ->put(route('tapas.update'), [
-             'tapas_enabled'      => '1',
-             'tapas_free'         => '1',
-             'max_tapa_variants'  => 3,
-             'kitchen_opens_at'   => '10:00',
-             'kitchen_closes_at'  => '23:00',
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+             'schedules'         => [
+                 ['opens_at' => '10:00', 'closes_at' => '16:00'],
+             ],
+         ])
+         ->assertRedirect(route('tapas.edit'));
+
+    $config = TapaConfig::where('user_id', $this->user->id)->first();
+    expect($config->schedules()->count())->toBe(1);
+    expect($config->schedules()->first()->opens_at)->toStartWith('10:00');
+});
+
+it('saves multiple kitchen schedule slots correctly', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+             'schedules'         => [
+                 ['opens_at' => '13:00', 'closes_at' => '16:30'],
+                 ['opens_at' => '20:00', 'closes_at' => '23:30'],
+             ],
          ]);
 
     $config = TapaConfig::where('user_id', $this->user->id)->first();
-
-    expect($config->kitchen_opens_at)->toStartWith('10:00')
-        ->and($config->kitchen_closes_at)->toStartWith('23:00');
+    expect($config->schedules()->count())->toBe(2);
 });
 
-it('allows null kitchen schedule meaning always open', function () {
+it('replaces existing schedules on update', function () {
+    $config = TapaConfig::factory()->create(['user_id' => $this->user->id, 'tapas_enabled' => true]);
+    $config->schedules()->create(['opens_at' => '09:00', 'closes_at' => '14:00']);
+    $config->schedules()->create(['opens_at' => '19:00', 'closes_at' => '23:00']);
+
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+             'schedules'         => [
+                 ['opens_at' => '12:00', 'closes_at' => '15:00'],
+             ],
+         ]);
+
+    $config->refresh();
+    expect($config->schedules()->count())->toBe(1);
+    expect($config->schedules()->first()->opens_at)->toStartWith('12:00');
+});
+
+it('allows no schedules meaning kitchen always open', function () {
     $this->actingAs($this->user)
          ->put(route('tapas.update'), [
              'tapas_enabled'     => '1',
@@ -492,46 +529,54 @@ it('allows null kitchen schedule meaning always open', function () {
          ])
          ->assertRedirect(route('tapas.edit'));
 
-    $this->assertDatabaseHas('tapa_configs', [
-        'user_id'          => $this->user->id,
-        'kitchen_opens_at' => null,
-        'kitchen_closes_at' => null,
-    ]);
+    $config = TapaConfig::where('user_id', $this->user->id)->first();
+    expect($config->schedules()->count())->toBe(0);
 });
 
-it('fails when only kitchen_opens_at is provided without kitchen_closes_at', function () {
+it('fails when a schedule slot is missing closes_at', function () {
     $this->actingAs($this->user)
          ->put(route('tapas.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
-             'kitchen_opens_at'  => '10:00',
-             // kitchen_closes_at ausente
+             'schedules'         => [
+                 ['opens_at' => '10:00'],
+             ],
          ])
-         ->assertSessionHasErrors('kitchen_closes_at');
+         ->assertSessionHasErrors('schedules.0.closes_at');
 });
 
-it('fails when only kitchen_closes_at is provided without kitchen_opens_at', function () {
+it('fails when a schedule slot has invalid time format', function () {
     $this->actingAs($this->user)
          ->put(route('tapas.update'), [
-             'tapas_enabled'      => '1',
-             'tapas_free'         => '1',
-             'max_tapa_variants'  => 3,
-             'kitchen_closes_at'  => '23:00',
-             // kitchen_opens_at ausente
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+             'schedules'         => [
+                 ['opens_at' => 'not-a-time', 'closes_at' => '23:00'],
+             ],
          ])
-         ->assertSessionHasErrors('kitchen_opens_at');
+         ->assertSessionHasErrors('schedules.0.opens_at');
+});
+
+it('fails when schedules array exceeds 10 slots', function () {
+    $slots = array_fill(0, 11, ['opens_at' => '10:00', 'closes_at' => '11:00']);
+
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+             'schedules'         => $slots,
+         ])
+         ->assertSessionHasErrors('schedules');
 });
 
 it('menu hides kitchen categories when kitchen is closed', function () {
     Carbon::setTestNow('2026-05-03 15:00:00');
 
-    TapaConfig::factory()->create([
-        'user_id'           => $this->user->id,
-        'tapas_enabled'     => true,
-        'kitchen_opens_at'  => '17:00',
-        'kitchen_closes_at' => '23:00',
-    ]);
+    $config = TapaConfig::factory()->create(['user_id' => $this->user->id, 'tapas_enabled' => true]);
+    $config->schedules()->create(['opens_at' => '17:00:00', 'closes_at' => '23:00:00']);
 
     $table           = Table::factory()->create(['user_id' => $this->user->id]);
     $kitchenCategory = Category::factory()->create(['user_id' => $this->user->id, 'destination' => 'kitchen']);
@@ -545,7 +590,7 @@ it('menu hides kitchen categories when kitchen is closed', function () {
     $response->assertOk();
     expect($response->viewData('kitchenOpen'))->toBeFalse();
 
-    $categories = $response->viewData('categories');
+    $categories   = $response->viewData('categories');
     $destinations = $categories->pluck('destination')->unique()->values()->toArray();
     expect($destinations)->not->toContain('kitchen');
 
@@ -553,12 +598,8 @@ it('menu hides kitchen categories when kitchen is closed', function () {
 });
 
 it('menu shows all categories when no schedule is configured', function () {
-    TapaConfig::factory()->create([
-        'user_id'           => $this->user->id,
-        'tapas_enabled'     => true,
-        'kitchen_opens_at'  => null,
-        'kitchen_closes_at' => null,
-    ]);
+    TapaConfig::factory()->create(['user_id' => $this->user->id, 'tapas_enabled' => true]);
+    // Sin schedules → cocina siempre abierta
 
     $table           = Table::factory()->create(['user_id' => $this->user->id]);
     $kitchenCategory = Category::factory()->create(['user_id' => $this->user->id, 'destination' => 'kitchen']);
@@ -578,18 +619,37 @@ it('menu shows all categories when no schedule is configured', function () {
         ->and($destinations)->toContain('bar');
 });
 
+it('menu is open when current time falls within any of multiple schedules', function () {
+    Carbon::setTestNow('2026-05-03 21:00:00');
+
+    $config = TapaConfig::factory()->create(['user_id' => $this->user->id, 'tapas_enabled' => true]);
+    // Mediodía: ya cerrado
+    $config->schedules()->create(['opens_at' => '13:00:00', 'closes_at' => '16:30:00']);
+    // Noche: abierto ahora
+    $config->schedules()->create(['opens_at' => '20:00:00', 'closes_at' => '23:30:00']);
+
+    $table       = Table::factory()->create(['user_id' => $this->user->id]);
+    $barCategory = Category::factory()->create(['user_id' => $this->user->id, 'destination' => 'bar']);
+    Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $barCategory->id, 'is_active' => true]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+    $response->assertOk();
+    expect($response->viewData('kitchenOpen'))->toBeTrue();
+
+    Carbon::setTestNow();
+});
+
 // ─── Sugerencia de tapa ───────────────────────────────────────────────────────
 
 it('shouldSuggest is true when conditions are met', function () {
     Carbon::setTestNow('2026-05-03 12:00:00');
 
-    TapaConfig::factory()->create([
+    $config = TapaConfig::factory()->create([
         'user_id'           => $this->user->id,
         'tapas_enabled'     => true,
         'max_tapa_variants' => 3,
-        'kitchen_opens_at'  => '10:00',
-        'kitchen_closes_at' => '23:00',
     ]);
+    $config->schedules()->create(['opens_at' => '10:00:00', 'closes_at' => '23:00:00']);
 
     $table        = Table::factory()->create(['user_id' => $this->user->id]);
     $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
@@ -623,13 +683,12 @@ it('shouldSuggest is false when tapas are disabled', function () {
 it('shouldSuggest is false when kitchen is closed', function () {
     Carbon::setTestNow('2026-05-03 15:00:00');
 
-    TapaConfig::factory()->create([
+    $config = TapaConfig::factory()->create([
         'user_id'           => $this->user->id,
         'tapas_enabled'     => true,
         'max_tapa_variants' => 3,
-        'kitchen_opens_at'  => '17:00',
-        'kitchen_closes_at' => '23:00',
     ]);
+    $config->schedules()->create(['opens_at' => '17:00:00', 'closes_at' => '23:00:00']);
 
     $table        = Table::factory()->create(['user_id' => $this->user->id]);
     $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
@@ -648,13 +707,12 @@ it('shouldSuggest is false when kitchen is closed', function () {
 it('shouldSuggest is false when max variants already reached', function () {
     Carbon::setTestNow('2026-05-03 12:00:00');
 
-    TapaConfig::factory()->create([
+    $config = TapaConfig::factory()->create([
         'user_id'           => $this->user->id,
         'tapas_enabled'     => true,
         'max_tapa_variants' => 2,
-        'kitchen_opens_at'  => '10:00',
-        'kitchen_closes_at' => '23:00',
     ]);
+    $config->schedules()->create(['opens_at' => '10:00:00', 'closes_at' => '23:00:00']);
 
     $table        = Table::factory()->create(['user_id' => $this->user->id]);
     $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
@@ -678,13 +736,12 @@ it('shouldSuggest is false when max variants already reached', function () {
 it('tapa products in view are limited to products from Tapas category', function () {
     Carbon::setTestNow('2026-05-03 12:00:00');
 
-    TapaConfig::factory()->create([
+    $config = TapaConfig::factory()->create([
         'user_id'           => $this->user->id,
         'tapas_enabled'     => true,
         'max_tapa_variants' => 5,
-        'kitchen_opens_at'  => '10:00',
-        'kitchen_closes_at' => '23:00',
     ]);
+    $config->schedules()->create(['opens_at' => '10:00:00', 'closes_at' => '23:00:00']);
 
     $table        = Table::factory()->create(['user_id' => $this->user->id]);
     $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
@@ -709,13 +766,12 @@ it('tapa products in view are limited to products from Tapas category', function
 it('tapa products only include active products from Tapas category', function () {
     Carbon::setTestNow('2026-05-03 12:00:00');
 
-    TapaConfig::factory()->create([
+    $config = TapaConfig::factory()->create([
         'user_id'           => $this->user->id,
         'tapas_enabled'     => true,
         'max_tapa_variants' => 5,
-        'kitchen_opens_at'  => '10:00',
-        'kitchen_closes_at' => '23:00',
     ]);
+    $config->schedules()->create(['opens_at' => '10:00:00', 'closes_at' => '23:00:00']);
 
     $table        = Table::factory()->create(['user_id' => $this->user->id]);
     $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
@@ -739,13 +795,12 @@ it('tapa products only include active products from Tapas category', function ()
 it('tapaVariantsUsed counts distinct tapa products in active orders', function () {
     Carbon::setTestNow('2026-05-03 12:00:00');
 
-    TapaConfig::factory()->create([
+    $config = TapaConfig::factory()->create([
         'user_id'           => $this->user->id,
         'tapas_enabled'     => true,
         'max_tapa_variants' => 5,
-        'kitchen_opens_at'  => '10:00',
-        'kitchen_closes_at' => '23:00',
     ]);
+    $config->schedules()->create(['opens_at' => '10:00:00', 'closes_at' => '23:00:00']);
 
     $table        = Table::factory()->create(['user_id' => $this->user->id]);
     $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);

--- a/tests/Unit/TapasCalculatorTest.php
+++ b/tests/Unit/TapasCalculatorTest.php
@@ -7,16 +7,15 @@
  * @author BenjaminDTS
  */
 
+use App\Models\KitchenSchedule;
 use App\Models\TapaConfig;
 use Illuminate\Support\Carbon;
 
 // ─── isKitchenOpen ────────────────────────────────────────────────────────────
 
-it('isKitchenOpen returns true with null schedule', function () {
-    $config = new TapaConfig([
-        'kitchen_opens_at'  => null,
-        'kitchen_closes_at' => null,
-    ]);
+it('isKitchenOpen returns true with no schedules configured', function () {
+    $config = new TapaConfig();
+    $config->setRelation('schedules', collect());
 
     expect($config->isKitchenOpen())->toBeTrue();
 });
@@ -24,10 +23,10 @@ it('isKitchenOpen returns true with null schedule', function () {
 it('isKitchenOpen returns true when current time is within schedule', function () {
     Carbon::setTestNow('2026-05-03 12:00:00');
 
-    $config = new TapaConfig([
-        'kitchen_opens_at'  => '10:00:00',
-        'kitchen_closes_at' => '23:00:00',
-    ]);
+    $config = new TapaConfig();
+    $config->setRelation('schedules', collect([
+        new KitchenSchedule(['opens_at' => '10:00:00', 'closes_at' => '23:00:00']),
+    ]));
 
     expect($config->isKitchenOpen())->toBeTrue();
 
@@ -37,10 +36,10 @@ it('isKitchenOpen returns true when current time is within schedule', function (
 it('isKitchenOpen returns false when current time is outside schedule', function () {
     Carbon::setTestNow('2026-05-03 09:00:00');
 
-    $config = new TapaConfig([
-        'kitchen_opens_at'  => '10:00:00',
-        'kitchen_closes_at' => '23:00:00',
-    ]);
+    $config = new TapaConfig();
+    $config->setRelation('schedules', collect([
+        new KitchenSchedule(['opens_at' => '10:00:00', 'closes_at' => '23:00:00']),
+    ]));
 
     expect($config->isKitchenOpen())->toBeFalse();
 
@@ -50,10 +49,10 @@ it('isKitchenOpen returns false when current time is outside schedule', function
 it('isKitchenOpen supports ranges crossing midnight', function () {
     Carbon::setTestNow('2026-05-03 01:00:00');
 
-    $config = new TapaConfig([
-        'kitchen_opens_at'  => '22:00:00',
-        'kitchen_closes_at' => '02:00:00',
-    ]);
+    $config = new TapaConfig();
+    $config->setRelation('schedules', collect([
+        new KitchenSchedule(['opens_at' => '22:00:00', 'closes_at' => '02:00:00']),
+    ]));
 
     expect($config->isKitchenOpen())->toBeTrue();
 
@@ -63,24 +62,42 @@ it('isKitchenOpen supports ranges crossing midnight', function () {
 it('isKitchenOpen returns false at midday when range crosses midnight', function () {
     Carbon::setTestNow('2026-05-03 12:00:00');
 
-    $config = new TapaConfig([
-        'kitchen_opens_at'  => '22:00:00',
-        'kitchen_closes_at' => '02:00:00',
-    ]);
+    $config = new TapaConfig();
+    $config->setRelation('schedules', collect([
+        new KitchenSchedule(['opens_at' => '22:00:00', 'closes_at' => '02:00:00']),
+    ]));
 
     expect($config->isKitchenOpen())->toBeFalse();
 
     Carbon::setTestNow();
 });
 
-it('isKitchenOpen returns false when only opens_at is null', function () {
-    $config = new TapaConfig([
-        'kitchen_opens_at'  => null,
-        'kitchen_closes_at' => '23:00:00',
-    ]);
+it('isKitchenOpen returns true when time matches any of multiple schedules', function () {
+    Carbon::setTestNow('2026-05-03 21:00:00');
 
-    // Un solo campo null = sin horario = siempre abierta
+    $config = new TapaConfig();
+    $config->setRelation('schedules', collect([
+        new KitchenSchedule(['opens_at' => '13:00:00', 'closes_at' => '16:30:00']),
+        new KitchenSchedule(['opens_at' => '20:00:00', 'closes_at' => '23:30:00']),
+    ]));
+
     expect($config->isKitchenOpen())->toBeTrue();
+
+    Carbon::setTestNow();
+});
+
+it('isKitchenOpen returns false when time falls in none of multiple schedules', function () {
+    Carbon::setTestNow('2026-05-03 18:00:00');
+
+    $config = new TapaConfig();
+    $config->setRelation('schedules', collect([
+        new KitchenSchedule(['opens_at' => '13:00:00', 'closes_at' => '16:30:00']),
+        new KitchenSchedule(['opens_at' => '20:00:00', 'closes_at' => '23:30:00']),
+    ]));
+
+    expect($config->isKitchenOpen())->toBeFalse();
+
+    Carbon::setTestNow();
 });
 
 // ─── shouldSuggestTapa ────────────────────────────────────────────────────────
@@ -88,12 +105,10 @@ it('isKitchenOpen returns false when only opens_at is null', function () {
 it('shouldSuggestTapa returns false when tapas disabled even if kitchen is open', function () {
     Carbon::setTestNow('2026-05-03 12:00:00');
 
-    $config = new TapaConfig([
-        'tapas_enabled'     => false,
-        'max_tapa_variants' => 3,
-        'kitchen_opens_at'  => '10:00:00',
-        'kitchen_closes_at' => '23:00:00',
-    ]);
+    $config = new TapaConfig(['tapas_enabled' => false, 'max_tapa_variants' => 3]);
+    $config->setRelation('schedules', collect([
+        new KitchenSchedule(['opens_at' => '10:00:00', 'closes_at' => '23:00:00']),
+    ]));
 
     expect($config->shouldSuggestTapa(2, 0))->toBeFalse();
 
@@ -103,12 +118,10 @@ it('shouldSuggestTapa returns false when tapas disabled even if kitchen is open'
 it('shouldSuggestTapa returns false when kitchen closed even if tapas enabled', function () {
     Carbon::setTestNow('2026-05-03 09:00:00');
 
-    $config = new TapaConfig([
-        'tapas_enabled'     => true,
-        'max_tapa_variants' => 3,
-        'kitchen_opens_at'  => '10:00:00',
-        'kitchen_closes_at' => '23:00:00',
-    ]);
+    $config = new TapaConfig(['tapas_enabled' => true, 'max_tapa_variants' => 3]);
+    $config->setRelation('schedules', collect([
+        new KitchenSchedule(['opens_at' => '10:00:00', 'closes_at' => '23:00:00']),
+    ]));
 
     expect($config->shouldSuggestTapa(2, 0))->toBeFalse();
 
@@ -116,34 +129,22 @@ it('shouldSuggestTapa returns false when kitchen closed even if tapas enabled', 
 });
 
 it('shouldSuggestTapa returns false when barItemsCount is zero', function () {
-    $config = new TapaConfig([
-        'tapas_enabled'     => true,
-        'max_tapa_variants' => 3,
-        'kitchen_opens_at'  => null,
-        'kitchen_closes_at' => null,
-    ]);
+    $config = new TapaConfig(['tapas_enabled' => true, 'max_tapa_variants' => 3]);
+    $config->setRelation('schedules', collect());
 
     expect($config->shouldSuggestTapa(0, 0))->toBeFalse();
 });
 
 it('shouldSuggestTapa returns false when max variants already reached', function () {
-    $config = new TapaConfig([
-        'tapas_enabled'     => true,
-        'max_tapa_variants' => 2,
-        'kitchen_opens_at'  => null,
-        'kitchen_closes_at' => null,
-    ]);
+    $config = new TapaConfig(['tapas_enabled' => true, 'max_tapa_variants' => 2]);
+    $config->setRelation('schedules', collect());
 
     expect($config->shouldSuggestTapa(3, 2))->toBeFalse();
 });
 
 it('shouldSuggestTapa returns true when all conditions are met', function () {
-    $config = new TapaConfig([
-        'tapas_enabled'     => true,
-        'max_tapa_variants' => 3,
-        'kitchen_opens_at'  => null,
-        'kitchen_closes_at' => null,
-    ]);
+    $config = new TapaConfig(['tapas_enabled' => true, 'max_tapa_variants' => 3]);
+    $config->setRelation('schedules', collect());
 
     expect($config->shouldSuggestTapa(2, 1))->toBeTrue();
 });


### PR DESCRIPTION
## Summary

- Categoría \"Tapas\" (destination=kitchen) se crea automáticamente al activar tapas
- Tapa extra de pago opcional que no consume slots de variantes
- Horario de cocina multi-tramo (mediodía + noche) con tabla `kitchen_schedules` — número ilimitado de tramos configurables hasta 10
- Banner informativo cuando la cocina está cerrada con hora de próxima apertura
- Modal de sugerencia de tapa al añadir una bebida al carrito (Alpine.js)
- 378 tests, 0 fallos

## Cambios principales

### Base de datos
- Migración: tabla `kitchen_schedules` (id, tapa_config_id FK, opens_at TIME, closes_at TIME)
- Migración: campos `extra_tapa_enabled` y `extra_tapa_price` en `tapa_configs`
- Eliminados campos planos `kitchen_opens_at` / `kitchen_closes_at`

### Modelos
- `KitchenSchedule` — modelo nuevo con `belongsTo TapaConfig`
- `TapaConfig` — `hasMany schedules()`, `isKitchenOpen()` (multi-tramo + cruce de medianoche), `nextOpeningTime()`, `shouldSuggestTapa()`

### Controladores
- `TapasController::update()` — valida array `schedules[]`, borra y recrea en cada guardado, `firstOrCreate` categoría Tapas
- `MenuController::show()` — carga schedules, calcula `kitchenOpen`, `nextOpeningTime`, `tapaVariantsUsed`, `shouldSuggest`

### Vistas
- `tapas/edit.blade.php` — UI dinámica x-for para añadir/eliminar tramos; datos en bloque `@php` para evitar parse error de Blade
- `menu/show.blade.php` — banner cocina cerrada, modal sugerencia tapa, intercepción `Alpine.store('cart').add()`

### Tests
- `TapasTest.php` — 46 tests Feature: auth, CRUD, multitenancy, categoría automática, tapa extra, multi-tramo, sugerencia
- `TapasCalculatorTest.php` — 12 tests Unit: `isKitchenOpen` (single/multi-tramo, cruce medianoche), `shouldSuggestTapa`
- Factories: `TapaConfigFactory` actualizada, `KitchenScheduleFactory` nueva

## Test plan

- [x] `php artisan test` → 378 passed, 0 failed
- [x] Happy path: activar tapas, configurar 2 tramos (mediodía + noche), guardar
- [x] Validación: falla sin `closes_at`, falla con formato inválido, falla con >10 tramos
- [x] Multitenancy: cada restaurante tiene su propia config independiente
- [x] Cocina cerrada: categorías kitchen ocultas en carta, banner visible
- [x] Sugerencia: modal aparece al añadir bebida si cocina abierta y variantes disponibles