### PR TITLE
test(bloque9.5): complete DashboardTest full coverage + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ php artisan make:factory NombreFactory --model=Nombre
 
 ## Progreso del desarrollo
 
-**Progreso global: 79%** (46/58 sub-bloques completados)
+**Progreso global: 88%** (51/58 sub-bloques completados)
 
 | Sub-bloque | Descripción | Estado |
 | ---------- | ----------- | ------ |
@@ -223,11 +223,11 @@ php artisan make:factory NombreFactory --model=Nombre
 | 13.4 | Gestión de negocios — crear admins, asignar plan, ver stats | Completado |
 | 13.5 | Mapa de negocios — Leaflet.js con pin por negocio | Completado |
 | 13.6 | Tests del Bloque 13 | Completado |
-| 9.1 | Ingresos desglosados por método de pago y período | Pendiente |
-| 9.2 | Mesa que más ingresos genera | Pendiente |
-| 9.3 | Platos más pedidos | Pendiente |
-| 9.4 | Horas punta y ticket medio por mesa | Pendiente |
-| 9.5 | Tests del Bloque 9 | Pendiente |
+| 9.1 | Ingresos desglosados por método de pago y período | Completado |
+| 9.2 | Mesa que más ingresos genera | Completado |
+| 9.3 | Platos más pedidos | Completado |
+| 9.4 | Horas punta y ticket medio por mesa | Completado |
+| 9.5 | Tests del Bloque 9 | Completado |
 | 11.1 | Design system (colores Zampa, tipografía, tokens Tailwind) | Pendiente |
 | 11.2 | Layout principal y navegación (sidebar, topbar, dark mode) | Pendiente |
 | 11.3 | Vistas del panel admin | Pendiente |

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -13,6 +13,7 @@ use Illuminate\View\View;
  * Panel principal del gerente con desglose de ingresos y métricas del negocio.
  *
  * @author BenjaminDTS
+ * @author AyrtonAlania
  */
 class DashboardController extends Controller
 {


### PR DESCRIPTION
## Qué incluye este PR

Cierre oficial del **Bloque 9.5 — Tests del Dashboard del gerente**.

### Cambios

- **`DashboardController.php`**: Añade `@author AyrtonAlania` debajo del `@author BenjaminDTS` existente (regla CLAUDE.md Caso B)
- **`README.md`**: Actualiza progreso global de **79% → 88%** (51/58 sub-bloques) y marca los sub-bloques 9.1–9.5 como `Completado`

### Contexto

Los 38 tests del Bloque 9 fueron añadidos en los PRs anteriores de cada sub-bloque (9.1–9.4). Este PR cierra el bloque con la documentación de autoría y la actualización del progreso.

### Suite de tests

```
php artisan test → 490 passed (974 assertions)
php artisan test tests/Feature/Bloque9/DashboardTest.php → 38 passed (88 assertions)
```

## Checklist CLAUDE.md

- [x] `php artisan test` pasa al 100%
- [x] Un commit por archivo
- [x] `@author AyrtonAlania` en cabecera de clase (sin modificar `@author BenjaminDTS`)
- [x] README actualizado al 88%
- [x] Bloque 9.5 → Completado