### PR TITLE
fix: Alpine x-data crash con schedules configurados en tapas config

### DIFF
--- a/resources/views/tapas/edit.blade.php
+++ b/resources/views/tapas/edit.blade.php
@@ -27,15 +27,17 @@
                 <form
                     method="POST"
                     action="{{ route('tapas.update') }}"
+                    data-schedules='{!! json_encode($schedulesForAlpine, JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_TAG) !!}'
                     x-data="{
                         tapas_enabled:      {{ $tapaConfig->tapas_enabled ? 'true' : 'false' }},
                         tapas_free:         {{ $tapaConfig->tapas_free ? 'true' : 'false' }},
                         price_mode:         '{{ old('price_mode', $tapaConfig->price_mode ?? 'fixed') }}',
                         extra_tapa_enabled: {{ $tapaConfig->extra_tapa_enabled ? 'true' : 'false' }},
-                        schedules: @json($schedulesForAlpine),
+                        schedules:          [],
                         addSchedule()    { this.schedules.push({ opens_at: '', closes_at: '' }); },
                         removeSchedule(i){ this.schedules.splice(i, 1); }
                     }"
+                    x-init="schedules = JSON.parse($el.getAttribute('data-schedules') || '[]')"
                 >
                     @csrf
                     @method('PUT')


### PR DESCRIPTION
## Problema

Alpine.js no inicializaba en la pagina de configuracion de tapas cuando habia tramos de horario configurados. Los toggles aparecian como puntos blancos sin estilo y se generaban 27 errores en consola (uno por directiva Alpine del formulario).

## Causa raiz

@json($schedulesForAlpine) usa JSON_HEX_QUOT que codifica las comillas dobles como ". Cuando Alpine evalua el valor del atributo x-data como JavaScript, " fuera de un string literal es un SyntaxError. Con schedules vacio el bug no se manifestaba.

## Solucion

- Schedules se mueve a un atributo data-schedules en el form usando json_encode con JSON_HEX_APOS|JSON_HEX_AMP|JSON_HEX_TAG (sin JSON_HEX_QUOT), produciendo comillas dobles reales dentro de un atributo delimitado por comillas simples.
- En x-data se inicializa schedules como array vacio.
- En x-init se parsea el JSON real con JSON.parse.

## Tests

- php artisan test tests/Feature/Bloque6/TapasTest.php: 62 passed (132 assertions)
