### PR TITLE
feat(bloque9.2): mesa más rentable del período en el dashboard

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -56,7 +56,15 @@ class DashboardController extends Controller
                 'cash_count'   => 0, 'card_count'   => 0, 'total_count'  => 0,
             ];
 
-        return view('dashboard.index', compact('period', 'from', 'to', 'summary'));
+        $topTable = (clone $base)
+            ->select('tables.name as table_name')
+            ->selectRaw('SUM(orders.total) as table_revenue, COUNT(*) as table_order_count')
+            ->groupBy('tables.id', 'tables.name')
+            ->orderByDesc('table_revenue')
+            ->limit(1)
+            ->first();
+
+        return view('dashboard.index', compact('period', 'from', 'to', 'summary', 'topTable'));
     }
 
     /**

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -157,8 +157,48 @@
                 </div>
             </section>
 
-            {{-- ─── Bloque 9.2: Mesa que más ingresos genera (pendiente) ─────────── --}}
-            {{-- Se implementará en el Bloque 9.2 --}}
+            {{-- ─── Bloque 9.2: Mesa que más ingresos genera ────────────────────── --}}
+            <section aria-labelledby="top-table-heading">
+                <h2 id="top-table-heading"
+                    class="text-base font-semibold text-gray-900 dark:text-white mb-4">
+                    Mesa más rentable del período
+                </h2>
+
+                @if($topTable)
+                    <div role="region" aria-label="Mesa con mayor ingreso del período"
+                         class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 p-6
+                                flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+
+                        <div class="flex items-center gap-4">
+                            <span class="text-4xl" aria-hidden="true">🏆</span>
+                            <div>
+                                <p class="text-xl font-bold text-gray-900 dark:text-white">
+                                    {{ $topTable->table_name }}
+                                </p>
+                                <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+                                    {{ $topTable->table_order_count }}
+                                    pedido{{ $topTable->table_order_count != 1 ? 's' : '' }} cobrado{{ $topTable->table_order_count != 1 ? 's' : '' }}
+                                </p>
+                            </div>
+                        </div>
+
+                        <div class="text-right">
+                            <p class="text-3xl font-bold text-indigo-600 dark:text-indigo-400 tabular-nums">
+                                {{ number_format($topTable->table_revenue, 2, ',', '.') }}&nbsp;€
+                            </p>
+                            <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">ingresos totales</p>
+                        </div>
+                    </div>
+                @else
+                    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 px-6 py-10 text-center">
+                        <p class="text-gray-400 dark:text-gray-500 text-sm">
+                            Sin pedidos cobrados en este período.
+                        </p>
+                    </div>
+                @endif
+            </section>
 
             {{-- ─── Bloque 9.3: Platos más pedidos (pendiente) ─────────────────── --}}
             {{-- Se implementará en el Bloque 9.3 --}}

--- a/tests/Feature/Bloque9/DashboardTest.php
+++ b/tests/Feature/Bloque9/DashboardTest.php
@@ -361,6 +361,7 @@ it('shows the table with highest revenue for the period', function () {
 
     $topTable = $this->actingAs($this->admin)
                      ->get(route('dashboard', ['period' => 'month']))
+                     ->assertOk()
                      ->viewData('topTable');
 
     expect($topTable->table_name)->toBe('Mesa 2');
@@ -382,6 +383,7 @@ it('top table calculation only includes the restaurants tables', function () {
 
     $topTable = $this->actingAs($this->admin)
                      ->get(route('dashboard', ['period' => 'month']))
+                     ->assertOk()
                      ->viewData('topTable');
 
     expect($topTable->table_name)->toBe('Mi Mesa');
@@ -401,6 +403,7 @@ it('top table calculation only counts paid orders', function () {
 
     $topTable = $this->actingAs($this->admin)
                      ->get(route('dashboard', ['period' => 'month']))
+                     ->assertOk()
                      ->viewData('topTable');
 
     expect((float) $topTable->table_revenue)->toBe(50.0);
@@ -410,6 +413,7 @@ it('top table calculation only counts paid orders', function () {
 it('returns null top table when no paid orders exist for the period', function () {
     $topTable = $this->actingAs($this->admin)
                      ->get(route('dashboard', ['period' => 'month']))
+                     ->assertOk()
                      ->viewData('topTable');
 
     expect($topTable)->toBeNull();
@@ -421,11 +425,12 @@ it('top table changes correctly when period filter changes', function () {
     Order::factory()->create([
         'table_id' => $table->id, 'payment_method' => 'cash',
         'payment_status' => 'paid', 'total' => 60.00,
-        'updated_at' => now()->subMonth()->midDay(),
+        'updated_at' => now()->subMonth()->startOfDay()->addHours(12),
     ]);
 
     $topTableMonth = $this->actingAs($this->admin)
                           ->get(route('dashboard', ['period' => 'month']))
+                          ->assertOk()
                           ->viewData('topTable');
 
     expect($topTableMonth)->toBeNull();
@@ -436,6 +441,7 @@ it('top table changes correctly when period filter changes', function () {
                                'from'   => now()->subMonth()->startOfMonth()->format('Y-m-d'),
                                'to'     => now()->subMonth()->endOfMonth()->format('Y-m-d'),
                            ]))
+                           ->assertOk()
                            ->viewData('topTable');
 
     expect((float) $topTableCustom->table_revenue)->toBe(60.0);
@@ -451,6 +457,7 @@ it('top table does not include tables from other restaurants', function () {
 
     $topTable = $this->actingAs($this->admin)
                      ->get(route('dashboard', ['period' => 'month']))
+                     ->assertOk()
                      ->viewData('topTable');
 
     expect($topTable)->toBeNull();

--- a/tests/Feature/Bloque9/DashboardTest.php
+++ b/tests/Feature/Bloque9/DashboardTest.php
@@ -343,3 +343,115 @@ it('staff admin can access dashboard and sees their admin restaurant data', func
 
     expect((float) $summary->cash_revenue)->toBe(55.0);
 });
+
+// ─── Bloque 9.2: Mesa más rentable ────────────────────────────────────────────
+
+it('shows the table with highest revenue for the period', function () {
+    $tableA = Table::factory()->create(['user_id' => $this->admin->id, 'name' => 'Mesa 1']);
+    $tableB = Table::factory()->create(['user_id' => $this->admin->id, 'name' => 'Mesa 2']);
+
+    Order::factory()->create([
+        'table_id' => $tableA->id, 'payment_method' => 'cash',
+        'payment_status' => 'paid', 'total' => 30.00, 'updated_at' => now(),
+    ]);
+    Order::factory()->create([
+        'table_id' => $tableB->id, 'payment_method' => 'cash',
+        'payment_status' => 'paid', 'total' => 80.00, 'updated_at' => now(),
+    ]);
+
+    $topTable = $this->actingAs($this->admin)
+                     ->get(route('dashboard', ['period' => 'month']))
+                     ->viewData('topTable');
+
+    expect($topTable->table_name)->toBe('Mesa 2');
+    expect((float) $topTable->table_revenue)->toBe(80.0);
+});
+
+it('top table calculation only includes the restaurants tables', function () {
+    $myTable    = Table::factory()->create(['user_id' => $this->admin->id, 'name' => 'Mi Mesa']);
+    $otherTable = Table::factory()->create(['user_id' => $this->other->id, 'name' => 'Mesa Ajena']);
+
+    Order::factory()->create([
+        'table_id' => $myTable->id, 'payment_method' => 'cash',
+        'payment_status' => 'paid', 'total' => 40.00, 'updated_at' => now(),
+    ]);
+    Order::factory()->create([
+        'table_id' => $otherTable->id, 'payment_method' => 'cash',
+        'payment_status' => 'paid', 'total' => 200.00, 'updated_at' => now(),
+    ]);
+
+    $topTable = $this->actingAs($this->admin)
+                     ->get(route('dashboard', ['period' => 'month']))
+                     ->viewData('topTable');
+
+    expect($topTable->table_name)->toBe('Mi Mesa');
+});
+
+it('top table calculation only counts paid orders', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id, 'name' => 'Mesa 1']);
+
+    Order::factory()->create([
+        'table_id' => $table->id, 'payment_method' => 'cash',
+        'payment_status' => 'paid', 'total' => 50.00, 'updated_at' => now(),
+    ]);
+    Order::factory()->create([
+        'table_id' => $table->id, 'payment_method' => 'cash',
+        'payment_status' => 'pending', 'total' => 999.00, 'updated_at' => now(),
+    ]);
+
+    $topTable = $this->actingAs($this->admin)
+                     ->get(route('dashboard', ['period' => 'month']))
+                     ->viewData('topTable');
+
+    expect((float) $topTable->table_revenue)->toBe(50.0);
+    expect((int) $topTable->table_order_count)->toBe(1);
+});
+
+it('returns null top table when no paid orders exist for the period', function () {
+    $topTable = $this->actingAs($this->admin)
+                     ->get(route('dashboard', ['period' => 'month']))
+                     ->viewData('topTable');
+
+    expect($topTable)->toBeNull();
+});
+
+it('top table changes correctly when period filter changes', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id, 'name' => 'Mesa 1']);
+
+    Order::factory()->create([
+        'table_id' => $table->id, 'payment_method' => 'cash',
+        'payment_status' => 'paid', 'total' => 60.00,
+        'updated_at' => now()->subMonth()->midDay(),
+    ]);
+
+    $topTableMonth = $this->actingAs($this->admin)
+                          ->get(route('dashboard', ['period' => 'month']))
+                          ->viewData('topTable');
+
+    expect($topTableMonth)->toBeNull();
+
+    $topTableCustom = $this->actingAs($this->admin)
+                           ->get(route('dashboard', [
+                               'period' => 'custom',
+                               'from'   => now()->subMonth()->startOfMonth()->format('Y-m-d'),
+                               'to'     => now()->subMonth()->endOfMonth()->format('Y-m-d'),
+                           ]))
+                           ->viewData('topTable');
+
+    expect((float) $topTableCustom->table_revenue)->toBe(60.0);
+});
+
+it('top table does not include tables from other restaurants', function () {
+    $otherTable = Table::factory()->create(['user_id' => $this->other->id]);
+
+    Order::factory()->create([
+        'table_id' => $otherTable->id, 'payment_method' => 'cash',
+        'payment_status' => 'paid', 'total' => 500.00, 'updated_at' => now(),
+    ]);
+
+    $topTable = $this->actingAs($this->admin)
+                     ->get(route('dashboard', ['period' => 'month']))
+                     ->viewData('topTable');
+
+    expect($topTable)->toBeNull();
+});


### PR DESCRIPTION
## Resumen

- `DashboardController::index()` calcula `$topTable`: mesa con mayor suma de `orders.total` en pedidos pagados del período, usando el mismo `$base` (JOIN + `ownerUserId()` + `payment_status=paid` + `whereBetween`) que el Bloque 9.1
- Vista `dashboard/index.blade.php`: sección con nombre de la mesa, total generado, número de pedidos y estado vacío cuando no hay datos
- Query sin N+1: un solo SELECT con GROUP BY + ORDER BY + LIMIT 1

## Tests

- 6 tests nuevos en `tests/Feature/Bloque9/DashboardTest.php` — 22/22 verdes
- Cubre: mesa con mayor ingreso, multitenancy (solo mesas del propio restaurante), solo pedidos paid, null cuando no hay datos, cambio de período

## Checklist

- [x] Rama parte de `main` actualizado (con 9.1 ya mergeado)
- [x] Un commit por archivo modificado
- [x] Mismo `ownerUserId()` y `whereBetween` que el 9.1
- [x] Solo `payment_status = paid`
- [x] Null guard en controlador y vista
- [x] Sin N+1 — query única con GROUP BY
- [x] 22/22 tests pasando

