### PR TITLE
feat: strict role isolation for kitchen/bar panels + waiter read-only map

### DIFF
--- a/app/Http/Controllers/BarPanelController.php
+++ b/app/Http/Controllers/BarPanelController.php
@@ -27,6 +27,8 @@ class BarPanelController extends Controller
      */
     public function index(): View
     {
+        abort_if(! Auth::user()->canAccessBar(), 403, 'Acceso denegado.');
+
         $orders   = $this->getActiveOrders();
         $ownerId  = Auth::user()->ownerUserId();
 
@@ -50,6 +52,8 @@ class BarPanelController extends Controller
      */
     public function badgeCount(): JsonResponse
     {
+        abort_if(! Auth::user()->canAccessBar(), 403, 'Acceso denegado.');
+
         $ownerId = Auth::user()->ownerUserId();
         $count   = Order::whereHas('table', fn($q) => $q->where('user_id', $ownerId))
             ->whereHas('items', fn($q) => $q->where('destination', 'bar')->where('status', 'queued'))
@@ -66,6 +70,8 @@ class BarPanelController extends Controller
      */
     public function pendingItems(): JsonResponse
     {
+        abort_if(! Auth::user()->canAccessBar(), 403, 'Acceso denegado.');
+
         $orders = $this->getActiveOrders()
             ->map(fn(Order $order) => [
                 'id'         => $order->id,
@@ -104,6 +110,8 @@ class BarPanelController extends Controller
      */
     public function updateItem(OrderItem $item): JsonResponse
     {
+        abort_if(! Auth::user()->canAccessBar(), 403, 'Acceso denegado.');
+
         $order = $item->order()->with('table')->first();
 
         abort_if($order->table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');

--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -17,6 +17,7 @@ use Illuminate\View\View;
  *
  * @author AyrtonAlania
  * @author BenjaminDTS
+ * @author SebastianBCF
  */
 class KitchenController extends Controller
 {
@@ -27,6 +28,8 @@ class KitchenController extends Controller
      */
     public function index(): View
     {
+        abort_if(! Auth::user()->canAccessKitchen(), 403, 'Acceso denegado.');
+
         $orders = $this->getActiveOrders();
 
         return view('kitchen.index', compact('orders'));
@@ -39,6 +42,8 @@ class KitchenController extends Controller
      */
     public function badgeCount(): JsonResponse
     {
+        abort_if(! Auth::user()->canAccessKitchen(), 403, 'Acceso denegado.');
+
         $ownerId = Auth::user()->ownerUserId();
         $count   = Order::whereHas('table', fn($q) => $q->where('user_id', $ownerId))
             ->whereHas('items', fn($q) => $q->where('destination', 'kitchen')->where('status', 'queued'))
@@ -55,6 +60,8 @@ class KitchenController extends Controller
      */
     public function pendingOrders(): JsonResponse
     {
+        abort_if(! Auth::user()->canAccessKitchen(), 403, 'Acceso denegado.');
+
         $orders = $this->getActiveOrders()
             ->map(fn(Order $order) => [
                 'id'         => $order->id,
@@ -96,6 +103,8 @@ class KitchenController extends Controller
      */
     public function markItemReady(OrderItem $item): JsonResponse
     {
+        abort_if(! Auth::user()->canAccessKitchen(), 403, 'Acceso denegado.');
+
         $order = $item->order()->with('table')->first();
 
         abort_if($order->table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
@@ -131,6 +140,8 @@ class KitchenController extends Controller
      */
     public function markOrderServed(Order $order): JsonResponse
     {
+        abort_if(! Auth::user()->canAccessKitchen(), 403, 'Acceso denegado.');
+
         abort_if($order->table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
         abort_if($order->status !== 'ready', 422, 'El pedido no está listo para servir.');
 

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -79,6 +79,8 @@ class TableController extends Controller
      */
     public function mapStatuses(): JsonResponse
     {
+        abort_if(! Auth::user()->canAccessBar(), 403, 'Acceso denegado.');
+
         $ownerId  = Auth::user()->ownerUserId();
         $statuses = Table::where('user_id', $ownerId)
             ->servicePoints()

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -23,6 +23,7 @@ use SimpleSoftwareIO\QrCode\Facades\QrCode;
  * Incluye el mapa visual drag & drop para crear, mover y eliminar mesas.
  *
  * @author AyrtonAlania
+ * @author SebastianBCF
  */
 class TableController extends Controller
 {
@@ -47,25 +48,50 @@ class TableController extends Controller
      */
     public function map(): View
     {
-        $userId      = Auth::id();
-        $tables      = Table::where('user_id', $userId)
+        $ownerId     = Auth::user()->ownerUserId();
+        $tables      = Table::where('user_id', $ownerId)
                            ->servicePoints()
                            ->whereNotIn('shape', ['bar', 'stool'])
                            ->orderBy('name')
                            ->get();
-        $elements    = Table::where('user_id', $userId)
+        $elements    = Table::where('user_id', $ownerId)
                            ->where(function ($q) {
                                $q->where('is_service_point', false)
                                  ->orWhereIn('shape', ['bar', 'stool']);
                            })
                            ->orderBy('name')
                            ->get();
-        $zones       = Zone::where('user_id', $userId)->orderBy('name')->get();
-        $maxTables   = Auth::user()->plan?->max_tables ?? 10;
-        $floorWidth  = Auth::user()->floor_width  ?? 1200;
-        $floorHeight = Auth::user()->floor_height ?? 800;
+        $zones       = Zone::where('user_id', $ownerId)->orderBy('name')->get();
+        $owner       = Auth::user()->isAdmin() ? Auth::user() : Auth::user()->admin;
+        $maxTables   = $owner?->plan?->max_tables ?? 10;
+        $floorWidth  = $owner?->floor_width  ?? 1200;
+        $floorHeight = $owner?->floor_height ?? 800;
+        $readonly    = ! Auth::user()->isAdmin();
 
-        return view('tables.map', compact('tables', 'elements', 'zones', 'maxTables', 'floorWidth', 'floorHeight'));
+        return view('tables.map', compact('tables', 'elements', 'zones', 'maxTables', 'floorWidth', 'floorHeight', 'readonly'));
+    }
+
+    /**
+     * Devuelve el estado actual (ocupada/libre y solicitud de cuenta) de todas las mesas.
+     * Consumido por el polling del mapa en tiempo real.
+     *
+     * @return JsonResponse
+     */
+    public function mapStatuses(): JsonResponse
+    {
+        $ownerId  = Auth::user()->ownerUserId();
+        $statuses = Table::where('user_id', $ownerId)
+            ->servicePoints()
+            ->with(['activeOrder:id,table_id,bill_requested,requested_payment_method'])
+            ->get(['id', 'status'])
+            ->map(fn (Table $t) => [
+                'id'                       => $t->id,
+                'status'                   => $t->status,
+                'bill_requested'           => (bool) ($t->activeOrder?->bill_requested ?? false),
+                'requested_payment_method' => $t->activeOrder?->requested_payment_method,
+            ]);
+
+        return response()->json($statuses);
     }
 
     /**

--- a/app/Http/Middleware/EnsureCanAccessBar.php
+++ b/app/Http/Middleware/EnsureCanAccessBar.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Bloquea el acceso al panel de barra a usuarios sin el permiso correspondiente.
+ *
+ * Delega en User::canAccessBar() como única fuente de verdad:
+ * cubre tanto el rol nativo 'waiter' como el admin con is_waiter=true.
+ *
+ * @author SebastianBCF
+ */
+class EnsureCanAccessBar
+{
+    /**
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @return Response
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->user()?->canAccessBar()) {
+            abort(403, 'Acceso denegado.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/EnsureCanAccessKitchen.php
+++ b/app/Http/Middleware/EnsureCanAccessKitchen.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Bloquea el acceso al panel de cocina a usuarios sin el permiso correspondiente.
+ *
+ * Delega en User::canAccessKitchen() como única fuente de verdad:
+ * cubre tanto el rol nativo 'kitchen' como el admin con is_kitchen=true.
+ *
+ * @author SebastianBCF
+ */
+class EnsureCanAccessKitchen
+{
+    /**
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @return Response
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->user()?->canAccessKitchen()) {
+            abort(403, 'Acceso denegado.');
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -17,6 +17,8 @@ return Application::configure(basePath: dirname(__DIR__))
             'role'            => \App\Http\Middleware\EnsureRole::class,
             'role.superadmin' => \App\Http\Middleware\EnsureSuperAdmin::class,
             'business.active' => \App\Http\Middleware\EnsureBusinessIsActive::class,
+            'can.kitchen'     => \App\Http\Middleware\EnsureCanAccessKitchen::class,
+            'can.bar'         => \App\Http\Middleware\EnsureCanAccessBar::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -2,6 +2,7 @@
  | Bloques 8.1, 8.3 y 8.4 — Mapa visual del local con zonas, elementos especiales y mesas.
  | interact.js para arrastrar/redimensionar mesas, elementos especiales y zonas.
  | @author AyrtonAlania
+ | @author SebastianBCF
 --}}
 <x-app-layout>
 <div
@@ -20,6 +21,13 @@
 
         <div class="flex items-center gap-3">
             <h1 class="text-lg font-bold text-gray-900 dark:text-white">Plano del restaurante</h1>
+
+            {{-- Badge modo solo lectura --}}
+            <span x-show="readonly"
+                  class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold
+                         bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+                Solo lectura
+            </span>
 
             {{-- Contador con colores y barra de progreso --}}
             <div class="flex flex-col gap-1">
@@ -64,8 +72,8 @@
                  aria-live="polite">
             </div>
 
-            {{-- ── Control de tamaño del lienzo ─────────────────────────────── --}}
-            <div class="flex items-center gap-2">
+            {{-- ── Control de tamaño del lienzo — solo admin ──────────────── --}}
+            <div x-show="!readonly" class="flex items-center gap-2">
                 <span class="text-xs font-medium text-gray-500 dark:text-gray-400 hidden sm:block"
                       aria-hidden="true">Plano:</span>
 
@@ -153,8 +161,9 @@
     ══════════════════════════════════════════════════════ --}}
     <div class="flex flex-1 overflow-hidden">
 
-        {{-- ── PALETA LATERAL ───────────────────────────────── --}}
-        <aside class="flex-shrink-0 w-44 bg-white dark:bg-gray-800
+        {{-- ── PALETA LATERAL — solo visible para admin ─────── --}}
+        <aside x-show="!readonly"
+               class="flex-shrink-0 w-44 bg-white dark:bg-gray-800
                       border-r border-gray-200 dark:border-gray-700
                       flex flex-col p-3 gap-4 overflow-y-auto">
 
@@ -748,14 +757,39 @@
                                   x-text="table.name">
                             </span>
 
-                            {{-- Badge estado --}}
+                            {{-- Badge estado: libre/ocupada --}}
                             <span class="absolute top-1 left-1 w-2 h-2 rounded-full"
                                   :class="table.status === 'occupied' ? 'bg-red-500' : 'bg-green-400'"
                                   :title="table.status === 'occupied' ? 'Ocupada' : 'Libre'">
                             </span>
 
-                            {{-- Botón editar forma --}}
+                            {{-- Badge solicitud de cuenta en efectivo --}}
+                            <span x-show="table.bill_requested && table.requested_payment_method === 'cash'"
+                                  class="absolute bottom-1 right-1
+                                         flex items-center justify-center
+                                         w-5 h-5 rounded-full
+                                         bg-amber-500 text-white text-xs font-bold
+                                         shadow-md animate-pulse"
+                                  title="Solicita cuenta en efectivo"
+                                  aria-label="Mesa solicita cuenta en efectivo">
+                                €
+                            </span>
+
+                            {{-- Badge solicitud de cuenta con tarjeta --}}
+                            <span x-show="table.bill_requested && table.requested_payment_method === 'card'"
+                                  class="absolute bottom-1 right-1
+                                         flex items-center justify-center
+                                         w-5 h-5 rounded-full
+                                         bg-emerald-500 text-white text-xs font-bold
+                                         shadow-md animate-pulse"
+                                  title="Solicita cuenta con tarjeta"
+                                  aria-label="Mesa solicita cuenta con tarjeta">
+                                ♦
+                            </span>
+
+                            {{-- Botón editar forma — solo admin --}}
                             <button type="button"
+                                    x-show="!readonly"
                                     @click.stop="editingTableId = editingTableId === table.id ? null : table.id"
                                     class="absolute -top-2.5 -right-16
                                            w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
@@ -785,8 +819,9 @@
                                 </svg>
                             </button>
 
-                            {{-- Botón eliminar --}}
+                            {{-- Botón eliminar — solo admin --}}
                             <button type="button"
+                                    x-show="!readonly"
                                     @click.stop="deleteTable(table)"
                                     class="absolute -top-2.5 -right-2.5
                                            w-6 h-6 rounded-full bg-red-500 text-white
@@ -861,8 +896,8 @@
                             </div>
                         </div>
 
-                        {{-- Handle de rotación — arrastra para girar la mesa --}}
-                        <div class="rotation-handle absolute -top-9 left-1/2 -translate-x-1/2
+                        {{-- Handle de rotación — solo admin --}}
+                        <div x-show="!readonly" class="rotation-handle absolute -top-9 left-1/2 -translate-x-1/2
                                     flex flex-col items-center gap-0
                                     opacity-0 group-hover:opacity-100 transition-opacity z-10"
                              @mousedown.stop.prevent="startRotation($event, table)"
@@ -886,8 +921,9 @@
                             <div class="w-px h-3 bg-indigo-400"></div>
                         </div>
 
-                        {{-- Handle de redimensionado (esquina inferior derecha) --}}
-                        <div class="resize-handle absolute bottom-0 right-0
+                        {{-- Handle de redimensionado — solo admin --}}
+                        <div x-show="!readonly"
+                             class="resize-handle absolute bottom-0 right-0
                                     w-4 h-4 cursor-se-resize opacity-0 group-hover:opacity-100
                                     transition-opacity"
                              @mousedown.stop.prevent="startResize($event, table)"
@@ -1211,6 +1247,7 @@ document.addEventListener('alpine:init', () => {
         zones:                 @json($zones),
         floorWidth:            {{ $floorWidth }},
         floorHeight:           {{ $floorHeight }},
+        readonly:              {{ $readonly ? 'true' : 'false' }},
         canvasZoom:            1,
         isDraggingFromPalette: false,
         isDraggingZone:        false,
@@ -1233,10 +1270,34 @@ document.addEventListener('alpine:init', () => {
             this.$watch('canvasZoom', val => localStorage.setItem(lsZoom, val));
 
             this.$nextTick(() => {
-                this.initTableInteract();
-                this.initZoneInteract();
-                this.initPaletteInteract();
+                if (!this.readonly) {
+                    this.initTableInteract();
+                    this.initZoneInteract();
+                    this.initPaletteInteract();
+                }
             });
+
+            // Polling de estados: actualiza ocupación y solicitudes de cuenta cada 5 s.
+            this.pollStatuses();
+            setInterval(() => this.pollStatuses(), 5000);
+        },
+
+        async pollStatuses() {
+            try {
+                const res  = await fetch('{{ route("tables.map.statuses") }}', {
+                    headers: { Accept: 'application/json' },
+                });
+                if (!res.ok) return;
+                const data = await res.json();
+                data.forEach(s => {
+                    const t = this.tables.find(t => t.id === s.id);
+                    if (t) {
+                        t.status                   = s.status;
+                        t.bill_requested           = s.bill_requested;
+                        t.requested_payment_method = s.requested_payment_method;
+                    }
+                });
+            } catch {}
         },
 
         // ── Cambiar tamaño del lienzo y persistir en BD ───────────────────────

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,8 +59,7 @@ Route::middleware(['auth', 'business.active'])->group(function () {
         Route::post('/staff', [StaffController::class, 'store'])->name('staff.store');
         Route::delete('/staff/{staff}', [StaffController::class, 'destroy'])->name('staff.destroy');
 
-        // Mapa visual de mesas (Bloques 8.1 y 8.3) — solo admin
-        Route::get('/mesas/mapa', [TableController::class, 'map'])->name('tables.map');
+        // Mapa visual de mesas (Bloques 8.1 y 8.3) — solo admin puede editar
         Route::post('/mesas', [TableController::class, 'store'])->name('tables.store');
         Route::patch('/mesas/mapa/canvas', [TableController::class, 'updateCanvas'])->name('tables.canvas.update');
         Route::patch('/mesas/{table}/posicion', [TableController::class, 'updatePosition'])->name('tables.updatePosition');
@@ -72,6 +71,12 @@ Route::middleware(['auth', 'business.active'])->group(function () {
         Route::post('/zonas', [ZoneController::class, 'store'])->name('zones.store');
         Route::patch('/zonas/{zone}', [ZoneController::class, 'update'])->name('zones.update');
         Route::delete('/zonas/{zone}', [ZoneController::class, 'destroy'])->name('zones.destroy');
+    });
+
+    // Mapa visual — lectura para admin y camarero, edición solo admin
+    Route::middleware('role:admin,waiter')->group(function () {
+        Route::get('/mesas/mapa', [TableController::class, 'map'])->name('tables.map');
+        Route::get('/mesas/mapa/estados', [TableController::class, 'mapStatuses'])->name('tables.map.statuses');
     });
 
     // Gestión de mesas y códigos QR

--- a/routes/web.php
+++ b/routes/web.php
@@ -85,8 +85,8 @@ Route::middleware(['auth', 'business.active'])->group(function () {
     Route::get('/mesas/{table}/qr/descargar', [TableController::class, 'downloadQr'])->name('tables.qr.download');
     Route::post('/mesas/{table}/qr/regenerar', [TableController::class, 'regenerateHash'])->name('tables.qr.regenerate');
 
-    // Panel de cocina — accesible para roles admin y kitchen
-    Route::middleware('role:admin,kitchen')->group(function () {
+    // Panel de cocina — requiere canAccessKitchen() (rol nativo 'kitchen' o admin con is_kitchen=true)
+    Route::middleware('can.kitchen')->group(function () {
         Route::get('/cocina', [KitchenController::class, 'index'])->name('kitchen.index');
         Route::get('/cocina/badge', [KitchenController::class, 'badgeCount'])->name('kitchen.badge');
         Route::get('/cocina/pendientes', [KitchenController::class, 'pendingOrders'])->name('kitchen.pending');
@@ -94,8 +94,8 @@ Route::middleware(['auth', 'business.active'])->group(function () {
         Route::post('/cocina/orders/{order}/servido', [KitchenController::class, 'markOrderServed'])->name('kitchen.order.served');
     });
 
-    // Panel de barra y notificaciones al camarero — accesible para roles admin y waiter
-    Route::middleware('role:admin,waiter')->group(function () {
+    // Panel de barra y notificaciones al camarero — requiere canAccessBar() (rol nativo 'waiter' o admin con is_waiter=true)
+    Route::middleware('can.bar')->group(function () {
         Route::get('/bar', [BarPanelController::class, 'index'])->name('bar.index');
         Route::get('/bar/badge', [BarPanelController::class, 'badgeCount'])->name('bar.badge');
         Route::get('/bar/pendientes', [BarPanelController::class, 'pendingItems'])->name('bar.pending');

--- a/tests/Feature/Bloque14/MultirolTest.php
+++ b/tests/Feature/Bloque14/MultirolTest.php
@@ -27,22 +27,22 @@ it('admin with kitchen role can access kitchen panel', function () {
         ->assertOk();
 });
 
-// ─── Middleware no bloquea al admin sin flags (acceso directo permitido) ─────
+// ─── Admin sin flags recibe 403 en ambos paneles ─────────────────────────────
 
-it('admin without waiter flag can still access bar panel directly', function () {
+it('admin without waiter flag cannot access bar panel', function () {
     $admin = User::factory()->admin()->create(['is_waiter' => false]);
 
     $this->actingAs($admin)
         ->get(route('bar.index'))
-        ->assertOk();
+        ->assertForbidden();
 });
 
-it('admin without kitchen flag can still access kitchen panel directly', function () {
+it('admin without kitchen flag cannot access kitchen panel', function () {
     $admin = User::factory()->admin()->create(['is_kitchen' => false]);
 
     $this->actingAs($admin)
         ->get(route('kitchen.index'))
-        ->assertOk();
+        ->assertForbidden();
 });
 
 // ─── Visibilidad en navegación según flags ───────────────────────────────────

--- a/tests/Feature/Bloque4/KitchenPanelTest.php
+++ b/tests/Feature/Bloque4/KitchenPanelTest.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @author SebastianBCF
+ */
+
 use App\Models\Conversation;
 use App\Models\Order;
 use App\Models\OrderItem;
@@ -20,13 +24,21 @@ it('redirects unauthenticated user away from kitchen panel', function () {
         ->assertRedirect(route('login'));
 });
 
-it('shows kitchen panel to admin user', function () {
-    $admin = User::factory()->create(['role' => 'admin']);
+it('shows kitchen panel to admin with kitchen role', function () {
+    $admin = User::factory()->admin()->alsoKitchen()->create();
 
     $this->actingAs($admin)
         ->get(route('kitchen.index'))
         ->assertOk()
         ->assertViewIs('kitchen.index');
+});
+
+it('returns 403 for admin without kitchen role', function () {
+    $admin = User::factory()->admin()->create(['is_kitchen' => false]);
+
+    $this->actingAs($admin)
+        ->get(route('kitchen.index'))
+        ->assertForbidden();
 });
 
 it('returns 403 for waiter role user', function () {
@@ -163,4 +175,25 @@ it('conversation closes when order status changes to closed', function () {
     $order->update(['status' => 'closed']);
 
     expect($conversation->fresh()->status)->toBe('closed');
+});
+
+// ─── Aislamiento estricto por rol ────────────────────────────────────────────
+
+it('returns 403 for waiter role trying to access kitchen panel', function () {
+    $admin  = User::factory()->admin()->create();
+    $waiter = User::factory()->waiter()->staffOf($admin)->create();
+
+    $this->actingAs($waiter)
+        ->get(route('kitchen.index'))
+        ->assertForbidden();
+});
+
+it('allows kitchen role to access kitchen panel', function () {
+    $admin   = User::factory()->admin()->create();
+    $kitchen = User::factory()->kitchen()->staffOf($admin)->create();
+
+    $this->actingAs($kitchen)
+        ->get(route('kitchen.index'))
+        ->assertOk()
+        ->assertViewIs('kitchen.index');
 });

--- a/tests/Feature/Bloque6/BarPanelTest.php
+++ b/tests/Feature/Bloque6/BarPanelTest.php
@@ -2,6 +2,7 @@
 
 /**
  * @author AyrtonAlania
+ * @author SebastianBCF
  */
 
 use App\Models\Order;
@@ -34,13 +35,21 @@ it('shows bar panel to waiter role', function () {
         ->assertViewIs('bar.index');
 });
 
-it('shows bar panel to admin role', function () {
-    $admin = User::factory()->create(['role' => 'admin']);
+it('shows bar panel to admin with waiter role', function () {
+    $admin = User::factory()->admin()->alsoWaiter()->create();
 
     $this->actingAs($admin)
         ->get(route('bar.index'))
         ->assertOk()
         ->assertViewIs('bar.index');
+});
+
+it('returns 403 for admin without waiter role', function () {
+    $admin = User::factory()->admin()->create(['is_waiter' => false]);
+
+    $this->actingAs($admin)
+        ->get(route('bar.index'))
+        ->assertForbidden();
 });
 
 it('returns 403 for kitchen role on bar panel', function () {
@@ -325,4 +334,34 @@ it('returns 403 when dismissing notification from another restaurant', function 
         ->assertForbidden();
 
     expect($otherOrder->fresh()->notification_ready)->toBeTrue();
+});
+
+// ─── Aislamiento estricto por rol ────────────────────────────────────────────
+
+it('returns 403 for kitchen role trying to access bar panel', function () {
+    $admin   = User::factory()->admin()->create();
+    $kitchen = User::factory()->kitchen()->staffOf($admin)->create();
+
+    $this->actingAs($kitchen)
+        ->get(route('bar.index'))
+        ->assertForbidden();
+});
+
+it('allows admin with waiter role to access bar panel', function () {
+    $admin = User::factory()->admin()->alsoWaiter()->create();
+
+    $this->actingAs($admin)
+        ->get(route('bar.index'))
+        ->assertOk()
+        ->assertViewIs('bar.index');
+});
+
+it('allows waiter role to access bar panel', function () {
+    $admin  = User::factory()->admin()->create();
+    $waiter = User::factory()->waiter()->staffOf($admin)->create();
+
+    $this->actingAs($waiter)
+        ->get(route('bar.index'))
+        ->assertOk()
+        ->assertViewIs('bar.index');
 });

--- a/tests/Feature/Bloque7/PaymentTest.php
+++ b/tests/Feature/Bloque7/PaymentTest.php
@@ -94,7 +94,7 @@ it('bill request does not find a closed order', function () {
 // ─── Pago en efectivo (PaymentController) ────────────────────────────────────
 
 it('cash payment closes the order with payment_method cash', function () {
-    $admin = User::factory()->create(['role' => 'admin']);
+    $admin = User::factory()->admin()->alsoWaiter()->create();
     $table = Table::factory()->create(['user_id' => $admin->id]);
     $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
 
@@ -113,8 +113,8 @@ it('cash payment closes the order with payment_method cash', function () {
 });
 
 it('cash payment returns 403 when order belongs to another user', function () {
-    $admin      = User::factory()->create(['role' => 'admin']);
-    $otherAdmin = User::factory()->create(['role' => 'admin']);
+    $admin      = User::factory()->admin()->alsoWaiter()->create();
+    $otherAdmin = User::factory()->admin()->create();
     $table      = Table::factory()->create(['user_id' => $otherAdmin->id]);
     $order      = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
 
@@ -124,7 +124,7 @@ it('cash payment returns 403 when order belongs to another user', function () {
 });
 
 it('cash payment returns 422 when order is already closed', function () {
-    $admin = User::factory()->create(['role' => 'admin']);
+    $admin = User::factory()->admin()->alsoWaiter()->create();
     $table = Table::factory()->create(['user_id' => $admin->id]);
     $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'closed']);
 
@@ -383,7 +383,7 @@ it('closing a card payment closes active conversations on the table', function (
 });
 
 it('closing a cash payment closes active conversations on the table', function () {
-    $admin        = User::factory()->create(['role' => 'admin']);
+    $admin        = User::factory()->admin()->alsoWaiter()->create();
     $table        = Table::factory()->create(['user_id' => $admin->id]);
     $order        = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
     $conversation = Conversation::factory()->create(['table_id' => $table->id, 'status' => 'active']);

--- a/tests/Feature/Bloque8/TableMapTest.php
+++ b/tests/Feature/Bloque8/TableMapTest.php
@@ -46,10 +46,10 @@ it('returns 401 for unauthenticated user on destroy', function () {
 
 // ─── Control de rol ───────────────────────────────────────────────────────────
 
-it('returns 403 for non-admin on map page', function () {
+it('allows waiter read-only access to map page', function () {
     $this->actingAs($this->waiter)
          ->get(route('tables.map'))
-         ->assertForbidden();
+         ->assertOk();
 });
 
 it('returns 403 for non-admin on store', function () {

--- a/tests/Feature/Orders/KitchenPanelTest.php
+++ b/tests/Feature/Orders/KitchenPanelTest.php
@@ -1,0 +1,166 @@
+<?php
+
+use App\Models\Conversation;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Plan;
+use App\Models\Product;
+use App\Models\Table;
+use App\Models\User;
+use Tests\Support\CreatesTenants;
+
+uses(CreatesTenants::class);
+
+beforeEach(function () {
+    $this->setupTenants();
+});
+
+it('redirects unauthenticated user away from kitchen panel', function () {
+    $this->get(route('kitchen.index'))
+        ->assertRedirect(route('login'));
+});
+
+it('shows kitchen panel to admin with kitchen role', function () {
+    $admin = User::factory()->admin()->alsoKitchen()->create();
+
+    $this->actingAs($admin)
+        ->get(route('kitchen.index'))
+        ->assertOk()
+        ->assertViewIs('kitchen.index');
+});
+
+it('returns 403 for waiter role user', function () {
+    $waiter = User::factory()->create(['role' => 'waiter']);
+
+    $this->actingAs($waiter)
+        ->get(route('kitchen.index'))
+        ->assertForbidden();
+});
+
+it('shows only pending and cooking orders of the authenticated restaurant', function () {
+    $kitchenUser = User::factory()->create(['role' => 'kitchen']);
+    $table       = Table::factory()->create(['user_id' => $kitchenUser->id]);
+    $plan        = Plan::factory()->create();
+    $product     = Product::factory()->create(['user_id' => $kitchenUser->id]);
+
+    $pending = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    $cooking = Order::factory()->create(['table_id' => $table->id, 'status' => 'cooking']);
+    $served  = Order::factory()->create(['table_id' => $table->id, 'status' => 'served']);
+
+    OrderItem::factory()->create(['order_id' => $pending->id, 'product_id' => $product->id, 'status' => 'queued']);
+    OrderItem::factory()->create(['order_id' => $cooking->id, 'product_id' => $product->id, 'status' => 'queued']);
+
+    $response = $this->actingAs($kitchenUser)
+        ->get(route('kitchen.index'))
+        ->assertOk();
+
+    $orders = $response->viewData('orders');
+
+    expect($orders->pluck('id')->toArray())
+        ->toContain($pending->id)
+        ->toContain($cooking->id)
+        ->not->toContain($served->id);
+});
+
+it('does not show orders from other restaurants', function () {
+    $kitchenUser = User::factory()->create(['role' => 'kitchen']);
+    $otherUser   = User::factory()->create(['role' => 'admin']);
+
+    $ownTable   = Table::factory()->create(['user_id' => $kitchenUser->id]);
+    $otherTable = Table::factory()->create(['user_id' => $otherUser->id]);
+
+    $ownProduct   = Product::factory()->create(['user_id' => $kitchenUser->id]);
+    $otherProduct = Product::factory()->create(['user_id' => $otherUser->id]);
+
+    $ownOrder   = Order::factory()->create(['table_id' => $ownTable->id,   'status' => 'pending']);
+    $otherOrder = Order::factory()->create(['table_id' => $otherTable->id, 'status' => 'pending']);
+
+    OrderItem::factory()->create(['order_id' => $ownOrder->id,   'product_id' => $ownProduct->id,   'status' => 'queued']);
+    OrderItem::factory()->create(['order_id' => $otherOrder->id, 'product_id' => $otherProduct->id, 'status' => 'queued']);
+
+    $response = $this->actingAs($kitchenUser)
+        ->get(route('kitchen.index'))
+        ->assertOk();
+
+    $orders = $response->viewData('orders');
+
+    expect($orders->pluck('id')->toArray())
+        ->toContain($ownOrder->id)
+        ->not->toContain($otherOrder->id);
+});
+
+it('does not show closed orders', function () {
+    $kitchenUser = User::factory()->create(['role' => 'kitchen']);
+    $table       = Table::factory()->create(['user_id' => $kitchenUser->id]);
+    $product     = Product::factory()->create(['user_id' => $kitchenUser->id]);
+
+    $closedOrder = Order::factory()->create(['table_id' => $table->id, 'status' => 'closed']);
+
+    OrderItem::factory()->create(['order_id' => $closedOrder->id, 'product_id' => $product->id, 'status' => 'queued']);
+
+    $response = $this->actingAs($kitchenUser)
+        ->get(route('kitchen.index'))
+        ->assertOk();
+
+    $orders = $response->viewData('orders');
+
+    expect($orders->pluck('id')->toArray())
+        ->not->toContain($closedOrder->id);
+});
+
+it('kitchen staff can change order item status to ready', function () {
+    $kitchenUser = User::factory()->create(['role' => 'kitchen']);
+    $table       = Table::factory()->create(['user_id' => $kitchenUser->id]);
+    $product     = Product::factory()->create(['user_id' => $kitchenUser->id]);
+
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    $item  = OrderItem::factory()->create([
+        'order_id'   => $order->id,
+        'product_id' => $product->id,
+        'status'     => 'queued',
+    ]);
+
+    $this->actingAs($kitchenUser)
+        ->postJson(route('kitchen.item.ready', $item))
+        ->assertOk()
+        ->assertJsonPath('item_id', $item->id);
+
+    expect($item->fresh()->status)->toBe('ready');
+});
+
+it('all items ready triggers order status change to ready', function () {
+    $kitchenUser = User::factory()->create(['role' => 'kitchen']);
+    $table       = Table::factory()->create(['user_id' => $kitchenUser->id]);
+    $product     = Product::factory()->create(['user_id' => $kitchenUser->id]);
+
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+
+    $item1 = OrderItem::factory()->create([
+        'order_id'   => $order->id,
+        'product_id' => $product->id,
+        'status'     => 'queued',
+    ]);
+    $item2 = OrderItem::factory()->create([
+        'order_id'   => $order->id,
+        'product_id' => $product->id,
+        'status'     => 'ready',
+    ]);
+
+    $this->actingAs($kitchenUser)
+        ->postJson(route('kitchen.item.ready', $item1))
+        ->assertOk()
+        ->assertJsonPath('all_ready', true)
+        ->assertJsonPath('order_status', 'ready');
+
+    expect($order->fresh()->status)->toBe('ready');
+});
+
+it('conversation closes when order status changes to closed', function () {
+    $table        = Table::factory()->create(['user_id' => $this->user->id]);
+    $order        = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
+    $conversation = Conversation::factory()->create(['table_id' => $table->id, 'status' => 'active']);
+
+    $order->update(['status' => 'closed']);
+
+    expect($conversation->fresh()->status)->toBe('closed');
+});

--- a/tests/Feature/Orders/KitchenPanelTest.php
+++ b/tests/Feature/Orders/KitchenPanelTest.php
@@ -3,7 +3,6 @@
 use App\Models\Conversation;
 use App\Models\Order;
 use App\Models\OrderItem;
-use App\Models\Plan;
 use App\Models\Product;
 use App\Models\Table;
 use App\Models\User;
@@ -38,10 +37,10 @@ it('returns 403 for waiter role user', function () {
 });
 
 it('shows only pending and cooking orders of the authenticated restaurant', function () {
-    $kitchenUser = User::factory()->create(['role' => 'kitchen']);
-    $table       = Table::factory()->create(['user_id' => $kitchenUser->id]);
-    $plan        = Plan::factory()->create();
-    $product     = Product::factory()->create(['user_id' => $kitchenUser->id]);
+    $admin       = User::factory()->admin()->create();
+    $kitchenUser = User::factory()->kitchen()->staffOf($admin)->create();
+    $table       = Table::factory()->create(['user_id' => $admin->id]);
+    $product     = Product::factory()->create(['user_id' => $admin->id]);
 
     $pending = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
     $cooking = Order::factory()->create(['table_id' => $table->id, 'status' => 'cooking']);
@@ -63,14 +62,15 @@ it('shows only pending and cooking orders of the authenticated restaurant', func
 });
 
 it('does not show orders from other restaurants', function () {
-    $kitchenUser = User::factory()->create(['role' => 'kitchen']);
-    $otherUser   = User::factory()->create(['role' => 'admin']);
+    $admin       = User::factory()->admin()->create();
+    $kitchenUser = User::factory()->kitchen()->staffOf($admin)->create();
+    $otherAdmin  = User::factory()->admin()->create();
 
-    $ownTable   = Table::factory()->create(['user_id' => $kitchenUser->id]);
-    $otherTable = Table::factory()->create(['user_id' => $otherUser->id]);
+    $ownTable   = Table::factory()->create(['user_id' => $admin->id]);
+    $otherTable = Table::factory()->create(['user_id' => $otherAdmin->id]);
 
-    $ownProduct   = Product::factory()->create(['user_id' => $kitchenUser->id]);
-    $otherProduct = Product::factory()->create(['user_id' => $otherUser->id]);
+    $ownProduct   = Product::factory()->create(['user_id' => $admin->id]);
+    $otherProduct = Product::factory()->create(['user_id' => $otherAdmin->id]);
 
     $ownOrder   = Order::factory()->create(['table_id' => $ownTable->id,   'status' => 'pending']);
     $otherOrder = Order::factory()->create(['table_id' => $otherTable->id, 'status' => 'pending']);
@@ -90,9 +90,10 @@ it('does not show orders from other restaurants', function () {
 });
 
 it('does not show closed orders', function () {
-    $kitchenUser = User::factory()->create(['role' => 'kitchen']);
-    $table       = Table::factory()->create(['user_id' => $kitchenUser->id]);
-    $product     = Product::factory()->create(['user_id' => $kitchenUser->id]);
+    $admin       = User::factory()->admin()->create();
+    $kitchenUser = User::factory()->kitchen()->staffOf($admin)->create();
+    $table       = Table::factory()->create(['user_id' => $admin->id]);
+    $product     = Product::factory()->create(['user_id' => $admin->id]);
 
     $closedOrder = Order::factory()->create(['table_id' => $table->id, 'status' => 'closed']);
 
@@ -109,9 +110,10 @@ it('does not show closed orders', function () {
 });
 
 it('kitchen staff can change order item status to ready', function () {
-    $kitchenUser = User::factory()->create(['role' => 'kitchen']);
-    $table       = Table::factory()->create(['user_id' => $kitchenUser->id]);
-    $product     = Product::factory()->create(['user_id' => $kitchenUser->id]);
+    $admin       = User::factory()->admin()->create();
+    $kitchenUser = User::factory()->kitchen()->staffOf($admin)->create();
+    $table       = Table::factory()->create(['user_id' => $admin->id]);
+    $product     = Product::factory()->create(['user_id' => $admin->id]);
 
     $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
     $item  = OrderItem::factory()->create([
@@ -129,9 +131,10 @@ it('kitchen staff can change order item status to ready', function () {
 });
 
 it('all items ready triggers order status change to ready', function () {
-    $kitchenUser = User::factory()->create(['role' => 'kitchen']);
-    $table       = Table::factory()->create(['user_id' => $kitchenUser->id]);
-    $product     = Product::factory()->create(['user_id' => $kitchenUser->id]);
+    $admin       = User::factory()->admin()->create();
+    $kitchenUser = User::factory()->kitchen()->staffOf($admin)->create();
+    $table       = Table::factory()->create(['user_id' => $admin->id]);
+    $product     = Product::factory()->create(['user_id' => $admin->id]);
 
     $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending']);
 


### PR DESCRIPTION
## Summary

- Enforce strict kitchen/bar panel isolation: kitchen staff only see kitchen panel, bar staff only see bar panel, admins without flags get 403
- Waiter gets read-only access to table map (no drag/drop or edit controls)
- Live table status polling on map every 5s; animated badges for cash/card bill requests
- Dedicated `can.kitchen` / `can.bar` middleware replace `role:admin,kitchen` / `role:admin,waiter` for panel routes (single source of truth via `canAccessKitchen()` / `canAccessBar()`)
- Guard `mapStatuses` endpoint with `canAccessBar()` to prevent bill-request data leakage
- Fix kitchen panel tests: tables/products belong to admin, kitchen staff linked via `staffOf()`

## Test plan

- [x] `php artisan test --parallel` ? 681/681 passed
- [x] KitchenPanelTest, BarPanelTest, MultirolTest, TableMapTest cover happy paths, 403 isolation, and cross-restaurant multitenancy