### PR TITLE
[feat] bloque9 — dashboard del gerente completo

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -6,6 +6,7 @@ use App\Models\Order;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 
 /**
@@ -76,7 +77,23 @@ class DashboardController extends Controller
             ->limit(10)
             ->get();
 
-        return view('dashboard.index', compact('period', 'from', 'to', 'summary', 'topTable', 'topProducts'));
+        $hourExpr = DB::connection()->getDriverName() === 'sqlite'
+            ? "CAST(strftime('%H', orders.updated_at) AS INTEGER)"
+            : 'HOUR(orders.updated_at)';
+
+        $peakHours = (clone $base)
+            ->selectRaw("{$hourExpr} as hour, COUNT(*) as order_count")
+            ->groupByRaw($hourExpr)
+            ->orderByDesc('order_count')
+            ->limit(3)
+            ->get();
+
+        $grand     = (float) $summary->cash_revenue + (float) $summary->card_revenue + (float) $summary->tip_revenue;
+        $avgTicket = $summary->total_count > 0
+            ? round($grand / $summary->total_count, 2)
+            : 0.0;
+
+        return view('dashboard.index', compact('period', 'from', 'to', 'summary', 'topTable', 'topProducts', 'peakHours', 'avgTicket', 'grand'));
     }
 
     /**

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -138,7 +138,6 @@
                     </div>
 
                     {{-- Total global --}}
-                    @php $grand = $summary->cash_revenue + $summary->card_revenue + $summary->tip_revenue; @endphp
                     <div role="region" aria-label="Total global cobrado en el período"
                          class="bg-indigo-600 dark:bg-indigo-700 rounded-2xl shadow-sm p-5">
                         <div class="flex items-center gap-2 mb-3">
@@ -269,8 +268,79 @@
                 </div>
             </section>
 
-            {{-- ─── Bloque 9.4: Horas punta y ticket medio (pendiente) ────────── --}}
-            {{-- Se implementará en el Bloque 9.4 --}}
+            {{-- ─── Bloque 9.4: Horas punta y ticket medio ────────────────────── --}}
+            <section aria-labelledby="peak-hours-heading">
+                <h2 id="peak-hours-heading"
+                    class="text-base font-semibold text-gray-900 dark:text-white mb-4">
+                    Horas punta y ticket medio
+                </h2>
+
+                <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+
+                    {{-- Ticket medio --}}
+                    <div role="region" aria-label="Ticket medio del período"
+                         class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">🧾</span>
+                            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Ticket medio</span>
+                        </div>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white tabular-nums">
+                            {{ number_format($avgTicket, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Por pedido cobrado</p>
+                    </div>
+
+                    {{-- Horas punta --}}
+                    <div role="region" aria-label="Horas punta del período"
+                         class="lg:col-span-2 bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 p-5">
+                        <div class="flex items-center gap-2 mb-4">
+                            <span class="text-xl" aria-hidden="true">⏰</span>
+                            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Horas punta (Top 3)</span>
+                        </div>
+
+                        @if($peakHours->isEmpty())
+                            <p class="text-sm text-gray-400 dark:text-gray-500">
+                                Sin pedidos cobrados en este período.
+                            </p>
+                        @else
+                            @php $maxCount = $peakHours->max('order_count'); @endphp
+                            <div class="space-y-3">
+                                @foreach($peakHours as $slot)
+                                    @php
+                                        $h    = (int) $slot->hour;
+                                        $next = $h === 23 ? '00' : str_pad($h + 1, 2, '0', STR_PAD_LEFT);
+                                        $label = str_pad($h, 2, '0', STR_PAD_LEFT) . ':00 – ' . $next . ':00';
+                                        $pct   = $maxCount > 0 ? round(($slot->order_count / $maxCount) * 100) : 0;
+                                    @endphp
+                                    <div>
+                                        <div class="flex items-center justify-between mb-1">
+                                            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                                {{ $label }}
+                                            </span>
+                                            <span class="text-sm font-semibold text-gray-900 dark:text-white tabular-nums">
+                                                {{ $slot->order_count }}
+                                                pedido{{ $slot->order_count != 1 ? 's' : '' }}
+                                            </span>
+                                        </div>
+                                        <div class="w-full bg-gray-100 dark:bg-gray-700 rounded-full h-2"
+                                             role="progressbar"
+                                             aria-valuenow="{{ $slot->order_count }}"
+                                             aria-valuemin="0"
+                                             aria-valuemax="{{ $maxCount }}"
+                                             aria-label="{{ $label }}: {{ $slot->order_count }} pedidos">
+                                            <div class="bg-indigo-500 dark:bg-indigo-400 h-2 rounded-full transition-all"
+                                                 style="width: {{ $pct }}%"></div>
+                                        </div>
+                                    </div>
+                                @endforeach
+                            </div>
+                        @endif
+                    </div>
+
+                </div>
+            </section>
 
         </div>
     </main>

--- a/tests/Feature/Bloque9/DashboardTest.php
+++ b/tests/Feature/Bloque9/DashboardTest.php
@@ -614,3 +614,152 @@ it('top table does not include tables from other restaurants', function () {
 
     expect($topTable)->toBeNull();
 });
+
+// ─── Bloque 9.4: Horas punta y ticket medio ───────────────────────────────────
+
+it('returns peak hours data in the view', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_status' => 'paid',
+        'total'          => 20.00,
+        'updated_at'     => now()->startOfMonth()->addDays(2)->addHours(14),
+    ]);
+
+    $peakHours = $this->actingAs($this->admin)
+                      ->get(route('dashboard', ['period' => 'month']))
+                      ->assertOk()
+                      ->viewData('peakHours');
+
+    expect($peakHours)->not->toBeEmpty();
+    expect((int) $peakHours->first()->hour)->toBe(14);
+});
+
+it('peak hours returns top 3 hours ordered by order count descending', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+    $day   = now()->startOfMonth()->addDays(2);
+
+    // Hour 14: 3 orders, Hour 20: 2 orders, Hour 9: 1 order (4th), Hour 11: 4 orders (1st)
+    foreach (range(1, 3) as $_) {
+        Order::factory()->create(['table_id' => $table->id, 'payment_status' => 'paid', 'total' => 10.00, 'updated_at' => $day->copy()->addHours(14)]);
+    }
+    foreach (range(1, 2) as $_) {
+        Order::factory()->create(['table_id' => $table->id, 'payment_status' => 'paid', 'total' => 10.00, 'updated_at' => $day->copy()->addHours(20)]);
+    }
+    Order::factory()->create(['table_id' => $table->id, 'payment_status' => 'paid', 'total' => 10.00, 'updated_at' => $day->copy()->addHours(9)]);
+    foreach (range(1, 4) as $_) {
+        Order::factory()->create(['table_id' => $table->id, 'payment_status' => 'paid', 'total' => 10.00, 'updated_at' => $day->copy()->addHours(11)]);
+    }
+
+    $peakHours = $this->actingAs($this->admin)
+                      ->get(route('dashboard', ['period' => 'month']))
+                      ->assertOk()
+                      ->viewData('peakHours');
+
+    expect($peakHours)->toHaveCount(3);
+    expect((int) $peakHours->first()->order_count)->toBe(4);
+    expect((int) $peakHours->first()->hour)->toBe(11);
+    expect((int) $peakHours->get(1)->order_count)->toBe(3);
+    expect((int) $peakHours->last()->order_count)->toBe(2);
+});
+
+it('peak hours returns empty collection when no paid orders exist', function () {
+    $peakHours = $this->actingAs($this->admin)
+                      ->get(route('dashboard', ['period' => 'month']))
+                      ->assertOk()
+                      ->viewData('peakHours');
+
+    expect($peakHours)->toBeEmpty();
+});
+
+it('peak hours only counts paid orders', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+    $at    = now()->startOfMonth()->addDays(2)->addHours(14);
+
+    Order::factory()->create(['table_id' => $table->id, 'payment_status' => 'paid',    'total' => 10.00, 'updated_at' => $at]);
+    Order::factory()->create(['table_id' => $table->id, 'payment_status' => 'pending', 'total' => 10.00, 'updated_at' => $at]);
+
+    $peakHours = $this->actingAs($this->admin)
+                      ->get(route('dashboard', ['period' => 'month']))
+                      ->assertOk()
+                      ->viewData('peakHours');
+
+    expect($peakHours)->toHaveCount(1);
+    expect((int) $peakHours->first()->order_count)->toBe(1);
+});
+
+it('peak hours only includes tables from the same restaurant', function () {
+    $myTable    = Table::factory()->create(['user_id' => $this->admin->id]);
+    $otherTable = Table::factory()->create(['user_id' => $this->other->id]);
+    $at         = now()->startOfMonth()->addDays(2)->addHours(14);
+
+    Order::factory()->create(['table_id' => $myTable->id,    'payment_status' => 'paid', 'total' => 10.00, 'updated_at' => $at]);
+    Order::factory()->create(['table_id' => $otherTable->id, 'payment_status' => 'paid', 'total' => 10.00, 'updated_at' => $at]);
+
+    $peakHours = $this->actingAs($this->admin)
+                      ->get(route('dashboard', ['period' => 'month']))
+                      ->assertOk()
+                      ->viewData('peakHours');
+
+    expect($peakHours)->toHaveCount(1);
+    expect((int) $peakHours->first()->order_count)->toBe(1);
+});
+
+it('calculates average ticket correctly', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id' => $table->id, 'payment_method' => 'cash',
+        'payment_status' => 'paid', 'total' => 30.00, 'tip' => 0, 'updated_at' => now(),
+    ]);
+    Order::factory()->create([
+        'table_id' => $table->id, 'payment_method' => 'card',
+        'payment_status' => 'paid', 'total' => 50.00, 'tip' => 5.00, 'updated_at' => now(),
+    ]);
+
+    $avgTicket = $this->actingAs($this->admin)
+                      ->get(route('dashboard', ['period' => 'month']))
+                      ->assertOk()
+                      ->viewData('avgTicket');
+
+    // (30 + 50 + 5) / 2 = 42.5
+    expect((float) $avgTicket)->toBe(42.5);
+});
+
+it('returns zero average ticket when no paid orders exist for the period', function () {
+    $avgTicket = $this->actingAs($this->admin)
+                      ->get(route('dashboard', ['period' => 'month']))
+                      ->assertOk()
+                      ->viewData('avgTicket');
+
+    expect((float) $avgTicket)->toBe(0.0);
+});
+
+it('average ticket updates correctly when period filter changes', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id' => $table->id, 'payment_method' => 'cash', 'payment_status' => 'paid',
+        'total' => 60.00, 'tip' => 0,
+        'updated_at' => now()->subMonth()->startOfDay()->addHours(12),
+    ]);
+
+    $avgTicketMonth = $this->actingAs($this->admin)
+                           ->get(route('dashboard', ['period' => 'month']))
+                           ->assertOk()
+                           ->viewData('avgTicket');
+
+    expect((float) $avgTicketMonth)->toBe(0.0);
+
+    $avgTicketCustom = $this->actingAs($this->admin)
+                            ->get(route('dashboard', [
+                                'period' => 'custom',
+                                'from'   => now()->subMonth()->startOfMonth()->format('Y-m-d'),
+                                'to'     => now()->subMonth()->endOfMonth()->format('Y-m-d'),
+                            ]))
+                            ->assertOk()
+                            ->viewData('avgTicket');
+
+    expect((float) $avgTicketCustom)->toBe(60.0);
+});


### PR DESCRIPTION
## Qué se implementa

- **9.1**: Ingresos desglosados por método de pago y período (efectivo, tarjeta, propinas, total global)
- **9.2**: Mesa que más ingresos genera en el período
- **9.3**: Platos más pedidos (top 10, excluyendo tapas del ranking)
- **9.4**: Horas punta (top 3 franjas horarias) y ticket medio por pedido
- **9.5**: Tests completos del Bloque 9 — 38 tests, 88 assertions, 100% verde

## Reglas aplicadas

- `ownerUserId()` para aislamiento entre restaurantes en todas las métricas
- Solo pedidos con `payment_status = paid` en todas las consultas
- El mismo filtro de período (`$base` + `whereBetween`) aplicado consistentemente mediante `(clone $base)`
- Categoría Tapas excluida del ranking de platos (`WHERE categories.name != 'Tapas'`)
- Compatibilidad SQLite/MySQL para agrupación por hora (`strftime` vs `HOUR()`)
- `$grand` calculado en el controlador y pasado a la vista (sin duplicación en `@php` Blade)

## Checklist CLAUDE.md

- [x] `php artisan test` pasa al 100% (490 tests en la suite completa)
- [x] Un commit por archivo modificado
- [x] `@author AyrtonAlania` añadido en `DashboardController` (debajo de `@author BenjaminDTS`)
- [x] README actualizado al 88% (51/58 sub-bloques completados)
- [x] CLAUDE.md actualizado: Bloque 9 → Completado
- [x] Reviewer: SHIP IT sin bloqueadores

## Suite completa

```
Tests: 490 passed (974 assertions)
Duration: 17.87s
```