### PR TITLE
Fix/notificaciones fantasma y empleados huerfanos

### DIFF
--- a/app/Http/Controllers/BarPanelController.php
+++ b/app/Http/Controllers/BarPanelController.php
@@ -27,9 +27,20 @@ class BarPanelController extends Controller
      */
     public function index(): View
     {
-        $orders = $this->getActiveOrders();
+        $orders   = $this->getActiveOrders();
+        $ownerId  = Auth::user()->ownerUserId();
 
-        return view('bar.index', compact('orders'));
+        $readyOrders = Order::with('table')
+            ->where('notification_ready', true)
+            ->whereHas('table', fn($q) => $q->where('user_id', $ownerId))
+            ->get()
+            ->map(fn(Order $order) => [
+                'id'    => $order->id,
+                'table' => $order->table->name,
+            ])
+            ->values();
+
+        return view('bar.index', compact('orders', 'readyOrders'));
     }
 
     /**

--- a/resources/views/bar/index.blade.php
+++ b/resources/views/bar/index.blade.php
@@ -252,7 +252,7 @@
   <script>
     function notificationPolling() {
       return {
-        readyOrders: [],
+        readyOrders: @json($readyOrders),
 
         init() {
           this.poll();

--- a/tests/Feature/Bloque6/NotificationTest.php
+++ b/tests/Feature/Bloque6/NotificationTest.php
@@ -2,6 +2,7 @@
 
 /**
  * @author AyrtonAlania
+ * @author SebastianBCF
  */
 
 use App\Models\Order;
@@ -94,6 +95,42 @@ it('multiple polls return the same notification without duplication', function (
     expect(count($second))->toBe(1);
     expect(count($third))->toBe(1);
     expect($first[0]['id'])->toBe($second[0]['id'])->toBe($third[0]['id']);
+});
+
+// ─── Regresión: readyOrders renderizado server-side (fix ghost flicker) ─────────
+
+it('bar panel includes ready notifications in initial html without polling', function () {
+    $waiter = User::factory()->create(['role' => 'waiter']);
+    $table  = Table::factory()->create(['user_id' => $waiter->id]);
+
+    $order = Order::factory()->create([
+        'table_id'           => $table->id,
+        'status'             => 'ready',
+        'notification_ready' => true,
+    ]);
+
+    $response = $this->actingAs($waiter)->get(route('bar.index'));
+
+    $response->assertOk();
+    // El JSON de readyOrders debe estar embebido en el HTML inicial
+    $response->assertSee('"id":' . $order->id, false);
+    $response->assertSee('"table":"' . $table->name . '"', false);
+});
+
+it('bar panel initial html has no ready orders when notification_ready is false', function () {
+    $waiter = User::factory()->create(['role' => 'waiter']);
+    $table  = Table::factory()->create(['user_id' => $waiter->id]);
+
+    Order::factory()->create([
+        'table_id'           => $table->id,
+        'status'             => 'ready',
+        'notification_ready' => false,
+    ]);
+
+    $response = $this->actingAs($waiter)->get(route('bar.index'));
+
+    $response->assertOk();
+    $response->assertSee('readyOrders: []', false);
 });
 
 // ─── Endpoint GET /notifications/bill-requests ────────────────────────────────


### PR DESCRIPTION
## 📝 Descripción
<!-- Resumen claro de los cambios introducidos en este PR -->


## 🔗 Issue Relacionado
<!-- Enlaza el issue o tarea que resuelve este PR -->
Closes #...

## 🔢 Bloque del Roadmap
<!-- Indica el bloque al que pertenece, ej: Bloque 1.6 -->
**Bloque:** X.X

## 🧩 Tipo de Cambio
- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Refactorización sin cambio de comportamiento
- [ ] `style` — Cambios visuales sin lógica
- [ ] `docs` — Solo documentación
- [ ] `test` — Pruebas

---

## ✅ Checklist — Backend (BenjaminDTS)
- [ ] La rama parte de `main` actualizado
- [ ] Un commit por acción concreta (rutas, controlador, vista por separado)
- [ ] Todos los métodos tienen PHPDoc completo (`@param`, `@return`)
- [ ] `@author` solo en la cabecera de la clase, nunca en los métodos
- [ ] `abort_if($model->user_id !== Auth::id(), 403)` en `edit`, `update` y `destroy`
- [ ] Validaciones con `$request->validate([...])` en `store` y `update`
- [ ] Mensajes flash implementados (`->with('success', '...')`)
- [ ] Si hay imágenes: se borra la vieja antes de guardar la nueva
- [ ] Migraciones documentadas si hay cambios en BBDD
- [ ] La aplicación arranca sin errores (`php artisan serve`)

## ✅ Checklist — Frontend (SebastianBCF)
- [ ] `npm run build` ejecutado con los cambios de Tailwind
- [ ] Vistas muestran correctamente los mensajes flash (`@if(session('success'))`)
- [ ] HTML5 semántico y Mobile-First
- [ ] Sin `console.log` en el código

## ✅ Checklist — QA (Ayrton)
- [ ] Happy path probado y funciona correctamente
- [ ] Validaciones del formulario verificadas (campos requeridos, formatos)
- [ ] Multitenancy verificado: un usuario no accede a datos de otro
- [ ] Mensajes flash de éxito y error aparecen correctamente
- [ ] No hay regresiones en funcionalidades existentes

---

## 📸 Capturas de Pantalla
<!-- Si aplica, añade capturas antes/después de los cambios visuales -->

## 🔗 Contexto Adicional
<!-- Cualquier información relevante para el revisor -->
