### PR TITLE
feat: admin multirole - waiter and kitchen flags

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -40,7 +40,17 @@ class ProfileController extends Controller
      */
     public function update(ProfileUpdateRequest $request): RedirectResponse
     {
-        $request->user()->fill($request->validated());
+        $data = $request->validated();
+
+        // Las flags multirrol solo aplican al gerente; se ignoran para staff.
+        if ($request->user()->role === 'admin') {
+            $data['is_waiter']  = $request->boolean('is_waiter');
+            $data['is_kitchen'] = $request->boolean('is_kitchen');
+        } else {
+            unset($data['is_waiter'], $data['is_kitchen']);
+        }
+
+        $request->user()->fill($data);
 
         if ($request->user()->isDirty('email')) {
             $request->user()->email_verified_at = null;

--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -6,6 +6,9 @@ use App\Models\User;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
+/**
+ * @author BenjaminDTS
+ */
 class ProfileUpdateRequest extends FormRequest
 {
     /**
@@ -25,6 +28,8 @@ class ProfileUpdateRequest extends FormRequest
                 'max:255',
                 Rule::unique(User::class)->ignore($this->user()->id),
             ],
+            'is_waiter'  => ['sometimes', 'boolean'],
+            'is_kitchen' => ['sometimes', 'boolean'],
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -28,6 +28,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property string $name        Nombre completo del usuario
  * @property string $email       Correo electrónico (login)
  * @property string $role          Rol: 'admin', 'waiter', 'kitchen', 'superadmin'
+ * @property bool   $is_waiter     Admin actuando también como camarero
+ * @property bool   $is_kitchen    Admin actuando también como cocinero
  * @property string|null $business_name  Nombre del negocio (solo admins/gerentes)
  * @property string|null $address        Dirección del negocio
  * @property float|null  $lat            Latitud del negocio
@@ -56,6 +58,8 @@ class User extends Authenticatable
         'email',
         'password',
         'role',
+        'is_waiter',
+        'is_kitchen',
         'admin_id',
         'business_name',
         'address',
@@ -84,8 +88,10 @@ class User extends Authenticatable
     {
         return [
             'email_verified_at' => 'datetime',
-            'password' => 'hashed',
-            'active' => 'boolean',
+            'password'          => 'hashed',
+            'active'            => 'boolean',
+            'is_waiter'         => 'boolean',
+            'is_kitchen'        => 'boolean',
         ];
     }
 
@@ -225,6 +231,50 @@ class User extends Authenticatable
     public function isStaff(): bool
     {
         return in_array($this->role, ['waiter', 'kitchen'], true);
+    }
+
+    /**
+     * Indica si el usuario puede actuar como camarero.
+     * Cubre el rol nativo 'waiter' y el admin con la opción activada.
+     *
+     * @return bool
+     */
+    public function isWaiter(): bool
+    {
+        return $this->role === 'waiter'
+            || ($this->role === 'admin' && (bool) $this->is_waiter);
+    }
+
+    /**
+     * Indica si el usuario puede actuar como cocinero.
+     * Cubre el rol nativo 'kitchen' y el admin con la opción activada.
+     *
+     * @return bool
+     */
+    public function isKitchen(): bool
+    {
+        return $this->role === 'kitchen'
+            || ($this->role === 'admin' && (bool) $this->is_kitchen);
+    }
+
+    /**
+     * Única fuente de verdad para el acceso al panel de Barra.
+     *
+     * @return bool
+     */
+    public function canAccessBar(): bool
+    {
+        return $this->isWaiter();
+    }
+
+    /**
+     * Única fuente de verdad para el acceso al panel de Cocina.
+     *
+     * @return bool
+     */
+    public function canAccessKitchen(): bool
+    {
+        return $this->isKitchen();
     }
 
     /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -113,6 +113,26 @@ class UserFactory extends Factory
     }
 
     /**
+     * Estado: admin que también actúa como camarero (is_waiter=true).
+     *
+     * @return static
+     */
+    public function alsoWaiter(): static
+    {
+        return $this->state(['is_waiter' => true]);
+    }
+
+    /**
+     * Estado: admin que también actúa como cocinero (is_kitchen=true).
+     *
+     * @return static
+     */
+    public function alsoKitchen(): static
+    {
+        return $this->state(['is_kitchen' => true]);
+    }
+
+    /**
      * Estado: admin con datos de negocio rellenos (business_name, address, lat, lng).
      *
      * @return static

--- a/database/migrations/2026_05_13_000001_add_extra_roles_to_users_table.php
+++ b/database/migrations/2026_05_13_000001_add_extra_roles_to_users_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Añade las columnas booleanas is_waiter e is_kitchen a la tabla users.
+ * Permite que un gerente (admin) asuma también el rol de camarero y/o cocinero
+ * sin necesidad de crear cuentas de staff separadas.
+ *
+ * @author BenjaminDTS
+ */
+return new class extends Migration
+{
+    /**
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_waiter')->default(false)->after('role');
+            $table->boolean('is_kitchen')->default(false)->after('is_waiter');
+        });
+
+        // Backfill: los admins existentes conservan el comportamiento actual
+        // (podían acceder a los paneles de barra y cocina antes del multirrol).
+        DB::table('users')
+            ->where('role', 'admin')
+            ->update(['is_waiter' => true, 'is_kitchen' => true]);
+    }
+
+    /**
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['is_waiter', 'is_kitchen']);
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -79,6 +79,8 @@ class DatabaseSeeder extends Seeder
                 'address'       => 'Calle Mayor 1, Madrid',
                 'lat'           => 40.4168,
                 'lng'           => -3.7038,
+                'is_waiter'     => true,
+                'is_kitchen'    => true,
             ]
         );
 

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -159,7 +159,7 @@
                     @endif
 
                     {{-- Panel de Cocina: admin y kitchen --}}
-                    @if(in_array(Auth::user()->role, ['admin', 'kitchen']))
+                    @if(Auth::user()->canAccessKitchen())
                     <span
                         x-data="kitchenBadge('{{ route('kitchen.badge') }}')"
                         x-init="init()"
@@ -178,7 +178,7 @@
                     @endif
 
                     {{-- Panel de Barra: admin y waiter --}}
-                    @if(in_array(Auth::user()->role, ['admin', 'waiter']))
+                    @if(Auth::user()->canAccessBar())
                     <span
                         x-data="barBadge('{{ route('bar.badge') }}')"
                         x-init="init()"
@@ -283,11 +283,14 @@
                     {{ __('Ingresos') }}
                 </x-responsive-nav-link>
 
+                @endif
+
+                @if(Auth::user()->canAccessKitchen() || Auth::user()->canAccessBar())
                 <h3 class="px-3 pt-3 pb-1 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500" role="presentation">{{ __('Servicio') }}</h3>
                 @endif
 
                 {{-- Panel de Cocina: admin y kitchen --}}
-                @if(in_array(Auth::user()->role, ['admin', 'kitchen']))
+                @if(Auth::user()->canAccessKitchen())
                 <span x-data="kitchenBadge('{{ route('kitchen.badge') }}')" x-init="init()" class="flex items-center">
                     <x-responsive-nav-link :href="route('kitchen.index')" :active="request()->routeIs('kitchen.*')">
                         {{ __('Cocina') }}
@@ -302,7 +305,7 @@
                 @endif
 
                 {{-- Panel de Barra: admin y waiter --}}
-                @if(in_array(Auth::user()->role, ['admin', 'waiter']))
+                @if(Auth::user()->canAccessBar())
                 <span x-data="barBadge('{{ route('bar.badge') }}')" x-init="init()" class="flex items-center">
                     <x-responsive-nav-link :href="route('bar.index')" :active="request()->routeIs('bar.*')">
                         {{ __('Barra') }}

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -47,6 +47,65 @@
             @endif
         </div>
 
+        @if(auth()->user()->role === 'admin')
+        <fieldset class="space-y-3">
+            <legend class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                {{ __('Roles adicionales') }}
+            </legend>
+            <p class="text-xs text-gray-500 dark:text-gray-400">
+                {{ __('Activa los paneles de servicio que quieres usar tú mismo como gerente.') }}
+            </p>
+
+            <div class="flex items-start gap-3">
+                <input
+                    id="is_waiter"
+                    name="is_waiter"
+                    type="checkbox"
+                    value="1"
+                    {{ old('is_waiter', auth()->user()->is_waiter) ? 'checked' : '' }}
+                    class="mt-0.5 h-4 w-4 rounded border-gray-300 text-indigo-600
+                           focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700"
+                    aria-describedby="is_waiter_hint"
+                >
+                <div>
+                    <label for="is_waiter" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {{ __('Camarero') }}
+                    </label>
+                    <p id="is_waiter_hint" class="text-xs text-gray-500 dark:text-gray-400">
+                        {{ __('Activa el panel de Barra en tu navegación.') }}
+                    </p>
+                </div>
+            </div>
+            @error('is_waiter')
+                <p role="alert" class="text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+            @enderror
+
+            <div class="flex items-start gap-3">
+                <input
+                    id="is_kitchen"
+                    name="is_kitchen"
+                    type="checkbox"
+                    value="1"
+                    {{ old('is_kitchen', auth()->user()->is_kitchen) ? 'checked' : '' }}
+                    class="mt-0.5 h-4 w-4 rounded border-gray-300 text-indigo-600
+                           focus:ring-indigo-500 dark:border-gray-600 dark:bg-gray-700"
+                    aria-describedby="is_kitchen_hint"
+                >
+                <div>
+                    <label for="is_kitchen" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {{ __('Cocinero') }}
+                    </label>
+                    <p id="is_kitchen_hint" class="text-xs text-gray-500 dark:text-gray-400">
+                        {{ __('Activa el panel de Cocina en tu navegación.') }}
+                    </p>
+                </div>
+            </div>
+            @error('is_kitchen')
+                <p role="alert" class="text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+            @enderror
+        </fieldset>
+        @endif
+
         <div class="flex items-center gap-4">
             <x-primary-button>{{ __('Save') }}</x-primary-button>
 

--- a/tests/Feature/Bloque14/MultirolTest.php
+++ b/tests/Feature/Bloque14/MultirolTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * @author AyrtonAlania
+ */
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+// ─── Acceso a paneles con flag activado ──────────────────────────────────────
+
+it('admin with waiter role can access bar panel', function () {
+    $admin = User::factory()->admin()->alsoWaiter()->create();
+
+    $this->actingAs($admin)
+        ->get(route('bar.index'))
+        ->assertOk();
+});
+
+it('admin with kitchen role can access kitchen panel', function () {
+    $admin = User::factory()->admin()->alsoKitchen()->create();
+
+    $this->actingAs($admin)
+        ->get(route('kitchen.index'))
+        ->assertOk();
+});
+
+// ─── Middleware no bloquea al admin sin flags (acceso directo permitido) ─────
+
+it('admin without waiter flag can still access bar panel directly', function () {
+    $admin = User::factory()->admin()->create(['is_waiter' => false]);
+
+    $this->actingAs($admin)
+        ->get(route('bar.index'))
+        ->assertOk();
+});
+
+it('admin without kitchen flag can still access kitchen panel directly', function () {
+    $admin = User::factory()->admin()->create(['is_kitchen' => false]);
+
+    $this->actingAs($admin)
+        ->get(route('kitchen.index'))
+        ->assertOk();
+});
+
+// ─── Visibilidad en navegación según flags ───────────────────────────────────
+
+it('admin with both roles sees both panels in navigation', function () {
+    $admin = User::factory()->admin()->alsoWaiter()->alsoKitchen()->create();
+
+    $this->actingAs($admin)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertSee('Barra')
+        ->assertSee('Cocina');
+});
+
+it('admin without waiter flag does not see bar link in navigation', function () {
+    $admin = User::factory()->admin()->create(['is_waiter' => false, 'is_kitchen' => false]);
+
+    $this->actingAs($admin)
+        ->get(route('dashboard'))
+        ->assertOk()
+        ->assertDontSee(route('bar.index'))
+        ->assertDontSee(route('kitchen.index'));
+});
+
+// ─── Perfil: activar y desactivar roles ──────────────────────────────────────
+
+it('admin can activate waiter role from profile', function () {
+    $admin = User::factory()->admin()->create(['is_waiter' => false]);
+
+    $this->actingAs($admin)
+        ->patch(route('profile.update'), [
+            'name'      => $admin->name,
+            'email'     => $admin->email,
+            'is_waiter' => '1',
+        ])
+        ->assertRedirect(route('profile.edit'));
+
+    expect($admin->fresh()->is_waiter)->toBeTrue();
+});
+
+it('admin can deactivate waiter role from profile', function () {
+    $admin = User::factory()->admin()->alsoWaiter()->create();
+
+    $this->actingAs($admin)
+        ->patch(route('profile.update'), [
+            'name'  => $admin->name,
+            'email' => $admin->email,
+            // is_waiter omitted (unchecked checkbox)
+        ])
+        ->assertRedirect(route('profile.edit'));
+
+    expect($admin->fresh()->is_waiter)->toBeFalse();
+});
+
+// ─── Roles nativos sin cambios ────────────────────────────────────────────────
+
+it('regular waiter role still works correctly', function () {
+    $admin  = User::factory()->admin()->create();
+    $waiter = User::factory()->waiter()->staffOf($admin)->create();
+
+    $this->actingAs($waiter)
+        ->get(route('bar.index'))
+        ->assertOk();
+});
+
+it('regular kitchen role still works correctly', function () {
+    $admin   = User::factory()->admin()->create();
+    $kitchen = User::factory()->kitchen()->staffOf($admin)->create();
+
+    $this->actingAs($kitchen)
+        ->get(route('kitchen.index'))
+        ->assertOk();
+});


### PR DESCRIPTION
## Summary

- Adds is_waiter and is_kitchen boolean columns to users table so an admin can simultaneously act as waiter and/or kitchen staff without creating separate accounts
- Profile form shows checkboxes (gated to admin role) to toggle each service role on/off
- Navigation shows Barra and Cocina links only when the corresponding flag is active
- Migration backfills existing admins with both flags enabled to preserve current behavior

## Test plan

- [ ] php artisan test tests/Feature/Bloque14/MultirolTest.php - 10 tests, all green
- [ ] php artisan test - full suite (674 tests) passes
- [x] Log in as admin@zampa.app ? Profile ? toggle Camarero / Cocinero ? save ? nav links appear/disappear
- [ ] Regular waiter and kitchen staff accounts unaffected

