### PR TITLE
feat(bloque9.1): dashboard del gerente con ingresos por método de pago y período

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -51,7 +51,10 @@ class DashboardController extends Controller
                 SUM(CASE WHEN orders.payment_method = 'card' THEN 1 ELSE 0 END)                         as card_count,
                 COUNT(*)                                                                                 as total_count
             ")
-            ->first();
+            ->first() ?? (object) [
+                'cash_revenue' => 0, 'card_revenue' => 0, 'tip_revenue'  => 0,
+                'cash_count'   => 0, 'card_count'   => 0, 'total_count'  => 0,
+            ];
 
         return view('dashboard.index', compact('period', 'from', 'to', 'summary'));
     }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Order;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+/**
+ * Panel principal del gerente con desglose de ingresos y métricas del negocio.
+ *
+ * @author BenjaminDTS
+ */
+class DashboardController extends Controller
+{
+    /**
+     * @param  Request  $request
+     * @return View
+     */
+    public function index(Request $request): View
+    {
+        $period = $request->query('period', 'month');
+        $from   = $request->query('from');
+        $to     = $request->query('to');
+
+        if ($period === 'custom') {
+            $request->validate([
+                'from' => ['required', 'date'],
+                'to'   => ['required', 'date', 'after_or_equal:from'],
+            ]);
+        }
+
+        [$start, $end] = $this->resolveDateRange($period, $from, $to);
+
+        $ownerUserId = Auth::user()->ownerUserId();
+
+        $base = Order::query()
+            ->join('tables', 'orders.table_id', '=', 'tables.id')
+            ->where('tables.user_id', $ownerUserId)
+            ->where('orders.payment_status', 'paid')
+            ->whereBetween('orders.updated_at', [$start, $end]);
+
+        $summary = (clone $base)
+            ->selectRaw("
+                COALESCE(SUM(CASE WHEN orders.payment_method = 'cash' THEN orders.total ELSE 0 END), 0) as cash_revenue,
+                COALESCE(SUM(CASE WHEN orders.payment_method = 'card' THEN orders.total ELSE 0 END), 0) as card_revenue,
+                COALESCE(SUM(CASE WHEN orders.payment_method = 'card' THEN orders.tip  ELSE 0 END), 0)  as tip_revenue,
+                SUM(CASE WHEN orders.payment_method = 'cash' THEN 1 ELSE 0 END)                         as cash_count,
+                SUM(CASE WHEN orders.payment_method = 'card' THEN 1 ELSE 0 END)                         as card_count,
+                COUNT(*)                                                                                 as total_count
+            ")
+            ->first();
+
+        return view('dashboard.index', compact('period', 'from', 'to', 'summary'));
+    }
+
+    /**
+     * @param  string       $period
+     * @param  string|null  $from
+     * @param  string|null  $to
+     * @return array{0: Carbon, 1: Carbon}
+     */
+    private function resolveDateRange(string $period, ?string $from, ?string $to): array
+    {
+        return match ($period) {
+            'today'  => [now()->startOfDay(),   now()->endOfDay()],
+            'week'   => [now()->startOfWeek(),  now()->endOfWeek()],
+            'year'   => [now()->startOfYear(),  now()->endOfYear()],
+            'custom' => [
+                Carbon::parse($from)->startOfDay(),
+                Carbon::parse($to)->endOfDay(),
+            ],
+            default  => [now()->startOfMonth(), now()->endOfMonth()],
+        };
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -25,7 +25,7 @@ class DashboardController extends Controller
         $from   = $request->query('from');
         $to     = $request->query('to');
 
-        if ($period === 'custom') {
+        if ($period === 'custom' && ($from !== null || $to !== null)) {
             $request->validate([
                 'from' => ['required', 'date'],
                 'to'   => ['required', 'date', 'after_or_equal:from'],

--- a/app/Http/Controllers/ManagerRevenueController.php
+++ b/app/Http/Controllers/ManagerRevenueController.php
@@ -32,7 +32,7 @@ class ManagerRevenueController extends Controller
         // JOIN en lugar de whereHas para evitar N+1 y garantizar multitenancy en una sola query
         $base = Order::query()
             ->join('tables', 'orders.table_id', '=', 'tables.id')
-            ->where('tables.user_id', Auth::id())
+            ->where('tables.user_id', Auth::user()->ownerUserId())
             ->where('orders.payment_status', 'paid')
             ->where('orders.updated_at', '>=', $start->toDateTimeString());
 

--- a/app/Http/Controllers/ManagerRevenueController.php
+++ b/app/Http/Controllers/ManagerRevenueController.php
@@ -23,10 +23,10 @@ class ManagerRevenueController extends Controller
     {
         $period = $request->query('period', 'month');
 
-        $start = match ($period) {
-            'today' => now()->startOfDay(),
-            'week'  => now()->startOfWeek(),
-            default => now()->startOfMonth(),
+        [$start, $end] = match ($period) {
+            'today' => [now()->startOfDay(),  now()->endOfDay()],
+            'week'  => [now()->startOfWeek(), now()->endOfWeek()],
+            default => [now()->startOfMonth(), now()->endOfMonth()],
         };
 
         // JOIN en lugar de whereHas para evitar N+1 y garantizar multitenancy en una sola query
@@ -34,13 +34,13 @@ class ManagerRevenueController extends Controller
             ->join('tables', 'orders.table_id', '=', 'tables.id')
             ->where('tables.user_id', Auth::user()->ownerUserId())
             ->where('orders.payment_status', 'paid')
-            ->where('orders.updated_at', '>=', $start->toDateTimeString());
+            ->whereBetween('orders.updated_at', [$start, $end]);
 
         $summary = (clone $base)
             ->selectRaw("
                 COALESCE(SUM(CASE WHEN orders.payment_method = 'cash' THEN orders.total ELSE 0 END), 0) as cash_revenue,
                 COALESCE(SUM(CASE WHEN orders.payment_method = 'card' THEN orders.total ELSE 0 END), 0) as card_revenue,
-                COALESCE(SUM(orders.tip), 0)                                                             as tip_revenue,
+                COALESCE(SUM(CASE WHEN orders.payment_method = 'card' THEN orders.tip  ELSE 0 END), 0)  as tip_revenue,
                 SUM(CASE WHEN orders.payment_method = 'cash' THEN 1 ELSE 0 END)                         as cash_count,
                 SUM(CASE WHEN orders.payment_method = 'card' THEN 1 ELSE 0 END)                         as card_count,
                 COUNT(*)                                                                                 as total_count

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -1,0 +1,171 @@
+<x-app-layout>
+    <x-slot name="header">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <h1 class="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
+                Dashboard
+            </h1>
+
+            {{-- Selector de período --}}
+            <nav aria-label="Filtro de período"
+                 class="flex flex-wrap gap-1 bg-gray-100 dark:bg-gray-700 rounded-xl p-1 self-start sm:self-auto">
+                @foreach(['today' => 'Hoy', 'week' => 'Esta semana', 'month' => 'Este mes', 'year' => 'Este año'] as $value => $label)
+                    <a href="{{ route('dashboard', ['period' => $value]) }}"
+                       aria-current="{{ $period === $value ? 'page' : 'false' }}"
+                       class="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors
+                              focus:outline-none focus:ring-2 focus:ring-indigo-500
+                              {{ $period === $value
+                                  ? 'bg-white dark:bg-gray-800 text-indigo-600 dark:text-indigo-400 shadow-sm'
+                                  : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white' }}">
+                        {{ $label }}
+                    </a>
+                @endforeach
+                <a href="{{ route('dashboard', ['period' => 'custom']) }}"
+                   aria-current="{{ $period === 'custom' ? 'page' : 'false' }}"
+                   class="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors
+                          focus:outline-none focus:ring-2 focus:ring-indigo-500
+                          {{ $period === 'custom'
+                              ? 'bg-white dark:bg-gray-800 text-indigo-600 dark:text-indigo-400 shadow-sm'
+                              : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white' }}">
+                    Personalizado
+                </a>
+            </nav>
+        </div>
+
+        {{-- Rango personalizado --}}
+        @if($period === 'custom')
+            <form method="GET" action="{{ route('dashboard') }}"
+                  class="mt-3 flex flex-col sm:flex-row gap-2 items-start sm:items-end"
+                  aria-label="Seleccionar rango de fechas">
+                <input type="hidden" name="period" value="custom">
+                <div class="flex flex-col gap-1">
+                    <label for="from" class="text-sm font-medium text-gray-700 dark:text-gray-300">Desde</label>
+                    <input id="from" type="date" name="from"
+                           value="{{ $from ?? now()->startOfMonth()->format('Y-m-d') }}"
+                           class="rounded-lg border border-gray-300 dark:border-gray-600
+                                  bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                                  px-3 py-1.5 text-sm focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+                           aria-required="true">
+                    @error('from')
+                        <p role="alert" class="text-xs text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+                <div class="flex flex-col gap-1">
+                    <label for="to" class="text-sm font-medium text-gray-700 dark:text-gray-300">Hasta</label>
+                    <input id="to" type="date" name="to"
+                           value="{{ $to ?? now()->endOfMonth()->format('Y-m-d') }}"
+                           class="rounded-lg border border-gray-300 dark:border-gray-600
+                                  bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                                  px-3 py-1.5 text-sm focus:ring-2 focus:ring-indigo-500 focus:outline-none"
+                           aria-required="true">
+                    @error('to')
+                        <p role="alert" class="text-xs text-red-600 dark:text-red-400">{{ $message }}</p>
+                    @enderror
+                </div>
+                <button type="submit"
+                        class="px-4 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium
+                               rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                    Aplicar
+                </button>
+            </form>
+        @endif
+    </x-slot>
+
+    <main id="main-content" class="py-6">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 space-y-8">
+
+            {{-- ─── Bloque 9.1: Desglose de ingresos ─────────────────────────────── --}}
+            <section aria-labelledby="income-heading">
+                <div class="flex items-center justify-between mb-4">
+                    <h2 id="income-heading"
+                        class="text-base font-semibold text-gray-900 dark:text-white">
+                        Ingresos del período
+                    </h2>
+                    <a href="{{ route('manager.income', ['period' => $period] + ($period === 'custom' ? ['from' => $from, 'to' => $to] : [])) }}"
+                       class="text-sm text-indigo-600 dark:text-indigo-400 hover:underline
+                              focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded">
+                        Ver detalle →
+                    </a>
+                </div>
+
+                <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
+
+                    {{-- Efectivo --}}
+                    <div role="region" aria-label="Total ingresos en efectivo"
+                         class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">💵</span>
+                            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Efectivo</span>
+                        </div>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white tabular-nums">
+                            {{ number_format($summary->cash_revenue, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                            {{ $summary->cash_count }}
+                            pedido{{ $summary->cash_count != 1 ? 's' : '' }}
+                        </p>
+                    </div>
+
+                    {{-- Tarjeta --}}
+                    <div role="region" aria-label="Total ingresos en tarjeta"
+                         class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">💳</span>
+                            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Tarjeta</span>
+                        </div>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white tabular-nums">
+                            {{ number_format($summary->card_revenue, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                            {{ $summary->card_count }}
+                            pedido{{ $summary->card_count != 1 ? 's' : '' }}
+                        </p>
+                    </div>
+
+                    {{-- Propinas --}}
+                    <div role="region" aria-label="Total propinas en tarjeta"
+                         class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">🎁</span>
+                            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Propinas</span>
+                        </div>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white tabular-nums">
+                            {{ number_format($summary->tip_revenue, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Solo pagos con tarjeta</p>
+                    </div>
+
+                    {{-- Total global --}}
+                    @php $grand = $summary->cash_revenue + $summary->card_revenue + $summary->tip_revenue; @endphp
+                    <div role="region" aria-label="Total global cobrado en el período"
+                         class="bg-indigo-600 dark:bg-indigo-700 rounded-2xl shadow-sm p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">💰</span>
+                            <span class="text-sm font-medium text-indigo-200">Total cobrado</span>
+                        </div>
+                        <p class="text-2xl font-bold text-white tabular-nums">
+                            {{ number_format($grand, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-indigo-300">
+                            {{ $summary->total_count }}
+                            pedido{{ $summary->total_count != 1 ? 's' : '' }}
+                        </p>
+                    </div>
+
+                </div>
+            </section>
+
+            {{-- ─── Bloque 9.2: Mesa que más ingresos genera (pendiente) ─────────── --}}
+            {{-- Se implementará en el Bloque 9.2 --}}
+
+            {{-- ─── Bloque 9.3: Platos más pedidos (pendiente) ─────────────────── --}}
+            {{-- Se implementará en el Bloque 9.3 --}}
+
+            {{-- ─── Bloque 9.4: Horas punta y ticket medio (pendiente) ────────── --}}
+            {{-- Se implementará en el Bloque 9.4 --}}
+
+        </div>
+    </main>
+</x-app-layout>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -13,9 +13,12 @@
 
                 <!-- Navigation Links -->
                 <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
+                    {{-- Dashboard: visible solo para gerente (admin) --}}
+                    @if(Auth::user()->role === 'admin')
                     <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                         {{ __('Dashboard') }}
                     </x-nav-link>
+                    @endif
                     {{-- Usamos categories.* para que se quede marcado si estás en index o en create --}}
                     <x-nav-link :href="route('categories.index')" :active="request()->routeIs('categories.*')">
                         {{ __('Categorías') }}
@@ -143,9 +146,12 @@
         <!-- Responsive Navigation Menu -->
         <div id="responsive-nav-menu" :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
             <div class="pt-2 pb-3 space-y-1">
+                {{-- Dashboard: visible solo para gerente (admin) --}}
+                @if(Auth::user()->role === 'admin')
                 <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
                     {{ __('Dashboard') }}
                 </x-responsive-nav-link>
+                @endif
                 {{-- NUEVO: Enlace a Categorías (Versión Móvil) --}}
                 <x-responsive-nav-link :href="route('categories.index')" :active="request()->routeIs('categories.*')">
                     {{ __('Categorías') }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,4 +1,5 @@
 <?php
+use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\IngredientController;
 use App\Http\Controllers\StaffController;
 use App\Http\Controllers\BarPanelController;
@@ -28,13 +29,9 @@ Route::get('/carta/{hash}', [MenuController::class, 'show'])
     ->middleware('throttle:60,1')
     ->name('menu.show');
 
-Route::get('/dashboard', function () {
-    if (Auth::user()->isSuperAdmin()) {
-        return redirect()->route('superadmin.dashboard');
-    }
-
-    return view('dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+Route::get('/dashboard', [DashboardController::class, 'index'])
+    ->middleware(['auth', 'verified', 'business.active', 'role:admin'])
+    ->name('dashboard');
 
 Route::middleware(['auth', 'business.active'])->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');

--- a/tests/Feature/Bloque9/DashboardTest.php
+++ b/tests/Feature/Bloque9/DashboardTest.php
@@ -1,0 +1,345 @@
+<?php
+
+/**
+ * @author AyrtonAlania
+ */
+
+use App\Models\Order;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+
+uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->admin = User::factory()->admin()->create();
+    $this->other = User::factory()->admin()->create();
+});
+
+// ─── Acceso y autenticación ────────────────────────────────────────────────────
+
+it('redirects unauthenticated user away from dashboard', function () {
+    $this->get(route('dashboard'))
+         ->assertRedirect(route('login'));
+});
+
+it('shows dashboard to admin user', function () {
+    $this->actingAs($this->admin)
+         ->get(route('dashboard'))
+         ->assertOk()
+         ->assertViewIs('dashboard.index');
+});
+
+it('returns 403 for waiter role', function () {
+    $waiter = User::factory()->waiter()->create();
+
+    $this->actingAs($waiter)
+         ->get(route('dashboard'))
+         ->assertForbidden();
+});
+
+it('returns 403 for kitchen role', function () {
+    $kitchen = User::factory()->kitchen()->create();
+
+    $this->actingAs($kitchen)
+         ->get(route('dashboard'))
+         ->assertForbidden();
+});
+
+// ─── Multitenancy ──────────────────────────────────────────────────────────────
+
+it('dashboard only shows income from the authenticated restaurant', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 50.00,
+        'updated_at'     => now(),
+    ]);
+
+    $summary = $this->actingAs($this->admin)
+                    ->get(route('dashboard', ['period' => 'month']))
+                    ->assertOk()
+                    ->viewData('summary');
+
+    expect((float) $summary->cash_revenue)->toBe(50.0);
+});
+
+it('dashboard does not show income from other restaurants', function () {
+    $otherTable = Table::factory()->create(['user_id' => $this->other->id]);
+
+    Order::factory()->create([
+        'table_id'       => $otherTable->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 100.00,
+        'updated_at'     => now(),
+    ]);
+
+    $summary = $this->actingAs($this->admin)
+                    ->get(route('dashboard', ['period' => 'month']))
+                    ->assertOk()
+                    ->viewData('summary');
+
+    expect((float) $summary->cash_revenue)->toBe(0.0);
+});
+
+// ─── Cálculo de ingresos ───────────────────────────────────────────────────────
+
+it('calculates cash income correctly for the period', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 30.00,
+        'tip'            => 0,
+        'updated_at'     => now(),
+    ]);
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 20.00,
+        'tip'            => 0,
+        'updated_at'     => now(),
+    ]);
+
+    $summary = $this->actingAs($this->admin)
+                    ->get(route('dashboard', ['period' => 'month']))
+                    ->viewData('summary');
+
+    expect((float) $summary->cash_revenue)->toBe(50.0);
+    expect((int) $summary->cash_count)->toBe(2);
+});
+
+it('calculates card income correctly for the period', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'card',
+        'payment_status' => 'paid',
+        'total'          => 45.00,
+        'tip'            => 0,
+        'updated_at'     => now(),
+    ]);
+
+    $summary = $this->actingAs($this->admin)
+                    ->get(route('dashboard', ['period' => 'month']))
+                    ->viewData('summary');
+
+    expect((float) $summary->card_revenue)->toBe(45.0);
+    expect((int) $summary->card_count)->toBe(1);
+});
+
+it('calculates card tips correctly for the period', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'card',
+        'payment_status' => 'paid',
+        'total'          => 40.00,
+        'tip'            => 5.00,
+        'updated_at'     => now(),
+    ]);
+
+    $summary = $this->actingAs($this->admin)
+                    ->get(route('dashboard', ['period' => 'month']))
+                    ->viewData('summary');
+
+    expect((float) $summary->tip_revenue)->toBe(5.0);
+});
+
+it('calculates total income correctly for the period', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 30.00,
+        'tip'            => 0,
+        'updated_at'     => now(),
+    ]);
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'card',
+        'payment_status' => 'paid',
+        'total'          => 40.00,
+        'tip'            => 5.00,
+        'updated_at'     => now(),
+    ]);
+
+    $summary = $this->actingAs($this->admin)
+                    ->get(route('dashboard', ['period' => 'month']))
+                    ->viewData('summary');
+
+    expect((int) $summary->total_count)->toBe(2);
+    // cash(30) + card(40) + tip(5) = 75
+    $grand = (float) $summary->cash_revenue
+           + (float) $summary->card_revenue
+           + (float) $summary->tip_revenue;
+    expect($grand)->toBe(75.0);
+});
+
+// ─── Solo pedidos pagados ──────────────────────────────────────────────────────
+
+it('only counts paid orders not pending or cancelled', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 50.00,
+        'updated_at'     => now(),
+    ]);
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'pending',
+        'total'          => 99.00,
+        'updated_at'     => now(),
+    ]);
+
+    $summary = $this->actingAs($this->admin)
+                    ->get(route('dashboard', ['period' => 'month']))
+                    ->viewData('summary');
+
+    expect((float) $summary->cash_revenue)->toBe(50.0);
+    expect((int) $summary->total_count)->toBe(1);
+});
+
+// ─── Filtros de período ────────────────────────────────────────────────────────
+
+it('filters income by today period', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 40.00,
+        'updated_at'     => now()->midDay(),
+    ]);
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 99.00,
+        'updated_at'     => now()->subDay()->midDay(),
+    ]);
+
+    $summary = $this->actingAs($this->admin)
+                    ->get(route('dashboard', ['period' => 'today']))
+                    ->viewData('summary');
+
+    expect((float) $summary->cash_revenue)->toBe(40.0);
+});
+
+it('filters income by this week period', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 60.00,
+        'updated_at'     => now()->startOfWeek()->addHours(12),
+    ]);
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 99.00,
+        'updated_at'     => now()->subWeek(),
+    ]);
+
+    $summary = $this->actingAs($this->admin)
+                    ->get(route('dashboard', ['period' => 'week']))
+                    ->viewData('summary');
+
+    expect((float) $summary->cash_revenue)->toBe(60.0);
+});
+
+it('filters income by this month period', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 70.00,
+        'updated_at'     => now()->startOfMonth()->addDays(5),
+    ]);
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 99.00,
+        'updated_at'     => now()->subMonth(),
+    ]);
+
+    $summary = $this->actingAs($this->admin)
+                    ->get(route('dashboard', ['period' => 'month']))
+                    ->viewData('summary');
+
+    expect((float) $summary->cash_revenue)->toBe(70.0);
+});
+
+it('filters income by custom date range', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 80.00,
+        'updated_at'     => Carbon::parse('2024-03-15 12:00:00'),
+    ]);
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 99.00,
+        'updated_at'     => Carbon::parse('2024-04-01 12:00:00'),
+    ]);
+
+    $summary = $this->actingAs($this->admin)
+                    ->get(route('dashboard', [
+                        'period' => 'custom',
+                        'from'   => '2024-03-01',
+                        'to'     => '2024-03-31',
+                    ]))
+                    ->viewData('summary');
+
+    expect((float) $summary->cash_revenue)->toBe(80.0);
+});
+
+// ─── Staff con admin_id (sub-gerente) ─────────────────────────────────────────
+
+it('staff admin can access dashboard and sees their admin restaurant data', function () {
+    $subAdmin = User::factory()->admin()->staffOf($this->admin)->create();
+
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 55.00,
+        'updated_at'     => now(),
+    ]);
+
+    $summary = $this->actingAs($subAdmin)
+                    ->get(route('dashboard', ['period' => 'month']))
+                    ->assertOk()
+                    ->viewData('summary');
+
+    expect((float) $summary->cash_revenue)->toBe(55.0);
+});


### PR DESCRIPTION
## Resumen

- Nuevo `DashboardController` en `/dashboard` (protegido por `role:admin`) con desglose de ingresos filtrable por hoy, semana, mes, año y rango personalizado de fechas
- Vista `dashboard/index.blade.php` con 4 tarjetas (efectivo, tarjeta, propinas, total global) + selector de período accesible + placeholders para bloques 9.2–9.4
- Link al Dashboard en navegación visible solo para `role = admin`
- Correcciones en `ManagerRevenueController`: `Auth::id()` → `ownerUserId()` (bug multitenancy), tip solo para pagos con tarjeta, `whereBetween` con límite superior

## Tests

- 16 feature tests en `tests/Feature/Bloque9/DashboardTest.php` — todos verdes
- Cubre: redirección sin auth, 403 waiter/kitchen, multitenancy, cálculos de efectivo/tarjeta/propinas/total, filtro `payment_status = paid`, períodos today/week/month/custom, sub-gerente con `admin_id` ve datos del admin dueño
- Suite completa: 468/468 passing

## Checklist

- [x] Rama parte de `main` actualizado
- [x] Un commit por archivo modificado
- [x] PHPDoc completo en todos los métodos
- [x] `ownerUserId()` para multitenancy en ambos controladores
- [x] Solo pedidos `payment_status = paid`
- [x] Propinas separadas del total de tarjeta
- [x] Filtro de período sin N+1 (JOIN explícito)
- [x] Accesibilidad: `main id=main-content`, `role=region`, `aria-label`, `aria-current`
- [x] Mobile-first con Tailwind
- [x] Tests al 100% sin fallos
