### PR TITLE
feat: Bloque 8.2 - Limite de mesas por plan con contador en tiempo real

### DIFF
--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -3,7 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Models\Table;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
@@ -16,6 +18,7 @@ use SimpleSoftwareIO\QrCode\Facades\QrCode;
  * Permite al gerente ver todas sus mesas con el QR generado
  * para cada una, descargar el QR en formato PNG o SVG, y
  * regenerar el unique_hash invalidando el QR anterior.
+ * Incluye el mapa visual drag & drop para crear, mover y eliminar mesas.
  *
  * @author AyrtonAlania
  */
@@ -34,6 +37,106 @@ class TableController extends Controller
             ->get();
 
         return view('tables.index', compact('tables'));
+    }
+
+    /**
+     * Muestra el mapa visual interactivo con drag & drop para gestionar mesas.
+     *
+     * @return View
+     */
+    public function map(): View
+    {
+        $tables    = Table::where('user_id', Auth::id())->orderBy('name')->get();
+        $maxTables = Auth::user()->plan?->max_tables ?? 10;
+
+        return view('tables.map', compact('tables', 'maxTables'));
+    }
+
+    /**
+     * Crea una nueva mesa desde el mapa visual.
+     *
+     * @param  Request  $request
+     * @return JsonResponse
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'name'       => 'required|string|max:50',
+            'shape'      => 'required|in:square,round,rectangle',
+            'position_x' => 'required|integer|min:0',
+            'position_y' => 'required|integer|min:0',
+            'width'      => 'required|integer|min:60|max:400',
+            'height'     => 'required|integer|min:60|max:400',
+        ]);
+
+        $count     = Table::where('user_id', Auth::id())->count();
+        $maxTables = Auth::user()->plan?->max_tables ?? 10;
+
+        if ($count >= $maxTables) {
+            return response()->json([
+                'success' => false,
+                'message' => "Has alcanzado el límite de {$maxTables} mesas de tu plan.",
+            ], 422);
+        }
+
+        $table = Table::create([
+            ...$data,
+            'user_id'     => Auth::id(),
+            'unique_hash' => Str::uuid()->toString(),
+            'status'      => 'free',
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $table,
+            'message' => "Mesa \"{$table->name}\" creada.",
+        ], 201);
+    }
+
+    /**
+     * Persiste la posición y dimensiones de una mesa tras soltarla en el mapa.
+     *
+     * @param  Request  $request
+     * @param  Table    $table
+     * @return JsonResponse
+     */
+    public function updatePosition(Request $request, Table $table): JsonResponse
+    {
+        abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+
+        $data = $request->validate([
+            'position_x' => 'required|integer|min:0',
+            'position_y' => 'required|integer|min:0',
+            'width'      => 'required|integer|min:60|max:400',
+            'height'     => 'required|integer|min:60|max:400',
+        ]);
+
+        $table->update($data);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $table,
+            'message' => 'Posición guardada.',
+        ]);
+    }
+
+    /**
+     * Elimina una mesa del mapa y de la base de datos.
+     *
+     * @param  Table  $table
+     * @return JsonResponse
+     */
+    public function destroy(Table $table): JsonResponse
+    {
+        abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+
+        $name = $table->name;
+        $table->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => "Mesa \"{$name}\" eliminada.",
+        ]);
     }
 
     /**

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -32,11 +32,10 @@ class TableController extends Controller
      */
     public function index(): View
     {
-        $tables = Table::where('user_id', Auth::id())
-            ->orderBy('name')
-            ->get();
+        $tables    = Table::where('user_id', Auth::id())->orderBy('name')->get();
+        $maxTables = Auth::user()->plan?->max_tables ?? 10;
 
-        return view('tables.index', compact('tables'));
+        return view('tables.index', compact('tables', 'maxTables'));
     }
 
     /**

--- a/resources/views/tables/index.blade.php
+++ b/resources/views/tables/index.blade.php
@@ -5,6 +5,18 @@
     {{-- Cabecera --}}
     <div class="flex justify-between items-center mb-4 sm:mb-6">
       <h2 class="text-xl sm:text-2xl font-bold text-gray-800">Mis Mesas y Códigos QR</h2>
+      @if(Auth::user()->isAdmin())
+      <a href="{{ route('tables.map') }}"
+         class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-white
+                bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
+         aria-label="Ir al mapa visual de mesas">
+        <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round"
+                d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"/>
+        </svg>
+        Ver Mapa
+      </a>
+      @endif
     </div>
 
     {{-- Mensaje flash --}}

--- a/resources/views/tables/index.blade.php
+++ b/resources/views/tables/index.blade.php
@@ -3,20 +3,41 @@
   <div class="max-w-6xl mx-auto px-4 sm:px-6 py-6 mt-4 sm:mt-10">
 
     {{-- Cabecera --}}
-    <div class="flex justify-between items-center mb-4 sm:mb-6">
-      <h2 class="text-xl sm:text-2xl font-bold text-gray-800">Mis Mesas y Códigos QR</h2>
-      @if(Auth::user()->isAdmin())
-      <a href="{{ route('tables.map') }}"
-         class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-white
-                bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
-         aria-label="Ir al mapa visual de mesas">
-        <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round"
-                d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"/>
-        </svg>
-        Ver Mapa
-      </a>
-      @endif
+    <div class="flex flex-wrap justify-between items-center gap-3 mb-4 sm:mb-6">
+      <h2 class="text-xl sm:text-2xl font-bold text-gray-800 dark:text-white">Mis Mesas y Códigos QR</h2>
+
+      <div class="flex flex-wrap items-center gap-3">
+        {{-- Contador de plan --}}
+        @php
+          $used     = $tables->count();
+          $pct      = $maxTables > 0 ? $used / $maxTables : 1;
+          $badgeCss = $used >= $maxTables
+              ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+              : ($pct >= 0.8
+                  ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+                  : 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400');
+        @endphp
+        <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium {{ $badgeCss }}"
+              aria-label="{{ $used }} de {{ $maxTables }} mesas usadas">
+          <svg aria-hidden="true" class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M3 3h7v7H3zm0 11h7v7H3zm11-11h7v7h-7zm0 11h7v7h-7z"/>
+          </svg>
+          {{ $used }} de {{ $maxTables }} mesas usadas
+        </span>
+
+        @if(Auth::user()->isAdmin())
+        <a href="{{ route('tables.map') }}"
+           class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-white
+                  bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
+           aria-label="Ir al mapa visual de mesas">
+          <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round"
+                  d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"/>
+          </svg>
+          Ver Mapa
+        </a>
+        @endif
+      </div>
     </div>
 
     {{-- Mensaje flash --}}

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -19,9 +19,33 @@
 
         <div class="flex items-center gap-3">
             <h1 class="text-lg font-bold text-gray-900 dark:text-white">Plano del restaurante</h1>
-            <span class="text-sm text-gray-400 dark:text-gray-500">
-                <span x-text="tables.length"></span> / {{ $maxTables }} mesas
-            </span>
+
+            {{-- Contador con colores y barra de progreso --}}
+            <div class="flex flex-col gap-1">
+                <span class="text-sm font-medium transition-colors"
+                      :class="{
+                          'text-emerald-600 dark:text-emerald-400': tables.length / {{ $maxTables }} < 0.8,
+                          'text-amber-600  dark:text-amber-400':    tables.length / {{ $maxTables }} >= 0.8 && tables.length < {{ $maxTables }},
+                          'text-red-600    dark:text-red-400':      tables.length >= {{ $maxTables }}
+                      }"
+                      :aria-label="`${tables.length} de {{ $maxTables }} mesas usadas`">
+                    <span x-text="tables.length"></span> de {{ $maxTables }} mesas usadas
+                </span>
+                <div class="w-32 h-1.5 bg-gray-200 dark:bg-gray-600 rounded-full overflow-hidden"
+                     role="progressbar"
+                     :aria-valuenow="tables.length"
+                     aria-valuemin="0"
+                     aria-valuemax="{{ $maxTables }}">
+                    <div class="h-full rounded-full transition-all duration-300"
+                         :style="`width:${Math.min(tables.length / {{ $maxTables }} * 100, 100)}%`"
+                         :class="{
+                             'bg-emerald-500': tables.length / {{ $maxTables }} < 0.8,
+                             'bg-amber-500':   tables.length / {{ $maxTables }} >= 0.8 && tables.length < {{ $maxTables }},
+                             'bg-red-500':     tables.length >= {{ $maxTables }}
+                         }">
+                    </div>
+                </div>
+            </div>
         </div>
 
         <div class="flex items-center gap-2">
@@ -66,7 +90,9 @@
             </p>
 
             {{-- Cuadrada --}}
-            <div class="palette-item group flex flex-col items-center gap-2 cursor-grab active:cursor-grabbing select-none"
+            <div class="palette-item group flex flex-col items-center gap-2 select-none transition-opacity"
+                 :class="tables.length >= {{ $maxTables }} ? 'opacity-40 cursor-not-allowed' : 'cursor-grab active:cursor-grabbing'"
+                 :title="tables.length >= {{ $maxTables }} ? 'Límite de mesas alcanzado' : 'Arrastrar al plano'"
                  data-shape="square" data-width="100" data-height="100">
                 <div class="w-14 h-14 rounded-lg border-2 border-dashed border-indigo-400
                             bg-indigo-50 dark:bg-indigo-900/30
@@ -80,7 +106,9 @@
             </div>
 
             {{-- Redonda --}}
-            <div class="palette-item group flex flex-col items-center gap-2 cursor-grab active:cursor-grabbing select-none"
+            <div class="palette-item group flex flex-col items-center gap-2 select-none transition-opacity"
+                 :class="tables.length >= {{ $maxTables }} ? 'opacity-40 cursor-not-allowed' : 'cursor-grab active:cursor-grabbing'"
+                 :title="tables.length >= {{ $maxTables }} ? 'Límite de mesas alcanzado' : 'Arrastrar al plano'"
                  data-shape="round" data-width="100" data-height="100">
                 <div class="w-14 h-14 rounded-full border-2 border-dashed border-emerald-400
                             bg-emerald-50 dark:bg-emerald-900/30
@@ -94,7 +122,9 @@
             </div>
 
             {{-- Rectangular --}}
-            <div class="palette-item group flex flex-col items-center gap-2 cursor-grab active:cursor-grabbing select-none"
+            <div class="palette-item group flex flex-col items-center gap-2 select-none transition-opacity"
+                 :class="tables.length >= {{ $maxTables }} ? 'opacity-40 cursor-not-allowed' : 'cursor-grab active:cursor-grabbing'"
+                 :title="tables.length >= {{ $maxTables }} ? 'Límite de mesas alcanzado' : 'Arrastrar al plano'"
                  data-shape="rectangle" data-width="150" data-height="90">
                 <div class="w-14 h-9 rounded-lg border-2 border-dashed border-amber-400
                             bg-amber-50 dark:bg-amber-900/30
@@ -407,6 +437,11 @@ document.addEventListener('alpine:init', () => {
                 inertia: false,
                 listeners: {
                     start: (event) => {
+                        if (this.tables.length >= {{ $maxTables }}) {
+                            this.showToast(`Límite de {{ $maxTables }} mesas alcanzado.`, true);
+                            return;
+                        }
+
                         dropShape = event.target.dataset.shape;
                         dropW     = parseInt(event.target.dataset.width)  || 100;
                         dropH     = parseInt(event.target.dataset.height) || 100;
@@ -448,10 +483,6 @@ document.addEventListener('alpine:init', () => {
                             cy >= canvasRect.top  && cy <= canvasRect.bottom;
 
                         if (!overCanvas) return;
-                        if (this.tables.length >= {{ $maxTables }}) {
-                            this.showToast('Límite de mesas alcanzado.', true);
-                            return;
-                        }
 
                         const name = await Alpine.store('tableModal').prompt();
                         if (!name) return;

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1,0 +1,558 @@
+{{--
+ | Bloque 8.1 — Mapa visual de mesas con drag & drop
+ | interact.js para arrastrar/redimensionar mesas en el plano del restaurante.
+ | @author AyrtonAlania
+--}}
+<x-app-layout>
+<div
+    class="flex flex-col h-screen bg-gray-100 dark:bg-gray-900"
+    x-data="tableMap()"
+    x-init="init()"
+>
+
+    {{-- ══════════════════════════════════════════════════════
+         TOPBAR
+    ══════════════════════════════════════════════════════ --}}
+    <header class="flex-shrink-0 flex items-center justify-between
+                   bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700
+                   px-4 sm:px-6 py-3 shadow-sm">
+
+        <div class="flex items-center gap-3">
+            <h1 class="text-lg font-bold text-gray-900 dark:text-white">Plano del restaurante</h1>
+            <span class="text-sm text-gray-400 dark:text-gray-500">
+                <span x-text="tables.length"></span> / {{ $maxTables }} mesas
+            </span>
+        </div>
+
+        <div class="flex items-center gap-2">
+            {{-- Toast --}}
+            <div x-show="toast.show"
+                 x-transition:enter="transition ease-out duration-200"
+                 x-transition:enter-start="opacity-0 translate-y-1"
+                 x-transition:enter-end="opacity-100 translate-y-0"
+                 x-transition:leave="transition ease-in duration-150"
+                 x-transition:leave-end="opacity-0"
+                 :class="toast.error ? 'bg-red-100 text-red-700 border-red-300' : 'bg-green-100 text-green-700 border-green-300'"
+                 class="border rounded-lg px-3 py-1.5 text-sm font-medium"
+                 x-text="toast.msg"
+                 role="alert"
+                 aria-live="polite">
+            </div>
+
+            <a href="{{ route('tables.index') }}"
+               class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium
+                      bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200
+                      hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
+                <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"/>
+                </svg>
+                Ver QR
+            </a>
+        </div>
+    </header>
+
+    {{-- ══════════════════════════════════════════════════════
+         BODY — Paleta + Canvas
+    ══════════════════════════════════════════════════════ --}}
+    <div class="flex flex-1 overflow-hidden">
+
+        {{-- ── PALETA LATERAL ───────────────────────────────── --}}
+        <aside class="flex-shrink-0 w-44 bg-white dark:bg-gray-800
+                      border-r border-gray-200 dark:border-gray-700
+                      flex flex-col p-3 gap-4 overflow-y-auto">
+
+            <p class="text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">
+                Arrastrar al plano
+            </p>
+
+            {{-- Cuadrada --}}
+            <div class="palette-item group flex flex-col items-center gap-2 cursor-grab active:cursor-grabbing select-none"
+                 data-shape="square" data-width="100" data-height="100">
+                <div class="w-14 h-14 rounded-lg border-2 border-dashed border-indigo-400
+                            bg-indigo-50 dark:bg-indigo-900/30
+                            group-hover:border-indigo-600 group-hover:bg-indigo-100 transition-colors
+                            flex items-center justify-center">
+                    <svg aria-hidden="true" class="w-6 h-6 text-indigo-500" fill="currentColor" viewBox="0 0 24 24">
+                        <rect x="3" y="3" width="18" height="18" rx="2"/>
+                    </svg>
+                </div>
+                <span class="text-xs font-medium text-gray-600 dark:text-gray-300">Cuadrada</span>
+            </div>
+
+            {{-- Redonda --}}
+            <div class="palette-item group flex flex-col items-center gap-2 cursor-grab active:cursor-grabbing select-none"
+                 data-shape="round" data-width="100" data-height="100">
+                <div class="w-14 h-14 rounded-full border-2 border-dashed border-emerald-400
+                            bg-emerald-50 dark:bg-emerald-900/30
+                            group-hover:border-emerald-600 group-hover:bg-emerald-100 transition-colors
+                            flex items-center justify-center">
+                    <svg aria-hidden="true" class="w-6 h-6 text-emerald-500" fill="currentColor" viewBox="0 0 24 24">
+                        <circle cx="12" cy="12" r="9"/>
+                    </svg>
+                </div>
+                <span class="text-xs font-medium text-gray-600 dark:text-gray-300">Redonda</span>
+            </div>
+
+            {{-- Rectangular --}}
+            <div class="palette-item group flex flex-col items-center gap-2 cursor-grab active:cursor-grabbing select-none"
+                 data-shape="rectangle" data-width="150" data-height="90">
+                <div class="w-14 h-9 rounded-lg border-2 border-dashed border-amber-400
+                            bg-amber-50 dark:bg-amber-900/30
+                            group-hover:border-amber-600 group-hover:bg-amber-100 transition-colors
+                            flex items-center justify-center">
+                    <svg aria-hidden="true" class="w-6 h-4 text-amber-500" fill="currentColor" viewBox="0 0 24 24">
+                        <rect x="2" y="5" width="20" height="14" rx="2"/>
+                    </svg>
+                </div>
+                <span class="text-xs font-medium text-gray-600 dark:text-gray-300">Rectangular</span>
+            </div>
+
+            <hr class="border-gray-200 dark:border-gray-700">
+
+            <p class="text-xs text-gray-400 dark:text-gray-500 leading-relaxed">
+                Arrastra una forma al plano para crear una mesa. Mueve y redimensiona desde los bordes.
+            </p>
+
+            <template x-if="tables.length >= {{ $maxTables }}">
+                <div class="rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 p-2 text-xs text-amber-700 dark:text-amber-400">
+                    Límite de <strong>{{ $maxTables }}</strong> mesas alcanzado.
+                </div>
+            </template>
+        </aside>
+
+        {{-- ── CANVAS ───────────────────────────────────────── --}}
+        <main id="main-content" class="flex-1 overflow-auto p-4">
+            <div
+                x-ref="canvas"
+                class="relative bg-white dark:bg-gray-800 rounded-xl shadow-inner
+                       border-2 border-dashed border-gray-200 dark:border-gray-700"
+                style="width: 1200px; height: 800px; min-width: 100%;"
+                aria-label="Plano del restaurante"
+            >
+                {{-- Cuadrícula decorativa --}}
+                <svg class="absolute inset-0 w-full h-full pointer-events-none opacity-30 dark:opacity-10"
+                     xmlns="http://www.w3.org/2000/svg">
+                    <defs>
+                        <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+                            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#94a3b8" stroke-width="0.5"/>
+                        </pattern>
+                    </defs>
+                    <rect width="100%" height="100%" fill="url(#grid)"/>
+                </svg>
+
+                {{-- Mesas existentes --}}
+                <template x-for="table in tables" :key="table.id">
+                    <div
+                        :data-table-id="table.id"
+                        class="table-item absolute group select-none touch-none"
+                        :style="`left:${table.position_x}px; top:${table.position_y}px;
+                                 width:${table.width}px; height:${table.height}px;`"
+                        :aria-label="`Mesa ${table.name}`"
+                    >
+                        {{-- Fondo de la mesa --}}
+                        <div class="w-full h-full relative flex items-center justify-center
+                                    bg-indigo-100 dark:bg-indigo-900/40
+                                    border-2 border-indigo-300 dark:border-indigo-600
+                                    shadow-md cursor-grab active:cursor-grabbing
+                                    transition-shadow hover:shadow-lg"
+                             :class="{
+                                'rounded-full':  table.shape === 'round',
+                                'rounded-xl':    table.shape === 'square',
+                                'rounded-lg':    table.shape === 'rectangle',
+                             }">
+
+                            {{-- Nombre --}}
+                            <span class="text-xs font-semibold text-indigo-700 dark:text-indigo-300
+                                         text-center px-1 leading-tight pointer-events-none"
+                                  x-text="table.name">
+                            </span>
+
+                            {{-- Badge estado --}}
+                            <span class="absolute top-1 left-1 w-2 h-2 rounded-full"
+                                  :class="table.status === 'occupied' ? 'bg-red-500' : 'bg-green-400'"
+                                  :title="table.status === 'occupied' ? 'Ocupada' : 'Libre'">
+                            </span>
+
+                            {{-- Botón eliminar --}}
+                            <button type="button"
+                                    @click.stop="deleteTable(table)"
+                                    class="absolute -top-2.5 -right-2.5
+                                           w-6 h-6 rounded-full bg-red-500 text-white
+                                           flex items-center justify-center
+                                           opacity-0 group-hover:opacity-100 transition-opacity
+                                           hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400
+                                           shadow-md"
+                                    :aria-label="`Eliminar mesa ${table.name}`">
+                                <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                                </svg>
+                            </button>
+                        </div>
+
+                        {{-- Handle de redimensionado (esquina inferior derecha) --}}
+                        <div class="resize-handle absolute bottom-0 right-0
+                                    w-4 h-4 cursor-se-resize opacity-0 group-hover:opacity-100
+                                    transition-opacity">
+                            <svg aria-hidden="true" viewBox="0 0 10 10" fill="none" class="w-full h-full text-indigo-400">
+                                <path d="M9 1L1 9M9 5L5 9M9 9H9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                            </svg>
+                        </div>
+                    </div>
+                </template>
+
+                {{-- Indicador de zona de soltar --}}
+                <div x-show="isDraggingFromPalette"
+                     class="absolute inset-0 rounded-xl border-4 border-dashed border-indigo-400
+                            bg-indigo-50/30 dark:bg-indigo-900/20 pointer-events-none
+                            flex items-center justify-center">
+                    <p class="text-indigo-500 font-semibold text-lg">Suelta aquí para crear la mesa</p>
+                </div>
+            </div>
+        </main>
+    </div>
+</div>
+
+{{-- Ghost element — sigue al cursor mientras se arrastra desde la paleta --}}
+<div id="palette-ghost"
+     class="fixed pointer-events-none z-50 hidden opacity-70
+            bg-indigo-200 border-2 border-indigo-500 shadow-xl flex items-center justify-center">
+    <span class="text-xs font-semibold text-indigo-700">Nueva mesa</span>
+</div>
+
+{{-- Modal: nombre de la nueva mesa --}}
+<div x-data
+     x-show="$store.tableModal.open"
+     x-transition:enter="transition ease-out duration-200"
+     x-transition:enter-start="opacity-0"
+     x-transition:enter-end="opacity-100"
+     class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+     aria-modal="true"
+     role="dialog"
+     aria-labelledby="modal-title"
+     @keydown.escape.window="$store.tableModal.cancel()">
+
+    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl p-6 w-full max-w-sm mx-4"
+         @click.stop>
+
+        <h2 id="modal-title" class="text-lg font-bold text-gray-900 dark:text-white mb-4">
+            Nueva mesa
+        </h2>
+
+        <div class="mb-4">
+            <label for="new-table-name" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Nombre de la mesa
+            </label>
+            <input id="new-table-name"
+                   type="text"
+                   x-model="$store.tableModal.name"
+                   @keydown.enter="$store.tableModal.confirm()"
+                   maxlength="50"
+                   placeholder="Ej: Mesa 1, Terraza A..."
+                   class="w-full rounded-lg border border-gray-300 dark:border-gray-600
+                          bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                          px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                   aria-required="true"
+                   x-init="$watch('$store.tableModal.open', v => v && $nextTick(() => $el.focus()))">
+        </div>
+
+        <div class="flex gap-2 justify-end">
+            <button type="button"
+                    @click="$store.tableModal.cancel()"
+                    class="px-4 py-2 rounded-lg text-sm font-medium
+                           text-gray-600 dark:text-gray-300
+                           bg-gray-100 dark:bg-gray-700
+                           hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
+                Cancelar
+            </button>
+            <button type="button"
+                    @click="$store.tableModal.confirm()"
+                    :disabled="!$store.tableModal.name.trim()"
+                    class="px-4 py-2 rounded-lg text-sm font-medium text-white
+                           bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50
+                           disabled:cursor-not-allowed transition-colors">
+                Crear
+            </button>
+        </div>
+    </div>
+</div>
+
+{{-- interact.js CDN --}}
+<script src="https://cdn.jsdelivr.net/npm/interactjs@1.10.27/dist/interact.min.js"></script>
+
+<script>
+document.addEventListener('alpine:init', () => {
+
+    // ── Store para el modal de nombre de nueva mesa ───────────────────────────
+    Alpine.store('tableModal', {
+        open:       false,
+        name:       '',
+        _resolve:   null,
+
+        prompt() {
+            this.name = '';
+            this.open = true;
+            return new Promise(resolve => { this._resolve = resolve; });
+        },
+
+        confirm() {
+            if (!this.name.trim()) return;
+            const name = this.name.trim();
+            this.open = false;
+            this._resolve?.(name);
+        },
+
+        cancel() {
+            this.open = false;
+            this._resolve?.(null);
+        },
+    });
+
+    // ── Componente principal del mapa ─────────────────────────────────────────
+    Alpine.data('tableMap', () => ({
+        tables:               @json($tables),
+        isDraggingFromPalette: false,
+        toast:                { show: false, msg: '', error: false, _timer: null },
+
+        init() {
+            this.$nextTick(() => {
+                this.initTableInteract();
+                this.initPaletteInteract();
+            });
+        },
+
+        // ── Toast ─────────────────────────────────────────────────────────────
+        showToast(msg, error = false) {
+            clearTimeout(this.toast._timer);
+            this.toast = { show: true, msg, error, _timer: null };
+            this.toast._timer = setTimeout(() => { this.toast.show = false; }, 3000);
+        },
+
+        // ── Interactividad de mesas existentes ────────────────────────────────
+        initTableInteract() {
+            interact('.table-item').unset();
+
+            interact('.table-item')
+                .draggable({
+                    inertia:    false,
+                    autoScroll: true,
+                    modifiers: [
+                        interact.modifiers.restrictRect({
+                            restriction: this.$refs.canvas,
+                            endOnly:     false,
+                        }),
+                    ],
+                    listeners: {
+                        move: (event) => {
+                            const el = event.target;
+                            const x  = (parseFloat(el.style.left) || 0) + event.dx;
+                            const y  = (parseFloat(el.style.top)  || 0) + event.dy;
+                            el.style.left = `${x}px`;
+                            el.style.top  = `${y}px`;
+                        },
+                        end: (event) => {
+                            const el  = event.target;
+                            const id  = parseInt(el.dataset.tableId);
+                            const x   = Math.round(parseFloat(el.style.left) || 0);
+                            const y   = Math.round(parseFloat(el.style.top)  || 0);
+                            const w   = Math.round(parseFloat(el.style.width)  || 100);
+                            const h   = Math.round(parseFloat(el.style.height) || 100);
+                            this.persistPosition(id, x, y, w, h);
+                        },
+                    },
+                })
+                .resizable({
+                    edges:   { left: false, right: true, bottom: true, top: false },
+                    inertia: false,
+                    modifiers: [
+                        interact.modifiers.restrictSize({
+                            min: { width: 60, height: 60 },
+                            max: { width: 400, height: 400 },
+                        }),
+                    ],
+                    listeners: {
+                        move: (event) => {
+                            const el = event.target;
+                            el.style.width  = `${event.rect.width}px`;
+                            el.style.height = `${event.rect.height}px`;
+                        },
+                        end: (event) => {
+                            const el = event.target;
+                            const id = parseInt(el.dataset.tableId);
+                            const x  = Math.round(parseFloat(el.style.left) || 0);
+                            const y  = Math.round(parseFloat(el.style.top)  || 0);
+                            const w  = Math.round(parseFloat(el.style.width)  || 100);
+                            const h  = Math.round(parseFloat(el.style.height) || 100);
+                            this.persistPosition(id, x, y, w, h);
+                        },
+                    },
+                });
+        },
+
+        // ── Reinicializar interact después de añadir una mesa ─────────────────
+        reinitInteract() {
+            this.$nextTick(() => this.initTableInteract());
+        },
+
+        // ── Paleta: drag-to-create ────────────────────────────────────────────
+        initPaletteInteract() {
+            const ghost     = document.getElementById('palette-ghost');
+            const canvasEl  = this.$refs.canvas;
+            let   dropShape = null;
+            let   dropW     = 100;
+            let   dropH     = 100;
+            let   dropX     = 0;
+            let   dropY     = 0;
+
+            interact('.palette-item').draggable({
+                inertia: false,
+                listeners: {
+                    start: (event) => {
+                        dropShape = event.target.dataset.shape;
+                        dropW     = parseInt(event.target.dataset.width)  || 100;
+                        dropH     = parseInt(event.target.dataset.height) || 100;
+
+                        ghost.style.width   = `${dropW}px`;
+                        ghost.style.height  = `${dropH}px`;
+                        ghost.style.borderRadius =
+                            dropShape === 'round' ? '9999px' :
+                            dropShape === 'square' ? '12px' : '8px';
+                        ghost.classList.remove('hidden');
+                        ghost.classList.add('flex');
+
+                        this.isDraggingFromPalette = true;
+                    },
+
+                    move: (event) => {
+                        const canvasRect = canvasEl.getBoundingClientRect();
+                        const cx         = event.clientX;
+                        const cy         = event.clientY;
+
+                        ghost.style.left = `${cx - dropW / 2}px`;
+                        ghost.style.top  = `${cy - dropH / 2}px`;
+
+                        dropX = Math.max(0, Math.round(cx - canvasRect.left - dropW / 2));
+                        dropY = Math.max(0, Math.round(cy - canvasRect.top  - dropH / 2));
+                    },
+
+                    end: async (event) => {
+                        ghost.classList.add('hidden');
+                        ghost.classList.remove('flex');
+                        this.isDraggingFromPalette = false;
+
+                        const canvasRect = canvasEl.getBoundingClientRect();
+                        const cx         = event.clientX;
+                        const cy         = event.clientY;
+
+                        const overCanvas =
+                            cx >= canvasRect.left && cx <= canvasRect.right &&
+                            cy >= canvasRect.top  && cy <= canvasRect.bottom;
+
+                        if (!overCanvas) return;
+                        if (this.tables.length >= {{ $maxTables }}) {
+                            this.showToast('Límite de mesas alcanzado.', true);
+                            return;
+                        }
+
+                        const name = await Alpine.store('tableModal').prompt();
+                        if (!name) return;
+
+                        await this.createTable(name, dropShape, dropX, dropY, dropW, dropH);
+                    },
+                },
+            });
+        },
+
+        // ── AJAX: crear mesa ──────────────────────────────────────────────────
+        async createTable(name, shape, x, y, w, h) {
+            try {
+                const res = await fetch('{{ route("tables.store") }}', {
+                    method:  'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                        'Accept':       'application/json',
+                    },
+                    body: JSON.stringify({
+                        name,
+                        shape,
+                        position_x: x,
+                        position_y: y,
+                        width:      w,
+                        height:     h,
+                    }),
+                });
+
+                const json = await res.json();
+
+                if (!res.ok || !json.success) {
+                    this.showToast(json.message ?? 'Error al crear la mesa.', true);
+                    return;
+                }
+
+                this.tables.push(json.data);
+                this.reinitInteract();
+                this.showToast(json.message);
+            } catch {
+                this.showToast('Error de red al crear la mesa.', true);
+            }
+        },
+
+        // ── AJAX: persistir posición ──────────────────────────────────────────
+        async persistPosition(id, x, y, w, h) {
+            const table = this.tables.find(t => t.id === id);
+            if (table) {
+                table.position_x = x;
+                table.position_y = y;
+                table.width      = w;
+                table.height     = h;
+            }
+
+            try {
+                const res = await fetch(`/mesas/${id}/posicion`, {
+                    method:  'PATCH',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                        'Accept':       'application/json',
+                    },
+                    body: JSON.stringify({ position_x: x, position_y: y, width: w, height: h }),
+                });
+
+                if (!res.ok) {
+                    this.showToast('Error al guardar la posición.', true);
+                }
+            } catch {
+                this.showToast('Error de red al guardar posición.', true);
+            }
+        },
+
+        // ── AJAX: eliminar mesa ───────────────────────────────────────────────
+        async deleteTable(table) {
+            if (!confirm(`¿Eliminar la mesa "${table.name}"? Esta acción no se puede deshacer.`)) return;
+
+            try {
+                const res = await fetch(`/mesas/${table.id}`, {
+                    method:  'DELETE',
+                    headers: {
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                        'Accept':       'application/json',
+                    },
+                });
+
+                const json = await res.json();
+
+                if (!res.ok || !json.success) {
+                    this.showToast(json.message ?? 'Error al eliminar la mesa.', true);
+                    return;
+                }
+
+                this.tables = this.tables.filter(t => t.id !== table.id);
+                this.showToast(json.message);
+            } catch {
+                this.showToast('Error de red al eliminar la mesa.', true);
+            }
+        },
+    }));
+});
+</script>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,6 +60,12 @@ Route::middleware(['auth', 'business.active'])->group(function () {
         Route::get('/staff/create', [StaffController::class, 'create'])->name('staff.create');
         Route::post('/staff', [StaffController::class, 'store'])->name('staff.store');
         Route::delete('/staff/{staff}', [StaffController::class, 'destroy'])->name('staff.destroy');
+
+        // Mapa visual de mesas (Bloque 8.1) — solo admin
+        Route::get('/mesas/mapa', [TableController::class, 'map'])->name('tables.map');
+        Route::post('/mesas', [TableController::class, 'store'])->name('tables.store');
+        Route::patch('/mesas/{table}/posicion', [TableController::class, 'updatePosition'])->name('tables.updatePosition');
+        Route::delete('/mesas/{table}', [TableController::class, 'destroy'])->name('tables.destroy');
     });
 
     // Gestión de mesas y códigos QR

--- a/tests/Feature/Bloque8/TableMapTest.php
+++ b/tests/Feature/Bloque8/TableMapTest.php
@@ -1,0 +1,348 @@
+<?php
+
+/**
+ * @author AyrtonAlania
+ */
+
+use App\Models\Plan;
+use App\Models\Table;
+use App\Models\User;
+
+uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    $plan         = Plan::factory()->create(['max_tables' => 5]);
+    $this->admin  = User::factory()->admin()->create(['plan_id' => $plan->id]);
+    $this->other  = User::factory()->admin()->create(['plan_id' => $plan->id]);
+    $this->waiter = User::factory()->waiter()->create(['admin_id' => $this->admin->id]);
+    $this->plan   = $plan;
+});
+
+// ─── Autenticación ────────────────────────────────────────────────────────────
+
+it('redirects unauthenticated user away from map', function () {
+    $this->get(route('tables.map'))
+         ->assertRedirect(route('login'));
+});
+
+it('returns 401 for unauthenticated user on store', function () {
+    $this->postJson(route('tables.store'), [])
+         ->assertUnauthorized();
+});
+
+it('returns 401 for unauthenticated user on updatePosition', function () {
+    $table = Table::factory()->for($this->admin)->create();
+
+    $this->patchJson(route('tables.updatePosition', $table), [])
+         ->assertUnauthorized();
+});
+
+it('returns 401 for unauthenticated user on destroy', function () {
+    $table = Table::factory()->for($this->admin)->create();
+
+    $this->deleteJson(route('tables.destroy', $table))
+         ->assertUnauthorized();
+});
+
+// ─── Control de rol ───────────────────────────────────────────────────────────
+
+it('returns 403 for non-admin on map page', function () {
+    $this->actingAs($this->waiter)
+         ->get(route('tables.map'))
+         ->assertForbidden();
+});
+
+it('returns 403 for non-admin on store', function () {
+    $this->actingAs($this->waiter)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Mesa 1',
+             'shape'      => 'square',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertForbidden();
+});
+
+it('returns 403 for non-admin on updatePosition', function () {
+    $table = Table::factory()->for($this->admin)->create();
+
+    $this->actingAs($this->waiter)
+         ->patchJson(route('tables.updatePosition', $table), [
+             'position_x' => 50,
+             'position_y' => 50,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertForbidden();
+});
+
+it('returns 403 for non-admin on destroy', function () {
+    $table = Table::factory()->for($this->admin)->create();
+
+    $this->actingAs($this->waiter)
+         ->deleteJson(route('tables.destroy', $table))
+         ->assertForbidden();
+});
+
+// ─── Map (GET /mesas/mapa) ────────────────────────────────────────────────────
+
+it('admin can access map view', function () {
+    $this->actingAs($this->admin)
+         ->get(route('tables.map'))
+         ->assertOk()
+         ->assertViewIs('tables.map');
+});
+
+it('map passes tables and maxTables to view', function () {
+    Table::factory()->for($this->admin)->count(2)->create();
+
+    $response = $this->actingAs($this->admin)
+                     ->get(route('tables.map'));
+
+    $response->assertViewHas('tables');
+    $response->assertViewHas('maxTables');
+    expect($response->viewData('tables'))->toHaveCount(2);
+});
+
+it('map only shows tables of the authenticated admin', function () {
+    Table::factory()->for($this->admin)->count(3)->create();
+    Table::factory()->for($this->other)->count(2)->create();
+
+    $response = $this->actingAs($this->admin)
+                     ->get(route('tables.map'));
+
+    expect($response->viewData('tables'))->toHaveCount(3);
+});
+
+// ─── Store (POST /mesas) ──────────────────────────────────────────────────────
+
+it('admin creates a table with valid data', function () {
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Mesa 1',
+             'shape'      => 'square',
+             'position_x' => 10,
+             'position_y' => 20,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertCreated()
+         ->assertJsonPath('success', true)
+         ->assertJsonPath('data.name', 'Mesa 1');
+});
+
+it('store saves table in database', function () {
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Terraza B',
+             'shape'      => 'round',
+             'position_x' => 50,
+             'position_y' => 80,
+             'width'      => 100,
+             'height'     => 100,
+         ]);
+
+    $this->assertDatabaseHas('tables', [
+        'name'    => 'Terraza B',
+        'user_id' => $this->admin->id,
+        'shape'   => 'round',
+    ]);
+});
+
+it('store assigns user_id of the authenticated admin', function () {
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Mesa Owner',
+             'shape'      => 'rectangle',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 150,
+             'height'     => 90,
+         ]);
+
+    $table = Table::where('name', 'Mesa Owner')->first();
+    expect($table->user_id)->toBe($this->admin->id);
+});
+
+it('store generates unique_hash automatically', function () {
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Mesa Hash',
+             'shape'      => 'square',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 100,
+             'height'     => 100,
+         ]);
+
+    $table = Table::where('name', 'Mesa Hash')->first();
+    expect($table->unique_hash)->not->toBeNull();
+    expect(strlen($table->unique_hash))->toBeGreaterThan(10);
+});
+
+it('fails to create table without name', function () {
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'shape'      => 'square',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertUnprocessable();
+});
+
+it('fails to create table without shape', function () {
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Mesa X',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertUnprocessable();
+});
+
+it('fails to create table with invalid shape', function () {
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Mesa X',
+             'shape'      => 'triangle',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertUnprocessable();
+});
+
+it('returns 422 with error message when plan limit is reached', function () {
+    Table::factory()->for($this->admin)->count(5)->create();
+
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Mesa Extra',
+             'shape'      => 'square',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertUnprocessable()
+         ->assertJsonPath('success', false);
+});
+
+// ─── UpdatePosition (PATCH /mesas/{table}/posicion) ──────────────────────────
+
+it('admin can update table position', function () {
+    $table = Table::factory()->for($this->admin)->create();
+
+    $this->actingAs($this->admin)
+         ->patchJson(route('tables.updatePosition', $table), [
+             'position_x' => 200,
+             'position_y' => 150,
+             'width'      => 120,
+             'height'     => 80,
+         ])
+         ->assertOk()
+         ->assertJsonPath('success', true);
+
+    $this->assertDatabaseHas('tables', [
+        'id'         => $table->id,
+        'position_x' => 200,
+        'position_y' => 150,
+        'width'      => 120,
+        'height'     => 80,
+    ]);
+});
+
+it('returns 403 when updating position of another admins table', function () {
+    $table = Table::factory()->for($this->other)->create();
+
+    $this->actingAs($this->admin)
+         ->patchJson(route('tables.updatePosition', $table), [
+             'position_x' => 50,
+             'position_y' => 50,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertForbidden();
+});
+
+it('fails to update position with negative coordinates', function () {
+    $table = Table::factory()->for($this->admin)->create();
+
+    $this->actingAs($this->admin)
+         ->patchJson(route('tables.updatePosition', $table), [
+             'position_x' => -10,
+             'position_y' => -20,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertUnprocessable();
+});
+
+// ─── Destroy (DELETE /mesas/{table}) ─────────────────────────────────────────
+
+it('admin can delete own table', function () {
+    $table = Table::factory()->for($this->admin)->create();
+
+    $this->actingAs($this->admin)
+         ->deleteJson(route('tables.destroy', $table))
+         ->assertOk()
+         ->assertJsonPath('success', true);
+
+    $this->assertDatabaseMissing('tables', ['id' => $table->id]);
+});
+
+it('destroy response includes table name in message', function () {
+    $table = Table::factory()->for($this->admin)->create(['name' => 'Mesa VIP']);
+
+    $response = $this->actingAs($this->admin)
+                     ->deleteJson(route('tables.destroy', $table));
+
+    expect($response->json('message'))->toContain('Mesa VIP');
+});
+
+it('returns 403 when deleting another admins table', function () {
+    $table = Table::factory()->for($this->other)->create();
+
+    $this->actingAs($this->admin)
+         ->deleteJson(route('tables.destroy', $table))
+         ->assertForbidden();
+});
+
+it('returns 404 when deleting a non-existent table', function () {
+    $this->actingAs($this->admin)
+         ->deleteJson(route('tables.destroy', 99999))
+         ->assertNotFound();
+});
+
+// ─── Unicidad de hashes ───────────────────────────────────────────────────────
+
+it('each created table has a unique_hash', function () {
+    $table = Table::factory()->for($this->admin)->create();
+    expect($table->unique_hash)->not->toBeNull();
+});
+
+it('unique hashes are unique across all tables', function () {
+    $tables = Table::factory()->for($this->admin)->count(5)->create();
+    $hashes = $tables->pluck('unique_hash')->unique();
+
+    expect($hashes)->toHaveCount(5);
+});
+
+it('public menu route returns 200 with valid table hash', function () {
+    $table = Table::factory()->for($this->admin)->create();
+
+    $this->get(route('menu.show', $table->unique_hash))
+         ->assertOk();
+});
+
+it('public menu route returns 404 with invalid hash', function () {
+    $this->get(route('menu.show', 'hash-invalido-xyz'))
+         ->assertNotFound();
+});

--- a/tests/Feature/Bloque8/TableMapTest.php
+++ b/tests/Feature/Bloque8/TableMapTest.php
@@ -346,3 +346,114 @@ it('public menu route returns 404 with invalid hash', function () {
     $this->get(route('menu.show', 'hash-invalido-xyz'))
          ->assertNotFound();
 });
+
+// ─── Límite del plan (Bloque 8.2) ─────────────────────────────────────────────
+
+it('allows creation when one slot remains in plan', function () {
+    Table::factory()->for($this->admin)->count(4)->create();
+
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Última Mesa',
+             'shape'      => 'square',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertCreated()
+         ->assertJsonPath('success', true);
+});
+
+it('blocks creation at exactly the plan limit', function () {
+    Table::factory()->for($this->admin)->count(5)->create();
+
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Mesa Extra',
+             'shape'      => 'square',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertUnprocessable()
+         ->assertJsonPath('success', false);
+
+    expect(Table::where('user_id', $this->admin->id)->count())->toBe(5);
+});
+
+it('limit error message includes the plan max_tables value', function () {
+    Table::factory()->for($this->admin)->count(5)->create();
+
+    $response = $this->actingAs($this->admin)
+                     ->postJson(route('tables.store'), [
+                         'name'       => 'Mesa X',
+                         'shape'      => 'square',
+                         'position_x' => 0,
+                         'position_y' => 0,
+                         'width'      => 100,
+                         'height'     => 100,
+                     ]);
+
+    expect($response->json('message'))->toContain('5');
+});
+
+it('counts only own tables towards the plan limit', function () {
+    Table::factory()->for($this->other)->count(5)->create();
+
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Mesa Propia',
+             'shape'      => 'round',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertCreated()
+         ->assertJsonPath('success', true);
+});
+
+it('user without plan defaults to limit of 10', function () {
+    $admin = User::factory()->admin()->create(['plan_id' => null]);
+    Table::factory()->for($admin)->count(10)->create();
+
+    $this->actingAs($admin)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Mesa Sin Plan',
+             'shape'      => 'square',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertUnprocessable()
+         ->assertJsonPath('success', false);
+});
+
+it('user without plan can still create up to 10 tables', function () {
+    $admin = User::factory()->admin()->create(['plan_id' => null]);
+    Table::factory()->for($admin)->count(9)->create();
+
+    $this->actingAs($admin)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Mesa 10',
+             'shape'      => 'square',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertCreated();
+});
+
+it('index view shows correct table count against plan limit', function () {
+    Table::factory()->for($this->admin)->count(3)->create();
+
+    $response = $this->actingAs($this->admin)
+                     ->get(route('tables.index'));
+
+    $response->assertViewHas('maxTables', 5);
+    expect($response->viewData('tables')->count())->toBe(3);
+});


### PR DESCRIPTION
﻿## Resumen

- Contador con texto exacto en colores (verde/ambar/rojo segun uso) y barra de progreso en el mapa
- Badge de plan en la pagina Mesas QR con el mismo codigo de colores
- Paleta de formas visualmente deshabilitada al llegar al limite
- Bloqueo del drag desde el evento start para evitar que aparezca el ghost element
- 7 nuevos tests de edge cases: ultimo slot, limite exacto, mensaje con numero, conteo por usuario, plan nulo

## Cambios

- app/Http/Controllers/TableController.php -- index() pasa maxTables a la vista
- resources/views/tables/index.blade.php -- badge de plan con colores
- resources/views/tables/map.blade.php -- contador con barra de progreso y paleta deshabilitada
- tests/Feature/Bloque8/TableMapTest.php -- 7 tests nuevos, total 37/37 PASS

## Criterios de aceptacion

- [x] No se puede crear una mesa si se alcanza plans.max_tables
- [x] UI muestra X de Y mesas usadas en mapa e index
- [x] Validacion en frontend y backend (422)
