### PR TITLE
Fix/empleados huerfanos

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -67,7 +67,7 @@ class ProfileController extends Controller
 
         Auth::logout();
 
-        $user->delete();
+        $user->forceDelete();
 
         $request->session()->invalidate();
         $request->session()->regenerateToken();

--- a/app/Http/Controllers/StaffController.php
+++ b/app/Http/Controllers/StaffController.php
@@ -80,7 +80,7 @@ class StaffController extends Controller
     {
         abort_if($staff->admin_id !== Auth::id(), 403, 'No puedes eliminar personal de otro restaurante.');
 
-        $staff->delete();
+        $staff->forceDelete();
 
         return redirect()
             ->route('staff.index')

--- a/app/Http/Controllers/SuperAdmin/SuperAdminBusinessController.php
+++ b/app/Http/Controllers/SuperAdmin/SuperAdminBusinessController.php
@@ -7,6 +7,8 @@ use App\Models\Plan;
 use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\View\View;
 
@@ -17,6 +19,7 @@ use Illuminate\View\View;
  * negocios y eliminarlos. Solo accesible para el rol superadmin.
  *
  * @author BenjaminDTS
+ * @author SebastianBCF
  */
 class SuperAdminBusinessController extends Controller
 {
@@ -104,10 +107,12 @@ class SuperAdminBusinessController extends Controller
     }
 
     /**
-     * Elimina un negocio y todo su personal de la plataforma.
+     * Elimina lógicamente un negocio (soft delete) y desactiva su staff.
      *
-     * El staff asociado (admin_id FK con nullOnDelete) tendrá admin_id = null
-     * automáticamente por la restricción de FK.
+     * El admin queda marcado con deleted_at. Su staff se desactiva (active = false)
+     * para que el middleware EnsureBusinessIsActive les bloquee el acceso.
+     * Los datos históricos (mesas, pedidos, menú) se conservan en la BD.
+     * La operación es atómica: si algo falla se hace rollback completo.
      *
      * @param  User  $business
      * @return RedirectResponse
@@ -117,7 +122,11 @@ class SuperAdminBusinessController extends Controller
         abort_if($business->role !== 'admin', 403, 'Acceso denegado.');
 
         $nombre = $business->business_name ?? $business->name;
-        $business->delete();
+
+        DB::transaction(function () use ($business): void {
+            User::where('admin_id', $business->id)->update(['active' => false]);
+            $business->delete();
+        });
 
         return redirect()->route('superadmin.businesses.index')
             ->with('success', "Negocio «{$nombre}» eliminado correctamente.");

--- a/app/Http/Middleware/EnsureBusinessIsActive.php
+++ b/app/Http/Middleware/EnsureBusinessIsActive.php
@@ -8,11 +8,14 @@ use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Bloquea el acceso al panel si el negocio (rol admin) está desactivado.
+ * Bloquea el acceso al panel si el negocio está desactivado o su admin fue eliminado.
  *
- * Solo aplica a usuarios con rol admin. Superadmins y staff no se ven afectados.
+ * - Admins inactivos (active = false): sesión cerrada, redirige a login.
+ * - Staff cuyo admin fue soft-deleted o desactivado: sesión cerrada, redirige a login.
+ * - Superadmins: no se ven afectados.
  *
  * @author BenjaminDTS
+ * @author SebastianBCF
  */
 class EnsureBusinessIsActive
 {
@@ -25,15 +28,37 @@ class EnsureBusinessIsActive
     {
         $user = Auth::user();
 
-        if ($user && $user->isAdmin() && ! $user->isActive()) {
-            Auth::logout();
-            $request->session()->invalidate();
-            $request->session()->regenerateToken();
+        if (! $user) {
+            return $next($request);
+        }
 
-            return redirect()->route('login')
-                ->withErrors(['email' => 'Tu cuenta está desactivada. Contacta con el administrador.']);
+        if ($user->isAdmin() && ! $user->isActive()) {
+            return $this->forceLogout($request, 'Tu cuenta está desactivada. Contacta con el administrador.');
+        }
+
+        if ($user->isStaff()) {
+            $admin = \App\Models\User::find($user->admin_id);
+
+            if ($admin === null || ! $admin->isActive()) {
+                return $this->forceLogout($request, 'El negocio al que perteneces ha sido desactivado o eliminado.');
+            }
         }
 
         return $next($request);
+    }
+
+    /**
+     * @param  Request  $request
+     * @param  string   $message
+     * @return Response
+     */
+    private function forceLogout(Request $request, string $message): Response
+    {
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect()->route('login')
+            ->withErrors(['email' => $message]);
     }
 }

--- a/app/Http/Middleware/EnsureBusinessIsActive.php
+++ b/app/Http/Middleware/EnsureBusinessIsActive.php
@@ -36,7 +36,7 @@ class EnsureBusinessIsActive
             return $this->forceLogout($request, 'Tu cuenta está desactivada. Contacta con el administrador.');
         }
 
-        if ($user->isStaff()) {
+        if ($user->isStaff() && $user->admin_id !== null) {
             $admin = \App\Models\User::find($user->admin_id);
 
             if ($admin === null || ! $admin->isActive()) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use App\Models\Order;
@@ -32,11 +33,13 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property float|null  $lng            Longitud del negocio
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
  * @author BenjaminDTS
+ * @author SebastianBCF
  */
 class User extends Authenticatable
 {
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, SoftDeletes;
 
     /**
      * Los atributos que se pueden asignar masivamente.

--- a/database/migrations/2026_05_12_192115_add_soft_deletes_to_users_table.php
+++ b/database/migrations/2026_05_12_192115_add_soft_deletes_to_users_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Añade soft deletes a la tabla users para borrado lógico reversible de admins.
+ *
+ * @author SebastianBCF
+ */
+return new class extends Migration
+{
+    /**
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/tests/Feature/Bloque13/BusinessManagementTest.php
+++ b/tests/Feature/Bloque13/BusinessManagementTest.php
@@ -8,6 +8,7 @@
 use App\Models\Plan;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 
 uses(RefreshDatabase::class);
 
@@ -292,13 +293,30 @@ it('deleted admin does not appear in businesses index', function () {
     expect($businesses->contains('id', $toDelete->id))->toBeFalse();
 });
 
-it('delete operation is atomic and staff deactivation rolls back on failure', function () {
+it('delete operation is atomic and rolls back on failure', function () {
     $toDelete = User::factory()->admin()->withBusiness()->create(['plan_id' => $this->plan->id]);
     $staff    = User::factory()->waiter()->create(['admin_id' => $toDelete->id]);
 
-    // Verificar que el admin y el staff existen antes del delete
-    expect(User::find($toDelete->id))->not->toBeNull();
+    $rolled = false;
+    try {
+        DB::transaction(function () use ($toDelete, $staff): void {
+            User::where('admin_id', $toDelete->id)->update(['active' => false]);
+
+            // Dentro de la transacción el staff ya aparece inactivo
+            expect($staff->fresh()->active)->toBeFalse();
+
+            // Forzar rollback
+            throw new \RuntimeException('forced rollback');
+        });
+    } catch (\RuntimeException) {
+        $rolled = true;
+    }
+
+    expect($rolled)->toBeTrue();
+    // Tras el rollback el staff vuelve a estar activo
     expect($staff->fresh()->active)->toBeTrue();
+    // El admin no fue soft-deleted
+    expect(User::withTrashed()->find($toDelete->id)->deleted_at)->toBeNull();
 });
 
 it('returns 403 when trying to toggle a non-admin user', function () {

--- a/tests/Feature/Bloque13/BusinessManagementTest.php
+++ b/tests/Feature/Bloque13/BusinessManagementTest.php
@@ -2,6 +2,7 @@
 
 /**
  * @author AyrtonAlania
+ * @author SebastianBCF
  */
 
 use App\Models\Plan;
@@ -234,27 +235,70 @@ it('superadmin can delete a business', function () {
          ->assertRedirect(route('superadmin.businesses.index'))
          ->assertSessionHas('success');
 
-    $this->assertDatabaseMissing('users', ['id' => $toDelete->id]);
+    // Soft delete: el registro sigue en BD pero con deleted_at
+    $this->assertSoftDeleted('users', ['id' => $toDelete->id]);
 });
 
-it('after hard delete staff of deleted admin has null admin_id', function () {
+it('staff is handled correctly when admin is deleted', function () {
     $toDelete = User::factory()->admin()->withBusiness()->create(['plan_id' => $this->plan->id]);
     $staff    = User::factory()->waiter()->create(['admin_id' => $toDelete->id]);
 
     $this->actingAs($this->superadmin)
          ->delete(route('superadmin.businesses.destroy', $toDelete));
 
-    expect($staff->fresh()->admin_id)->toBeNull();
-});
-
-it('after hard delete staff is not also deleted', function () {
-    $toDelete = User::factory()->admin()->withBusiness()->create(['plan_id' => $this->plan->id]);
-    $staff    = User::factory()->waiter()->create(['admin_id' => $toDelete->id]);
-
-    $this->actingAs($this->superadmin)
-         ->delete(route('superadmin.businesses.destroy', $toDelete));
-
+    // Staff sigue existiendo con su admin_id intacto
     $this->assertDatabaseHas('users', ['id' => $staff->id]);
+    expect($staff->fresh()->admin_id)->toBe($toDelete->id);
+    // Staff queda desactivado para bloquear el acceso al panel
+    expect($staff->fresh()->active)->toBeFalse();
+});
+
+it('staff cannot login after their admin is deleted', function () {
+    $toDelete = User::factory()->admin()->withBusiness()->create(['plan_id' => $this->plan->id]);
+    $staff    = User::factory()->waiter()->create(['admin_id' => $toDelete->id]);
+
+    $this->actingAs($this->superadmin)
+         ->delete(route('superadmin.businesses.destroy', $toDelete));
+
+    // El middleware EnsureBusinessIsActive debe bloquear al staff
+    $this->actingAs($staff->fresh())
+         ->get(route('bar.index'))
+         ->assertRedirect(route('login'));
+});
+
+it('admin data integrity is maintained after deletion', function () {
+    $toDelete = User::factory()->admin()->withBusiness()->create(['plan_id' => $this->plan->id]);
+
+    $this->actingAs($this->superadmin)
+         ->delete(route('superadmin.businesses.destroy', $toDelete));
+
+    // El admin sigue en BD (soft delete), datos intactos
+    $trashed = User::withTrashed()->find($toDelete->id);
+    expect($trashed)->not->toBeNull()
+        ->and($trashed->deleted_at)->not->toBeNull()
+        ->and($trashed->email)->toBe($toDelete->email);
+});
+
+it('deleted admin does not appear in businesses index', function () {
+    $toDelete = User::factory()->admin()->withBusiness()->create(['plan_id' => $this->plan->id]);
+
+    $this->actingAs($this->superadmin)
+         ->delete(route('superadmin.businesses.destroy', $toDelete));
+
+    $response = $this->actingAs($this->superadmin)
+                     ->get(route('superadmin.businesses.index'));
+
+    $businesses = $response->viewData('businesses');
+    expect($businesses->contains('id', $toDelete->id))->toBeFalse();
+});
+
+it('delete operation is atomic and staff deactivation rolls back on failure', function () {
+    $toDelete = User::factory()->admin()->withBusiness()->create(['plan_id' => $this->plan->id]);
+    $staff    = User::factory()->waiter()->create(['admin_id' => $toDelete->id]);
+
+    // Verificar que el admin y el staff existen antes del delete
+    expect(User::find($toDelete->id))->not->toBeNull();
+    expect($staff->fresh()->active)->toBeTrue();
 });
 
 it('returns 403 when trying to toggle a non-admin user', function () {


### PR DESCRIPTION
## 📝 Descripción
<!-- Resumen claro de los cambios introducidos en este PR -->


## 🔗 Issue Relacionado
<!-- Enlaza el issue o tarea que resuelve este PR -->
Closes #...

## 🔢 Bloque del Roadmap
<!-- Indica el bloque al que pertenece, ej: Bloque 1.6 -->
**Bloque:** X.X

## 🧩 Tipo de Cambio
- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Refactorización sin cambio de comportamiento
- [ ] `style` — Cambios visuales sin lógica
- [ ] `docs` — Solo documentación
- [ ] `test` — Pruebas

---

## ✅ Checklist — Backend (BenjaminDTS)
- [ ] La rama parte de `main` actualizado
- [ ] Un commit por acción concreta (rutas, controlador, vista por separado)
- [ ] Todos los métodos tienen PHPDoc completo (`@param`, `@return`)
- [ ] `@author` solo en la cabecera de la clase, nunca en los métodos
- [ ] `abort_if($model->user_id !== Auth::id(), 403)` en `edit`, `update` y `destroy`
- [ ] Validaciones con `$request->validate([...])` en `store` y `update`
- [ ] Mensajes flash implementados (`->with('success', '...')`)
- [ ] Si hay imágenes: se borra la vieja antes de guardar la nueva
- [ ] Migraciones documentadas si hay cambios en BBDD
- [ ] La aplicación arranca sin errores (`php artisan serve`)

## ✅ Checklist — Frontend (SebastianBCF)
- [ ] `npm run build` ejecutado con los cambios de Tailwind
- [ ] Vistas muestran correctamente los mensajes flash (`@if(session('success'))`)
- [ ] HTML5 semántico y Mobile-First
- [ ] Sin `console.log` en el código

## ✅ Checklist — QA (Ayrton)
- [ ] Happy path probado y funciona correctamente
- [ ] Validaciones del formulario verificadas (campos requeridos, formatos)
- [ ] Multitenancy verificado: un usuario no accede a datos de otro
- [ ] Mensajes flash de éxito y error aparecen correctamente
- [ ] No hay regresiones en funcionalidades existentes

---

## 📸 Capturas de Pantalla
<!-- Si aplica, añade capturas antes/después de los cambios visuales -->

## 🔗 Contexto Adicional
<!-- Cualquier información relevante para el revisor -->
