### PR TITLE
feat(bloque8): mapa visual con zonas, elementos especiales y drag&drop

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -29,7 +29,7 @@ class MenuController extends Controller
      */
     public function show(string $hash): View
     {
-        $table  = Table::where('unique_hash', $hash)->firstOrFail();
+        $table  = Table::where('unique_hash', $hash)->where('is_service_point', true)->firstOrFail();
         $config = $table->user->tapaConfig;
 
         if ($config) {

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -139,8 +139,8 @@ class TableController extends Controller
         abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
 
         $data = $request->validate([
-            'position_x' => 'required|integer|min:0',
-            'position_y' => 'required|integer|min:0',
+            'position_x' => 'required|integer|min:-3000',
+            'position_y' => 'required|integer|min:-3000',
             'width'      => 'required|integer|min:40|max:800',
             'height'     => 'required|integer|min:40|max:800',
             'rotation'   => 'sometimes|integer|min:0|max:359',

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -34,7 +34,7 @@ class TableController extends Controller
      */
     public function index(): View
     {
-        $tables    = Table::where('user_id', Auth::id())->orderBy('name')->get();
+        $tables    = Table::where('user_id', Auth::id())->servicePoints()->orderBy('name')->get();
         $maxTables = Auth::user()->plan?->max_tables ?? 10;
 
         return view('tables.index', compact('tables', 'maxTables'));
@@ -48,8 +48,18 @@ class TableController extends Controller
     public function map(): View
     {
         $userId      = Auth::id();
-        $tables      = Table::where('user_id', $userId)->servicePoints()->orderBy('name')->get();
-        $elements    = Table::where('user_id', $userId)->where('is_service_point', false)->orderBy('name')->get();
+        $tables      = Table::where('user_id', $userId)
+                           ->servicePoints()
+                           ->whereNotIn('shape', ['bar', 'stool'])
+                           ->orderBy('name')
+                           ->get();
+        $elements    = Table::where('user_id', $userId)
+                           ->where(function ($q) {
+                               $q->where('is_service_point', false)
+                                 ->orWhereIn('shape', ['bar', 'stool']);
+                           })
+                           ->orderBy('name')
+                           ->get();
         $zones       = Zone::where('user_id', $userId)->orderBy('name')->get();
         $maxTables   = Auth::user()->plan?->max_tables ?? 10;
         $floorWidth  = Auth::user()->floor_width  ?? 1200;
@@ -98,7 +108,9 @@ class TableController extends Controller
             'zone_id'          => ['sometimes', 'nullable', Rule::exists('zones', 'id')->where('user_id', Auth::id())],
         ]);
 
-        $isServicePoint = $data['is_service_point'] ?? true;
+        $isServicePoint = in_array($data['shape'], ['bar', 'stool'])
+            ? false
+            : ($data['is_service_point'] ?? true);
 
         if ($isServicePoint) {
             $count     = Table::where('user_id', Auth::id())->servicePoints()->count();

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Table;
+use App\Models\Zone;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -39,16 +40,42 @@ class TableController extends Controller
     }
 
     /**
-     * Muestra el mapa visual interactivo con drag & drop para gestionar mesas.
+     * Muestra el mapa visual interactivo con drag & drop para gestionar mesas y zonas.
      *
      * @return View
      */
     public function map(): View
     {
-        $tables    = Table::where('user_id', Auth::id())->orderBy('name')->get();
-        $maxTables = Auth::user()->plan?->max_tables ?? 10;
+        $userId      = Auth::id();
+        $tables      = Table::where('user_id', $userId)->servicePoints()->orderBy('name')->get();
+        $elements    = Table::where('user_id', $userId)->where('is_service_point', false)->orderBy('name')->get();
+        $zones       = Zone::where('user_id', $userId)->orderBy('name')->get();
+        $maxTables   = Auth::user()->plan?->max_tables ?? 10;
+        $floorWidth  = Auth::user()->floor_width  ?? 1200;
+        $floorHeight = Auth::user()->floor_height ?? 800;
 
-        return view('tables.map', compact('tables', 'maxTables'));
+        return view('tables.map', compact('tables', 'elements', 'zones', 'maxTables', 'floorWidth', 'floorHeight'));
+    }
+
+    /**
+     * Guarda las dimensiones personalizadas del canvas del plano.
+     *
+     * @param  Request  $request
+     * @return JsonResponse
+     */
+    public function updateCanvas(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'floor_width'  => 'required|integer|min:800|max:3000',
+            'floor_height' => 'required|integer|min:600|max:2000',
+        ]);
+
+        Auth::user()->update($data);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Dimensiones del plano guardadas.',
+        ]);
     }
 
     /**
@@ -60,29 +87,36 @@ class TableController extends Controller
     public function store(Request $request): JsonResponse
     {
         $data = $request->validate([
-            'name'       => 'required|string|max:50',
-            'shape'      => 'required|in:square,round,rectangle',
-            'position_x' => 'required|integer|min:0',
-            'position_y' => 'required|integer|min:0',
-            'width'      => 'required|integer|min:60|max:400',
-            'height'     => 'required|integer|min:60|max:400',
+            'name'             => 'required|string|max:50',
+            'shape'            => 'required|in:square,round,rectangle,bar,stool',
+            'position_x'       => 'required|integer|min:0',
+            'position_y'       => 'required|integer|min:0',
+            'width'            => 'required|integer|min:40|max:800',
+            'height'           => 'required|integer|min:40|max:400',
+            'is_service_point' => 'sometimes|boolean',
+            'zone_id'          => 'sometimes|nullable|exists:zones,id',
         ]);
 
-        $count     = Table::where('user_id', Auth::id())->count();
-        $maxTables = Auth::user()->plan?->max_tables ?? 10;
+        $isServicePoint = $data['is_service_point'] ?? true;
 
-        if ($count >= $maxTables) {
-            return response()->json([
-                'success' => false,
-                'message' => "Has alcanzado el límite de {$maxTables} mesas de tu plan.",
-            ], 422);
+        if ($isServicePoint) {
+            $count     = Table::where('user_id', Auth::id())->servicePoints()->count();
+            $maxTables = Auth::user()->plan?->max_tables ?? 10;
+
+            if ($count >= $maxTables) {
+                return response()->json([
+                    'success' => false,
+                    'message' => "Has alcanzado el límite de {$maxTables} mesas de tu plan.",
+                ], 422);
+            }
         }
 
         $table = Table::create([
             ...$data,
-            'user_id'     => Auth::id(),
-            'unique_hash' => Str::uuid()->toString(),
-            'status'      => 'free',
+            'user_id'          => Auth::id(),
+            'unique_hash'      => Str::uuid()->toString(),
+            'status'           => 'free',
+            'is_service_point' => $isServicePoint,
         ]);
 
         return response()->json([
@@ -156,7 +190,7 @@ class TableController extends Controller
         abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
 
         $data = $request->validate([
-            'shape' => 'required|in:square,round,rectangle',
+            'shape' => 'required|in:square,round,rectangle,bar,stool',
         ]);
 
         $table->update($data);
@@ -165,6 +199,8 @@ class TableController extends Controller
             'square'    => 'cuadrada',
             'round'     => 'redonda',
             'rectangle' => 'rectangular',
+            'bar'       => 'barra',
+            'stool'     => 'taburete',
         };
 
         return response()->json([

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 use SimpleSoftwareIO\QrCode\Facades\QrCode;
 
@@ -94,7 +95,7 @@ class TableController extends Controller
             'width'            => 'required|integer|min:40|max:800',
             'height'           => 'required|integer|min:40|max:400',
             'is_service_point' => 'sometimes|boolean',
-            'zone_id'          => 'sometimes|nullable|exists:zones,id',
+            'zone_id'          => ['sometimes', 'nullable', Rule::exists('zones', 'id')->where('user_id', Auth::id())],
         ]);
 
         $isServicePoint = $data['is_service_point'] ?? true;

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -141,8 +141,8 @@ class TableController extends Controller
         $data = $request->validate([
             'position_x' => 'required|integer|min:0',
             'position_y' => 'required|integer|min:0',
-            'width'      => 'required|integer|min:60|max:400',
-            'height'     => 'required|integer|min:60|max:400',
+            'width'      => 'required|integer|min:40|max:800',
+            'height'     => 'required|integer|min:40|max:800',
             'rotation'   => 'sometimes|integer|min:0|max:359',
         ]);
 

--- a/app/Http/Controllers/ZoneController.php
+++ b/app/Http/Controllers/ZoneController.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Zone;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Class ZoneController
+ *
+ * Gestión de zonas del plano del restaurante (terraza, comedor, barra).
+ * Solo accesible para el gerente (admin). Todas las operaciones son AJAX/JSON.
+ *
+ * @author AyrtonAlania
+ */
+class ZoneController extends Controller
+{
+    /**
+     * Crea una nueva zona en el plano del restaurante.
+     *
+     * @param  Request  $request
+     * @return JsonResponse
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'name'       => 'required|string|max:50',
+            'color'      => ['required', 'string', 'regex:/^#[0-9a-fA-F]{3,6}$/'],
+            'position_x' => 'required|integer|min:0',
+            'position_y' => 'required|integer|min:0',
+            'width'      => 'required|integer|min:80|max:2000',
+            'height'     => 'required|integer|min:60|max:1500',
+        ]);
+
+        $zone = Zone::create([
+            ...$data,
+            'user_id'  => Auth::id(),
+            'rotation' => 0,
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $zone,
+            'message' => "Zona \"{$zone->name}\" creada.",
+        ], 201);
+    }
+
+    /**
+     * Actualiza posición, dimensiones, nombre y color de una zona.
+     *
+     * @param  Request  $request
+     * @param  Zone     $zone
+     * @return JsonResponse
+     */
+    public function update(Request $request, Zone $zone): JsonResponse
+    {
+        abort_if($zone->user_id !== Auth::id(), 403, 'Acceso denegado.');
+
+        $data = $request->validate([
+            'name'       => 'sometimes|string|max:50',
+            'color'      => ['sometimes', 'string', 'regex:/^#[0-9a-fA-F]{3,6}$/'],
+            'position_x' => 'sometimes|integer|min:0',
+            'position_y' => 'sometimes|integer|min:0',
+            'width'      => 'sometimes|integer|min:80|max:2000',
+            'height'     => 'sometimes|integer|min:60|max:1500',
+            'rotation'   => 'sometimes|integer|min:0|max:359',
+        ]);
+
+        $zone->update($data);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $zone,
+            'message' => "Zona \"{$zone->name}\" actualizada.",
+        ]);
+    }
+
+    /**
+     * Elimina una zona. Las mesas asignadas pasan a zone_id = null (nullOnDelete).
+     *
+     * @param  Zone  $zone
+     * @return JsonResponse
+     */
+    public function destroy(Zone $zone): JsonResponse
+    {
+        abort_if($zone->user_id !== Auth::id(), 403, 'Acceso denegado.');
+
+        $name = $zone->name;
+        $zone->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => "Zona \"{$name}\" eliminada.",
+        ]);
+    }
+}

--- a/app/Models/Table.php
+++ b/app/Models/Table.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -13,17 +14,22 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  *
  * Representa una mesa física en el restaurante.
  * Incluye datos de posición para el plano visual (Editor de Mapa).
+ * Los elementos especiales (barra, taburetes) tienen is_service_point = false
+ * y no generan QR ni aparecen en la carta pública.
  *
  * @package App\Models
- * @property int $id
- * @property int $user_id       Dueño de la mesa
- * @property string $name       Nombre o número (Ej: "Mesa 1", "Terraza 2")
- * @property string $unique_hash Código único para el QR
- * @property string $status     Estado: 'free', 'occupied'
- * @property int $position_x    Coordenada X en el plano
- * @property int $position_y    Coordenada Y en el plano
- * @property int $width         Ancho de la mesa (px)
- * @property int $height        Alto de la mesa (px)
+ * @property int      $id
+ * @property int      $user_id          Dueño de la mesa
+ * @property int|null $zone_id          Zona a la que pertenece (nullable)
+ * @property string   $name             Nombre o número (Ej: "Mesa 1", "Terraza 2")
+ * @property string   $unique_hash      Código único para el QR
+ * @property string   $status           Estado: 'free', 'occupied'
+ * @property int      $position_x       Coordenada X en el plano
+ * @property int      $position_y       Coordenada Y en el plano
+ * @property int      $width            Ancho de la mesa (px)
+ * @property int      $height           Alto de la mesa (px)
+ * @property bool     $is_service_point Si genera QR y acepta pedidos
+ * @author AyrtonAlania
  */
 class Table extends Model
 {
@@ -31,6 +37,7 @@ class Table extends Model
 
     protected $fillable = [
         'user_id',
+        'zone_id',
         'name',
         'unique_hash',
         'status',
@@ -39,11 +46,18 @@ class Table extends Model
         'width',
         'height',
         'shape',
-        'rotation'
+        'rotation',
+        'is_service_point',
+    ];
+
+    protected $casts = [
+        'is_service_point' => 'boolean',
     ];
 
     /**
      * El restaurante al que pertenece la mesa.
+     *
+     * @return BelongsTo
      */
     public function user(): BelongsTo
     {
@@ -51,7 +65,19 @@ class Table extends Model
     }
 
     /**
+     * La zona del plano a la que pertenece esta mesa.
+     *
+     * @return BelongsTo
+     */
+    public function zone(): BelongsTo
+    {
+        return $this->belongsTo(Zone::class);
+    }
+
+    /**
      * Historial de todos los pedidos hechos en esta mesa.
+     *
+     * @return HasMany
      */
     public function orders(): HasMany
     {
@@ -61,12 +87,24 @@ class Table extends Model
     /**
      * Obtiene EXCLUSIVAMENTE el pedido actual (el que no está cerrado).
      * Útil para saber qué se está consumiendo ahora mismo.
-     * * @return HasOne|null
+     *
+     * @return HasOne
      */
-    public function activeOrder()
+    public function activeOrder(): HasOne
     {
         return $this->hasOne(Order::class)
             ->where('status', '!=', 'closed')
             ->latestOfMany();
+    }
+
+    /**
+     * Scope: solo mesas con carta pública y capacidad de recibir pedidos.
+     *
+     * @param  Builder  $query
+     * @return Builder
+     */
+    public function scopeServicePoints(Builder $query): Builder
+    {
+        return $query->where('is_service_point', true);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use App\Models\Order;
 use App\Models\Table;
+use App\Models\Zone;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
@@ -30,9 +31,12 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property string|null $address        Dirección del negocio
  * @property float|null  $lat            Latitud del negocio
  * @property float|null  $lng            Longitud del negocio
+ * @property int         $floor_width    Ancho del canvas del plano (px)
+ * @property int         $floor_height   Alto del canvas del plano (px)
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @author BenjaminDTS
+ * @author AyrtonAlania
  */
 class User extends Authenticatable
 {
@@ -55,6 +59,8 @@ class User extends Authenticatable
         'address',
         'lat',
         'lng',
+        'floor_width',
+        'floor_height',
     ];
 
     /**
@@ -103,6 +109,16 @@ class User extends Authenticatable
     public function tables(): HasMany
     {
         return $this->hasMany(Table::class);
+    }
+
+    /**
+     * Obtiene las Zonas definidas en el plano del restaurante.
+     *
+     * @return HasMany
+     */
+    public function zones(): HasMany
+    {
+        return $this->hasMany(Zone::class);
     }
 
     /**

--- a/app/Models/Zone.php
+++ b/app/Models/Zone.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Class Zone
+ *
+ * Representa una zona del local (terraza, comedor interior, barra).
+ * Visible como región coloreada en el plano del restaurante.
+ *
+ * @package App\Models
+ * @property int    $id
+ * @property int    $user_id     Propietario (restaurante)
+ * @property string $name        Nombre de la zona
+ * @property string $color       Color hex para visualización en el plano
+ * @property int    $position_x  Coordenada X en el plano
+ * @property int    $position_y  Coordenada Y en el plano
+ * @property int    $width       Ancho en px
+ * @property int    $height      Alto en px
+ * @property int    $rotation    Rotación en grados
+ * @author AyrtonAlania
+ */
+class Zone extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'color',
+        'position_x',
+        'position_y',
+        'width',
+        'height',
+        'rotation',
+    ];
+
+    /**
+     * @return BelongsTo
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Mesas asignadas a esta zona.
+     * Al eliminar la zona, las mesas pasan a zone_id = null (nullOnDelete en migración).
+     *
+     * @return HasMany
+     */
+    public function tables(): HasMany
+    {
+        return $this->hasMany(Table::class);
+    }
+}

--- a/database/factories/TableFactory.php
+++ b/database/factories/TableFactory.php
@@ -17,16 +17,18 @@ class TableFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id'     => User::factory(),
-            'name'        => 'Mesa ' . fake()->unique()->numberBetween(1, 50),
-            'unique_hash' => Str::uuid()->toString(),
-            'status'      => 'free',
-            'position_x'  => 0,
-            'position_y'  => 0,
-            'width'       => 100,
-            'height'      => 100,
-            'shape'       => 'square',
-            'rotation'    => 0,
+            'user_id'          => User::factory(),
+            'zone_id'          => null,
+            'name'             => 'Mesa ' . fake()->unique()->numberBetween(1, 50),
+            'unique_hash'      => Str::uuid()->toString(),
+            'status'           => 'free',
+            'position_x'       => 0,
+            'position_y'       => 0,
+            'width'            => 100,
+            'height'           => 100,
+            'shape'            => 'square',
+            'rotation'         => 0,
+            'is_service_point' => true,
         ];
     }
 }

--- a/database/factories/ZoneFactory.php
+++ b/database/factories/ZoneFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Zone>
+ */
+class ZoneFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id'    => User::factory(),
+            'name'       => fake()->randomElement(['Terraza', 'Comedor interior', 'Barra', 'VIP', 'Jardín']),
+            'color'      => fake()->hexColor(),
+            'position_x' => fake()->numberBetween(0, 400),
+            'position_y' => fake()->numberBetween(0, 300),
+            'width'      => fake()->numberBetween(150, 400),
+            'height'     => fake()->numberBetween(100, 300),
+            'rotation'   => 0,
+        ];
+    }
+}

--- a/database/factories/ZoneFactory.php
+++ b/database/factories/ZoneFactory.php
@@ -18,7 +18,7 @@ class ZoneFactory extends Factory
         return [
             'user_id'    => User::factory(),
             'name'       => fake()->randomElement(['Terraza', 'Comedor interior', 'Barra', 'VIP', 'Jardín']),
-            'color'      => fake()->hexColor(),
+            'color'      => '#' . fake()->hexColor(),
             'position_x' => fake()->numberBetween(0, 400),
             'position_y' => fake()->numberBetween(0, 300),
             'width'      => fake()->numberBetween(150, 400),

--- a/database/migrations/2026_05_12_000001_create_zones_table.php
+++ b/database/migrations/2026_05_12_000001_create_zones_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('zones', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('name');
+            $table->string('color', 20)->default('#6366f1');
+            $table->integer('position_x')->default(50);
+            $table->integer('position_y')->default(50);
+            $table->integer('width')->default(300);
+            $table->integer('height')->default(200);
+            $table->integer('rotation')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('zones');
+    }
+};

--- a/database/migrations/2026_05_12_000002_add_zone_and_service_point_to_tables.php
+++ b/database/migrations/2026_05_12_000002_add_zone_and_service_point_to_tables.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('tables', function (Blueprint $table) {
+            $table->foreignId('zone_id')->nullable()->after('rotation')
+                  ->constrained('zones')->nullOnDelete();
+            $table->boolean('is_service_point')->default(true)->after('zone_id');
+        });
+
+        // Extend shape enum to include bar and stool (MySQL only; SQLite ignores enum constraints)
+        if (Schema::getConnection()->getDriverName() !== 'sqlite') {
+            DB::statement("ALTER TABLE `tables` MODIFY `shape` ENUM('square','round','rectangle','bar','stool') NOT NULL DEFAULT 'square'");
+        }
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->integer('floor_width')->default(1200)->after('lng');
+            $table->integer('floor_height')->default(800)->after('floor_width');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('tables', function (Blueprint $table) {
+            $table->dropForeign(['zone_id']);
+            $table->dropColumn(['zone_id', 'is_service_point']);
+        });
+
+        if (Schema::getConnection()->getDriverName() !== 'sqlite') {
+            DB::statement("ALTER TABLE `tables` MODIFY `shape` ENUM('square','round','rectangle') NOT NULL DEFAULT 'square'");
+        }
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['floor_width', 'floor_height']);
+        });
+    }
+};

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -347,51 +347,43 @@
                     </div>
                 </template>
 
-                {{-- Elementos especiales: barra y taburetes (z-index 10, sin QR) --}}
-                <template x-for="element in elements" :key="'e'+element.id">
+                {{-- Barras especiales: usa table-item para interact.js, idéntico al sistema de mesas --}}
+                <template x-for="bar in elements.filter(e => e.shape === 'bar')" :key="'b'+bar.id">
                     <div
-                        :data-table-id="element.id"
-                        class="element-item absolute group select-none touch-none"
-                        :style="`left:${element.position_x}px; top:${element.position_y}px;
-                                 width:${element.width}px; height:${element.height}px;
-                                 transform:rotate(${element.rotation ?? 0}deg);
+                        :data-table-id="bar.id"
+                        class="table-item absolute group select-none touch-none"
+                        :style="`left:${bar.position_x}px; top:${bar.position_y}px;
+                                 width:${bar.width}px; height:${bar.height}px;
+                                 transform:rotate(${bar.rotation ?? 0}deg);
                                  transform-origin:center;
                                  z-index:10;`"
-                        :aria-label="element.shape === 'bar' ? `Barra: ${element.name}` : `Taburete: ${element.name}`"
+                        :aria-label="`Barra: ${bar.name}`"
                     >
                         <div class="w-full h-full relative flex items-center justify-center
+                                    rounded-lg
                                     bg-amber-100 dark:bg-amber-900/40
                                     border-2 border-amber-400 dark:border-amber-600
                                     shadow-md cursor-grab active:cursor-grabbing
-                                    transition-shadow hover:shadow-lg"
-                             :class="{
-                                'rounded-full': element.shape === 'stool',
-                                'rounded-lg':   element.shape === 'bar',
-                             }"
-                             @mousedown.prevent="startElementDrag($event, element)">
+                                    transition-shadow hover:shadow-lg">
 
                             <span class="text-xs font-semibold text-amber-800 dark:text-amber-300
                                          text-center px-1 leading-tight pointer-events-none"
-                                  x-text="element.name">
+                                  x-text="bar.name">
                             </span>
 
-                            {{-- Badge tipo --}}
-                            <span class="absolute top-1 left-1 text-xs text-amber-600 dark:text-amber-400 pointer-events-none leading-none"
-                                  x-text="element.shape === 'bar' ? '🍺' : '●'">
-                            </span>
+                            <span class="absolute top-1 left-1 text-xs text-amber-600 dark:text-amber-400 pointer-events-none leading-none">🍺</span>
 
                             {{-- Botón editar nombre --}}
                             <button type="button"
-                                    @mousedown.stop
-                                    @click.stop="editingTableId = editingTableId === element.id ? null : element.id"
+                                    @click.stop="editingTableId = editingTableId === bar.id ? null : bar.id"
                                     class="absolute -top-2.5 -right-9
                                            w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
                                            flex items-center justify-center
                                            opacity-0 group-hover:opacity-100 transition-opacity
                                            hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-400
                                            shadow-md"
-                                    :aria-label="`Editar ${element.name}`"
-                                    :aria-expanded="editingTableId === element.id">
+                                    :aria-label="`Editar ${bar.name}`"
+                                    :aria-expanded="editingTableId === bar.id">
                                 <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z"/>
                                 </svg>
@@ -399,22 +391,21 @@
 
                             {{-- Botón eliminar --}}
                             <button type="button"
-                                    @mousedown.stop
-                                    @click.stop="deleteElement(element)"
+                                    @click.stop="deleteElement(bar)"
                                     class="absolute -top-2.5 -right-2.5
                                            w-6 h-6 rounded-full bg-red-500 text-white
                                            flex items-center justify-center
                                            opacity-0 group-hover:opacity-100 transition-opacity
                                            hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400
                                            shadow-md"
-                                    :aria-label="`Eliminar ${element.name}`">
+                                    :aria-label="`Eliminar ${bar.name}`">
                                 <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
                                 </svg>
                             </button>
 
                             {{-- Panel de edición de nombre --}}
-                            <div x-show="editingTableId === element.id"
+                            <div x-show="editingTableId === bar.id"
                                  x-transition:enter="transition ease-out duration-150"
                                  x-transition:enter-start="opacity-0 scale-95"
                                  x-transition:enter-end="opacity-100 scale-100"
@@ -424,36 +415,35 @@
                                         border border-gray-200 dark:border-gray-700
                                         p-3 min-w-max"
                                  role="dialog"
-                                 :aria-label="`Editar ${element.name}`">
-
+                                 :aria-label="`Editar ${bar.name}`">
                                 <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Nombre</p>
                                 <div class="flex gap-1">
                                     <input type="text"
-                                           :value="element.name"
-                                           @keydown.enter.stop="updateName(element, $event.target.value); $event.target.blur()"
-                                           @blur.stop="updateName(element, $event.target.value)"
+                                           :value="bar.name"
+                                           @keydown.enter.stop="updateName(bar, $event.target.value); $event.target.blur()"
+                                           @blur.stop="updateName(bar, $event.target.value)"
                                            @click.stop
                                            maxlength="50"
                                            class="w-full rounded-lg border border-gray-300 dark:border-gray-600
                                                   bg-white dark:bg-gray-700 text-gray-900 dark:text-white
                                                   px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
-                                           :aria-label="`Nombre de ${element.name}`">
+                                           :aria-label="`Nombre de ${bar.name}`">
                                 </div>
                             </div>
                         </div>
 
-                        {{-- Handle de rotación para elementos especiales --}}
+                        {{-- Handle de rotación --}}
                         <div class="rotation-handle absolute -top-9 left-1/2 -translate-x-1/2
                                     flex flex-col items-center gap-0
                                     opacity-0 group-hover:opacity-100 transition-opacity z-10"
-                             @mousedown.stop.prevent="startRotation($event, element)"
-                             @mouseenter.stop="rotTooltip = { show: true, x: $event.clientX, y: $event.clientY, deg: element.rotation ?? 0 }"
-                             @mousemove.stop="rotTooltip.x = $event.clientX; rotTooltip.y = $event.clientY; rotTooltip.deg = element.rotation ?? 0"
+                             @mousedown.stop.prevent="startRotation($event, bar)"
+                             @mouseenter.stop="rotTooltip = { show: true, x: $event.clientX, y: $event.clientY, deg: bar.rotation ?? 0 }"
+                             @mousemove.stop="rotTooltip.x = $event.clientX; rotTooltip.y = $event.clientY; rotTooltip.deg = bar.rotation ?? 0"
                              @mouseleave.stop="if (!isRotating) rotTooltip.show = false"
                              role="button"
                              tabindex="0"
                              style="cursor: url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2720%27 height=%2720%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3C/svg%3E') 10 10, grab;"
-                             :aria-label="`Rotar ${element.name} (arrastra para girar)`">
+                             :aria-label="`Rotar ${bar.name} (arrastra para girar)`">
                             <div class="w-6 h-6 rounded-full
                                         bg-white dark:bg-gray-800
                                         border-2 border-amber-400 shadow-md
@@ -471,9 +461,136 @@
                         <div class="resize-handle absolute bottom-0 right-0
                                     w-4 h-4 cursor-se-resize opacity-0 group-hover:opacity-100
                                     transition-opacity"
-                             @mousedown.stop.prevent="startResize($event, element)"
+                             @mousedown.stop.prevent="startResize($event, bar)"
                              role="button"
-                             :aria-label="`Redimensionar ${element.name}`">
+                             :aria-label="`Redimensionar ${bar.name}`">
+                            <svg aria-hidden="true" viewBox="0 0 10 10" fill="none" class="w-full h-full text-amber-400">
+                                <path d="M9 1L1 9M9 5L5 9M9 9H9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                            </svg>
+                        </div>
+                    </div>
+                </template>
+
+                {{-- Taburetes: drag Alpine-nativo --}}
+                <template x-for="stool in elements.filter(e => e.shape === 'stool')" :key="'s'+stool.id">
+                    <div
+                        :data-table-id="stool.id"
+                        class="element-item absolute group select-none touch-none"
+                        :style="`left:${stool.position_x}px; top:${stool.position_y}px;
+                                 width:${stool.width}px; height:${stool.height}px;
+                                 transform:rotate(${stool.rotation ?? 0}deg);
+                                 transform-origin:center;
+                                 z-index:10;`"
+                        :aria-label="`Taburete: ${stool.name}`"
+                    >
+                        <div class="w-full h-full relative flex items-center justify-center
+                                    rounded-full
+                                    bg-amber-100 dark:bg-amber-900/40
+                                    border-2 border-amber-400 dark:border-amber-600
+                                    shadow-md cursor-grab active:cursor-grabbing
+                                    transition-shadow hover:shadow-lg"
+                             @mousedown.prevent="startElementDrag($event, stool)">
+
+                            <span class="text-xs font-semibold text-amber-800 dark:text-amber-300
+                                         text-center px-1 leading-tight pointer-events-none"
+                                  x-text="stool.name">
+                            </span>
+
+                            <span class="absolute top-1 left-1 text-xs text-amber-600 dark:text-amber-400 pointer-events-none leading-none">●</span>
+
+                            {{-- Botón editar nombre --}}
+                            <button type="button"
+                                    @mousedown.stop
+                                    @click.stop="editingTableId = editingTableId === stool.id ? null : stool.id"
+                                    class="absolute -top-2.5 -right-9
+                                           w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
+                                           flex items-center justify-center
+                                           opacity-0 group-hover:opacity-100 transition-opacity
+                                           hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-400
+                                           shadow-md"
+                                    :aria-label="`Editar ${stool.name}`"
+                                    :aria-expanded="editingTableId === stool.id">
+                                <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z"/>
+                                </svg>
+                            </button>
+
+                            {{-- Botón eliminar --}}
+                            <button type="button"
+                                    @mousedown.stop
+                                    @click.stop="deleteElement(stool)"
+                                    class="absolute -top-2.5 -right-2.5
+                                           w-6 h-6 rounded-full bg-red-500 text-white
+                                           flex items-center justify-center
+                                           opacity-0 group-hover:opacity-100 transition-opacity
+                                           hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400
+                                           shadow-md"
+                                    :aria-label="`Eliminar ${stool.name}`">
+                                <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                                </svg>
+                            </button>
+
+                            {{-- Panel de edición de nombre --}}
+                            <div x-show="editingTableId === stool.id"
+                                 x-transition:enter="transition ease-out duration-150"
+                                 x-transition:enter-start="opacity-0 scale-95"
+                                 x-transition:enter-end="opacity-100 scale-100"
+                                 @click.stop
+                                 class="absolute top-7 right-0 z-20
+                                        bg-white dark:bg-gray-800 rounded-xl shadow-xl
+                                        border border-gray-200 dark:border-gray-700
+                                        p-3 min-w-max"
+                                 role="dialog"
+                                 :aria-label="`Editar ${stool.name}`">
+                                <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Nombre</p>
+                                <div class="flex gap-1">
+                                    <input type="text"
+                                           :value="stool.name"
+                                           @keydown.enter.stop="updateName(stool, $event.target.value); $event.target.blur()"
+                                           @blur.stop="updateName(stool, $event.target.value)"
+                                           @click.stop
+                                           maxlength="50"
+                                           class="w-full rounded-lg border border-gray-300 dark:border-gray-600
+                                                  bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                                                  px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+                                           :aria-label="`Nombre de ${stool.name}`">
+                                </div>
+                            </div>
+                        </div>
+
+                        {{-- Handle de rotación --}}
+                        <div class="rotation-handle absolute -top-9 left-1/2 -translate-x-1/2
+                                    flex flex-col items-center gap-0
+                                    opacity-0 group-hover:opacity-100 transition-opacity z-10"
+                             @mousedown.stop.prevent="startRotation($event, stool)"
+                             @mouseenter.stop="rotTooltip = { show: true, x: $event.clientX, y: $event.clientY, deg: stool.rotation ?? 0 }"
+                             @mousemove.stop="rotTooltip.x = $event.clientX; rotTooltip.y = $event.clientY; rotTooltip.deg = stool.rotation ?? 0"
+                             @mouseleave.stop="if (!isRotating) rotTooltip.show = false"
+                             role="button"
+                             tabindex="0"
+                             style="cursor: url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2720%27 height=%2720%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3C/svg%3E') 10 10, grab;"
+                             :aria-label="`Rotar ${stool.name} (arrastra para girar)`">
+                            <div class="w-6 h-6 rounded-full
+                                        bg-white dark:bg-gray-800
+                                        border-2 border-amber-400 shadow-md
+                                        flex items-center justify-center text-amber-500
+                                        transition-all duration-150
+                                        hover:bg-amber-500 hover:border-amber-600 hover:text-white hover:scale-110">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"/>
+                                </svg>
+                            </div>
+                            <div class="w-px h-3 bg-amber-400"></div>
+                        </div>
+
+                        {{-- Handle de redimensionado --}}
+                        <div class="resize-handle absolute bottom-0 right-0
+                                    w-4 h-4 cursor-se-resize opacity-0 group-hover:opacity-100
+                                    transition-opacity"
+                             @mousedown.stop.prevent="startResize($event, stool)"
+                             role="button"
+                             :aria-label="`Redimensionar ${stool.name}`">
                             <svg aria-hidden="true" viewBox="0 0 10 10" fill="none" class="w-full h-full text-amber-400">
                                 <path d="M9 1L1 9M9 5L5 9M9 9H9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
                             </svg>

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -301,7 +301,7 @@
                              x-transition:enter-start="opacity-0"
                              x-transition:enter-end="opacity-100"
                              @click.stop
-                             @click.outside="editingZoneId = null"
+                             @click.outside="if (!isRotating) editingZoneId = null"
                              class="absolute top-7 right-0 z-30
                                     bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                     border border-gray-200 dark:border-gray-700
@@ -441,7 +441,7 @@
                                  x-transition:enter-start="opacity-0"
                                  x-transition:enter-end="opacity-100"
                                  @click.stop
-                                 @click.outside="editingTableId = null"
+                                 @click.outside="if (!isRotating) editingTableId = null"
                                  class="absolute top-7 right-0 z-20
                                         bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                         border border-gray-200 dark:border-gray-700
@@ -570,7 +570,7 @@
                                  x-transition:enter-start="opacity-0"
                                  x-transition:enter-end="opacity-100"
                                  @click.stop
-                                 @click.outside="editingTableId = null"
+                                 @click.outside="if (!isRotating) editingTableId = null"
                                  class="absolute top-7 right-0 z-20
                                         bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                         border border-gray-200 dark:border-gray-700
@@ -721,7 +721,7 @@
                                  x-transition:enter-start="opacity-0"
                                  x-transition:enter-end="opacity-100"
                                  @click.stop
-                                 @click.outside="editingTableId = null"
+                                 @click.outside="if (!isRotating) editingTableId = null"
                                  class="absolute top-7 right-0 z-20
                                         bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                         border border-gray-200 dark:border-gray-700
@@ -1261,7 +1261,8 @@ document.addEventListener('alpine:init', () => {
             const onUp = async () => {
                 document.removeEventListener('mousemove', onMove);
                 document.removeEventListener('mouseup',   onUp);
-                this.isRotating            = false;
+                // Defer so the click event (fired after mouseup) sees isRotating = true
+                setTimeout(() => { this.isRotating = false; }, 0);
                 this.rotTooltip.show       = false;
                 document.body.style.cursor = '';
                 await this.persistZoneRotation(zone.id, zone.rotation ?? 0);
@@ -1874,7 +1875,8 @@ document.addEventListener('alpine:init', () => {
             const onUp = async () => {
                 document.removeEventListener('mousemove', onMove);
                 document.removeEventListener('mouseup',   onUp);
-                this.isRotating            = false;
+                // Defer so the click event (fired after mouseup) sees isRotating = true
+                setTimeout(() => { this.isRotating = false; }, 0);
                 this.rotTooltip.show       = false;
                 document.body.style.cursor = '';
                 await this.persistPosition(table.id, table.position_x, table.position_y, table.width, table.height);

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -351,7 +351,7 @@
                 <template x-for="element in elements" :key="'e'+element.id">
                     <div
                         :data-table-id="element.id"
-                        class="table-item absolute group select-none touch-none"
+                        class="element-item absolute group select-none touch-none"
                         :style="`left:${element.position_x}px; top:${element.position_y}px;
                                  width:${element.width}px; height:${element.height}px;
                                  transform:rotate(${element.rotation ?? 0}deg);
@@ -367,7 +367,8 @@
                              :class="{
                                 'rounded-full': element.shape === 'stool',
                                 'rounded-lg':   element.shape === 'bar',
-                             }">
+                             }"
+                             @mousedown.prevent="startElementDrag($event, element)">
 
                             <span class="text-xs font-semibold text-amber-800 dark:text-amber-300
                                          text-center px-1 leading-tight pointer-events-none"
@@ -381,6 +382,7 @@
 
                             {{-- Botón editar nombre --}}
                             <button type="button"
+                                    @mousedown.stop
                                     @click.stop="editingTableId = editingTableId === element.id ? null : element.id"
                                     class="absolute -top-2.5 -right-9
                                            w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
@@ -397,6 +399,7 @@
 
                             {{-- Botón eliminar --}}
                             <button type="button"
+                                    @mousedown.stop
                                     @click.stop="deleteElement(element)"
                                     class="absolute -top-2.5 -right-2.5
                                            w-6 h-6 rounded-full bg-red-500 text-white
@@ -1070,6 +1073,33 @@ document.addEventListener('alpine:init', () => {
                 document.removeEventListener('mouseup',   onUp);
                 document.body.style.cursor = '';
                 await this.persistZonePosition(zone.id, zone.position_x, zone.position_y);
+            };
+
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup',   onUp);
+        },
+
+        // ── Drag nativo de elemento especial (barra/taburete) ────────────────
+        startElementDrag(event, element) {
+            const startMX = event.clientX;
+            const startMY = event.clientY;
+            const startPx = element.position_x;
+            const startPy = element.position_y;
+
+            document.body.style.cursor = 'grabbing';
+
+            const onMove = (e) => {
+                const maxX = this.floorWidth  - element.width;
+                const maxY = this.floorHeight - element.height;
+                element.position_x = Math.max(0, Math.min(maxX, Math.round(startPx + (e.clientX - startMX))));
+                element.position_y = Math.max(0, Math.min(maxY, Math.round(startPy + (e.clientY - startMY))));
+            };
+
+            const onUp = async () => {
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup',   onUp);
+                document.body.style.cursor = '';
+                await this.persistPosition(element.id, element.position_x, element.position_y, element.width, element.height);
             };
 
             document.addEventListener('mousemove', onMove);

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1053,7 +1053,6 @@ document.addEventListener('alpine:init', () => {
         // ── Drag nativo de zona: actualiza zone.position_x/y reactivamente ───
         startZoneDrag(event, zone) {
             const canvasEl  = this.$refs.canvas;
-            const canvasRect = canvasEl.getBoundingClientRect();
             const startMX   = event.clientX;
             const startMY   = event.clientY;
             const startPx   = zone.position_x;
@@ -1062,8 +1061,8 @@ document.addEventListener('alpine:init', () => {
             document.body.style.cursor = 'grabbing';
 
             const onMove = (e) => {
-                const maxX = this.floorWidth  - zone.width;
-                const maxY = this.floorHeight - zone.height;
+                const maxX = canvasEl.offsetWidth  - zone.width;
+                const maxY = canvasEl.offsetHeight - zone.height;
                 zone.position_x = Math.max(0, Math.min(maxX, Math.round(startPx + (e.clientX - startMX))));
                 zone.position_y = Math.max(0, Math.min(maxY, Math.round(startPy + (e.clientY - startMY))));
             };
@@ -1081,16 +1080,17 @@ document.addEventListener('alpine:init', () => {
 
         // ── Drag nativo de elemento especial (barra/taburete) ────────────────
         startElementDrag(event, element) {
-            const startMX = event.clientX;
-            const startMY = event.clientY;
-            const startPx = element.position_x;
-            const startPy = element.position_y;
+            const canvasEl  = this.$refs.canvas;
+            const startMX   = event.clientX;
+            const startMY   = event.clientY;
+            const startPx   = element.position_x;
+            const startPy   = element.position_y;
 
             document.body.style.cursor = 'grabbing';
 
             const onMove = (e) => {
-                const maxX = this.floorWidth  - element.width;
-                const maxY = this.floorHeight - element.height;
+                const maxX = canvasEl.offsetWidth  - element.width;
+                const maxY = canvasEl.offsetHeight - element.height;
                 element.position_x = Math.max(0, Math.min(maxX, Math.round(startPx + (e.clientX - startMX))));
                 element.position_y = Math.max(0, Math.min(maxY, Math.round(startPy + (e.clientY - startMY))));
             };

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1142,15 +1142,15 @@ document.addEventListener('alpine:init', () => {
                             const id   = parseInt(el.dataset.tableId);
                             const item = this.tables.find(t => t.id === id) ?? this.elements.find(e => e.id === id);
                             if (item) {
-                                item.position_x = Math.max(0, Math.round(x));
-                                item.position_y = Math.max(0, Math.round(y));
+                                item.position_x = Math.round(x);
+                                item.position_y = Math.round(y);
                             }
                         },
                         end: (event) => {
                             const el  = event.target;
                             const id  = parseInt(el.dataset.tableId);
-                            const x   = Math.max(0, Math.round(parseFloat(el.style.left) || 0));
-                            const y   = Math.max(0, Math.round(parseFloat(el.style.top)  || 0));
+                            const x   = Math.round(parseFloat(el.style.left) || 0);
+                            const y   = Math.round(parseFloat(el.style.top)  || 0);
                             const w   = Math.round(parseFloat(el.style.width)  || 100);
                             const h   = Math.round(parseFloat(el.style.height) || 100);
                             this.persistPosition(id, x, y, w, h);

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -351,7 +351,7 @@
                 <template x-for="element in elements" :key="'e'+element.id">
                     <div
                         :data-table-id="element.id"
-                        :class="`${element.shape === 'bar' ? 'table-item' : 'element-item'} absolute group select-none touch-none`"
+                        class="element-item absolute group select-none touch-none"
                         :style="`left:${element.position_x}px; top:${element.position_y}px;
                                  width:${element.width}px; height:${element.height}px;
                                  transform:rotate(${element.rotation ?? 0}deg);
@@ -368,7 +368,7 @@
                                 'rounded-full': element.shape === 'stool',
                                 'rounded-lg':   element.shape === 'bar',
                              }"
-                             @mousedown="element.shape !== 'bar' && ($event.preventDefault() || startElementDrag($event, element))">
+                             @mousedown.prevent="startElementDrag($event, element)">
 
                             <span class="text-xs font-semibold text-amber-800 dark:text-amber-300
                                          text-center px-1 leading-tight pointer-events-none"
@@ -1078,17 +1078,10 @@ document.addEventListener('alpine:init', () => {
 
         // ── Drag nativo de elemento especial (barra/taburete) ────────────────
         startElementDrag(event, element) {
-            const canvasEl  = this.$refs.canvas;
-
-            // Leer posición real del DOM para evitar valor obsoleto del estado Alpine
-            const outerEl   = canvasEl.querySelector(`[data-table-id="${element.id}"]`);
-            const startPx   = outerEl ? (parseFloat(outerEl.style.left) || 0) : element.position_x;
-            const startPy   = outerEl ? (parseFloat(outerEl.style.top)  || 0) : element.position_y;
-            element.position_x = startPx;
-            element.position_y = startPy;
-
-            const startMX   = event.clientX;
-            const startMY   = event.clientY;
+            const startPx = element.position_x;
+            const startPy = element.position_y;
+            const startMX = event.clientX;
+            const startMY = event.clientY;
 
             document.body.style.cursor = 'grabbing';
 

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -368,7 +368,7 @@
                                 'rounded-full': element.shape === 'stool',
                                 'rounded-lg':   element.shape === 'bar',
                              }"
-                             @mousedown.prevent="element.shape !== 'bar' && startElementDrag($event, element)">
+                             @mousedown="element.shape !== 'bar' && ($event.preventDefault() || startElementDrag($event, element))">
 
                             <span class="text-xs font-semibold text-amber-800 dark:text-amber-300
                                          text-center px-1 leading-tight pointer-events-none"

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1,6 +1,6 @@
 {{--
- | Bloques 8.1 y 8.3 — Mapa visual de mesas con drag & drop y formas configurables
- | interact.js para arrastrar/redimensionar mesas en el plano del restaurante.
+ | Bloques 8.1, 8.3 y 8.4 — Mapa visual del local con zonas, elementos especiales y mesas.
+ | interact.js para arrastrar/redimensionar mesas, elementos especiales y zonas.
  | @author AyrtonAlania
 --}}
 <x-app-layout>
@@ -8,6 +8,7 @@
     class="flex flex-col h-screen bg-gray-100 dark:bg-gray-900"
     x-data="tableMap()"
     x-init="init()"
+    @mouseup.window="if(isRotating||isRotatingZone){}"
 >
 
     {{-- ══════════════════════════════════════════════════════
@@ -139,6 +140,72 @@
 
             <hr class="border-gray-200 dark:border-gray-700">
 
+            {{-- Elementos especiales --}}
+            <p class="text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">
+                Especiales
+            </p>
+
+            {{-- Barra del bar --}}
+            <div class="special-item group flex flex-col items-center gap-2 select-none cursor-grab active:cursor-grabbing transition-opacity"
+                 data-shape="bar" data-width="200" data-height="60"
+                 title="Arrastrar al plano (no genera QR)">
+                <div class="w-14 h-7 rounded border-2 border-dashed border-amber-700
+                            bg-amber-100 dark:bg-amber-900/30
+                            group-hover:border-amber-800 group-hover:bg-amber-200 transition-colors
+                            flex items-center justify-center">
+                    <svg aria-hidden="true" class="w-5 h-3 text-amber-700" fill="currentColor" viewBox="0 0 24 12">
+                        <rect x="0" y="0" width="24" height="12" rx="2"/>
+                    </svg>
+                </div>
+                <span class="text-xs font-medium text-gray-600 dark:text-gray-300">Barra</span>
+            </div>
+
+            {{-- Taburete --}}
+            <div class="special-item group flex flex-col items-center gap-2 select-none cursor-grab active:cursor-grabbing transition-opacity"
+                 data-shape="stool" data-width="50" data-height="50"
+                 title="Arrastrar al plano (no genera QR)">
+                <div class="w-10 h-10 rounded-full border-2 border-dashed border-amber-600
+                            bg-amber-50 dark:bg-amber-900/30
+                            group-hover:border-amber-700 group-hover:bg-amber-100 transition-colors
+                            flex items-center justify-center">
+                    <svg aria-hidden="true" class="w-5 h-5 text-amber-600" fill="currentColor" viewBox="0 0 24 24">
+                        <circle cx="12" cy="12" r="6"/>
+                    </svg>
+                </div>
+                <span class="text-xs font-medium text-gray-600 dark:text-gray-300">Taburete</span>
+            </div>
+
+            <hr class="border-gray-200 dark:border-gray-700">
+
+            {{-- Zonas --}}
+            <p class="text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">
+                Zonas
+            </p>
+
+            <div class="flex items-center gap-2">
+                <label for="zone-color-picker" class="text-xs text-gray-500 dark:text-gray-400">Color</label>
+                <input id="zone-color-picker"
+                       type="color"
+                       x-model="zoneColor"
+                       class="w-8 h-8 rounded cursor-pointer border border-gray-200 dark:border-gray-600 p-0.5"
+                       aria-label="Color de la nueva zona">
+            </div>
+
+            <div class="zone-palette-item group flex flex-col items-center gap-2 select-none cursor-grab active:cursor-grabbing"
+                 data-width="300" data-height="200"
+                 title="Arrastrar al plano para crear una zona">
+                <div class="w-14 h-9 rounded border-2 border-dashed flex items-center justify-center transition-colors"
+                     :style="`border-color: ${zoneColor}; background-color: ${zoneColor}22;`">
+                    <svg aria-hidden="true" class="w-6 h-4" :style="`color: ${zoneColor}`" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <rect x="3" y="3" width="18" height="18" rx="2"/>
+                        <line x1="3" y1="12" x2="21" y2="12" stroke-dasharray="3 2"/>
+                    </svg>
+                </div>
+                <span class="text-xs font-medium text-gray-600 dark:text-gray-300">Zona</span>
+            </div>
+
+            <hr class="border-gray-200 dark:border-gray-700">
+
             <p class="text-xs text-gray-400 dark:text-gray-500 leading-relaxed">
                 Arrastra una forma al plano para crear una mesa. Mueve y redimensiona desde los bordes.
             </p>
@@ -156,9 +223,9 @@
                 x-ref="canvas"
                 class="relative bg-white dark:bg-gray-800 rounded-xl shadow-inner
                        border-2 border-dashed border-gray-200 dark:border-gray-700"
-                style="width: 1200px; height: 800px; min-width: 100%;"
+                :style="`width:${floorWidth}px; height:${floorHeight}px; min-width:100%;`"
                 aria-label="Plano del restaurante"
-                @click="editingTableId = null"
+                @click="editingTableId = null; editingZoneId = null"
             >
                 {{-- Cuadrícula decorativa --}}
                 <svg class="absolute inset-0 w-full h-full pointer-events-none opacity-30 dark:opacity-10"
@@ -170,6 +237,236 @@
                     </defs>
                     <rect width="100%" height="100%" fill="url(#grid)"/>
                 </svg>
+
+                {{-- Zonas (capa de fondo, z-index 5) --}}
+                <template x-for="zone in zones" :key="'z'+zone.id">
+                    <div
+                        :data-zone-id="zone.id"
+                        class="zone-item absolute group select-none touch-none"
+                        :style="`
+                            left:${zone.position_x}px;
+                            top:${zone.position_y}px;
+                            width:${zone.width}px;
+                            height:${zone.height}px;
+                            background-color:${zone.color}22;
+                            border:2px solid ${zone.color};
+                            z-index:5;
+                            pointer-events:all;
+                        `"
+                        :aria-label="`Zona ${zone.name}`"
+                    >
+                        {{-- Etiqueta de zona --}}
+                        <span class="absolute bottom-1 left-1 text-xs font-semibold px-1.5 py-0.5 rounded pointer-events-none"
+                              :style="`color:${zone.color}; background:rgba(255,255,255,0.85);`"
+                              x-text="zone.name">
+                        </span>
+
+                        {{-- Botón editar zona --}}
+                        <button type="button"
+                                @click.stop="editingZoneId = editingZoneId === zone.id ? null : zone.id"
+                                class="absolute -top-2.5 -right-16
+                                       w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
+                                       flex items-center justify-center
+                                       opacity-0 group-hover:opacity-100 transition-opacity
+                                       hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-400
+                                       shadow-md"
+                                :aria-label="`Editar zona ${zone.name}`"
+                                :aria-expanded="editingZoneId === zone.id">
+                            <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z"/>
+                            </svg>
+                        </button>
+
+                        {{-- Botón eliminar zona --}}
+                        <button type="button"
+                                @click.stop="deleteZone(zone)"
+                                class="absolute -top-2.5 -right-2.5
+                                       w-6 h-6 rounded-full bg-red-500 text-white
+                                       flex items-center justify-center
+                                       opacity-0 group-hover:opacity-100 transition-opacity
+                                       hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400
+                                       shadow-md"
+                                :aria-label="`Eliminar zona ${zone.name}`">
+                            <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                            </svg>
+                        </button>
+
+                        {{-- Panel de edición de zona --}}
+                        <div x-show="editingZoneId === zone.id"
+                             x-transition:enter="transition ease-out duration-150"
+                             x-transition:enter-start="opacity-0 scale-95"
+                             x-transition:enter-end="opacity-100 scale-100"
+                             @click.stop
+                             class="absolute top-7 right-0 z-30
+                                    bg-white dark:bg-gray-800 rounded-xl shadow-xl
+                                    border border-gray-200 dark:border-gray-700
+                                    p-3 min-w-max"
+                             role="dialog"
+                             :aria-label="`Editar zona ${zone.name}`">
+
+                            <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Nombre</p>
+                            <div class="flex gap-1 mb-3">
+                                <input type="text"
+                                       :value="zone.name"
+                                       @keydown.enter.stop="updateZoneName(zone, $event.target.value); $event.target.blur()"
+                                       @blur.stop="updateZoneName(zone, $event.target.value)"
+                                       @click.stop
+                                       maxlength="50"
+                                       class="w-full rounded-lg border border-gray-300 dark:border-gray-600
+                                              bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                                              px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                       :aria-label="`Nombre de la zona ${zone.name}`">
+                            </div>
+
+                            <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Color</p>
+                            <div class="flex items-center gap-2 mb-2">
+                                <input type="color"
+                                       :value="zone.color"
+                                       @change.stop="updateZoneColor(zone, $event.target.value)"
+                                       @click.stop
+                                       class="w-8 h-8 rounded cursor-pointer border border-gray-200 p-0.5"
+                                       :aria-label="`Color de la zona ${zone.name}`">
+                                <span class="text-xs text-gray-500 font-mono" x-text="zone.color"></span>
+                            </div>
+                        </div>
+
+                        {{-- Handle de redimensionado de zona --}}
+                        <div class="zone-resize-handle absolute bottom-0 right-0
+                                    w-4 h-4 cursor-se-resize opacity-0 group-hover:opacity-100
+                                    transition-opacity"
+                             @mousedown.stop.prevent="startZoneResize($event, zone)"
+                             role="button"
+                             :aria-label="`Redimensionar zona ${zone.name}`">
+                            <svg aria-hidden="true" viewBox="0 0 10 10" fill="none" class="w-full h-full" :style="`color:${zone.color}`">
+                                <path d="M9 1L1 9M9 5L5 9M9 9H9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                            </svg>
+                        </div>
+                    </div>
+                </template>
+
+                {{-- Elementos especiales: barra y taburetes (z-index 10, sin QR) --}}
+                <template x-for="element in elements" :key="'e'+element.id">
+                    <div
+                        :data-table-id="element.id"
+                        class="table-item absolute group select-none touch-none"
+                        :style="`left:${element.position_x}px; top:${element.position_y}px;
+                                 width:${element.width}px; height:${element.height}px;
+                                 transform:rotate(${element.rotation ?? 0}deg);
+                                 transform-origin:center;
+                                 z-index:10;`"
+                        :aria-label="element.shape === 'bar' ? `Barra: ${element.name}` : `Taburete: ${element.name}`"
+                    >
+                        <div class="w-full h-full relative flex items-center justify-center
+                                    bg-amber-100 dark:bg-amber-900/40
+                                    border-2 border-amber-400 dark:border-amber-600
+                                    shadow-md cursor-grab active:cursor-grabbing
+                                    transition-shadow hover:shadow-lg"
+                             :class="{
+                                'rounded-full': element.shape === 'stool',
+                                'rounded-lg':   element.shape === 'bar',
+                             }">
+
+                            <span class="text-xs font-semibold text-amber-800 dark:text-amber-300
+                                         text-center px-1 leading-tight pointer-events-none"
+                                  x-text="element.name">
+                            </span>
+
+                            {{-- Badge tipo --}}
+                            <span class="absolute top-1 left-1 text-xs text-amber-600 dark:text-amber-400 pointer-events-none leading-none"
+                                  x-text="element.shape === 'bar' ? '🍺' : '●'">
+                            </span>
+
+                            {{-- Botón editar nombre --}}
+                            <button type="button"
+                                    @click.stop="editingTableId = editingTableId === element.id ? null : element.id"
+                                    class="absolute -top-2.5 -right-9
+                                           w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
+                                           flex items-center justify-center
+                                           opacity-0 group-hover:opacity-100 transition-opacity
+                                           hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-400
+                                           shadow-md"
+                                    :aria-label="`Editar ${element.name}`"
+                                    :aria-expanded="editingTableId === element.id">
+                                <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z"/>
+                                </svg>
+                            </button>
+
+                            {{-- Botón eliminar --}}
+                            <button type="button"
+                                    @click.stop="deleteElement(element)"
+                                    class="absolute -top-2.5 -right-2.5
+                                           w-6 h-6 rounded-full bg-red-500 text-white
+                                           flex items-center justify-center
+                                           opacity-0 group-hover:opacity-100 transition-opacity
+                                           hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400
+                                           shadow-md"
+                                    :aria-label="`Eliminar ${element.name}`">
+                                <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                                </svg>
+                            </button>
+
+                            {{-- Panel de edición de nombre --}}
+                            <div x-show="editingTableId === element.id"
+                                 x-transition:enter="transition ease-out duration-150"
+                                 x-transition:enter-start="opacity-0 scale-95"
+                                 x-transition:enter-end="opacity-100 scale-100"
+                                 @click.stop
+                                 class="absolute top-7 right-0 z-20
+                                        bg-white dark:bg-gray-800 rounded-xl shadow-xl
+                                        border border-gray-200 dark:border-gray-700
+                                        p-3 min-w-max"
+                                 role="dialog"
+                                 :aria-label="`Editar ${element.name}`">
+
+                                <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Nombre</p>
+                                <div class="flex gap-1">
+                                    <input type="text"
+                                           :value="element.name"
+                                           @keydown.enter.stop="updateName(element, $event.target.value); $event.target.blur()"
+                                           @blur.stop="updateName(element, $event.target.value)"
+                                           @click.stop
+                                           maxlength="50"
+                                           class="w-full rounded-lg border border-gray-300 dark:border-gray-600
+                                                  bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                                                  px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500"
+                                           :aria-label="`Nombre de ${element.name}`">
+                                </div>
+                            </div>
+                        </div>
+
+                        {{-- Handle de rotación para elementos especiales --}}
+                        <div class="rotation-handle absolute -top-9 left-1/2 -translate-x-1/2
+                                    flex flex-col items-center gap-0
+                                    opacity-0 group-hover:opacity-100 transition-opacity z-10"
+                             @mousedown.stop.prevent="startRotation($event, element)"
+                             role="button"
+                             tabindex="0"
+                             style="cursor:grab;"
+                             :aria-label="`Rotar ${element.name}`">
+                            <div class="w-5 h-5 rounded-full bg-white dark:bg-gray-800 border-2 border-amber-400 shadow-md flex items-center justify-center text-amber-500">
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"/>
+                                </svg>
+                            </div>
+                            <div class="w-px h-3 bg-amber-400"></div>
+                        </div>
+
+                        {{-- Handle de redimensionado --}}
+                        <div class="resize-handle absolute bottom-0 right-0
+                                    w-4 h-4 cursor-se-resize opacity-0 group-hover:opacity-100
+                                    transition-opacity"
+                             @mousedown.stop.prevent="startResize($event, element)"
+                             role="button"
+                             :aria-label="`Redimensionar ${element.name}`">
+                            <svg aria-hidden="true" viewBox="0 0 10 10" fill="none" class="w-full h-full text-amber-400">
+                                <path d="M9 1L1 9M9 5L5 9M9 9H9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                            </svg>
+                        </div>
+                    </div>
+                </template>
 
                 {{-- Mesas existentes --}}
                 <template x-for="table in tables" :key="table.id">
@@ -659,15 +956,24 @@ document.addEventListener('alpine:init', () => {
     // ── Componente principal del mapa ─────────────────────────────────────────
     Alpine.data('tableMap', () => ({
         tables:                @json($tables),
+        elements:              @json($elements),
+        zones:                 @json($zones),
+        floorWidth:            {{ $floorWidth }},
+        floorHeight:           {{ $floorHeight }},
         isDraggingFromPalette: false,
+        isDraggingZone:        false,
         editingTableId:        null,
+        editingZoneId:         null,
         isRotating:            false,
+        isRotatingZone:        false,
+        zoneColor:             '#6366f1',
         toast:                 { show: false, msg: '', error: false, _timer: null },
         rotTooltip:            { show: false, x: 0, y: 0, deg: 0 },
 
         init() {
             this.$nextTick(() => {
                 this.initTableInteract();
+                this.initZoneInteract();
                 this.initPaletteInteract();
             });
         },
@@ -721,7 +1027,45 @@ document.addEventListener('alpine:init', () => {
             this.$nextTick(() => this.initTableInteract());
         },
 
-        // ── Paleta: drag-to-create ────────────────────────────────────────────
+        // ── Interactividad de zonas (drag para mover) ─────────────────────────
+        initZoneInteract() {
+            interact('.zone-item').unset();
+
+            interact('.zone-item')
+                .draggable({
+                    ignoreFrom:  '.zone-resize-handle',
+                    inertia:    false,
+                    autoScroll: true,
+                    modifiers: [
+                        interact.modifiers.restrictRect({
+                            restriction: this.$refs.canvas,
+                            endOnly:     false,
+                        }),
+                    ],
+                    listeners: {
+                        move: (event) => {
+                            const el = event.target;
+                            const x  = (parseFloat(el.style.left) || 0) + event.dx;
+                            const y  = (parseFloat(el.style.top)  || 0) + event.dy;
+                            el.style.left = `${x}px`;
+                            el.style.top  = `${y}px`;
+                        },
+                        end: (event) => {
+                            const el  = event.target;
+                            const id  = parseInt(el.dataset.zoneId);
+                            const x   = Math.round(parseFloat(el.style.left) || 0);
+                            const y   = Math.round(parseFloat(el.style.top)  || 0);
+                            this.persistZonePosition(id, x, y);
+                        },
+                    },
+                });
+        },
+
+        reinitZoneInteract() {
+            this.$nextTick(() => this.initZoneInteract());
+        },
+
+        // ── Paleta: drag-to-create (mesas, especiales y zonas) ────────────────
         initPaletteInteract() {
             const ghost     = document.getElementById('palette-ghost');
             const canvasEl  = this.$refs.canvas;
@@ -789,6 +1133,103 @@ document.addEventListener('alpine:init', () => {
                     },
                 },
             });
+
+            // ── Paleta de elementos especiales (barra, taburete) ─────────────
+            interact('.special-item').draggable({
+                inertia: false,
+                listeners: {
+                    start: (event) => {
+                        const shape = event.target.dataset.shape;
+                        const dropW = parseInt(event.target.dataset.width)  || 80;
+                        const dropH = parseInt(event.target.dataset.height) || 50;
+
+                        ghost.style.width        = `${dropW}px`;
+                        ghost.style.height       = `${dropH}px`;
+                        ghost.style.borderRadius = shape === 'stool' ? '9999px' : '8px';
+                        ghost.style.borderColor  = '#d97706';
+                        ghost.style.background   = 'rgba(251,191,36,0.3)';
+                        ghost.classList.remove('hidden');
+                        ghost.classList.add('flex');
+                        this.isDraggingFromPalette = true;
+                    },
+                    move: (event) => {
+                        const w = parseInt(event.target.dataset.width)  || 80;
+                        const h = parseInt(event.target.dataset.height) || 50;
+                        ghost.style.left = `${event.clientX - w / 2}px`;
+                        ghost.style.top  = `${event.clientY - h / 2}px`;
+                        const rect = canvasEl.getBoundingClientRect();
+                        dropX = Math.max(0, Math.round(event.clientX - rect.left - w / 2));
+                        dropY = Math.max(0, Math.round(event.clientY - rect.top  - h / 2));
+                        dropShape = event.target.dataset.shape;
+                        dropW     = w;
+                        dropH     = h;
+                    },
+                    end: async (event) => {
+                        ghost.classList.add('hidden');
+                        ghost.classList.remove('flex');
+                        ghost.style.borderColor = '';
+                        ghost.style.background  = '';
+                        this.isDraggingFromPalette = false;
+
+                        const rect = canvasEl.getBoundingClientRect();
+                        const over = event.clientX >= rect.left && event.clientX <= rect.right &&
+                                     event.clientY >= rect.top  && event.clientY <= rect.bottom;
+                        if (!over) return;
+
+                        const name = await Alpine.store('tableModal').prompt();
+                        if (!name) return;
+
+                        await this.createSpecialElement(name, dropShape, dropX, dropY, dropW, dropH);
+                    },
+                },
+            });
+
+            // ── Paleta de zonas ───────────────────────────────────────────────
+            interact('.zone-palette-item').draggable({
+                inertia: false,
+                listeners: {
+                    start: (event) => {
+                        const w = parseInt(event.target.dataset.width)  || 300;
+                        const h = parseInt(event.target.dataset.height) || 200;
+                        ghost.style.width        = `${w}px`;
+                        ghost.style.height       = `${h}px`;
+                        ghost.style.borderRadius = '8px';
+                        ghost.style.borderColor  = this.zoneColor;
+                        ghost.style.background   = this.zoneColor + '33';
+                        ghost.classList.remove('hidden');
+                        ghost.classList.add('flex');
+                        this.isDraggingZone = true;
+                    },
+                    move: (event) => {
+                        const w = parseInt(event.target.dataset.width)  || 300;
+                        const h = parseInt(event.target.dataset.height) || 200;
+                        ghost.style.left = `${event.clientX - w / 2}px`;
+                        ghost.style.top  = `${event.clientY - h / 2}px`;
+                        const rect = canvasEl.getBoundingClientRect();
+                        dropX = Math.max(0, Math.round(event.clientX - rect.left - w / 2));
+                        dropY = Math.max(0, Math.round(event.clientY - rect.top  - h / 2));
+                        dropW = w;
+                        dropH = h;
+                    },
+                    end: async (event) => {
+                        ghost.classList.add('hidden');
+                        ghost.classList.remove('flex');
+                        ghost.style.borderColor = '';
+                        ghost.style.background  = '';
+                        this.isDraggingZone = false;
+
+                        const rect = canvasEl.getBoundingClientRect();
+                        const over = event.clientX >= rect.left && event.clientX <= rect.right &&
+                                     event.clientY >= rect.top  && event.clientY <= rect.bottom;
+                        if (!over) return;
+
+                        const name = await Alpine.store('tableModal').prompt();
+                        if (!name) return;
+
+                        await this.createZone(name, this.zoneColor, dropX, dropY, dropW, dropH);
+                    },
+                },
+            });
         },
 
         // ── AJAX: crear mesa ──────────────────────────────────────────────────
@@ -804,10 +1245,11 @@ document.addEventListener('alpine:init', () => {
                     body: JSON.stringify({
                         name,
                         shape,
-                        position_x: x,
-                        position_y: y,
-                        width:      w,
-                        height:     h,
+                        position_x:       x,
+                        position_y:       y,
+                        width:            w,
+                        height:           h,
+                        is_service_point: true,
                     }),
                 });
 
@@ -823,6 +1265,198 @@ document.addEventListener('alpine:init', () => {
                 this.showToast(json.message);
             } catch {
                 this.showToast('Error de red al crear la mesa.', true);
+            }
+        },
+
+        // ── AJAX: crear elemento especial (barra, taburete) ──────────────────
+        async createSpecialElement(name, shape, x, y, w, h) {
+            try {
+                const res = await fetch('{{ route("tables.store") }}', {
+                    method:  'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                        'Accept':       'application/json',
+                    },
+                    body: JSON.stringify({
+                        name,
+                        shape,
+                        position_x:       x,
+                        position_y:       y,
+                        width:            w,
+                        height:           h,
+                        is_service_point: false,
+                    }),
+                });
+
+                const json = await res.json();
+
+                if (!res.ok || !json.success) {
+                    this.showToast(json.message ?? 'Error al crear el elemento.', true);
+                    return;
+                }
+
+                this.elements.push(json.data);
+                this.reinitInteract();
+                this.showToast(json.message);
+            } catch {
+                this.showToast('Error de red al crear el elemento.', true);
+            }
+        },
+
+        // ── AJAX: crear zona ──────────────────────────────────────────────────
+        async createZone(name, color, x, y, w, h) {
+            try {
+                const res = await fetch('{{ route("zones.store") }}', {
+                    method:  'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                        'Accept':       'application/json',
+                    },
+                    body: JSON.stringify({ name, color, position_x: x, position_y: y, width: w, height: h }),
+                });
+
+                const json = await res.json();
+
+                if (!res.ok || !json.success) {
+                    this.showToast(json.message ?? 'Error al crear la zona.', true);
+                    return;
+                }
+
+                this.zones.push(json.data);
+                this.reinitZoneInteract();
+                this.showToast(json.message);
+            } catch {
+                this.showToast('Error de red al crear la zona.', true);
+            }
+        },
+
+        // ── AJAX: actualizar nombre de zona ───────────────────────────────────
+        async updateZoneName(zone, name) {
+            name = name.trim();
+            if (!name || name === zone.name) return;
+            const prev = zone.name;
+            zone.name  = name;
+
+            try {
+                const res = await fetch(`/zonas/${zone.id}`, {
+                    method:  'PATCH',
+                    headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
+                    body: JSON.stringify({ name }),
+                });
+                const json = await res.json();
+                if (!res.ok || !json.success) { zone.name = prev; this.showToast(json.message ?? 'Error.', true); return; }
+                this.showToast(json.message);
+            } catch {
+                zone.name = prev;
+                this.showToast('Error de red.', true);
+            }
+        },
+
+        // ── AJAX: actualizar color de zona ────────────────────────────────────
+        async updateZoneColor(zone, color) {
+            const prev = zone.color;
+            zone.color = color;
+
+            try {
+                const res = await fetch(`/zonas/${zone.id}`, {
+                    method:  'PATCH',
+                    headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
+                    body: JSON.stringify({ color }),
+                });
+                const json = await res.json();
+                if (!res.ok || !json.success) { zone.color = prev; this.showToast(json.message ?? 'Error.', true); }
+            } catch {
+                zone.color = prev;
+                this.showToast('Error de red.', true);
+            }
+        },
+
+        // ── AJAX: persistir posición de zona ──────────────────────────────────
+        async persistZonePosition(id, x, y) {
+            const zone = this.zones.find(z => z.id === id);
+            if (zone) { zone.position_x = x; zone.position_y = y; }
+
+            try {
+                const res = await fetch(`/zonas/${id}`, {
+                    method:  'PATCH',
+                    headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
+                    body: JSON.stringify({ position_x: x, position_y: y, width: zone?.width ?? 300, height: zone?.height ?? 200 }),
+                });
+                if (!res.ok) this.showToast('Error al guardar la posición de la zona.', true);
+            } catch {
+                this.showToast('Error de red.', true);
+            }
+        },
+
+        // ── Resize de zona ────────────────────────────────────────────────────
+        startZoneResize(event, zone) {
+            const startMX = event.clientX;
+            const startMY = event.clientY;
+            const startW  = zone.width;
+            const startH  = zone.height;
+            document.body.style.cursor = 'se-resize';
+
+            const onMove = (e) => {
+                zone.width  = Math.min(2000, Math.max(80,  startW + (e.clientX - startMX)));
+                zone.height = Math.min(1500, Math.max(60,  startH + (e.clientY - startMY)));
+            };
+
+            const onUp = async () => {
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup',   onUp);
+                document.body.style.cursor = '';
+                try {
+                    await fetch(`/zonas/${zone.id}`, {
+                        method:  'PATCH',
+                        headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
+                        body: JSON.stringify({ position_x: zone.position_x, position_y: zone.position_y, width: zone.width, height: zone.height }),
+                    });
+                } catch {
+                    this.showToast('Error al guardar dimensiones.', true);
+                }
+            };
+
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup',   onUp);
+        },
+
+        // ── AJAX: eliminar zona ───────────────────────────────────────────────
+        async deleteZone(zone) {
+            const confirmed = await Alpine.store('deleteModal').prompt({ name: `Zona "${zone.name}"` });
+            if (!confirmed) return;
+
+            try {
+                const res = await fetch(`/zonas/${zone.id}`, {
+                    method:  'DELETE',
+                    headers: { 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
+                });
+                const json = await res.json();
+                if (!res.ok || !json.success) { this.showToast(json.message ?? 'Error al eliminar.', true); return; }
+                this.zones = this.zones.filter(z => z.id !== zone.id);
+                this.showToast(json.message);
+            } catch {
+                this.showToast('Error de red.', true);
+            }
+        },
+
+        // ── AJAX: eliminar elemento especial ──────────────────────────────────
+        async deleteElement(element) {
+            const confirmed = await Alpine.store('deleteModal').prompt(element);
+            if (!confirmed) return;
+
+            try {
+                const res = await fetch(`/mesas/${element.id}`, {
+                    method:  'DELETE',
+                    headers: { 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
+                });
+                const json = await res.json();
+                if (!res.ok || !json.success) { this.showToast(json.message ?? 'Error al eliminar.', true); return; }
+                this.elements = this.elements.filter(e => e.id !== element.id);
+                this.showToast(json.message);
+            } catch {
+                this.showToast('Error de red.', true);
             }
         },
 

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1490,8 +1490,8 @@ document.addEventListener('alpine:init', () => {
                 const localDX =  dx * cosθ + dy * sinθ;
                 const localDY = -dx * sinθ + dy * cosθ;
 
-                const newW = Math.min(400, Math.max(60, startW + localDX));
-                const newH = Math.min(400, Math.max(60, startH + localDY));
+                const newW = Math.min(800, Math.max(40, startW + localDX));
+                const newH = Math.min(800, Math.max(40, startH + localDY));
                 const dW   = newW - startW;
                 const dH   = newH - startH;
 
@@ -1515,12 +1515,12 @@ document.addEventListener('alpine:init', () => {
 
         // ── AJAX: persistir posición, dimensiones y rotación ─────────────────
         async persistPosition(id, x, y, w, h) {
-            const table = this.tables.find(t => t.id === id);
-            if (table) {
-                table.position_x = x;
-                table.position_y = y;
-                table.width      = w;
-                table.height     = h;
+            const item = this.tables.find(t => t.id === id) ?? this.elements.find(e => e.id === id);
+            if (item) {
+                item.position_x = x;
+                item.position_y = y;
+                item.width      = w;
+                item.height     = h;
             }
 
             try {
@@ -1536,7 +1536,7 @@ document.addEventListener('alpine:init', () => {
                         position_y: y,
                         width:      w,
                         height:     h,
-                        rotation:   table?.rotation ?? 0,
+                        rotation:   item?.rotation ?? 0,
                     }),
                 });
 

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -298,13 +298,14 @@
                         {{-- Panel de edición de zona --}}
                         <div x-show="editingZoneId === zone.id"
                              x-transition:enter="transition ease-out duration-150"
-                             x-transition:enter-start="opacity-0 scale-95"
-                             x-transition:enter-end="opacity-100 scale-100"
+                             x-transition:enter-start="opacity-0"
+                             x-transition:enter-end="opacity-100"
                              @click.stop
                              class="absolute top-7 right-0 z-30
                                     bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                     border border-gray-200 dark:border-gray-700
                                     p-3 min-w-max"
+                             :style="`transform:rotate(-${zone.rotation ?? 0}deg); transform-origin:top right;`"
                              role="dialog"
                              :aria-label="`Editar zona ${zone.name}`">
 
@@ -436,13 +437,14 @@
                             {{-- Panel de edición de nombre --}}
                             <div x-show="editingTableId === bar.id"
                                  x-transition:enter="transition ease-out duration-150"
-                                 x-transition:enter-start="opacity-0 scale-95"
-                                 x-transition:enter-end="opacity-100 scale-100"
+                                 x-transition:enter-start="opacity-0"
+                                 x-transition:enter-end="opacity-100"
                                  @click.stop
                                  class="absolute top-7 right-0 z-20
                                         bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                         border border-gray-200 dark:border-gray-700
                                         p-3 min-w-max"
+                                 :style="`transform:rotate(-${bar.rotation ?? 0}deg); transform-origin:top right;`"
                                  role="dialog"
                                  :aria-label="`Editar ${bar.name}`">
                                 <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Nombre</p>
@@ -563,13 +565,14 @@
                             {{-- Panel de edición de nombre --}}
                             <div x-show="editingTableId === stool.id"
                                  x-transition:enter="transition ease-out duration-150"
-                                 x-transition:enter-start="opacity-0 scale-95"
-                                 x-transition:enter-end="opacity-100 scale-100"
+                                 x-transition:enter-start="opacity-0"
+                                 x-transition:enter-end="opacity-100"
                                  @click.stop
                                  class="absolute top-7 right-0 z-20
                                         bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                         border border-gray-200 dark:border-gray-700
                                         p-3 min-w-max"
+                                 :style="`transform:rotate(-${stool.rotation ?? 0}deg); transform-origin:top right;`"
                                  role="dialog"
                                  :aria-label="`Editar ${stool.name}`">
                                 <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Nombre</p>
@@ -712,13 +715,14 @@
                             {{-- Panel de edición (solo forma) --}}
                             <div x-show="editingTableId === table.id"
                                  x-transition:enter="transition ease-out duration-150"
-                                 x-transition:enter-start="opacity-0 scale-95"
-                                 x-transition:enter-end="opacity-100 scale-100"
+                                 x-transition:enter-start="opacity-0"
+                                 x-transition:enter-end="opacity-100"
                                  @click.stop
                                  class="absolute top-7 right-0 z-20
                                         bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                         border border-gray-200 dark:border-gray-700
                                         p-3 min-w-max"
+                                 :style="`transform:rotate(-${table.rotation ?? 0}deg); transform-origin:top right;`"
                                  role="dialog"
                                  :aria-label="`Forma de mesa ${table.name}`">
 

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -264,7 +264,7 @@
                         {{-- Botón editar zona --}}
                         <button type="button"
                                 @click.stop="editingZoneId = editingZoneId === zone.id ? null : zone.id"
-                                class="absolute -top-2.5 -right-16
+                                class="absolute -top-2.5 -right-9
                                        w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
                                        flex items-center justify-center
                                        opacity-0 group-hover:opacity-100 transition-opacity

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1133,11 +1133,18 @@ document.addEventListener('alpine:init', () => {
                     ],
                     listeners: {
                         move: (event) => {
-                            const el = event.target;
-                            const x  = (parseFloat(el.style.left) || 0) + event.dx;
-                            const y  = (parseFloat(el.style.top)  || 0) + event.dy;
+                            const el   = event.target;
+                            const x    = (parseFloat(el.style.left) || 0) + event.dx;
+                            const y    = (parseFloat(el.style.top)  || 0) + event.dy;
                             el.style.left = `${x}px`;
                             el.style.top  = `${y}px`;
+                            // Sync Alpine data during drag so `:style` re-renders never overwrite interact.js
+                            const id   = parseInt(el.dataset.tableId);
+                            const item = this.tables.find(t => t.id === id) ?? this.elements.find(e => e.id === id);
+                            if (item) {
+                                item.position_x = Math.max(0, Math.round(x));
+                                item.position_y = Math.max(0, Math.round(y));
+                            }
                         },
                         end: (event) => {
                             const el  = event.target;

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -242,7 +242,7 @@
                 <template x-for="zone in zones" :key="'z'+zone.id">
                     <div
                         :data-zone-id="zone.id"
-                        class="zone-item absolute group select-none touch-none"
+                        class="zone-item absolute group select-none touch-none cursor-grab"
                         :style="`
                             left:${zone.position_x}px;
                             top:${zone.position_y}px;
@@ -252,7 +252,6 @@
                             border:2px solid ${zone.color};
                             z-index:${editingZoneId === zone.id ? 20 : 5};
                             pointer-events:all;
-                            cursor:grab;
                             transform:rotate(${zone.rotation ?? 0}deg);
                             transform-origin:center;
                         `"

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -250,10 +250,12 @@
                             height:${zone.height}px;
                             background-color:${zone.color}22;
                             border:2px solid ${zone.color};
-                            z-index:5;
+                            z-index:${editingZoneId === zone.id ? 20 : 5};
                             pointer-events:all;
+                            cursor:grab;
                         `"
                         :aria-label="`Zona ${zone.name}`"
+                        @mousedown.prevent.self="startZoneDrag($event, zone)"
                     >
                         {{-- Etiqueta de zona --}}
                         <span class="absolute bottom-1 left-1 text-xs font-semibold px-1.5 py-0.5 rounded pointer-events-none"
@@ -1036,42 +1038,42 @@ document.addEventListener('alpine:init', () => {
             this.$nextTick(() => this.initTableInteract());
         },
 
-        // ── Interactividad de zonas (drag para mover) ─────────────────────────
+        // ── Interactividad de zonas (drag nativo Alpine para mover) ──────────
         initZoneInteract() {
             interact('.zone-item').unset();
-
-            interact('.zone-item')
-                .draggable({
-                    ignoreFrom:  '.zone-resize-handle',
-                    inertia:    false,
-                    autoScroll: true,
-                    modifiers: [
-                        interact.modifiers.restrictRect({
-                            restriction: this.$refs.canvas,
-                            endOnly:     false,
-                        }),
-                    ],
-                    listeners: {
-                        move: (event) => {
-                            const el = event.target;
-                            const x  = (parseFloat(el.style.left) || 0) + event.dx;
-                            const y  = (parseFloat(el.style.top)  || 0) + event.dy;
-                            el.style.left = `${x}px`;
-                            el.style.top  = `${y}px`;
-                        },
-                        end: (event) => {
-                            const el  = event.target;
-                            const id  = parseInt(el.dataset.zoneId);
-                            const x   = Math.round(parseFloat(el.style.left) || 0);
-                            const y   = Math.round(parseFloat(el.style.top)  || 0);
-                            this.persistZonePosition(id, x, y);
-                        },
-                    },
-                });
         },
 
         reinitZoneInteract() {
             this.$nextTick(() => this.initZoneInteract());
+        },
+
+        // ── Drag nativo de zona: actualiza zone.position_x/y reactivamente ───
+        startZoneDrag(event, zone) {
+            const canvasEl  = this.$refs.canvas;
+            const canvasRect = canvasEl.getBoundingClientRect();
+            const startMX   = event.clientX;
+            const startMY   = event.clientY;
+            const startPx   = zone.position_x;
+            const startPy   = zone.position_y;
+
+            document.body.style.cursor = 'grabbing';
+
+            const onMove = (e) => {
+                const maxX = this.floorWidth  - zone.width;
+                const maxY = this.floorHeight - zone.height;
+                zone.position_x = Math.max(0, Math.min(maxX, Math.round(startPx + (e.clientX - startMX))));
+                zone.position_y = Math.max(0, Math.min(maxY, Math.round(startPy + (e.clientY - startMY))));
+            };
+
+            const onUp = async () => {
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup',   onUp);
+                document.body.style.cursor = '';
+                await this.persistZonePosition(zone.id, zone.position_x, zone.position_y);
+            };
+
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup',   onUp);
         },
 
         // ── Paleta: drag-to-create (mesas, especiales y zonas) ────────────────
@@ -1384,14 +1386,11 @@ document.addEventListener('alpine:init', () => {
 
         // ── AJAX: persistir posición de zona ──────────────────────────────────
         async persistZonePosition(id, x, y) {
-            const zone = this.zones.find(z => z.id === id);
-            if (zone) { zone.position_x = x; zone.position_y = y; }
-
             try {
                 const res = await fetch(`/zonas/${id}`, {
                     method:  'PATCH',
                     headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
-                    body: JSON.stringify({ position_x: x, position_y: y, width: zone?.width ?? 300, height: zone?.height ?? 200 }),
+                    body: JSON.stringify({ position_x: x, position_y: y }),
                 });
                 if (!res.ok) this.showToast('Error al guardar la posición de la zona.', true);
             } catch {

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -346,10 +346,15 @@
                              tabindex="0"
                              style="cursor: url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2720%27 height=%2720%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3C/svg%3E') 10 10, grab;"
                              :aria-label="`Rotar zona ${zone.name} (arrastra para girar)`">
-                            <div class="w-6 h-6 rounded-full bg-white dark:bg-gray-800 shadow-md
+                            <div x-data="{ hov: false }"
+                                 class="w-6 h-6 rounded-full shadow-md
                                         flex items-center justify-center
                                         transition-all duration-150 hover:scale-110"
-                                 :style="`border:2px solid ${zone.color}; color:${zone.color};`">
+                                 :style="hov
+                                     ? `border:2px solid ${zone.color}; background-color:${zone.color}; color:white;`
+                                     : `border:2px solid ${zone.color}; background-color:${zone.color}22; color:${zone.color};`"
+                                 @mouseenter.stop="hov = true"
+                                 @mouseleave.stop="hov = false">
                                 <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"/>
                                 </svg>

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -442,12 +442,20 @@
                                     flex flex-col items-center gap-0
                                     opacity-0 group-hover:opacity-100 transition-opacity z-10"
                              @mousedown.stop.prevent="startRotation($event, element)"
+                             @mouseenter.stop="rotTooltip = { show: true, x: $event.clientX, y: $event.clientY, deg: element.rotation ?? 0 }"
+                             @mousemove.stop="rotTooltip.x = $event.clientX; rotTooltip.y = $event.clientY; rotTooltip.deg = element.rotation ?? 0"
+                             @mouseleave.stop="if (!isRotating) rotTooltip.show = false"
                              role="button"
                              tabindex="0"
-                             style="cursor:grab;"
-                             :aria-label="`Rotar ${element.name}`">
-                            <div class="w-5 h-5 rounded-full bg-white dark:bg-gray-800 border-2 border-amber-400 shadow-md flex items-center justify-center text-amber-500">
-                                <svg class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
+                             style="cursor: url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2720%27 height=%2720%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3C/svg%3E') 10 10, grab;"
+                             :aria-label="`Rotar ${element.name} (arrastra para girar)`">
+                            <div class="w-6 h-6 rounded-full
+                                        bg-white dark:bg-gray-800
+                                        border-2 border-amber-400 shadow-md
+                                        flex items-center justify-center text-amber-500
+                                        transition-all duration-150
+                                        hover:bg-amber-500 hover:border-amber-600 hover:text-white hover:scale-110">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"/>
                                 </svg>
                             </div>

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -253,6 +253,8 @@
                             z-index:${editingZoneId === zone.id ? 20 : 5};
                             pointer-events:all;
                             cursor:grab;
+                            transform:rotate(${zone.rotation ?? 0}deg);
+                            transform-origin:center;
                         `"
                         :aria-label="`Zona ${zone.name}`"
                         @mousedown.prevent.self="startZoneDrag($event, zone)"
@@ -331,6 +333,29 @@
                                        :aria-label="`Color de la zona ${zone.name}`">
                                 <span class="text-xs text-gray-500 font-mono" x-text="zone.color"></span>
                             </div>
+                        </div>
+
+                        {{-- Handle de rotación de zona (color sincronizado con zone.color) --}}
+                        <div class="absolute -top-9 left-1/2 -translate-x-1/2
+                                    flex flex-col items-center gap-0
+                                    opacity-0 group-hover:opacity-100 transition-opacity z-10"
+                             @mousedown.stop.prevent="startZoneRotation($event, zone)"
+                             @mouseenter.stop="rotTooltip = { show: true, x: $event.clientX, y: $event.clientY, deg: zone.rotation ?? 0 }"
+                             @mousemove.stop="rotTooltip.x = $event.clientX; rotTooltip.y = $event.clientY; rotTooltip.deg = zone.rotation ?? 0"
+                             @mouseleave.stop="if (!isRotating) rotTooltip.show = false"
+                             role="button"
+                             tabindex="0"
+                             style="cursor: url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2720%27 height=%2720%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3C/svg%3E') 10 10, grab;"
+                             :aria-label="`Rotar zona ${zone.name} (arrastra para girar)`">
+                            <div class="w-6 h-6 rounded-full bg-white dark:bg-gray-800 shadow-md
+                                        flex items-center justify-center
+                                        transition-all duration-150 hover:scale-110"
+                                 :style="`border:2px solid ${zone.color}; color:${zone.color};`">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"/>
+                                </svg>
+                            </div>
+                            <div class="w-px h-3" :style="`background-color:${zone.color};`"></div>
                         </div>
 
                         {{-- Handle de redimensionado de zona --}}
@@ -1200,6 +1225,40 @@ document.addEventListener('alpine:init', () => {
             document.addEventListener('mouseup',   onUp);
         },
 
+        // ── Rotación libre de zona arrastrando el handle ─────────────────────
+        startZoneRotation(event, zone) {
+            const canvasRect = this.$refs.canvas.getBoundingClientRect();
+            const centerX    = canvasRect.left + zone.position_x + zone.width  / 2;
+            const centerY    = canvasRect.top  + zone.position_y + zone.height / 2;
+
+            this.isRotating            = true;
+            this.rotTooltip.show       = true;
+            document.body.style.cursor = "url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2720%27 height=%2720%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3C/svg%3E') 10 10, grabbing";
+
+            const onMove = (e) => {
+                const dx    = e.clientX - centerX;
+                const dy    = e.clientY - centerY;
+                let   angle = Math.atan2(dy, dx) * (180 / Math.PI) + 90;
+                angle = ((angle % 360) + 360) % 360;
+                zone.rotation       = Math.round(angle);
+                this.rotTooltip.x   = e.clientX;
+                this.rotTooltip.y   = e.clientY;
+                this.rotTooltip.deg = zone.rotation;
+            };
+
+            const onUp = async () => {
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup',   onUp);
+                this.isRotating            = false;
+                this.rotTooltip.show       = false;
+                document.body.style.cursor = '';
+                await this.persistZoneRotation(zone.id, zone.rotation ?? 0);
+            };
+
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup',   onUp);
+        },
+
         // ── Drag nativo de elemento especial (barra/taburete) ────────────────
         startElementDrag(event, element) {
             const startPx = element.position_x;
@@ -1545,6 +1604,20 @@ document.addEventListener('alpine:init', () => {
                     body: JSON.stringify({ position_x: x, position_y: y }),
                 });
                 if (!res.ok) this.showToast('Error al guardar la posición de la zona.', true);
+            } catch {
+                this.showToast('Error de red.', true);
+            }
+        },
+
+        // ── AJAX: persistir rotación de zona ──────────────────────────────────
+        async persistZoneRotation(id, rotation) {
+            try {
+                const res = await fetch(`/zonas/${id}`, {
+                    method:  'PATCH',
+                    headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
+                    body: JSON.stringify({ rotation }),
+                });
+                if (!res.ok) this.showToast('Error al guardar la rotación de la zona.', true);
             } catch {
                 this.showToast('Error de red.', true);
             }

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1086,8 +1086,11 @@ document.addEventListener('alpine:init', () => {
             document.body.style.cursor = 'grabbing';
 
             const onMove = (e) => {
-                element.position_x = Math.max(0, Math.round(startPx + (e.clientX - startMX)));
-                element.position_y = Math.max(0, Math.round(startPy + (e.clientY - startMY)));
+                const canvas = this.$refs.canvas;
+                const maxX = Math.max(0, canvas.offsetWidth  - element.width);
+                const maxY = Math.max(0, canvas.offsetHeight - element.height);
+                element.position_x = Math.max(0, Math.min(maxX, Math.round(startPx + (e.clientX - startMX))));
+                element.position_y = Math.max(0, Math.min(maxY, Math.round(startPy + (e.clientY - startMY))));
             };
 
             const onUp = async () => {

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -351,7 +351,7 @@
                 <template x-for="element in elements" :key="'e'+element.id">
                     <div
                         :data-table-id="element.id"
-                        class="element-item absolute group select-none touch-none"
+                        :class="`${element.shape === 'bar' ? 'table-item' : 'element-item'} absolute group select-none touch-none`"
                         :style="`left:${element.position_x}px; top:${element.position_y}px;
                                  width:${element.width}px; height:${element.height}px;
                                  transform:rotate(${element.rotation ?? 0}deg);
@@ -368,7 +368,7 @@
                                 'rounded-full': element.shape === 'stool',
                                 'rounded-lg':   element.shape === 'bar',
                              }"
-                             @mousedown.prevent="startElementDrag($event, element)">
+                             @mousedown.prevent="element.shape !== 'bar' && startElementDrag($event, element)">
 
                             <span class="text-xs font-semibold text-amber-800 dark:text-amber-300
                                          text-center px-1 leading-tight pointer-events-none"

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1061,10 +1061,8 @@ document.addEventListener('alpine:init', () => {
             document.body.style.cursor = 'grabbing';
 
             const onMove = (e) => {
-                const maxX = canvasEl.offsetWidth  - zone.width;
-                const maxY = canvasEl.offsetHeight - zone.height;
-                zone.position_x = Math.max(0, Math.min(maxX, Math.round(startPx + (e.clientX - startMX))));
-                zone.position_y = Math.max(0, Math.min(maxY, Math.round(startPy + (e.clientY - startMY))));
+                zone.position_x = Math.max(0, Math.round(startPx + (e.clientX - startMX)));
+                zone.position_y = Math.max(0, Math.round(startPy + (e.clientY - startMY)));
             };
 
             const onUp = async () => {
@@ -1092,24 +1090,11 @@ document.addEventListener('alpine:init', () => {
             const startMX   = event.clientX;
             const startMY   = event.clientY;
 
-            // Bounding box visual rotado (calculado una vez al iniciar el drag)
-            const θRad      = ((element.rotation ?? 0) % 360) * Math.PI / 180;
-            const cosθ      = Math.abs(Math.cos(θRad));
-            const sinθ      = Math.abs(Math.sin(θRad));
-            const hw        = element.width  / 2;
-            const hh        = element.height / 2;
-            const hvw       = hw * cosθ + hh * sinθ;
-            const hvh       = hw * sinθ + hh * cosθ;
-            const minX      = Math.max(0, Math.round(hvw - hw));
-            const maxX      = Math.round(canvasEl.offsetWidth  - hw - hvw);
-            const minY      = Math.max(0, Math.round(hvh - hh));
-            const maxY      = Math.round(canvasEl.offsetHeight - hh - hvh);
-
             document.body.style.cursor = 'grabbing';
 
             const onMove = (e) => {
-                element.position_x = Math.max(minX, Math.min(maxX, Math.round(startPx + (e.clientX - startMX))));
-                element.position_y = Math.max(minY, Math.min(maxY, Math.round(startPy + (e.clientY - startMY))));
+                element.position_x = Math.max(0, Math.round(startPx + (e.clientX - startMX)));
+                element.position_y = Math.max(0, Math.round(startPy + (e.clientY - startMY)));
             };
 
             const onUp = async () => {

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -484,7 +484,8 @@
                         :style="`left:${table.position_x}px; top:${table.position_y}px;
                                  width:${table.width}px; height:${table.height}px;
                                  transform: rotate(${table.rotation ?? 0}deg);
-                                 transform-origin: center;`"
+                                 transform-origin: center;
+                                 z-index: 10;`"
                         :aria-label="`Mesa ${table.name}`"
                     >
                         {{-- Fondo de la mesa --}}

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1142,8 +1142,8 @@ document.addEventListener('alpine:init', () => {
                         end: (event) => {
                             const el  = event.target;
                             const id  = parseInt(el.dataset.tableId);
-                            const x   = Math.round(parseFloat(el.style.left) || 0);
-                            const y   = Math.round(parseFloat(el.style.top)  || 0);
+                            const x   = Math.max(0, Math.round(parseFloat(el.style.left) || 0));
+                            const y   = Math.max(0, Math.round(parseFloat(el.style.top)  || 0));
                             const w   = Math.round(parseFloat(el.style.width)  || 100);
                             const h   = Math.round(parseFloat(el.style.height) || 100);
                             this.persistPosition(id, x, y, w, h);

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -266,7 +266,7 @@
 
                         {{-- Botón editar zona --}}
                         <button type="button"
-                                @click.stop="editingZoneId = editingZoneId === zone.id ? null : zone.id"
+                                @click.stop="if (!isRotating) editingZoneId = editingZoneId === zone.id ? null : zone.id"
                                 class="absolute -top-2.5 -right-9
                                        w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
                                        flex items-center justify-center
@@ -301,6 +301,7 @@
                              x-transition:enter-start="opacity-0"
                              x-transition:enter-end="opacity-100"
                              @click.stop
+                             @click.outside="editingZoneId = null"
                              class="absolute top-7 right-0 z-30
                                     bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                     border border-gray-200 dark:border-gray-700
@@ -313,7 +314,7 @@
                             <div class="flex gap-1 mb-3">
                                 <input type="text"
                                        :value="zone.name"
-                                       @keydown.enter.stop="updateZoneName(zone, $event.target.value); $event.target.blur()"
+                                       @keydown.enter.stop="updateZoneName(zone, $event.target.value); editingZoneId = null; $event.target.blur()"
                                        @blur.stop="updateZoneName(zone, $event.target.value)"
                                        @click.stop
                                        maxlength="50"
@@ -405,7 +406,7 @@
 
                             {{-- Botón editar nombre --}}
                             <button type="button"
-                                    @click.stop="editingTableId = editingTableId === bar.id ? null : bar.id"
+                                    @click.stop="if (!isRotating) editingTableId = editingTableId === bar.id ? null : bar.id"
                                     class="absolute -top-2.5 -right-9
                                            w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
                                            flex items-center justify-center
@@ -440,6 +441,7 @@
                                  x-transition:enter-start="opacity-0"
                                  x-transition:enter-end="opacity-100"
                                  @click.stop
+                                 @click.outside="editingTableId = null"
                                  class="absolute top-7 right-0 z-20
                                         bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                         border border-gray-200 dark:border-gray-700
@@ -451,7 +453,7 @@
                                 <div class="flex gap-1">
                                     <input type="text"
                                            :value="bar.name"
-                                           @keydown.enter.stop="updateName(bar, $event.target.value); $event.target.blur()"
+                                           @keydown.enter.stop="updateName(bar, $event.target.value); editingTableId = null; $event.target.blur()"
                                            @blur.stop="updateName(bar, $event.target.value)"
                                            @click.stop
                                            maxlength="50"
@@ -532,7 +534,7 @@
                             {{-- Botón editar nombre --}}
                             <button type="button"
                                     @mousedown.stop
-                                    @click.stop="editingTableId = editingTableId === stool.id ? null : stool.id"
+                                    @click.stop="if (!isRotating) editingTableId = editingTableId === stool.id ? null : stool.id"
                                     class="absolute -top-2.5 -right-9
                                            w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
                                            flex items-center justify-center
@@ -568,6 +570,7 @@
                                  x-transition:enter-start="opacity-0"
                                  x-transition:enter-end="opacity-100"
                                  @click.stop
+                                 @click.outside="editingTableId = null"
                                  class="absolute top-7 right-0 z-20
                                         bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                         border border-gray-200 dark:border-gray-700
@@ -579,7 +582,7 @@
                                 <div class="flex gap-1">
                                     <input type="text"
                                            :value="stool.name"
-                                           @keydown.enter.stop="updateName(stool, $event.target.value); $event.target.blur()"
+                                           @keydown.enter.stop="updateName(stool, $event.target.value); editingTableId = null; $event.target.blur()"
                                            @blur.stop="updateName(stool, $event.target.value)"
                                            @click.stop
                                            maxlength="50"
@@ -668,7 +671,7 @@
 
                             {{-- Botón editar forma --}}
                             <button type="button"
-                                    @click.stop="editingTableId = editingTableId === table.id ? null : table.id"
+                                    @click.stop="if (!isRotating) editingTableId = editingTableId === table.id ? null : table.id"
                                     class="absolute -top-2.5 -right-16
                                            w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
                                            flex items-center justify-center
@@ -718,6 +721,7 @@
                                  x-transition:enter-start="opacity-0"
                                  x-transition:enter-end="opacity-100"
                                  @click.stop
+                                 @click.outside="editingTableId = null"
                                  class="absolute top-7 right-0 z-20
                                         bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                         border border-gray-200 dark:border-gray-700
@@ -731,7 +735,7 @@
                                 <div class="flex gap-1 mb-3">
                                     <input type="text"
                                            :value="table.name"
-                                           @keydown.enter.stop="updateName(table, $event.target.value); $event.target.blur()"
+                                           @keydown.enter.stop="updateName(table, $event.target.value); editingTableId = null; $event.target.blur()"
                                            @blur.stop="updateName(table, $event.target.value)"
                                            @click.stop
                                            maxlength="50"
@@ -1784,8 +1788,7 @@ document.addEventListener('alpine:init', () => {
         // ── AJAX: actualizar forma de mesa existente ──────────────────────────
         async updateShape(table, shape) {
             const prev = table.shape;
-            table.shape       = shape;
-            this.editingTableId = null;
+            table.shape = shape;
 
             try {
                 const res = await fetch(`/mesas/${table.id}/forma`, {

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1080,19 +1080,30 @@ document.addEventListener('alpine:init', () => {
 
         // ── Drag nativo de elemento especial (barra/taburete) ────────────────
         startElementDrag(event, element) {
-            const canvasEl  = this.$refs.canvas;
-            const startMX   = event.clientX;
-            const startMY   = event.clientY;
-            const startPx   = element.position_x;
-            const startPy   = element.position_y;
+            const canvasEl    = this.$refs.canvas;
+            const startMX     = event.clientX;
+            const startMY     = event.clientY;
+            const startPx     = element.position_x;
+            const startPy     = element.position_y;
+
+            // Bounding box visual rotado: los límites se calculan una sola vez al iniciar el drag
+            const θRad        = ((element.rotation ?? 0) % 360) * Math.PI / 180;
+            const cosθ        = Math.abs(Math.cos(θRad));
+            const sinθ        = Math.abs(Math.sin(θRad));
+            const hw          = element.width  / 2;
+            const hh          = element.height / 2;
+            const halfVisualW = hw * cosθ + hh * sinθ;
+            const halfVisualH = hw * sinθ + hh * cosθ;
+            const minX        = Math.max(0, Math.round(halfVisualW - hw));
+            const maxX        = Math.round(canvasEl.offsetWidth  - hw - halfVisualW);
+            const minY        = Math.max(0, Math.round(halfVisualH - hh));
+            const maxY        = Math.round(canvasEl.offsetHeight - hh - halfVisualH);
 
             document.body.style.cursor = 'grabbing';
 
             const onMove = (e) => {
-                const maxX = canvasEl.offsetWidth  - element.width;
-                const maxY = canvasEl.offsetHeight - element.height;
-                element.position_x = Math.max(0, Math.min(maxX, Math.round(startPx + (e.clientX - startMX))));
-                element.position_y = Math.max(0, Math.min(maxY, Math.round(startPy + (e.clientY - startMY))));
+                element.position_x = Math.max(minX, Math.min(maxX, Math.round(startPx + (e.clientX - startMX))));
+                element.position_y = Math.max(minY, Math.min(maxY, Math.round(startPy + (e.clientY - startMY))));
             };
 
             const onUp = async () => {

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -266,7 +266,7 @@
 
                         {{-- Botón editar zona --}}
                         <button type="button"
-                                @click.stop="if (!isRotating) editingZoneId = editingZoneId === zone.id ? null : zone.id"
+                                @click.stop="editingZoneId = editingZoneId === zone.id ? null : zone.id"
                                 class="absolute -top-2.5 -right-9
                                        w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
                                        flex items-center justify-center
@@ -298,15 +298,13 @@
                         {{-- Panel de edición de zona --}}
                         <div x-show="editingZoneId === zone.id"
                              x-transition:enter="transition ease-out duration-150"
-                             x-transition:enter-start="opacity-0"
-                             x-transition:enter-end="opacity-100"
+                             x-transition:enter-start="opacity-0 scale-95"
+                             x-transition:enter-end="opacity-100 scale-100"
                              @click.stop
-                             @click.outside="if (!isRotating) editingZoneId = null"
                              class="absolute top-7 right-0 z-30
                                     bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                     border border-gray-200 dark:border-gray-700
                                     p-3 min-w-max"
-                             :style="`transform:rotate(-${zone.rotation ?? 0}deg); transform-origin:top right;`"
                              role="dialog"
                              :aria-label="`Editar zona ${zone.name}`">
 
@@ -314,7 +312,7 @@
                             <div class="flex gap-1 mb-3">
                                 <input type="text"
                                        :value="zone.name"
-                                       @keydown.enter.stop="updateZoneName(zone, $event.target.value); editingZoneId = null; $event.target.blur()"
+                                       @keydown.enter.stop="updateZoneName(zone, $event.target.value); $event.target.blur()"
                                        @blur.stop="updateZoneName(zone, $event.target.value)"
                                        @click.stop
                                        maxlength="50"
@@ -406,7 +404,7 @@
 
                             {{-- Botón editar nombre --}}
                             <button type="button"
-                                    @click.stop="if (!isRotating) editingTableId = editingTableId === bar.id ? null : bar.id"
+                                    @click.stop="editingTableId = editingTableId === bar.id ? null : bar.id"
                                     class="absolute -top-2.5 -right-9
                                            w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
                                            flex items-center justify-center
@@ -438,22 +436,20 @@
                             {{-- Panel de edición de nombre --}}
                             <div x-show="editingTableId === bar.id"
                                  x-transition:enter="transition ease-out duration-150"
-                                 x-transition:enter-start="opacity-0"
-                                 x-transition:enter-end="opacity-100"
+                                 x-transition:enter-start="opacity-0 scale-95"
+                                 x-transition:enter-end="opacity-100 scale-100"
                                  @click.stop
-                                 @click.outside="if (!isRotating) editingTableId = null"
                                  class="absolute top-7 right-0 z-20
                                         bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                         border border-gray-200 dark:border-gray-700
                                         p-3 min-w-max"
-                                 :style="`transform:rotate(-${bar.rotation ?? 0}deg); transform-origin:top right;`"
                                  role="dialog"
                                  :aria-label="`Editar ${bar.name}`">
                                 <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Nombre</p>
                                 <div class="flex gap-1">
                                     <input type="text"
                                            :value="bar.name"
-                                           @keydown.enter.stop="updateName(bar, $event.target.value); editingTableId = null; $event.target.blur()"
+                                           @keydown.enter.stop="updateName(bar, $event.target.value); $event.target.blur()"
                                            @blur.stop="updateName(bar, $event.target.value)"
                                            @click.stop
                                            maxlength="50"
@@ -534,7 +530,7 @@
                             {{-- Botón editar nombre --}}
                             <button type="button"
                                     @mousedown.stop
-                                    @click.stop="if (!isRotating) editingTableId = editingTableId === stool.id ? null : stool.id"
+                                    @click.stop="editingTableId = editingTableId === stool.id ? null : stool.id"
                                     class="absolute -top-2.5 -right-9
                                            w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
                                            flex items-center justify-center
@@ -567,22 +563,20 @@
                             {{-- Panel de edición de nombre --}}
                             <div x-show="editingTableId === stool.id"
                                  x-transition:enter="transition ease-out duration-150"
-                                 x-transition:enter-start="opacity-0"
-                                 x-transition:enter-end="opacity-100"
+                                 x-transition:enter-start="opacity-0 scale-95"
+                                 x-transition:enter-end="opacity-100 scale-100"
                                  @click.stop
-                                 @click.outside="if (!isRotating) editingTableId = null"
                                  class="absolute top-7 right-0 z-20
                                         bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                         border border-gray-200 dark:border-gray-700
                                         p-3 min-w-max"
-                                 :style="`transform:rotate(-${stool.rotation ?? 0}deg); transform-origin:top right;`"
                                  role="dialog"
                                  :aria-label="`Editar ${stool.name}`">
                                 <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Nombre</p>
                                 <div class="flex gap-1">
                                     <input type="text"
                                            :value="stool.name"
-                                           @keydown.enter.stop="updateName(stool, $event.target.value); editingTableId = null; $event.target.blur()"
+                                           @keydown.enter.stop="updateName(stool, $event.target.value); $event.target.blur()"
                                            @blur.stop="updateName(stool, $event.target.value)"
                                            @click.stop
                                            maxlength="50"
@@ -671,7 +665,7 @@
 
                             {{-- Botón editar forma --}}
                             <button type="button"
-                                    @click.stop="if (!isRotating) editingTableId = editingTableId === table.id ? null : table.id"
+                                    @click.stop="editingTableId = editingTableId === table.id ? null : table.id"
                                     class="absolute -top-2.5 -right-16
                                            w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
                                            flex items-center justify-center
@@ -718,15 +712,13 @@
                             {{-- Panel de edición (solo forma) --}}
                             <div x-show="editingTableId === table.id"
                                  x-transition:enter="transition ease-out duration-150"
-                                 x-transition:enter-start="opacity-0"
-                                 x-transition:enter-end="opacity-100"
+                                 x-transition:enter-start="opacity-0 scale-95"
+                                 x-transition:enter-end="opacity-100 scale-100"
                                  @click.stop
-                                 @click.outside="if (!isRotating) editingTableId = null"
                                  class="absolute top-7 right-0 z-20
                                         bg-white dark:bg-gray-800 rounded-xl shadow-xl
                                         border border-gray-200 dark:border-gray-700
                                         p-3 min-w-max"
-                                 :style="`transform:rotate(-${table.rotation ?? 0}deg); transform-origin:top right;`"
                                  role="dialog"
                                  :aria-label="`Forma de mesa ${table.name}`">
 
@@ -735,7 +727,7 @@
                                 <div class="flex gap-1 mb-3">
                                     <input type="text"
                                            :value="table.name"
-                                           @keydown.enter.stop="updateName(table, $event.target.value); editingTableId = null; $event.target.blur()"
+                                           @keydown.enter.stop="updateName(table, $event.target.value); $event.target.blur()"
                                            @blur.stop="updateName(table, $event.target.value)"
                                            @click.stop
                                            maxlength="50"
@@ -1261,8 +1253,7 @@ document.addEventListener('alpine:init', () => {
             const onUp = async () => {
                 document.removeEventListener('mousemove', onMove);
                 document.removeEventListener('mouseup',   onUp);
-                // Defer so the click event (fired after mouseup) sees isRotating = true
-                setTimeout(() => { this.isRotating = false; }, 0);
+                this.isRotating            = false;
                 this.rotTooltip.show       = false;
                 document.body.style.cursor = '';
                 await this.persistZoneRotation(zone.id, zone.rotation ?? 0);
@@ -1790,6 +1781,7 @@ document.addEventListener('alpine:init', () => {
         async updateShape(table, shape) {
             const prev = table.shape;
             table.shape = shape;
+            this.editingTableId = null;
 
             try {
                 const res = await fetch(`/mesas/${table.id}/forma`, {
@@ -1875,8 +1867,7 @@ document.addEventListener('alpine:init', () => {
             const onUp = async () => {
                 document.removeEventListener('mousemove', onMove);
                 document.removeEventListener('mouseup',   onUp);
-                // Defer so the click event (fired after mouseup) sees isRotating = true
-                setTimeout(() => { this.isRotating = false; }, 0);
+                this.isRotating            = false;
                 this.rotTooltip.show       = false;
                 document.body.style.cursor = '';
                 await this.persistPosition(table.id, table.position_x, table.position_y, table.width, table.height);

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1080,24 +1080,30 @@ document.addEventListener('alpine:init', () => {
 
         // ── Drag nativo de elemento especial (barra/taburete) ────────────────
         startElementDrag(event, element) {
-            const canvasEl    = this.$refs.canvas;
-            const startMX     = event.clientX;
-            const startMY     = event.clientY;
-            const startPx     = element.position_x;
-            const startPy     = element.position_y;
+            const canvasEl  = this.$refs.canvas;
 
-            // Bounding box visual rotado: los límites se calculan una sola vez al iniciar el drag
-            const θRad        = ((element.rotation ?? 0) % 360) * Math.PI / 180;
-            const cosθ        = Math.abs(Math.cos(θRad));
-            const sinθ        = Math.abs(Math.sin(θRad));
-            const hw          = element.width  / 2;
-            const hh          = element.height / 2;
-            const halfVisualW = hw * cosθ + hh * sinθ;
-            const halfVisualH = hw * sinθ + hh * cosθ;
-            const minX        = Math.max(0, Math.round(halfVisualW - hw));
-            const maxX        = Math.round(canvasEl.offsetWidth  - hw - halfVisualW);
-            const minY        = Math.max(0, Math.round(halfVisualH - hh));
-            const maxY        = Math.round(canvasEl.offsetHeight - hh - halfVisualH);
+            // Leer posición real del DOM para evitar valor obsoleto del estado Alpine
+            const outerEl   = canvasEl.querySelector(`[data-table-id="${element.id}"]`);
+            const startPx   = outerEl ? (parseFloat(outerEl.style.left) || 0) : element.position_x;
+            const startPy   = outerEl ? (parseFloat(outerEl.style.top)  || 0) : element.position_y;
+            element.position_x = startPx;
+            element.position_y = startPy;
+
+            const startMX   = event.clientX;
+            const startMY   = event.clientY;
+
+            // Bounding box visual rotado (calculado una vez al iniciar el drag)
+            const θRad      = ((element.rotation ?? 0) % 360) * Math.PI / 180;
+            const cosθ      = Math.abs(Math.cos(θRad));
+            const sinθ      = Math.abs(Math.sin(θRad));
+            const hw        = element.width  / 2;
+            const hh        = element.height / 2;
+            const hvw       = hw * cosθ + hh * sinθ;
+            const hvh       = hw * sinθ + hh * cosθ;
+            const minX      = Math.max(0, Math.round(hvw - hw));
+            const maxX      = Math.round(canvasEl.offsetWidth  - hw - hvw);
+            const minY      = Math.max(0, Math.round(hvh - hh));
+            const maxY      = Math.round(canvasEl.offsetHeight - hh - hvh);
 
             document.body.style.cursor = 'grabbing';
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,7 @@ use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\ProductController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\TableController;
+use App\Http\Controllers\ZoneController;
 use App\Http\Controllers\SuperAdmin\SuperAdminDashboardController;
 use App\Http\Controllers\SuperAdmin\SuperAdminPlanController;
 use App\Http\Controllers\SuperAdmin\SuperAdminBusinessController;
@@ -61,10 +62,16 @@ Route::middleware(['auth', 'business.active'])->group(function () {
         // Mapa visual de mesas (Bloques 8.1 y 8.3) — solo admin
         Route::get('/mesas/mapa', [TableController::class, 'map'])->name('tables.map');
         Route::post('/mesas', [TableController::class, 'store'])->name('tables.store');
+        Route::patch('/mesas/mapa/canvas', [TableController::class, 'updateCanvas'])->name('tables.canvas.update');
         Route::patch('/mesas/{table}/posicion', [TableController::class, 'updatePosition'])->name('tables.updatePosition');
         Route::patch('/mesas/{table}/forma', [TableController::class, 'updateShape'])->name('tables.updateShape');
         Route::patch('/mesas/{table}/nombre', [TableController::class, 'updateName'])->name('tables.updateName');
         Route::delete('/mesas/{table}', [TableController::class, 'destroy'])->name('tables.destroy');
+
+        // Gestión de zonas del plano — solo admin
+        Route::post('/zonas', [ZoneController::class, 'store'])->name('zones.store');
+        Route::patch('/zonas/{zone}', [ZoneController::class, 'update'])->name('zones.update');
+        Route::delete('/zonas/{zone}', [ZoneController::class, 'destroy'])->name('zones.destroy');
     });
 
     // Gestión de mesas y códigos QR

--- a/tests/Feature/Bloque8/TableMapTest.php
+++ b/tests/Feature/Bloque8/TableMapTest.php
@@ -272,13 +272,28 @@ it('returns 403 when updating position of another admins table', function () {
          ->assertForbidden();
 });
 
-it('fails to update position with negative coordinates', function () {
+it('accepts negative coordinates for rotated elements near canvas edge', function () {
+    $table = Table::factory()->for($this->admin)->create();
+
+    // Elementos rotados pueden requerir position_x/y negativa para que
+    // su bounding box visual quede pegado al borde del canvas.
+    $this->actingAs($this->admin)
+         ->patchJson(route('tables.updatePosition', $table), [
+             'position_x' => -150,
+             'position_y' => -150,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertOk();
+});
+
+it('fails to update position with extremely negative coordinates', function () {
     $table = Table::factory()->for($this->admin)->create();
 
     $this->actingAs($this->admin)
          ->patchJson(route('tables.updatePosition', $table), [
-             'position_x' => -10,
-             'position_y' => -20,
+             'position_x' => -3001,
+             'position_y' => -3001,
              'width'      => 100,
              'height'     => 100,
          ])

--- a/tests/Feature/Bloque8/ZoneTest.php
+++ b/tests/Feature/Bloque8/ZoneTest.php
@@ -1,0 +1,229 @@
+<?php
+
+/**
+ * @author AyrtonAlania
+ */
+
+use App\Models\Plan;
+use App\Models\Table;
+use App\Models\User;
+use App\Models\Zone;
+
+uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    $plan        = Plan::factory()->create(['max_tables' => 3]);
+    $this->user  = User::factory()->admin()->create(['plan_id' => $plan->id]);
+    $this->other = User::factory()->admin()->create(['plan_id' => $plan->id]);
+    $this->plan  = $plan;
+});
+
+// ─── Creación de zonas ────────────────────────────────────────────────────────
+
+it('gerente can create a zone', function () {
+    $this->actingAs($this->user)
+         ->postJson(route('zones.store'), [
+             'name'       => 'Terraza',
+             'color'      => '#6366f1',
+             'position_x' => 50,
+             'position_y' => 50,
+             'width'      => 300,
+             'height'     => 200,
+         ])
+         ->assertCreated()
+         ->assertJson(['success' => true]);
+
+    $this->assertDatabaseHas('zones', [
+        'name'    => 'Terraza',
+        'user_id' => $this->user->id,
+        'color'   => '#6366f1',
+    ]);
+});
+
+it('fails to create a zone without name', function () {
+    $this->actingAs($this->user)
+         ->postJson(route('zones.store'), [
+             'color'      => '#6366f1',
+             'position_x' => 50,
+             'position_y' => 50,
+             'width'      => 300,
+             'height'     => 200,
+         ])
+         ->assertUnprocessable();
+});
+
+it('fails to create a zone with invalid color', function () {
+    $this->actingAs($this->user)
+         ->postJson(route('zones.store'), [
+             'name'       => 'VIP',
+             'color'      => 'not-a-color',
+             'position_x' => 50,
+             'position_y' => 50,
+             'width'      => 300,
+             'height'     => 200,
+         ])
+         ->assertUnprocessable();
+});
+
+// ─── Actualización de zonas ───────────────────────────────────────────────────
+
+it('gerente can update a zone name and color', function () {
+    $zone = Zone::factory()->create(['user_id' => $this->user->id]);
+
+    $this->actingAs($this->user)
+         ->patchJson(route('zones.update', $zone), [
+             'name'  => 'Comedor interior',
+             'color' => '#10b981',
+         ])
+         ->assertOk()
+         ->assertJson(['success' => true]);
+
+    $this->assertDatabaseHas('zones', [
+        'id'    => $zone->id,
+        'name'  => 'Comedor interior',
+        'color' => '#10b981',
+    ]);
+});
+
+it('gerente can update zone position', function () {
+    $zone = Zone::factory()->create(['user_id' => $this->user->id]);
+
+    $this->actingAs($this->user)
+         ->patchJson(route('zones.update', $zone), [
+             'position_x' => 150,
+             'position_y' => 80,
+             'width'      => 400,
+             'height'     => 250,
+         ])
+         ->assertOk();
+
+    $this->assertDatabaseHas('zones', [
+        'id'         => $zone->id,
+        'position_x' => 150,
+        'position_y' => 80,
+    ]);
+});
+
+// ─── Eliminación de zonas ─────────────────────────────────────────────────────
+
+it('gerente can delete a zone', function () {
+    $zone = Zone::factory()->create(['user_id' => $this->user->id]);
+
+    $this->actingAs($this->user)
+         ->deleteJson(route('zones.destroy', $zone))
+         ->assertOk()
+         ->assertJson(['success' => true]);
+
+    $this->assertDatabaseMissing('zones', ['id' => $zone->id]);
+});
+
+it('deleting a zone does not delete its tables', function () {
+    $zone  = Zone::factory()->create(['user_id' => $this->user->id]);
+    $table = Table::factory()->create([
+        'user_id' => $this->user->id,
+        'zone_id' => $zone->id,
+    ]);
+
+    $this->actingAs($this->user)
+         ->deleteJson(route('zones.destroy', $zone));
+
+    $this->assertDatabaseMissing('zones', ['id' => $zone->id]);
+    $this->assertDatabaseHas('tables', ['id' => $table->id]);
+    $this->assertDatabaseHas('tables', ['id' => $table->id, 'zone_id' => null]);
+});
+
+// ─── Multitenancy ─────────────────────────────────────────────────────────────
+
+it('zone is scoped to the restaurant owner on update', function () {
+    $zone = Zone::factory()->create(['user_id' => $this->user->id]);
+
+    $this->actingAs($this->other)
+         ->patchJson(route('zones.update', $zone), ['name' => 'Hack'])
+         ->assertForbidden();
+});
+
+it('cannot delete another restaurants zone', function () {
+    $zone = Zone::factory()->create(['user_id' => $this->other->id]);
+
+    $this->actingAs($this->user)
+         ->deleteJson(route('zones.destroy', $zone))
+         ->assertForbidden();
+});
+
+it('zone data is isolated per restaurant', function () {
+    Zone::factory()->create(['user_id' => $this->other->id, 'name' => 'Zona secreta']);
+
+    $response = $this->actingAs($this->user)
+         ->get(route('tables.map'));
+
+    $response->assertOk();
+    $response->assertDontSee('Zona secreta');
+});
+
+// ─── Elementos especiales ─────────────────────────────────────────────────────
+
+it('stool element does not appear in public menu', function () {
+    $stool = Table::factory()->create([
+        'user_id'          => $this->user->id,
+        'shape'            => 'stool',
+        'is_service_point' => false,
+    ]);
+
+    $this->get(route('menu.show', $stool->unique_hash))
+         ->assertNotFound();
+});
+
+it('bar element does not appear in public menu', function () {
+    $bar = Table::factory()->create([
+        'user_id'          => $this->user->id,
+        'shape'            => 'bar',
+        'is_service_point' => false,
+    ]);
+
+    $this->get(route('menu.show', $bar->unique_hash))
+         ->assertNotFound();
+});
+
+it('service point tables still appear in public menu', function () {
+    $table = Table::factory()->create([
+        'user_id'          => $this->user->id,
+        'is_service_point' => true,
+    ]);
+
+    $this->get(route('menu.show', $table->unique_hash))
+         ->assertOk();
+});
+
+it('creating a stool does not count against plan limit', function () {
+    Table::factory()->create(['user_id' => $this->user->id, 'is_service_point' => true]);
+    Table::factory()->create(['user_id' => $this->user->id, 'is_service_point' => true]);
+    Table::factory()->create(['user_id' => $this->user->id, 'is_service_point' => true]);
+
+    // Plan limit (3) reached for service points — stool should still be allowed
+    $this->actingAs($this->user)
+         ->postJson(route('tables.store'), [
+             'name'             => 'Taburete 1',
+             'shape'            => 'stool',
+             'position_x'       => 10,
+             'position_y'       => 10,
+             'width'            => 50,
+             'height'           => 50,
+             'is_service_point' => false,
+         ])
+         ->assertCreated();
+});
+
+it('gerente can assign a table to a zone', function () {
+    $zone  = Zone::factory()->create(['user_id' => $this->user->id]);
+    $table = Table::factory()->create(['user_id' => $this->user->id]);
+
+    $this->actingAs($this->user)
+         ->patchJson(route('tables.updatePosition', $table), [
+             'position_x' => 100,
+             'position_y' => 100,
+             'width'      => 100,
+             'height'     => 100,
+             'rotation'   => 0,
+         ])
+         ->assertOk();
+});

--- a/tests/Feature/Bloque8/ZoneTest.php
+++ b/tests/Feature/Bloque8/ZoneTest.php
@@ -215,15 +215,34 @@ it('creating a stool does not count against plan limit', function () {
 
 it('gerente can assign a table to a zone', function () {
     $zone  = Zone::factory()->create(['user_id' => $this->user->id]);
-    $table = Table::factory()->create(['user_id' => $this->user->id]);
 
     $this->actingAs($this->user)
-         ->patchJson(route('tables.updatePosition', $table), [
+         ->postJson(route('tables.store'), [
+             'name'       => 'Mesa asignada',
+             'shape'      => 'square',
              'position_x' => 100,
              'position_y' => 100,
              'width'      => 100,
              'height'     => 100,
-             'rotation'   => 0,
+             'zone_id'    => $zone->id,
          ])
-         ->assertOk();
+         ->assertCreated();
+
+    $this->assertDatabaseHas('tables', ['name' => 'Mesa asignada', 'zone_id' => $zone->id]);
+});
+
+it('cannot assign a table to a zone owned by another restaurant', function () {
+    $foreignZone = Zone::factory()->create(['user_id' => $this->other->id]);
+
+    $this->actingAs($this->user)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Mesa IDOR',
+             'shape'      => 'square',
+             'position_x' => 10,
+             'position_y' => 10,
+             'width'      => 100,
+             'height'     => 100,
+             'zone_id'    => $foreignZone->id,
+         ])
+         ->assertUnprocessable();
 });


### PR DESCRIPTION
## Resumen

- **Zonas**: crear, mover (drag nativo Alpine), redimensionar, renombrar, cambiar color y eliminar zonas en el plano. Al editar, el panel sube a `z-index:20` para quedar por encima de mesas y elementos.
- **Elementos especiales**: barra y taburete arrastrables desde la paleta, con rotación, resize y eliminación. No generan QR ni cuentan contra el límite del plan.
- **Canvas configurable**: dimensiones guardadas por restaurante (`floor_width`, `floor_height`).
- **Migraciones**: tabla `zones`, columnas `zone_id` + `is_service_point` en `tables`, `floor_width` + `floor_height` en `users`, shapes `bar` y `stool`.
- **Multitenancy**: `abort_if` en todos los endpoints mutables; `Rule::exists()->where('user_id')` para prevenir IDOR en `zone_id`.
- **MenuController**: bloquea acceso QR a elementos no service-point (`is_service_point = false`).
- **Tests**: `tests/Feature/Bloque8/ZoneTest.php` — 16 tests cubriendo CRUD de zonas, multitenancy, nullOnDelete, visibilidad pública y límite del plan.

## Fixes incluidos

- Drag de zonas reemplazado por patrón Alpine nativo (`startZoneDrag`) — interact.js sobreescribía el `:style` binding causando que la posición nunca se guardara en tiempo real.
- Panel de edición de zona: z-index dinámico (`5` → `20` al editar) para renderizarse por encima de mesas y elementos especiales.
- Handle de rotación en elementos especiales: estilos copiados de mesas (cursor SVG + tooltip de grados).
- `persistPosition` busca en `this.elements` además de `this.tables` para especiales.
- Validación `min:40` en width/height para permitir taburetes pequeños.
- Botones editar/eliminar de zona sin espacio entre ellos.

## Plan de test

- [ ] `php artisan test tests/Feature/Bloque8/ZoneTest.php` → 16 tests en verde
- [ ] `php artisan test` → suite completa sin regresiones
- [ ] Crear zona desde paleta → mover → posición persiste al recargar
- [ ] Abrir panel de edición con una mesa detrás → panel visible e interactivo
- [ ] Crear barra y taburete → verificar que no aparecen en carta pública (404)
- [ ] Taburete no cuenta contra el límite del plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)