### PR TITLE
[feat] bloque14.1 — migraciones, modelos y factories del menú del día

### DIFF
--- a/app/Models/DailyMenu.php
+++ b/app/Models/DailyMenu.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Class DailyMenu
+ *
+ * Representa el menú del día configurado por el gerente del restaurante.
+ * Puede definirse para un día de la semana (rotación semanal) o para una
+ * fecha específica (que tiene prioridad sobre el día de la semana).
+ *
+ * @property int              $user_id        ID del usuario propietario
+ * @property string           $title          Título del menú
+ * @property string|null      $description    Descripción del menú
+ * @property float            $price          Precio total del menú
+ * @property int|null         $max_per_day    Límite de menús disponibles por día
+ * @property bool             $is_active      Si el menú está activo
+ * @property string|null      $day_of_week    Día de la semana para rotación semanal
+ * @property \Carbon\Carbon|null $specific_date Fecha específica (tiene prioridad)
+ *
+ * @author Ayrtonalania
+ */
+class DailyMenu extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'title',
+        'description',
+        'price',
+        'max_per_day',
+        'is_active',
+        'day_of_week',
+        'specific_date',
+    ];
+
+    protected $casts = [
+        'price'         => 'decimal:2',
+        'is_active'     => 'boolean',
+        'specific_date' => 'date',
+    ];
+
+    /**
+     * El usuario propietario del menú.
+     *
+     * @return BelongsTo
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Las secciones del menú ordenadas por display_order.
+     *
+     * @return HasMany
+     */
+    public function sections(): HasMany
+    {
+        return $this->hasMany(DailyMenuSection::class)->orderBy('display_order');
+    }
+
+    /**
+     * Las reglas de timing del menú ordenadas por round_number.
+     *
+     * @return HasMany
+     */
+    public function timingRules(): HasMany
+    {
+        return $this->hasMany(DailyMenuTimingRule::class)->orderBy('round_number');
+    }
+
+    /**
+     * Los pedidos de menú del día asociados.
+     *
+     * @return HasMany
+     */
+    public function orders(): HasMany
+    {
+        return $this->hasMany(DailyMenuOrder::class);
+    }
+
+    /**
+     * Scope: filtra solo menús activos.
+     *
+     * @param  Builder $query
+     * @return Builder
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true);
+    }
+
+    /**
+     * Devuelve el menú del día vigente para el usuario dado.
+     * Prioridad: specific_date > day_of_week.
+     *
+     * @param  int       $userId
+     * @return self|null
+     */
+    public static function forToday(int $userId): ?self
+    {
+        $byDate = static::where('user_id', $userId)
+            ->where('specific_date', today())
+            ->where('is_active', true)
+            ->first();
+
+        if ($byDate) {
+            return $byDate;
+        }
+
+        return static::where('user_id', $userId)
+            ->where('day_of_week', strtolower(now()->englishDayOfWeek))
+            ->where('is_active', true)
+            ->first();
+    }
+}

--- a/app/Models/DailyMenuOrder.php
+++ b/app/Models/DailyMenuOrder.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Class DailyMenuOrder
+ *
+ * Vincula un Order normal con un DailyMenu, registrando las selecciones
+ * del cliente, el estado de progreso de las rondas y los ajustes de timing.
+ *
+ * @property int        $order_id                ID del pedido padre (Order)
+ * @property int        $daily_menu_id           ID del menú del día seleccionado
+ * @property int        $rounds_total            Total de rondas configuradas
+ * @property int        $current_round           Ronda en curso
+ * @property array|null $client_timing_overrides Ajustes de timing elegidos por el cliente
+ * @property string     $status                  pending|in_progress|completed|cancelled
+ *
+ * @author Ayrtonalania
+ */
+class DailyMenuOrder extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'order_id',
+        'daily_menu_id',
+        'rounds_total',
+        'current_round',
+        'client_timing_overrides',
+        'status',
+    ];
+
+    protected $casts = [
+        'client_timing_overrides' => 'array',
+        'current_round'           => 'integer',
+    ];
+
+    /**
+     * El pedido padre al que pertenece este pedido de menú.
+     *
+     * @return BelongsTo
+     */
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    /**
+     * El menú del día seleccionado por el cliente.
+     *
+     * @return BelongsTo
+     */
+    public function dailyMenu(): BelongsTo
+    {
+        return $this->belongsTo(DailyMenu::class);
+    }
+
+    /**
+     * Las selecciones de productos por sección del menú.
+     *
+     * @return HasMany
+     */
+    public function selections(): HasMany
+    {
+        return $this->hasMany(DailyMenuOrderSelection::class);
+    }
+
+    /**
+     * Cancela el pedido de menú del día actualizando su estado en base de datos.
+     *
+     * @return void
+     */
+    public function cancel(): void
+    {
+        $this->update(['status' => 'cancelled']);
+    }
+}

--- a/app/Models/DailyMenuOrderSelection.php
+++ b/app/Models/DailyMenuOrderSelection.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -20,6 +21,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class DailyMenuOrderSelection extends Model
 {
+    use HasFactory;
+
     protected $fillable = [
         'daily_menu_order_id',
         'daily_menu_section_id',

--- a/app/Models/DailyMenuOrderSelection.php
+++ b/app/Models/DailyMenuOrderSelection.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Class DailyMenuOrderSelection
+ *
+ * Registra la elección concreta de un producto dentro de una sección
+ * del menú del día por parte del cliente.
+ *
+ * @property int $daily_menu_order_id   ID del pedido de menú del día
+ * @property int $daily_menu_section_id ID de la sección del menú
+ * @property int $product_id            ID del producto elegido
+ * @property int $quantity              Cantidad seleccionada
+ *
+ * @author Ayrtonalania
+ */
+class DailyMenuOrderSelection extends Model
+{
+    protected $fillable = [
+        'daily_menu_order_id',
+        'daily_menu_section_id',
+        'product_id',
+        'quantity',
+    ];
+
+    protected $casts = [
+        'quantity' => 'integer',
+    ];
+
+    /**
+     * El pedido de menú al que pertenece esta selección.
+     *
+     * @return BelongsTo
+     */
+    public function dailyMenuOrder(): BelongsTo
+    {
+        return $this->belongsTo(DailyMenuOrder::class);
+    }
+
+    /**
+     * La sección del menú del día a la que corresponde esta elección.
+     *
+     * @return BelongsTo
+     */
+    public function section(): BelongsTo
+    {
+        return $this->belongsTo(DailyMenuSection::class, 'daily_menu_section_id');
+    }
+
+    /**
+     * El producto seleccionado por el cliente.
+     *
+     * @return BelongsTo
+     */
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/app/Models/DailyMenuSection.php
+++ b/app/Models/DailyMenuSection.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+/**
+ * Class DailyMenuSection
+ *
+ * Representa una sección del menú del día (primer plato, segundo plato, etc.).
+ * Contiene los productos disponibles para que el cliente elija en esa sección.
+ *
+ * @property int    $daily_menu_id  ID del menú al que pertenece
+ * @property string $type           Tipo: first_course|second_course|dessert|coffee|drink|bread
+ * @property bool   $is_required    Si la sección es obligatoria para confirmar el pedido
+ * @property bool   $is_free        Si la sección está incluida en el precio total del menú
+ * @property int    $max_quantity   Cantidad máxima que el cliente puede seleccionar
+ * @property int    $display_order  Orden de presentación en el stepper
+ *
+ * @author Ayrtonalania
+ */
+class DailyMenuSection extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'daily_menu_id',
+        'type',
+        'is_required',
+        'is_free',
+        'max_quantity',
+        'display_order',
+    ];
+
+    protected $casts = [
+        'is_required' => 'boolean',
+        'is_free'     => 'boolean',
+    ];
+
+    /**
+     * El menú del día al que pertenece esta sección.
+     *
+     * @return BelongsTo
+     */
+    public function dailyMenu(): BelongsTo
+    {
+        return $this->belongsTo(DailyMenu::class);
+    }
+
+    /**
+     * Los productos disponibles para elegir en esta sección.
+     *
+     * @return BelongsToMany
+     */
+    public function products(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            Product::class,
+            'daily_menu_section_products',
+            'daily_menu_section_id',
+            'product_id'
+        )->withTimestamps();
+    }
+}

--- a/app/Models/DailyMenuSectionProduct.php
+++ b/app/Models/DailyMenuSectionProduct.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Class DailyMenuSectionProduct
+ *
+ * Modelo explícito de la tabla pivote que relaciona secciones del menú
+ * con sus productos disponibles.
+ *
+ * @property int $daily_menu_section_id  ID de la sección
+ * @property int $product_id             ID del producto
+ *
+ * @author Ayrtonalania
+ */
+class DailyMenuSectionProduct extends Model
+{
+    protected $fillable = [
+        'daily_menu_section_id',
+        'product_id',
+    ];
+
+    /**
+     * La sección del menú del día a la que pertenece.
+     *
+     * @return BelongsTo
+     */
+    public function section(): BelongsTo
+    {
+        return $this->belongsTo(DailyMenuSection::class, 'daily_menu_section_id');
+    }
+
+    /**
+     * El producto asociado a esta entrada de la sección.
+     *
+     * @return BelongsTo
+     */
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/app/Models/DailyMenuTimingRule.php
+++ b/app/Models/DailyMenuTimingRule.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Class DailyMenuTimingRule
+ *
+ * Define los tiempos de entrega entre rondas del menú del día.
+ * Cada regla agrupa secciones en una ronda y establece el delay
+ * por defecto y el tiempo estimado de preparación en cocina/barra.
+ *
+ * @property int   $daily_menu_id           ID del menú
+ * @property int   $round_number            Número de ronda (1, 2, ...)
+ * @property int   $default_delay_minutes   Espera por defecto antes de enviar esta ronda
+ * @property int   $estimated_prep_minutes  Tiempo estimado de preparación en cocina/barra
+ * @property array $section_types           Tipos de sección incluidos en esta ronda
+ *
+ * @author Ayrtonalania
+ */
+class DailyMenuTimingRule extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'daily_menu_id',
+        'round_number',
+        'default_delay_minutes',
+        'estimated_prep_minutes',
+        'section_types',
+    ];
+
+    protected $casts = [
+        'section_types' => 'array',
+    ];
+
+    /**
+     * El menú del día al que pertenece esta regla de timing.
+     *
+     * @return BelongsTo
+     */
+    public function dailyMenu(): BelongsTo
+    {
+        return $this->belongsTo(DailyMenu::class);
+    }
+}

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -19,12 +19,17 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string $destination   'kitchen' o 'bar', copiado de la categoría del producto
  *
  * @author BenjaminDTS
+ * @author Ayrtonalania
  */
 class OrderItem extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['order_id', 'product_id', 'quantity', 'price', 'status', 'destination'];
+    protected $fillable = ['order_id', 'product_id', 'quantity', 'price', 'status', 'destination', 'is_daily_menu'];
+
+    protected $casts = [
+        'is_daily_menu' => 'boolean',
+    ];
 
     /**
      * El pedido general al que pertenece esta línea.

--- a/database/factories/DailyMenuFactory.php
+++ b/database/factories/DailyMenuFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\DailyMenu>
+ */
+class DailyMenuFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id'       => User::factory(),
+            'title'         => fake()->words(3, true) . ' del día',
+            'description'   => fake()->sentence(),
+            'price'         => fake()->randomFloat(2, 8, 18),
+            'max_per_day'   => null,
+            'is_active'     => true,
+            'day_of_week'   => fake()->randomElement([
+                'monday', 'tuesday', 'wednesday', 'thursday',
+                'friday', 'saturday', 'sunday',
+            ]),
+            'specific_date' => null,
+        ];
+    }
+}

--- a/database/factories/DailyMenuOrderFactory.php
+++ b/database/factories/DailyMenuOrderFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DailyMenu;
+use App\Models\Order;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\DailyMenuOrder>
+ */
+class DailyMenuOrderFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'order_id'                => Order::factory(),
+            'daily_menu_id'           => DailyMenu::factory(),
+            'rounds_total'            => 2,
+            'current_round'           => 0,
+            'client_timing_overrides' => null,
+            'status'                  => 'pending',
+        ];
+    }
+}

--- a/database/factories/DailyMenuOrderSelectionFactory.php
+++ b/database/factories/DailyMenuOrderSelectionFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DailyMenuOrder;
+use App\Models\DailyMenuSection;
+use App\Models\Product;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\DailyMenuOrderSelection>
+ */
+class DailyMenuOrderSelectionFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'daily_menu_order_id'   => DailyMenuOrder::factory(),
+            'daily_menu_section_id' => DailyMenuSection::factory(),
+            'product_id'            => Product::factory(),
+            'quantity'              => 1,
+        ];
+    }
+}

--- a/database/factories/DailyMenuSectionFactory.php
+++ b/database/factories/DailyMenuSectionFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DailyMenu;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\DailyMenuSection>
+ */
+class DailyMenuSectionFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'daily_menu_id' => DailyMenu::factory(),
+            'type'          => fake()->randomElement([
+                'first_course', 'second_course', 'dessert',
+                'coffee', 'drink', 'bread',
+            ]),
+            'is_required'   => true,
+            'is_free'       => false,
+            'max_quantity'  => 1,
+            'display_order' => fake()->numberBetween(0, 5),
+        ];
+    }
+}

--- a/database/factories/DailyMenuTimingRuleFactory.php
+++ b/database/factories/DailyMenuTimingRuleFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DailyMenu;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\DailyMenuTimingRule>
+ */
+class DailyMenuTimingRuleFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'daily_menu_id'          => DailyMenu::factory(),
+            'round_number'           => 1,
+            'default_delay_minutes'  => fake()->numberBetween(10, 30),
+            'estimated_prep_minutes' => fake()->numberBetween(5, 15),
+            'section_types'          => ['first_course'],
+        ];
+    }
+}

--- a/database/migrations/2026_05_16_000001_create_daily_menus_table.php
+++ b/database/migrations/2026_05_16_000001_create_daily_menus_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('daily_menus', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->decimal('price', 8, 2);
+            $table->unsignedInteger('max_per_day')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->enum('day_of_week', [
+                'monday', 'tuesday', 'wednesday', 'thursday',
+                'friday', 'saturday', 'sunday',
+            ])->nullable();
+            $table->date('specific_date')->nullable();
+            $table->timestamps();
+
+            $table->index('day_of_week');
+            $table->index('specific_date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('daily_menus');
+    }
+};

--- a/database/migrations/2026_05_16_000002_create_daily_menu_sections_table.php
+++ b/database/migrations/2026_05_16_000002_create_daily_menu_sections_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('daily_menu_sections', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('daily_menu_id')->constrained()->onDelete('cascade');
+            $table->enum('type', [
+                'first_course', 'second_course', 'dessert',
+                'coffee', 'drink', 'bread',
+            ]);
+            $table->boolean('is_required')->default(true);
+            $table->boolean('is_free')->default(false);
+            $table->unsignedTinyInteger('max_quantity')->default(1);
+            $table->unsignedTinyInteger('display_order')->default(0);
+            $table->timestamps();
+
+            $table->index('daily_menu_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('daily_menu_sections');
+    }
+};

--- a/database/migrations/2026_05_16_000003_create_daily_menu_section_products_table.php
+++ b/database/migrations/2026_05_16_000003_create_daily_menu_section_products_table.php
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->foreignId('product_id')->constrained()->onDelete('cascade');
             $table->timestamps();
 
-            $table->unique(['daily_menu_section_id', 'product_id']);
+            $table->unique(['daily_menu_section_id', 'product_id'], 'dmsec_products_unique');
         });
     }
 

--- a/database/migrations/2026_05_16_000003_create_daily_menu_section_products_table.php
+++ b/database/migrations/2026_05_16_000003_create_daily_menu_section_products_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('daily_menu_section_products', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('daily_menu_section_id')
+                ->constrained('daily_menu_sections')
+                ->onDelete('cascade');
+            $table->foreignId('product_id')->constrained()->onDelete('cascade');
+            $table->timestamps();
+
+            $table->unique(['daily_menu_section_id', 'product_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('daily_menu_section_products');
+    }
+};

--- a/database/migrations/2026_05_16_000004_create_daily_menu_timing_rules_table.php
+++ b/database/migrations/2026_05_16_000004_create_daily_menu_timing_rules_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('daily_menu_timing_rules', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('daily_menu_id')->constrained()->onDelete('cascade');
+            $table->unsignedTinyInteger('round_number');
+            $table->unsignedSmallInteger('default_delay_minutes');
+            $table->unsignedSmallInteger('estimated_prep_minutes');
+            $table->json('section_types');
+            $table->timestamps();
+
+            $table->unique(['daily_menu_id', 'round_number']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('daily_menu_timing_rules');
+    }
+};

--- a/database/migrations/2026_05_16_000005_create_daily_menu_orders_table.php
+++ b/database/migrations/2026_05_16_000005_create_daily_menu_orders_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('daily_menu_orders', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained()->onDelete('cascade')->unique();
+            $table->foreignId('daily_menu_id')->constrained()->onDelete('cascade');
+            $table->unsignedTinyInteger('rounds_total');
+            $table->unsignedTinyInteger('current_round')->default(0);
+            $table->json('client_timing_overrides')->nullable();
+            $table->enum('status', ['pending', 'in_progress', 'completed', 'cancelled'])
+                ->default('pending');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('daily_menu_orders');
+    }
+};

--- a/database/migrations/2026_05_16_000006_create_daily_menu_order_selections_table.php
+++ b/database/migrations/2026_05_16_000006_create_daily_menu_order_selections_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('daily_menu_order_selections', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('daily_menu_order_id')
+                ->constrained('daily_menu_orders')
+                ->onDelete('cascade');
+            $table->foreignId('daily_menu_section_id')
+                ->constrained('daily_menu_sections')
+                ->onDelete('cascade');
+            $table->foreignId('product_id')->constrained()->onDelete('cascade');
+            $table->unsignedTinyInteger('quantity')->default(1);
+            $table->timestamps();
+
+            $table->index('daily_menu_order_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('daily_menu_order_selections');
+    }
+};

--- a/database/migrations/2026_05_16_000007_add_is_daily_menu_to_order_items.php
+++ b/database/migrations/2026_05_16_000007_add_is_daily_menu_to_order_items.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->boolean('is_daily_menu')->default(false)->after('destination');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->dropColumn('is_daily_menu');
+        });
+    }
+};


### PR DESCRIPTION
## Qué se implementa

- 7 migraciones nuevas: \`daily_menus\`, \`daily_menu_sections\`, \`daily_menu_section_products\`, \`daily_menu_timing_rules\`, \`daily_menu_orders\`, \`daily_menu_order_selections\`
- Migración adicional: columna \`is_daily_menu\` en \`order_items\` (vía \`Schema::table()\`)
- 6 modelos nuevos con relaciones, casts y PHPDoc completo
- \`DailyMenu::forToday()\` con prioridad \`specific_date\` > \`day_of_week\`
- \`DailyMenuOrder::cancel()\` para cancelar pedidos de menú del día (persiste en BD)
- 5 factories nuevas para uso en tests de bloques 14.2 a 14.6

## Fixes post-review

- \`HasFactory\` añadido a \`DailyMenuOrderSelection\` (blocker del reviewer)
- Nombre del índice único de \`daily_menu_section_products\` acortado a \`dmsec_products_unique\` para respetar el límite de 64 caracteres de MySQL

## Verificaciones completadas

- \`php artisan migrate:fresh --seed\` — todas las tablas en DONE, sin errores
- \`DailyMenu::forToday()\` verificado en tinker (3 casos):
  - Solo \`specific_date = today\` → devuelve el menú por fecha ✓
  - Solo \`day_of_week\` del día actual → devuelve el menú por día ✓
  - Ambos activos → gana \`specific_date\` (prioridad correcta) ✓
- \`DailyMenuOrder::cancel()\` verificado en tinker: \`pending\` → \`cancelled\` persiste en BD ✓
- \`php artisan test\` — 556 tests passing, 0 fallos (sin regresiones)

## Reglas aplicadas

- Un commit por archivo
- \`@author Ayrtonalania\` en cabecera de todos los modelos nuevos
- Migraciones en orden numérico secuencial (\`2026_05_16_000001\` → \`2026_05_16_000007\`)
- \`down()\` correcto e inverso en todas las migraciones

## Checklist CLAUDE.md

- [x] \`php artisan migrate:fresh --seed\` sin errores
- [x] \`php artisan test\` — 556 tests en verde
- [x] Un commit por archivo
- [x] \`@author Ayrtonalania\` en cabeceras de clase
- [x] \`forToday()\` verificado en tinker (3 casos)
- [x] \`cancel()\` persiste en BD
- [x] Reviewer: SHIP IT (tras fixes)

## Prerequisito para 14.2 a 14.6

Este PR debe estar mergeado antes de construir controladores, rutas, jobs o tests del Menú del Día.