### PR TITLE
feat(bloque9.3): platos más pedidos del período en el dashboard

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -64,7 +64,19 @@ class DashboardController extends Controller
             ->limit(1)
             ->first();
 
-        return view('dashboard.index', compact('period', 'from', 'to', 'summary', 'topTable'));
+        $topProducts = (clone $base)
+            ->join('order_items', 'orders.id', '=', 'order_items.order_id')
+            ->join('products', 'order_items.product_id', '=', 'products.id')
+            ->join('categories', 'products.category_id', '=', 'categories.id')
+            ->where('categories.name', '!=', 'Tapas')
+            ->select('products.id', 'products.name as product_name')
+            ->selectRaw('SUM(order_items.quantity) as times_ordered, SUM(order_items.quantity * order_items.price) as product_revenue')
+            ->groupBy('products.id', 'products.name')
+            ->orderByDesc('times_ordered')
+            ->limit(10)
+            ->get();
+
+        return view('dashboard.index', compact('period', 'from', 'to', 'summary', 'topTable', 'topProducts'));
     }
 
     /**

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -200,8 +200,74 @@
                 @endif
             </section>
 
-            {{-- ─── Bloque 9.3: Platos más pedidos (pendiente) ─────────────────── --}}
-            {{-- Se implementará en el Bloque 9.3 --}}
+            {{-- ─── Bloque 9.3: Platos más pedidos ────────────────────────────── --}}
+            <section aria-labelledby="top-products-heading">
+                <h2 id="top-products-heading"
+                    class="text-base font-semibold text-gray-900 dark:text-white mb-4">
+                    Platos más pedidos del período
+                </h2>
+
+                <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                            border border-gray-200 dark:border-gray-700">
+
+                    @if($topProducts->isEmpty())
+                        <div class="px-6 py-10 text-center">
+                            <p class="text-gray-400 dark:text-gray-500 text-sm">
+                                Sin pedidos cobrados en este período.
+                            </p>
+                        </div>
+                    @else
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700"
+                                   aria-label="Ranking de platos más pedidos">
+                                <thead class="bg-gray-50 dark:bg-gray-700/50">
+                                    <tr>
+                                        <th scope="col"
+                                            class="px-5 py-3 text-left text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider w-10">
+                                            #
+                                        </th>
+                                        <th scope="col"
+                                            class="px-5 py-3 text-left text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Plato
+                                        </th>
+                                        <th scope="col"
+                                            class="px-5 py-3 text-right text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Veces pedido
+                                        </th>
+                                        <th scope="col"
+                                            class="px-5 py-3 text-right text-xs font-medium
+                                                   text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                            Ingresos
+                                        </th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-gray-100 dark:divide-gray-700/60">
+                                    @foreach($topProducts as $i => $product)
+                                        <tr class="hover:bg-gray-50 dark:hover:bg-gray-700/30 transition-colors">
+                                            <td class="px-5 py-3 text-sm font-medium text-gray-400 dark:text-gray-500 tabular-nums">
+                                                {{ $i + 1 }}
+                                            </td>
+                                            <td class="px-5 py-3 text-sm font-medium text-gray-900 dark:text-white">
+                                                {{ $product->product_name }}
+                                            </td>
+                                            <td class="px-5 py-3 text-sm text-right text-gray-700 dark:text-gray-300 tabular-nums">
+                                                {{ $product->times_ordered }}
+                                            </td>
+                                            <td class="px-5 py-3 text-sm text-right font-semibold
+                                                       text-gray-900 dark:text-white tabular-nums">
+                                                {{ number_format($product->product_revenue, 2, ',', '.') }}&nbsp;€
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    @endif
+                </div>
+            </section>
 
             {{-- ─── Bloque 9.4: Horas punta y ticket medio (pendiente) ────────── --}}
             {{-- Se implementará en el Bloque 9.4 --}}

--- a/tests/Feature/Bloque9/DashboardTest.php
+++ b/tests/Feature/Bloque9/DashboardTest.php
@@ -419,6 +419,158 @@ it('returns null top table when no paid orders exist for the period', function (
     expect($topTable)->toBeNull();
 });
 
+// ─── Bloque 9.3: Platos más pedidos ───────────────────────────────────────────
+
+it('shows top ordered products for the period', function () {
+    $table    = Table::factory()->create(['user_id' => $this->admin->id]);
+    $category = \App\Models\Category::factory()->create(['user_id' => $this->admin->id, 'name' => 'Entrantes']);
+    $product  = \App\Models\Product::factory()->create(['user_id' => $this->admin->id, 'category_id' => $category->id, 'name' => 'Croquetas']);
+    $order    = Order::factory()->create(['table_id' => $table->id, 'payment_status' => 'paid', 'updated_at' => now()]);
+
+    \App\Models\OrderItem::factory()->create(['order_id' => $order->id, 'product_id' => $product->id, 'quantity' => 3, 'price' => 6.00]);
+
+    $topProducts = $this->actingAs($this->admin)
+                        ->get(route('dashboard', ['period' => 'month']))
+                        ->assertOk()
+                        ->viewData('topProducts');
+
+    expect($topProducts)->toHaveCount(1);
+    expect($topProducts->first()->product_name)->toBe('Croquetas');
+    expect((int) $topProducts->first()->times_ordered)->toBe(3);
+    expect((float) $topProducts->first()->product_revenue)->toBe(18.0);
+});
+
+it('top products only includes the restaurants products', function () {
+    $myTable    = Table::factory()->create(['user_id' => $this->admin->id]);
+    $otherTable = Table::factory()->create(['user_id' => $this->other->id]);
+
+    $myCat    = \App\Models\Category::factory()->create(['user_id' => $this->admin->id]);
+    $otherCat = \App\Models\Category::factory()->create(['user_id' => $this->other->id]);
+
+    $myProduct    = \App\Models\Product::factory()->create(['user_id' => $this->admin->id, 'category_id' => $myCat->id, 'name' => 'Mi Plato']);
+    $otherProduct = \App\Models\Product::factory()->create(['user_id' => $this->other->id, 'category_id' => $otherCat->id, 'name' => 'Plato Ajeno']);
+
+    $myOrder    = Order::factory()->create(['table_id' => $myTable->id, 'payment_status' => 'paid', 'updated_at' => now()]);
+    $otherOrder = Order::factory()->create(['table_id' => $otherTable->id, 'payment_status' => 'paid', 'updated_at' => now()]);
+
+    \App\Models\OrderItem::factory()->create(['order_id' => $myOrder->id, 'product_id' => $myProduct->id, 'quantity' => 1, 'price' => 10.00]);
+    \App\Models\OrderItem::factory()->create(['order_id' => $otherOrder->id, 'product_id' => $otherProduct->id, 'quantity' => 5, 'price' => 10.00]);
+
+    $topProducts = $this->actingAs($this->admin)
+                        ->get(route('dashboard', ['period' => 'month']))
+                        ->assertOk()
+                        ->viewData('topProducts');
+
+    expect($topProducts)->toHaveCount(1);
+    expect($topProducts->first()->product_name)->toBe('Mi Plato');
+});
+
+it('top products are ordered by quantity descending', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+    $cat   = \App\Models\Category::factory()->create(['user_id' => $this->admin->id]);
+
+    $productA = \App\Models\Product::factory()->create(['user_id' => $this->admin->id, 'category_id' => $cat->id, 'name' => 'Plato A']);
+    $productB = \App\Models\Product::factory()->create(['user_id' => $this->admin->id, 'category_id' => $cat->id, 'name' => 'Plato B']);
+
+    $order = Order::factory()->create(['table_id' => $table->id, 'payment_status' => 'paid', 'updated_at' => now()]);
+
+    \App\Models\OrderItem::factory()->create(['order_id' => $order->id, 'product_id' => $productA->id, 'quantity' => 2, 'price' => 10.00]);
+    \App\Models\OrderItem::factory()->create(['order_id' => $order->id, 'product_id' => $productB->id, 'quantity' => 7, 'price' => 10.00]);
+
+    $topProducts = $this->actingAs($this->admin)
+                        ->get(route('dashboard', ['period' => 'month']))
+                        ->assertOk()
+                        ->viewData('topProducts');
+
+    expect($topProducts->first()->product_name)->toBe('Plato B');
+    expect($topProducts->last()->product_name)->toBe('Plato A');
+});
+
+it('top products calculation only counts paid orders', function () {
+    $table   = Table::factory()->create(['user_id' => $this->admin->id]);
+    $cat     = \App\Models\Category::factory()->create(['user_id' => $this->admin->id]);
+    $product = \App\Models\Product::factory()->create(['user_id' => $this->admin->id, 'category_id' => $cat->id]);
+
+    $paid    = Order::factory()->create(['table_id' => $table->id, 'payment_status' => 'paid',    'updated_at' => now()]);
+    $pending = Order::factory()->create(['table_id' => $table->id, 'payment_status' => 'pending', 'updated_at' => now()]);
+
+    \App\Models\OrderItem::factory()->create(['order_id' => $paid->id,    'product_id' => $product->id, 'quantity' => 2, 'price' => 5.00]);
+    \App\Models\OrderItem::factory()->create(['order_id' => $pending->id, 'product_id' => $product->id, 'quantity' => 9, 'price' => 5.00]);
+
+    $topProducts = $this->actingAs($this->admin)
+                        ->get(route('dashboard', ['period' => 'month']))
+                        ->assertOk()
+                        ->viewData('topProducts');
+
+    expect((int) $topProducts->first()->times_ordered)->toBe(2);
+});
+
+it('top products excludes tapas category products', function () {
+    $table     = Table::factory()->create(['user_id' => $this->admin->id]);
+    $normalCat = \App\Models\Category::factory()->create(['user_id' => $this->admin->id, 'name' => 'Entrantes']);
+    $tapasCat  = \App\Models\Category::factory()->create(['user_id' => $this->admin->id, 'name' => 'Tapas']);
+
+    $normalProduct = \App\Models\Product::factory()->create(['user_id' => $this->admin->id, 'category_id' => $normalCat->id, 'name' => 'Croquetas']);
+    $tapasProduct  = \App\Models\Product::factory()->create(['user_id' => $this->admin->id, 'category_id' => $tapasCat->id,  'name' => 'Tapa de queso']);
+
+    $order = Order::factory()->create(['table_id' => $table->id, 'payment_status' => 'paid', 'updated_at' => now()]);
+
+    \App\Models\OrderItem::factory()->create(['order_id' => $order->id, 'product_id' => $normalProduct->id, 'quantity' => 1, 'price' => 8.00]);
+    \App\Models\OrderItem::factory()->create(['order_id' => $order->id, 'product_id' => $tapasProduct->id,  'quantity' => 5, 'price' => 1.50]);
+
+    $topProducts = $this->actingAs($this->admin)
+                        ->get(route('dashboard', ['period' => 'month']))
+                        ->assertOk()
+                        ->viewData('topProducts');
+
+    $names = $topProducts->pluck('product_name')->toArray();
+    expect($names)->toContain('Croquetas');
+    expect($names)->not->toContain('Tapa de queso');
+});
+
+it('top products does not include products from other restaurants', function () {
+    $otherTable   = Table::factory()->create(['user_id' => $this->other->id]);
+    $otherCat     = \App\Models\Category::factory()->create(['user_id' => $this->other->id]);
+    $otherProduct = \App\Models\Product::factory()->create(['user_id' => $this->other->id, 'category_id' => $otherCat->id]);
+    $otherOrder   = Order::factory()->create(['table_id' => $otherTable->id, 'payment_status' => 'paid', 'updated_at' => now()]);
+
+    \App\Models\OrderItem::factory()->create(['order_id' => $otherOrder->id, 'product_id' => $otherProduct->id, 'quantity' => 10, 'price' => 10.00]);
+
+    $topProducts = $this->actingAs($this->admin)
+                        ->get(route('dashboard', ['period' => 'month']))
+                        ->assertOk()
+                        ->viewData('topProducts');
+
+    expect($topProducts)->toBeEmpty();
+});
+
+it('returns empty list when no paid orders exist for the period', function () {
+    $topProducts = $this->actingAs($this->admin)
+                        ->get(route('dashboard', ['period' => 'month']))
+                        ->assertOk()
+                        ->viewData('topProducts');
+
+    expect($topProducts)->toBeEmpty();
+});
+
+it('limits results to top 10 products', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+    $cat   = \App\Models\Category::factory()->create(['user_id' => $this->admin->id]);
+    $order = Order::factory()->create(['table_id' => $table->id, 'payment_status' => 'paid', 'updated_at' => now()]);
+
+    foreach (range(1, 11) as $i) {
+        $product = \App\Models\Product::factory()->create(['user_id' => $this->admin->id, 'category_id' => $cat->id]);
+        \App\Models\OrderItem::factory()->create(['order_id' => $order->id, 'product_id' => $product->id, 'quantity' => $i, 'price' => 5.00]);
+    }
+
+    $topProducts = $this->actingAs($this->admin)
+                        ->get(route('dashboard', ['period' => 'month']))
+                        ->assertOk()
+                        ->viewData('topProducts');
+
+    expect($topProducts)->toHaveCount(10);
+});
+
 it('top table changes correctly when period filter changes', function () {
     $table = Table::factory()->create(['user_id' => $this->admin->id, 'name' => 'Mesa 1']);
 


### PR DESCRIPTION
## Resumen

- `DashboardController::index()` calcula `$topProducts`: top 10 productos ordenados por `SUM(quantity)` en pedidos pagados del período, excluyendo categoría Tapas, con ingresos `SUM(quantity * price)`
- Query sin N+1: un solo SELECT con 3 JOINs + GROUP BY + ORDER BY + LIMIT 10, clonando el mismo `$base` del 9.1 (ownerUserId + payment_status=paid + whereBetween)
- Vista `dashboard/index.blade.php`: tabla con posición, nombre, veces pedido e ingresos; estado vacío si no hay datos

## Tests

- 8 tests nuevos en `tests/Feature/Bloque9/DashboardTest.php` — 30/30 verdes
- Cubre: happy path, solo restaurante propio, orden descendente, solo paid, exclusión de Tapas, multitenancy, lista vacía, límite de 10

## Checklist

- [x] Rama desde `main` con 9.2 mergeado
- [x] Un commit por archivo
- [x] Mismo `ownerUserId()` + `whereBetween` que 9.1 y 9.2
- [x] Categoría Tapas excluida (`categories.name != 'Tapas'`)
- [x] Limitado a top 10
- [x] Sin N+1
- [x] 30/30 tests pasando
