### PR TITLE
[feat] tapas — modalidad de precio, exclusion del listado y proteccion de categoria

### DIFF
--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -21,6 +21,10 @@ class OrderController extends Controller
     /**
      * Persiste un nuevo pedido recibido desde la carta digital pública.
      *
+     * Para ítems de la categoría "Tapas", el precio del snapshot se resuelve
+     * usando TapaConfig::getPriceForProduct() según la modalidad activa,
+     * garantizando que lo cobrado coincide con lo mostrado al cliente.
+     *
      * @param  Request  $request
      * @return JsonResponse
      */
@@ -37,9 +41,10 @@ class OrderController extends Controller
             'items.*.modifications.*.amount_charged' => 'nullable|numeric|min:0',
         ]);
 
-        $table = Table::where('unique_hash', $validated['table_hash'])->firstOrFail();
+        $table      = Table::where('unique_hash', $validated['table_hash'])->firstOrFail();
+        $tapaConfig = $table->user->tapaConfig?->load('schedules');
 
-        $order = DB::transaction(function () use ($validated, $table) {
+        $order = DB::transaction(function () use ($validated, $table, $tapaConfig) {
             $order = Order::create([
                 'table_id'       => $table->id,
                 'status'         => 'pending',
@@ -52,18 +57,22 @@ class OrderController extends Controller
             foreach ($validated['items'] as $itemData) {
                 $product = Product::with('category')->findOrFail($itemData['product_id']);
 
+                $basePrice = ($tapaConfig && $tapaConfig->tapas_enabled && $tapaConfig->isTapaProduct($product))
+                    ? $tapaConfig->getPriceForProduct($product)
+                    : (float) $product->price;
+
                 $extraCharge = collect($itemData['modifications'] ?? [])
                     ->where('action', 'add')
                     ->sum('amount_charged');
 
-                $unitPrice = (float) $product->price + (float) $extraCharge;
+                $unitPrice = $basePrice + (float) $extraCharge;
                 $total    += $unitPrice * $itemData['quantity'];
 
                 $orderItem = OrderItem::create([
                     'order_id'    => $order->id,
                     'product_id'  => $product->id,
                     'quantity'    => $itemData['quantity'],
-                    'price'       => $product->price,
+                    'price'       => $basePrice,
                     'status'      => 'queued',
                     'destination' => $product->category->destination,
                 ]);

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Category;
+use App\Models\TapaConfig;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
@@ -105,6 +106,14 @@ class CategoryController extends Controller
             'destination' => 'required|in:kitchen,bar',
         ]);
 
+        if ($category->name === 'Tapas' && $validated['name'] !== 'Tapas') {
+            $ownerId    = Auth::user()->ownerUserId();
+            $tapaConfig = TapaConfig::where('user_id', $ownerId)->first();
+            if ($tapaConfig?->tapas_enabled) {
+                return back()->withErrors(['name' => 'No puedes renombrar la categoría "Tapas" mientras el sistema de tapas esté activo.']);
+            }
+        }
+
         $category->update($validated);
 
         return redirect()->route('categories.index')->with('success', '¡Categoría actualizada correctamente!');
@@ -119,6 +128,14 @@ class CategoryController extends Controller
     public function destroy(Category $category): RedirectResponse
     {
         abort_if($category->user_id !== Auth::user()->ownerUserId(), 403);
+
+        if ($category->name === 'Tapas') {
+            $ownerId    = Auth::user()->ownerUserId();
+            $tapaConfig = TapaConfig::where('user_id', $ownerId)->first();
+            if ($tapaConfig?->tapas_enabled) {
+                return back()->withErrors(['general' => 'No puedes eliminar la categoría "Tapas" mientras el sistema de tapas esté activo.']);
+            }
+        }
 
         $category->delete();
 

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -41,6 +41,7 @@ class MenuController extends Controller
 
         $categories = Category::where('user_id', $table->user_id)
             ->when(! $kitchenOpen, fn ($q) => $q->where('destination', 'bar'))
+            ->when($config && $config->tapas_enabled, fn ($q) => $q->where('name', '!=', 'Tapas'))
             ->with([
                 'products' => function ($query) {
                     $query->where('is_active', true)

--- a/app/Http/Controllers/TapasController.php
+++ b/app/Http/Controllers/TapasController.php
@@ -7,13 +7,15 @@ use App\Models\TapaConfig;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 
 /**
  * Class TapasController
  *
  * Permite al gerente configurar el sistema de tapas del restaurante:
- * activar/desactivar, modo gratuito/de pago, precio, variantes máximas,
+ * activar/desactivar, modo gratuito/de pago, modalidad de precio
+ * (fijo global o por producto), precio, variantes máximas,
  * tapa extra de pago y tramos horarios de apertura de cocina.
  *
  * @author BenjaminDTS
@@ -33,6 +35,7 @@ class TapasController extends Controller
             [
                 'tapas_enabled'      => false,
                 'tapas_free'         => true,
+                'price_mode'         => 'fixed',
                 'max_tapa_variants'  => 3,
                 'tapa_price'         => null,
                 'extra_tapa_enabled' => false,
@@ -47,6 +50,12 @@ class TapasController extends Controller
 
     /**
      * Guarda la configuración de tapas del restaurante.
+     *
+     * Reglas de precio:
+     *  - Si tapas_free = true: precio y modalidad ignorados, tapa_price = null.
+     *  - Si tapas_free = false y price_mode = 'fixed': tapa_price obligatorio.
+     *  - Si tapas_free = false y price_mode = 'per_product': tapa_price = null.
+     *
      * Al activar tapas crea automáticamente la categoría 'Tapas' con destination=kitchen.
      * Reemplaza los tramos horarios de cocina por los enviados en el formulario.
      *
@@ -55,11 +64,18 @@ class TapasController extends Controller
      */
     public function update(Request $request): RedirectResponse
     {
+        $tapasFree  = $request->boolean('tapas_free');
+        $priceMode  = $request->input('price_mode', 'fixed');
+
         $request->validate([
             'tapas_enabled'            => ['sometimes', 'boolean'],
             'tapas_free'               => ['sometimes', 'boolean'],
+            'price_mode'               => ['nullable', 'in:fixed,per_product'],
             'max_tapa_variants'        => ['required', 'integer', 'min:1', 'max:20'],
-            'tapa_price'               => ['required_if:tapas_free,0', 'nullable', 'numeric', 'min:0', 'max:999.99'],
+            'tapa_price'               => [
+                Rule::requiredIf(fn () => ! $tapasFree && $priceMode === 'fixed'),
+                'nullable', 'numeric', 'min:0', 'max:999.99',
+            ],
             'extra_tapa_enabled'       => ['sometimes', 'boolean'],
             'extra_tapa_price'         => ['required_if:extra_tapa_enabled,1', 'nullable', 'numeric', 'min:0', 'max:999.99'],
             'schedules'                => ['nullable', 'array', 'max:10'],
@@ -69,8 +85,15 @@ class TapasController extends Controller
 
         $userId       = Auth::id();
         $tapasEnabled = $request->boolean('tapas_enabled');
-        $tapasFree    = $request->boolean('tapas_free');
         $extraEnabled = $request->boolean('extra_tapa_enabled');
+
+        // Normalizar modalidad: si tapas son gratuitas el precio_mode es irrelevante
+        $resolvedMode = $tapasFree ? 'fixed' : $priceMode;
+
+        // tapa_price solo aplica en modalidad fija y tapas de pago
+        $resolvedPrice = ($tapasFree || $resolvedMode === 'per_product')
+            ? null
+            : ($request->input('tapa_price') ?? null);
 
         if ($tapasEnabled) {
             Category::firstOrCreate(
@@ -84,8 +107,9 @@ class TapasController extends Controller
             [
                 'tapas_enabled'      => $tapasEnabled,
                 'tapas_free'         => $tapasFree,
+                'price_mode'         => $resolvedMode,
                 'max_tapa_variants'  => $request->integer('max_tapa_variants'),
-                'tapa_price'         => $tapasFree ? null : ($request->input('tapa_price') ?? null),
+                'tapa_price'         => $resolvedPrice,
                 'extra_tapa_enabled' => $extraEnabled,
                 'extra_tapa_price'   => $extraEnabled ? ($request->input('extra_tapa_price') ?? null) : null,
             ]

--- a/app/Models/TapaConfig.php
+++ b/app/Models/TapaConfig.php
@@ -13,15 +13,17 @@ use Illuminate\Support\Carbon;
  *
  * Configuración del sistema de tapas de un restaurante (relación 1:1 con User).
  * Permite al gerente activar tapas, definir si son gratuitas o de pago,
- * el precio unitario, el número máximo de variantes distintas por pedido,
- * la tapa extra de pago y los tramos horarios de apertura de cocina.
+ * la modalidad de precio (fijo global o por producto), el número máximo de
+ * variantes distintas por pedido, la tapa extra de pago y los tramos horarios
+ * de apertura de cocina.
  *
  * @package App\Models
  * @property int        $user_id
  * @property bool       $tapas_enabled       Si el sistema de tapas está activo
  * @property bool       $tapas_free          true = gratuitas, false = de pago
+ * @property string     $price_mode          'fixed' = precio global | 'per_product' = precio individual
  * @property int        $max_tapa_variants   Máximo de variantes distintas por mesa
- * @property float|null $tapa_price          Precio por tapa (solo si tapas_free = false)
+ * @property float|null $tapa_price          Precio fijo global (solo si price_mode = fixed y tapas_free = false)
  * @property bool       $extra_tapa_enabled  Si se permite pedir una tapa extra de pago
  * @property float|null $extra_tapa_price    Precio de la tapa extra (obligatorio si extra_tapa_enabled)
  *
@@ -38,6 +40,7 @@ class TapaConfig extends Model
         'user_id',
         'tapas_enabled',
         'tapas_free',
+        'price_mode',
         'max_tapa_variants',
         'tapa_price',
         'extra_tapa_enabled',
@@ -50,6 +53,7 @@ class TapaConfig extends Model
     protected $casts = [
         'tapas_enabled'      => 'boolean',
         'tapas_free'         => 'boolean',
+        'price_mode'         => 'string',
         'max_tapa_variants'  => 'integer',
         'tapa_price'         => 'decimal:2',
         'extra_tapa_enabled' => 'boolean',
@@ -157,5 +161,44 @@ class TapaConfig extends Model
         }
 
         return $tapaVariantsUsed < $this->max_tapa_variants;
+    }
+
+    /**
+     * Devuelve el precio que el cliente debe pagar por una tapa según la modalidad activa.
+     *
+     * Si tapas son gratuitas     → 0.0
+     * Si price_mode = 'fixed'    → precio fijo global (tapa_price)
+     * Si price_mode = per_product → precio individual del producto
+     *
+     * La tapa extra tiene siempre su propio precio (extra_tapa_price), independiente de esta lógica.
+     *
+     * @param  Product  $product
+     * @return float
+     */
+    public function getPriceForProduct(Product $product): float
+    {
+        if ($this->tapas_free) {
+            return 0.0;
+        }
+
+        if ($this->price_mode === 'fixed') {
+            return (float) ($this->tapa_price ?? 0);
+        }
+
+        return (float) $product->price;
+    }
+
+    /**
+     * Determina si un producto pertenece a la categoría "Tapas" de este restaurante.
+     * Usado para aplicar el precio de tapa en lugar del precio normal del producto.
+     *
+     * @param  Product  $product  Debe tener la relación 'category' cargada
+     * @return bool
+     */
+    public function isTapaProduct(Product $product): bool
+    {
+        return $product->category_id !== null
+            && $product->category?->name === 'Tapas'
+            && $product->category?->user_id === $this->user_id;
     }
 }

--- a/database/factories/TapaConfigFactory.php
+++ b/database/factories/TapaConfigFactory.php
@@ -21,6 +21,7 @@ class TapaConfigFactory extends Factory
             'user_id'            => User::factory(),
             'tapas_enabled'      => false,
             'tapas_free'         => true,
+            'price_mode'         => 'fixed',
             'max_tapa_variants'  => 3,
             'tapa_price'         => null,
             'extra_tapa_enabled' => false,

--- a/database/migrations/2026_05_06_000001_add_price_mode_to_tapa_configs_table.php
+++ b/database/migrations/2026_05_06_000001_add_price_mode_to_tapa_configs_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Añade la modalidad de precio al sistema de tapas.
+ *
+ * 'fixed'       → precio fijo global (tapa_price) para todas las tapas
+ * 'per_product' → cada tapa usa el precio individual del producto
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tapa_configs', function (Blueprint $table) {
+            $table->enum('price_mode', ['fixed', 'per_product'])
+                  ->default('fixed')
+                  ->after('tapas_free');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tapa_configs', function (Blueprint $table) {
+            $table->dropColumn('price_mode');
+        });
+    }
+};

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -36,10 +36,12 @@
             ]);
         })->values();
 
+        // El precio de cada tapa se resuelve en backend (getPriceForProduct) para que
+        // Alpine no tenga que replicar la lógica de modalidad de precio.
         $tapaProductsForAlpine = $tapaProducts->map(fn ($p) => [
             'id'    => $p->id,
             'name'  => $p->name,
-            'price' => (float) $p->price,
+            'price' => $tapaConfig ? (float) $tapaConfig->getPriceForProduct($p) : (float) $p->price,
         ])->values();
 
         $tapaConfigForAlpine = [
@@ -123,11 +125,11 @@
                 },
 
                 addTapa(tapaProduct) {
-                    const price = this.tapaConfig.free ? 0 : this.tapaConfig.tapaPrice;
+                    // tapaProduct.price ya viene resuelto por getPriceForProduct() en el backend
                     this.add({
                         id:          tapaProduct.id,
                         name:        tapaProduct.name,
-                        price:       price,
+                        price:       tapaProduct.price,
                         destination: 'kitchen',
                         removable:   [],
                         extras:      [],

--- a/resources/views/tapas/edit.blade.php
+++ b/resources/views/tapas/edit.blade.php
@@ -30,6 +30,7 @@
                     x-data="{
                         tapas_enabled:      {{ $tapaConfig->tapas_enabled ? 'true' : 'false' }},
                         tapas_free:         {{ $tapaConfig->tapas_free ? 'true' : 'false' }},
+                        price_mode:         '{{ old('price_mode', $tapaConfig->price_mode ?? 'fixed') }}',
                         extra_tapa_enabled: {{ $tapaConfig->extra_tapa_enabled ? 'true' : 'false' }},
                         schedules: @json($schedulesForAlpine),
                         addSchedule()    { this.schedules.push({ opens_at: '', closes_at: '' }); },
@@ -95,10 +96,62 @@
                             <input type="hidden" name="tapas_free" :value="tapas_free ? '1' : '0'">
                         </div>
 
-                        {{-- Precio por tapa (solo si de pago) --}}
+                        {{-- Modalidad de precio (solo si de pago) --}}
                         <div x-show="!tapas_free" x-transition>
+                            <fieldset>
+                                <legend class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                                    {{ __('Modalidad de precio') }}
+                                    <span aria-hidden="true" class="text-red-500 ml-0.5">*</span>
+                                </legend>
+                                <p id="price-mode-desc" class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                                    {{ __('Elige cómo se calcula el precio que ve el cliente para cada tapa.') }}
+                                </p>
+                                <div class="space-y-3" aria-describedby="price-mode-desc">
+                                    <label class="flex items-start gap-3 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="price_mode"
+                                            value="fixed"
+                                            x-model="price_mode"
+                                            class="mt-0.5 h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                        >
+                                        <span>
+                                            <span class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                                {{ __('Precio fijo para todas las tapas') }}
+                                            </span>
+                                            <span class="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                                                {{ __('Configuras un único precio que aplica a todas las tapas del menú.') }}
+                                            </span>
+                                        </span>
+                                    </label>
+                                    <label class="flex items-start gap-3 cursor-pointer">
+                                        <input
+                                            type="radio"
+                                            name="price_mode"
+                                            value="per_product"
+                                            x-model="price_mode"
+                                            class="mt-0.5 h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                        >
+                                        <span>
+                                            <span class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                                {{ __('Precio individual por producto') }}
+                                            </span>
+                                            <span class="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                                                {{ __('Cada tapa usa el precio configurado en su ficha de producto.') }}
+                                            </span>
+                                        </span>
+                                    </label>
+                                </div>
+                                @error('price_mode')
+                                    <p id="error-price_mode" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                                @enderror
+                            </fieldset>
+                        </div>
+
+                        {{-- Precio fijo global (solo si de pago y modalidad fija) --}}
+                        <div x-show="!tapas_free && price_mode === 'fixed'" x-transition>
                             <label for="tapa_price" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                                {{ __('Precio por tapa (€)') }}
+                                {{ __('Precio fijo por tapa (€)') }}
                                 <span aria-hidden="true" class="text-red-500 ml-0.5">*</span>
                             </label>
                             <input
@@ -117,6 +170,13 @@
                             @error('tapa_price')
                                 <p id="error-tapa_price" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                             @enderror
+                        </div>
+
+                        {{-- Aviso precio por producto --}}
+                        <div x-show="!tapas_free && price_mode === 'per_product'" x-transition>
+                            <p class="text-sm text-indigo-700 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/20 rounded-md px-3 py-2">
+                                {{ __('El precio de cada tapa se configura en la ficha del producto dentro de la categoría "Tapas".') }}
+                            </p>
                         </div>
 
                         {{-- ── SECCIÓN 2: Tapa extra ────────────────────── --}}

--- a/tests/Feature/Bloque6/TapasTest.php
+++ b/tests/Feature/Bloque6/TapasTest.php
@@ -1094,6 +1094,43 @@ it('allows deleting Tapas category when tapas_disabled', function () {
     $this->assertDatabaseMissing('categories', ['id' => $tapasCategory->id]);
 });
 
+it('tapas category products are not shown in main menu listing when tapas enabled', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => true,
+    ]);
+
+    $table        = Table::factory()->create(['user_id' => $this->user->id]);
+    $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
+    $barCategory  = Category::factory()->create(['user_id' => $this->user->id, 'destination' => 'bar']);
+
+    Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $tapaCategory->id, 'is_active' => true]);
+    Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $barCategory->id, 'is_active' => true]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+
+    $response->assertOk();
+    $categories = $response->viewData('categories');
+    expect($categories->pluck('name')->toArray())->not->toContain('Tapas');
+});
+
+it('tapas category products appear in main listing when tapas disabled', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => false,
+    ]);
+
+    $table        = Table::factory()->create(['user_id' => $this->user->id]);
+    $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
+    Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $tapaCategory->id, 'is_active' => true]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+    $response->assertOk();
+
+    $categories = $response->viewData('categories');
+    expect($categories->pluck('name')->toArray())->toContain('Tapas');
+});
+
 // ─── tapaVariantsUsed counts distinct tapa products ──────────────────────────
 
 it('tapaVariantsUsed counts distinct tapa products in active orders', function () {

--- a/tests/Feature/Bloque6/TapasTest.php
+++ b/tests/Feature/Bloque6/TapasTest.php
@@ -792,6 +792,310 @@ it('tapa products only include active products from Tapas category', function ()
     Carbon::setTestNow();
 });
 
+// ─── Modalidad de precio (price_mode) ────────────────────────────────────────
+
+it('saves price_mode fixed correctly', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '0',
+             'price_mode'        => 'fixed',
+             'max_tapa_variants' => 3,
+             'tapa_price'        => '1.00',
+         ]);
+
+    $config = TapaConfig::where('user_id', $this->user->id)->first();
+    expect($config->price_mode)->toBe('fixed');
+});
+
+it('saves price_mode per_product correctly', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '0',
+             'price_mode'        => 'per_product',
+             'max_tapa_variants' => 3,
+         ])
+         ->assertRedirect(route('tapas.edit'));
+
+    $config = TapaConfig::where('user_id', $this->user->id)->first();
+    expect($config->price_mode)->toBe('per_product')
+        ->and($config->tapa_price)->toBeNull();
+});
+
+it('fails to save paid tapas with fixed price mode and no global price', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '0',
+             'price_mode'        => 'fixed',
+             'max_tapa_variants' => 3,
+             // tapa_price ausente
+         ])
+         ->assertSessionHasErrors('tapa_price');
+});
+
+it('allows saving paid tapas with per_product mode and no global price', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '0',
+             'price_mode'        => 'per_product',
+             'max_tapa_variants' => 3,
+         ])
+         ->assertSessionMissing('errors')
+         ->assertRedirect(route('tapas.edit'));
+});
+
+it('allows saving free tapas without any price regardless of mode', function () {
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '1',
+             'max_tapa_variants' => 3,
+         ])
+         ->assertSessionMissing('errors')
+         ->assertRedirect(route('tapas.edit'));
+
+    $config = TapaConfig::where('user_id', $this->user->id)->first();
+    expect($config->tapa_price)->toBeNull();
+});
+
+it('clears tapa_price when mode changes to per_product', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_free'    => false,
+        'price_mode'    => 'fixed',
+        'tapa_price'    => 2.50,
+    ]);
+
+    $this->actingAs($this->user)
+         ->put(route('tapas.update'), [
+             'tapas_enabled'     => '1',
+             'tapas_free'        => '0',
+             'price_mode'        => 'per_product',
+             'max_tapa_variants' => 3,
+         ]);
+
+    $this->assertDatabaseHas('tapa_configs', [
+        'user_id'    => $this->user->id,
+        'tapa_price' => null,
+        'price_mode' => 'per_product',
+    ]);
+});
+
+it('tapa order item saves resolved price for fixed mode not product price', function () {
+    $tapaConfig = TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => true,
+        'tapas_free'    => false,
+        'price_mode'    => 'fixed',
+        'tapa_price'    => 1.50,
+    ]);
+
+    $table        = Table::factory()->create(['user_id' => $this->user->id]);
+    $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
+    $tapaProduct  = Product::factory()->create([
+        'user_id'     => $this->user->id,
+        'category_id' => $tapaCategory->id,
+        'price'       => 9.99,
+        'is_active'   => true,
+    ]);
+
+    $response = $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items'      => [
+            ['product_id' => $tapaProduct->id, 'quantity' => 1],
+        ],
+    ]);
+
+    $response->assertCreated();
+    $this->assertDatabaseHas('order_items', [
+        'product_id' => $tapaProduct->id,
+        'price'      => 1.50,
+    ]);
+});
+
+it('tapa order item saves product price for per_product mode', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => true,
+        'tapas_free'    => false,
+        'price_mode'    => 'per_product',
+        'tapa_price'    => null,
+    ]);
+
+    $table        = Table::factory()->create(['user_id' => $this->user->id]);
+    $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
+    $tapaProduct  = Product::factory()->create([
+        'user_id'     => $this->user->id,
+        'category_id' => $tapaCategory->id,
+        'price'       => 3.75,
+        'is_active'   => true,
+    ]);
+
+    $response = $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items'      => [
+            ['product_id' => $tapaProduct->id, 'quantity' => 1],
+        ],
+    ]);
+
+    $response->assertCreated();
+    $this->assertDatabaseHas('order_items', [
+        'product_id' => $tapaProduct->id,
+        'price'      => 3.75,
+    ]);
+});
+
+it('tapa order item saves 0 when tapas are free', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => true,
+        'tapas_free'    => true,
+    ]);
+
+    $table        = Table::factory()->create(['user_id' => $this->user->id]);
+    $tapaCategory = Category::factory()->create(['user_id' => $this->user->id, 'name' => 'Tapas', 'destination' => 'kitchen']);
+    $tapaProduct  = Product::factory()->create([
+        'user_id'     => $this->user->id,
+        'category_id' => $tapaCategory->id,
+        'price'       => 5.00,
+        'is_active'   => true,
+    ]);
+
+    $response = $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items'      => [
+            ['product_id' => $tapaProduct->id, 'quantity' => 1],
+        ],
+    ]);
+
+    $response->assertCreated();
+    $this->assertDatabaseHas('order_items', [
+        'product_id' => $tapaProduct->id,
+        'price'      => 0,
+    ]);
+});
+
+it('non-tapa products always use product price regardless of tapa config', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => true,
+        'tapas_free'    => false,
+        'price_mode'    => 'fixed',
+        'tapa_price'    => 1.00,
+    ]);
+
+    $table       = Table::factory()->create(['user_id' => $this->user->id]);
+    $barCategory = Category::factory()->create(['user_id' => $this->user->id, 'destination' => 'bar']);
+    $drink       = Product::factory()->create([
+        'user_id'     => $this->user->id,
+        'category_id' => $barCategory->id,
+        'price'       => 2.80,
+        'is_active'   => true,
+    ]);
+
+    $response = $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items'      => [
+            ['product_id' => $drink->id, 'quantity' => 1],
+        ],
+    ]);
+
+    $response->assertCreated();
+    $this->assertDatabaseHas('order_items', [
+        'product_id' => $drink->id,
+        'price'      => 2.80,
+    ]);
+});
+
+// ─── Protección de categoría Tapas ───────────────────────────────────────────
+
+it('blocks renaming Tapas category when tapas_enabled', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => true,
+    ]);
+
+    $tapasCategory = Category::factory()->create([
+        'user_id'     => $this->user->id,
+        'name'        => 'Tapas',
+        'destination' => 'kitchen',
+    ]);
+
+    $this->actingAs($this->user)
+         ->put(route('categories.update', $tapasCategory), [
+             'name'        => 'Pinchos',
+             'destination' => 'kitchen',
+         ])
+         ->assertSessionHasErrors('name');
+
+    $this->assertDatabaseHas('categories', ['id' => $tapasCategory->id, 'name' => 'Tapas']);
+});
+
+it('allows renaming Tapas category when tapas_disabled', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => false,
+    ]);
+
+    $tapasCategory = Category::factory()->create([
+        'user_id'     => $this->user->id,
+        'name'        => 'Tapas',
+        'destination' => 'kitchen',
+    ]);
+
+    $this->actingAs($this->user)
+         ->put(route('categories.update', $tapasCategory), [
+             'name'        => 'Pinchos',
+             'destination' => 'kitchen',
+         ])
+         ->assertRedirect(route('categories.index'));
+
+    $this->assertDatabaseHas('categories', ['id' => $tapasCategory->id, 'name' => 'Pinchos']);
+});
+
+it('blocks deleting Tapas category when tapas_enabled', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => true,
+    ]);
+
+    $tapasCategory = Category::factory()->create([
+        'user_id'     => $this->user->id,
+        'name'        => 'Tapas',
+        'destination' => 'kitchen',
+    ]);
+
+    $this->actingAs($this->user)
+         ->delete(route('categories.destroy', $tapasCategory))
+         ->assertSessionHasErrors('general');
+
+    $this->assertDatabaseHas('categories', ['id' => $tapasCategory->id]);
+});
+
+it('allows deleting Tapas category when tapas_disabled', function () {
+    TapaConfig::factory()->create([
+        'user_id'       => $this->user->id,
+        'tapas_enabled' => false,
+    ]);
+
+    $tapasCategory = Category::factory()->create([
+        'user_id'     => $this->user->id,
+        'name'        => 'Tapas',
+        'destination' => 'kitchen',
+    ]);
+
+    $this->actingAs($this->user)
+         ->delete(route('categories.destroy', $tapasCategory))
+         ->assertRedirect(route('categories.index'));
+
+    $this->assertDatabaseMissing('categories', ['id' => $tapasCategory->id]);
+});
+
+// ─── tapaVariantsUsed counts distinct tapa products ──────────────────────────
+
 it('tapaVariantsUsed counts distinct tapa products in active orders', function () {
     Carbon::setTestNow('2026-05-03 12:00:00');
 

--- a/tests/Unit/TapasCalculatorTest.php
+++ b/tests/Unit/TapasCalculatorTest.php
@@ -148,3 +148,75 @@ it('shouldSuggestTapa returns true when all conditions are met', function () {
 
     expect($config->shouldSuggestTapa(2, 1))->toBeTrue();
 });
+
+// ─── getPriceForProduct ───────────────────────────────────────────────────────
+
+it('getPriceForProduct returns 0 when tapas are free regardless of product price', function () {
+    $config = new TapaConfig([
+        'tapas_enabled' => true,
+        'tapas_free'    => true,
+        'price_mode'    => 'fixed',
+        'tapa_price'    => '3.00',
+    ]);
+
+    $product        = new \App\Models\Product();
+    $product->price = 9.99;
+
+    expect($config->getPriceForProduct($product))->toBe(0.0);
+});
+
+it('getPriceForProduct returns global fixed price when mode is fixed', function () {
+    $config = new TapaConfig([
+        'tapas_enabled' => true,
+        'tapas_free'    => false,
+        'price_mode'    => 'fixed',
+        'tapa_price'    => '1.50',
+    ]);
+
+    $product        = new \App\Models\Product();
+    $product->price = 9.99;
+
+    expect($config->getPriceForProduct($product))->toBe(1.50);
+});
+
+it('getPriceForProduct returns product price when mode is per_product', function () {
+    $config = new TapaConfig([
+        'tapas_enabled' => true,
+        'tapas_free'    => false,
+        'price_mode'    => 'per_product',
+        'tapa_price'    => null,
+    ]);
+
+    $product        = new \App\Models\Product();
+    $product->price = 3.75;
+
+    expect($config->getPriceForProduct($product))->toBe(3.75);
+});
+
+it('getPriceForProduct returns 0 when tapas are free even with per_product mode', function () {
+    $config = new TapaConfig([
+        'tapas_enabled' => true,
+        'tapas_free'    => true,
+        'price_mode'    => 'per_product',
+        'tapa_price'    => null,
+    ]);
+
+    $product        = new \App\Models\Product();
+    $product->price = 5.00;
+
+    expect($config->getPriceForProduct($product))->toBe(0.0);
+});
+
+it('getPriceForProduct returns 0 when fixed mode and tapa_price is null', function () {
+    $config = new TapaConfig([
+        'tapas_enabled' => true,
+        'tapas_free'    => false,
+        'price_mode'    => 'fixed',
+        'tapa_price'    => null,
+    ]);
+
+    $product        = new \App\Models\Product();
+    $product->price = 4.00;
+
+    expect($config->getPriceForProduct($product))->toBe(0.0);
+});


### PR DESCRIPTION
## Qué se implementa

- **Modalidad de precio** (nueva): fijo global (`tapa_price`) o por producto — campo `price_mode` ENUM en `tapa_configs`
- **Categoría Tapas oculta** del listado general de la carta cuando tapas están activas
- **Precio resuelto en backend** — `TapaConfig::getPriceForProduct()` calcula el precio según la modalidad y lo serializa en el JSON de Alpine (sin duplicar lógica en JS)
- **Precio obligatorio** según modalidad: fijo global requiere `tapa_price`; por producto no
- **OrderItems con precio correcto** — `Api\OrderController` usa `isTapaProduct()` + `getPriceForProduct()` para el snapshot, no `product->price`
- **Protección de categoría Tapas** — `CategoryController` bloquea rename/delete cuando `tapas_enabled = true`
- **Formulario actualizado** — selector de modalidad con radio buttons WCAG-accesibles y aviso contextual según opción elegida

## Reglas de negocio clave

- Sin `price_mode` en el request (formularios antiguos) se asume `fixed` — retrocompatible
- `tapas_free = true` siempre devuelve precio 0, ignorando la modalidad configurada
- La tapa extra (`extra_tapa_price`) siempre tiene precio fijo propio, independiente de `price_mode`
- Al desactivar tapas: la categoría Tapas NO se borra
- Los productos de la categoría Tapas solo aparecen en el modal de sugerencia, nunca en el listado normal

## Checklist

- [x] `php artisan test` -> 452 passed, 0 failed
- [x] Un commit por archivo
- [x] Validaciones server-side en TapasController con Rule::requiredIf
- [x] @author BenjaminDTS en TapaConfig
- [x] Reviewer: SHIP IT tras corregir el blocker (exclusion de Tapas del listado general)

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `database/migrations/2026_05_06_000001_add_price_mode_to_tapa_configs_table.php` | Nueva migración |
| `app/Models/TapaConfig.php` | `price_mode` en fillable/casts + `getPriceForProduct()` + `isTapaProduct()` |
| `database/factories/TapaConfigFactory.php` | Añade `price_mode => fixed` |
| `app/Http/Controllers/TapasController.php` | Validación `price_mode` + coherencia de precio al guardar |
| `app/Http/Controllers/MenuController.php` | Excluye categoría Tapas del listado general |
| `app/Http/Controllers/Api/OrderController.php` | Snapshot con `getPriceForProduct()` para tapas |
| `app/Http/Controllers/CategoryController.php` | Bloquea rename/delete de Tapas si `tapas_enabled` |
| `resources/views/tapas/edit.blade.php` | Radio buttons `price_mode` con Alpine binding |
| `resources/views/menu/show.blade.php` | Precio resuelto en backend, `addTapa` simplificado |
| `tests/Feature/Bloque6/TapasTest.php` | +20 tests nuevos |
| `tests/Unit/TapasCalculatorTest.php` | +5 unit tests para `getPriceForProduct` |