### PR TITLE
[feat] bloque14.2 — panel del gerente para gestión del menú del día

### DIFF
--- a/app/Http/Controllers/DailyMenuController.php
+++ b/app/Http/Controllers/DailyMenuController.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\DailyMenu;
+use App\Models\DailyMenuSection;
+use App\Models\Product;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\View\View;
+
+/**
+ * Class DailyMenuController
+ *
+ * Gestiona el CRUD del Menú del Día desde el panel del gerente.
+ * Permite crear, editar, eliminar y configurar menús del día (plantillas
+ * semanales y excepciones por fecha), gestionar sus secciones con productos
+ * y configurar las rondas de timing de envío a cocina/barra.
+ *
+ * @package App\Http\Controllers
+ * @author Ayrtonalania
+ */
+class DailyMenuController extends Controller
+{
+    /**
+     * Muestra el listado de menús del día del usuario autenticado.
+     * Incluye un resumen semanal con el estado de cada día de la semana.
+     *
+     * @return View
+     */
+    public function index(): View
+    {
+        $ownerId = Auth::user()->ownerUserId();
+
+        $menus = DailyMenu::where('user_id', $ownerId)
+            ->orderByRaw("CASE WHEN specific_date IS NOT NULL THEN 0 ELSE 1 END")
+            ->orderBy('specific_date')
+            ->orderByRaw("FIELD(day_of_week, 'monday','tuesday','wednesday','thursday','friday','saturday','sunday')")
+            ->paginate(15);
+
+        $weekDays = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
+        $today    = now()->startOfDay();
+        $nextWeek = now()->addDays(7)->endOfDay();
+
+        $weekSummary = [];
+        foreach ($weekDays as $day) {
+            $menu = DailyMenu::where('user_id', $ownerId)
+                ->where('day_of_week', $day)
+                ->where('is_active', true)
+                ->first();
+
+            $exception = DailyMenu::where('user_id', $ownerId)
+                ->whereNotNull('specific_date')
+                ->whereBetween('specific_date', [$today, $nextWeek])
+                ->where('is_active', true)
+                ->first();
+
+            $weekSummary[$day] = [
+                'menu'      => $menu,
+                'exception' => $exception,
+            ];
+        }
+
+        return view('daily-menus.index', compact('menus', 'weekSummary'));
+    }
+
+    /**
+     * Muestra el formulario para crear un nuevo menú del día.
+     *
+     * @return View
+     */
+    public function create(): View
+    {
+        return view('daily-menus.create');
+    }
+
+    /**
+     * Almacena un nuevo menú del día en la base de datos.
+     *
+     * @param  Request $request
+     * @return RedirectResponse
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'title'         => 'required|string|max:255',
+            'description'   => 'nullable|string|max:1000',
+            'price'         => 'required|numeric|min:0.01',
+            'max_per_day'   => 'nullable|integer|min:1',
+            'is_active'     => 'boolean',
+            'day_of_week'   => 'nullable|in:monday,tuesday,wednesday,thursday,friday,saturday,sunday|required_without:specific_date',
+            'specific_date' => 'nullable|date|after_or_equal:today|required_without:day_of_week',
+        ]);
+
+        $ownerId = Auth::user()->ownerUserId();
+
+        if (!empty($validated['day_of_week'])) {
+            $exists = DailyMenu::where('user_id', $ownerId)
+                ->where('day_of_week', $validated['day_of_week'])
+                ->where('is_active', true)
+                ->exists();
+
+            if ($exists) {
+                return back()->withInput()->withErrors([
+                    'day_of_week' => 'Ya existe un menú activo para ese día de la semana.',
+                ]);
+            }
+        }
+
+        if (!empty($validated['specific_date'])) {
+            $exists = DailyMenu::where('user_id', $ownerId)
+                ->where('specific_date', $validated['specific_date'])
+                ->where('is_active', true)
+                ->exists();
+
+            if ($exists) {
+                return back()->withInput()->withErrors([
+                    'specific_date' => 'Ya existe un menú activo para esa fecha específica.',
+                ]);
+            }
+        }
+
+        $validated['is_active'] = $request->boolean('is_active', true);
+
+        $menu = DailyMenu::create(array_merge($validated, ['user_id' => $ownerId]));
+
+        return redirect()
+            ->route('daily-menus.sections', $menu)
+            ->with('success', 'Menú del Día creado. Configura ahora sus secciones.');
+    }
+
+    /**
+     * Muestra el formulario para editar un menú del día existente.
+     *
+     * @param  DailyMenu $dailyMenu
+     * @return View
+     */
+    public function edit(DailyMenu $dailyMenu): View
+    {
+        abort_if($dailyMenu->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
+
+        return view('daily-menus.edit', compact('dailyMenu'));
+    }
+
+    /**
+     * Actualiza un menú del día en la base de datos.
+     *
+     * @param  Request   $request
+     * @param  DailyMenu $dailyMenu
+     * @return RedirectResponse
+     */
+    public function update(Request $request, DailyMenu $dailyMenu): RedirectResponse
+    {
+        abort_if($dailyMenu->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
+
+        $validated = $request->validate([
+            'title'         => 'required|string|max:255',
+            'description'   => 'nullable|string|max:1000',
+            'price'         => 'required|numeric|min:0.01',
+            'max_per_day'   => 'nullable|integer|min:1',
+            'is_active'     => 'boolean',
+            'day_of_week'   => 'nullable|in:monday,tuesday,wednesday,thursday,friday,saturday,sunday|required_without:specific_date',
+            'specific_date' => 'nullable|date|required_without:day_of_week',
+        ]);
+
+        $ownerId = Auth::user()->ownerUserId();
+
+        if (!empty($validated['day_of_week'])) {
+            $exists = DailyMenu::where('user_id', $ownerId)
+                ->where('day_of_week', $validated['day_of_week'])
+                ->where('is_active', true)
+                ->where('id', '!=', $dailyMenu->id)
+                ->exists();
+
+            if ($exists) {
+                return back()->withInput()->withErrors([
+                    'day_of_week' => 'Ya existe un menú activo para ese día de la semana.',
+                ]);
+            }
+        }
+
+        if (!empty($validated['specific_date'])) {
+            $exists = DailyMenu::where('user_id', $ownerId)
+                ->where('specific_date', $validated['specific_date'])
+                ->where('is_active', true)
+                ->where('id', '!=', $dailyMenu->id)
+                ->exists();
+
+            if ($exists) {
+                return back()->withInput()->withErrors([
+                    'specific_date' => 'Ya existe un menú activo para esa fecha específica.',
+                ]);
+            }
+        }
+
+        $validated['is_active'] = $request->boolean('is_active');
+
+        $dailyMenu->update($validated);
+
+        return redirect()
+            ->route('daily-menus.index')
+            ->with('success', 'Menú del Día actualizado correctamente.');
+    }
+
+    /**
+     * Elimina un menú del día (las secciones se eliminan en cascada por FK).
+     *
+     * @param  DailyMenu $dailyMenu
+     * @return RedirectResponse
+     */
+    public function destroy(DailyMenu $dailyMenu): RedirectResponse
+    {
+        abort_if($dailyMenu->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
+
+        $dailyMenu->delete();
+
+        return redirect()
+            ->route('daily-menus.index')
+            ->with('success', 'Menú del Día eliminado correctamente.');
+    }
+
+    /**
+     * Muestra la vista de configuración de secciones y timing del menú.
+     *
+     * @param  DailyMenu $dailyMenu
+     * @return View
+     */
+    public function sections(DailyMenu $dailyMenu): View
+    {
+        abort_if($dailyMenu->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
+
+        $dailyMenu->load('sections.products', 'timingRules');
+
+        $products = Product::where('user_id', Auth::user()->ownerUserId())
+            ->where('is_active', true)
+            ->with('category')
+            ->orderBy('name')
+            ->get();
+
+        $sectionTypes = ['first_course', 'second_course', 'dessert', 'coffee', 'drink', 'bread'];
+
+        return view('daily-menus.sections', compact('dailyMenu', 'products', 'sectionTypes'));
+    }
+
+    /**
+     * Sincroniza los productos asignados a una sección del menú.
+     *
+     * @param  Request          $request
+     * @param  DailyMenu        $dailyMenu
+     * @param  DailyMenuSection $section
+     * @return RedirectResponse
+     */
+    public function syncProducts(Request $request, DailyMenu $dailyMenu, DailyMenuSection $section): RedirectResponse
+    {
+        abort_if($dailyMenu->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
+        abort_if($section->daily_menu_id !== $dailyMenu->id, 403, 'Acceso denegado.');
+
+        $validated = $request->validate([
+            'product_ids'   => 'nullable|array',
+            'product_ids.*' => 'integer|exists:products,id',
+        ]);
+
+        if (!empty($validated['product_ids'])) {
+            $invalid = Product::whereIn('id', $validated['product_ids'])
+                ->where('user_id', '!=', Auth::user()->ownerUserId())
+                ->exists();
+
+            if ($invalid) {
+                abort(403, 'Acceso denegado.');
+            }
+        }
+
+        DB::transaction(function () use ($section, $validated) {
+            $section->products()->sync($validated['product_ids'] ?? []);
+        });
+
+        return redirect()
+            ->route('daily-menus.sections', $dailyMenu)
+            ->with('success', 'Productos de la sección actualizados.');
+    }
+
+    /**
+     * Guarda la configuración de rondas de timing del menú del día.
+     * Elimina las reglas anteriores y las reemplaza en una sola transacción.
+     *
+     * @param  Request   $request
+     * @param  DailyMenu $dailyMenu
+     * @return RedirectResponse
+     */
+    public function storeTiming(Request $request, DailyMenu $dailyMenu): RedirectResponse
+    {
+        abort_if($dailyMenu->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
+
+        $request->validate([
+            'rounds'                          => 'required|array|min:1|max:4',
+            'rounds.*.round_number'           => 'required|integer|min:1|max:4',
+            'rounds.*.default_delay_minutes'  => 'required|integer|min:0',
+            'rounds.*.estimated_prep_minutes' => 'required|integer|min:1',
+            'rounds.*.section_types'          => 'required|array|min:1',
+            'rounds.*.section_types.*'        => 'in:first_course,second_course,dessert,coffee,drink,bread',
+        ]);
+
+        DB::transaction(function () use ($request, $dailyMenu) {
+            $dailyMenu->timingRules()->delete();
+            foreach ($request->rounds as $round) {
+                $dailyMenu->timingRules()->create($round);
+            }
+        });
+
+        return redirect()
+            ->route('daily-menus.sections', $dailyMenu)
+            ->with('success', 'Configuración de tiempos guardada correctamente.');
+    }
+}

--- a/app/Http/Controllers/DailyMenuController.php
+++ b/app/Http/Controllers/DailyMenuController.php
@@ -245,6 +245,60 @@ class DailyMenuController extends Controller
     }
 
     /**
+     * Crea una nueva sección para el menú del día.
+     *
+     * @param  Request   $request
+     * @param  DailyMenu $dailyMenu
+     * @return RedirectResponse
+     */
+    public function storeSection(Request $request, DailyMenu $dailyMenu): RedirectResponse
+    {
+        abort_if($dailyMenu->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
+
+        $validated = $request->validate([
+            'section_type' => 'required|in:first_course,second_course,dessert,coffee,drink,bread',
+        ]);
+
+        $alreadyExists = $dailyMenu->sections()->where('type', $validated['section_type'])->exists();
+        if ($alreadyExists) {
+            return back()->with('error', 'Esa sección ya existe en este menú.');
+        }
+
+        $displayOrder = $dailyMenu->sections()->count() + 1;
+
+        $dailyMenu->sections()->create([
+            'type'          => $validated['section_type'],
+            'is_required'   => false,
+            'is_free'       => false,
+            'max_quantity'  => 1,
+            'display_order' => $displayOrder,
+        ]);
+
+        return redirect()
+            ->route('daily-menus.sections', $dailyMenu)
+            ->with('success', 'Sección añadida correctamente.');
+    }
+
+    /**
+     * Elimina una sección del menú del día.
+     *
+     * @param  DailyMenu        $dailyMenu
+     * @param  DailyMenuSection $section
+     * @return RedirectResponse
+     */
+    public function destroySection(DailyMenu $dailyMenu, DailyMenuSection $section): RedirectResponse
+    {
+        abort_if($dailyMenu->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
+        abort_if($section->daily_menu_id !== $dailyMenu->id, 403, 'Acceso denegado.');
+
+        $section->delete();
+
+        return redirect()
+            ->route('daily-menus.sections', $dailyMenu)
+            ->with('success', 'Sección eliminada correctamente.');
+    }
+
+    /**
      * Sincroniza los productos asignados a una sección del menú.
      *
      * @param  Request          $request

--- a/app/Http/Controllers/DailyMenuController.php
+++ b/app/Http/Controllers/DailyMenuController.php
@@ -35,6 +35,7 @@ class DailyMenuController extends Controller
         $ownerId = Auth::user()->ownerUserId();
 
         $menus = DailyMenu::where('user_id', $ownerId)
+            ->withCount('sections')
             ->orderByRaw("CASE WHEN specific_date IS NOT NULL THEN 0 ELSE 1 END")
             ->orderBy('specific_date')
             ->orderByRaw("FIELD(day_of_week, 'monday','tuesday','wednesday','thursday','friday','saturday','sunday')")
@@ -44,22 +45,25 @@ class DailyMenuController extends Controller
         $today    = now()->startOfDay();
         $nextWeek = now()->addDays(7)->endOfDay();
 
+        // Pre-cargar menús semanales y excepciones en 2 queries para evitar N+1
+        $weeklyMenus = DailyMenu::where('user_id', $ownerId)
+            ->where('is_active', true)
+            ->whereIn('day_of_week', $weekDays)
+            ->get()
+            ->keyBy('day_of_week');
+
+        $upcomingExceptions = DailyMenu::where('user_id', $ownerId)
+            ->where('is_active', true)
+            ->whereNotNull('specific_date')
+            ->whereBetween('specific_date', [$today, $nextWeek])
+            ->get()
+            ->keyBy(fn ($m) => strtolower($m->specific_date->englishDayOfWeek));
+
         $weekSummary = [];
         foreach ($weekDays as $day) {
-            $menu = DailyMenu::where('user_id', $ownerId)
-                ->where('day_of_week', $day)
-                ->where('is_active', true)
-                ->first();
-
-            $exception = DailyMenu::where('user_id', $ownerId)
-                ->whereNotNull('specific_date')
-                ->whereBetween('specific_date', [$today, $nextWeek])
-                ->where('is_active', true)
-                ->first();
-
             $weekSummary[$day] = [
-                'menu'      => $menu,
-                'exception' => $exception,
+                'menu'      => $weeklyMenus->get($day),
+                'exception' => $upcomingExceptions->get($day),
             ];
         }
 
@@ -347,7 +351,7 @@ class DailyMenuController extends Controller
     {
         abort_if($dailyMenu->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
-        $request->validate([
+        $validated = $request->validate([
             'rounds'                          => 'required|array|min:1|max:4',
             'rounds.*.round_number'           => 'required|integer|min:1|max:4',
             'rounds.*.default_delay_minutes'  => 'required|integer|min:0',
@@ -356,9 +360,9 @@ class DailyMenuController extends Controller
             'rounds.*.section_types.*'        => 'in:first_course,second_course,dessert,coffee,drink,bread',
         ]);
 
-        DB::transaction(function () use ($request, $dailyMenu) {
+        DB::transaction(function () use ($validated, $dailyMenu) {
             $dailyMenu->timingRules()->delete();
-            foreach ($request->rounds as $round) {
+            foreach ($validated['rounds'] as $round) {
                 $dailyMenu->timingRules()->create($round);
             }
         });

--- a/resources/views/daily-menus/create.blade.php
+++ b/resources/views/daily-menus/create.blade.php
@@ -1,0 +1,175 @@
+{{-- @author Ayrtonalania --}}
+<x-app-layout>
+  <x-slot name="header">
+    <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+      Nuevo Menú del Día
+    </h2>
+  </x-slot>
+
+  <div class="py-12">
+    <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 sm:p-8">
+
+        <form action="{{ route('daily-menus.store') }}" method="POST" novalidate>
+          @csrf
+
+          <div class="space-y-5">
+
+            {{-- Título --}}
+            <div>
+              <label for="title" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Título <span class="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <input type="text" id="title" name="title"
+                     value="{{ old('title') }}"
+                     aria-required="true"
+                     aria-describedby="{{ $errors->has('title') ? 'error-title' : '' }}"
+                     class="w-full border rounded-md px-3 py-2 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100
+                            {{ $errors->has('title') ? 'border-red-500' : 'border-gray-300' }}">
+              @error('title')
+                <p id="error-title" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+              @enderror
+            </div>
+
+            {{-- Descripción --}}
+            <div>
+              <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Descripción
+              </label>
+              <textarea id="description" name="description" rows="3"
+                        aria-describedby="{{ $errors->has('description') ? 'error-description' : '' }}"
+                        class="w-full border rounded-md px-3 py-2 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100
+                               {{ $errors->has('description') ? 'border-red-500' : 'border-gray-300' }}">{{ old('description') }}</textarea>
+              @error('description')
+                <p id="error-description" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+              @enderror
+            </div>
+
+            {{-- Precio y Max por día --}}
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label for="price" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Precio (€) <span class="text-red-500" aria-hidden="true">*</span>
+                </label>
+                <input type="number" id="price" name="price"
+                       value="{{ old('price') }}"
+                       step="0.01" min="0.01"
+                       aria-required="true"
+                       aria-describedby="{{ $errors->has('price') ? 'error-price' : '' }}"
+                       class="w-full border rounded-md px-3 py-2 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100
+                              {{ $errors->has('price') ? 'border-red-500' : 'border-gray-300' }}">
+                @error('price')
+                  <p id="error-price" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+              </div>
+              <div>
+                <label for="max_per_day" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Máximo por día
+                </label>
+                <input type="number" id="max_per_day" name="max_per_day"
+                       value="{{ old('max_per_day') }}"
+                       min="1"
+                       aria-describedby="hint-max_per_day {{ $errors->has('max_per_day') ? 'error-max_per_day' : '' }}"
+                       class="w-full border rounded-md px-3 py-2 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100
+                              {{ $errors->has('max_per_day') ? 'border-red-500' : 'border-gray-300' }}">
+                <p id="hint-max_per_day" class="mt-1 text-xs text-gray-400">Vacío = sin límite</p>
+                @error('max_per_day')
+                  <p id="error-max_per_day" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+              </div>
+            </div>
+
+            {{-- Activo --}}
+            <div class="flex items-center gap-3">
+              <input type="hidden" name="is_active" value="0">
+              <input type="checkbox" id="is_active" name="is_active" value="1"
+                     {{ old('is_active', true) ? 'checked' : '' }}
+                     class="h-4 w-4 text-orange-500 border-gray-300 rounded">
+              <label for="is_active" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                Menú activo
+              </label>
+            </div>
+
+            {{-- Selector de modo: día de semana vs fecha específica --}}
+            <div x-data="{
+                   mode: '{{ old('day_of_week') ? 'week' : (old('specific_date') ? 'date' : 'week') }}'
+                 }">
+              <fieldset>
+                <legend class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Programación <span class="text-red-500" aria-hidden="true">*</span>
+                </legend>
+                <div class="flex gap-4 mb-3">
+                  <label class="flex items-center gap-2 cursor-pointer">
+                    <input type="radio" name="_mode" value="week"
+                           x-model="mode"
+                           class="h-4 w-4 text-orange-500 border-gray-300">
+                    <span class="text-sm text-gray-700 dark:text-gray-300">Día de la semana</span>
+                  </label>
+                  <label class="flex items-center gap-2 cursor-pointer">
+                    <input type="radio" name="_mode" value="date"
+                           x-model="mode"
+                           class="h-4 w-4 text-orange-500 border-gray-300">
+                    <span class="text-sm text-gray-700 dark:text-gray-300">Fecha específica</span>
+                  </label>
+                </div>
+
+                {{-- Selector día de semana --}}
+                <div x-show="mode === 'week'" x-cloak>
+                  <label for="day_of_week" class="block text-sm text-gray-600 dark:text-gray-400 mb-1">
+                    Día de la semana
+                  </label>
+                  <select id="day_of_week" name="day_of_week"
+                          :required="mode === 'week'"
+                          aria-describedby="{{ $errors->has('day_of_week') ? 'error-day_of_week' : '' }}"
+                          class="w-full border rounded-md px-3 py-2 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100
+                                 {{ $errors->has('day_of_week') ? 'border-red-500' : 'border-gray-300' }}">
+                    <option value="">— Seleccionar —</option>
+                    @foreach(['monday' => 'Lunes', 'tuesday' => 'Martes', 'wednesday' => 'Miércoles', 'thursday' => 'Jueves', 'friday' => 'Viernes', 'saturday' => 'Sábado', 'sunday' => 'Domingo'] as $val => $label)
+                      <option value="{{ $val }}" {{ old('day_of_week') === $val ? 'selected' : '' }}>
+                        {{ $label }}
+                      </option>
+                    @endforeach
+                  </select>
+                  @error('day_of_week')
+                    <p id="error-day_of_week" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                  @enderror
+                </div>
+
+                {{-- Input fecha específica --}}
+                <div x-show="mode === 'date'" x-cloak>
+                  <label for="specific_date" class="block text-sm text-gray-600 dark:text-gray-400 mb-1">
+                    Fecha
+                  </label>
+                  <input type="date" id="specific_date" name="specific_date"
+                         value="{{ old('specific_date') }}"
+                         min="{{ date('Y-m-d') }}"
+                         :required="mode === 'date'"
+                         aria-describedby="{{ $errors->has('specific_date') ? 'error-specific_date' : '' }}"
+                         class="w-full border rounded-md px-3 py-2 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100
+                                {{ $errors->has('specific_date') ? 'border-red-500' : 'border-gray-300' }}">
+                  @error('specific_date')
+                    <p id="error-specific_date" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                  @enderror
+                </div>
+              </fieldset>
+            </div>
+
+          </div>
+
+          {{-- Acciones --}}
+          <div class="flex justify-end gap-3 mt-6 pt-4 border-t border-gray-200 dark:border-gray-700">
+            <a href="{{ route('daily-menus.index') }}"
+               class="px-4 py-2 text-sm text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-md">
+              Cancelar
+            </a>
+            <button type="submit"
+                    class="px-4 py-2 text-sm text-white bg-orange-500 hover:bg-orange-700 rounded-md font-medium">
+              Guardar
+            </button>
+          </div>
+
+        </form>
+      </div>
+    </div>
+  </div>
+</x-app-layout>

--- a/resources/views/daily-menus/edit.blade.php
+++ b/resources/views/daily-menus/edit.blade.php
@@ -1,0 +1,177 @@
+{{-- @author Ayrtonalania --}}
+<x-app-layout>
+  <x-slot name="header">
+    <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+      Editar Menú del Día — {{ $dailyMenu->title }}
+    </h2>
+  </x-slot>
+
+  <div class="py-12">
+    <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 sm:p-8">
+
+        <form action="{{ route('daily-menus.update', $dailyMenu) }}" method="POST" novalidate>
+          @csrf
+          @method('PUT')
+
+          <div class="space-y-5">
+
+            {{-- Título --}}
+            <div>
+              <label for="title" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Título <span class="text-red-500" aria-hidden="true">*</span>
+              </label>
+              <input type="text" id="title" name="title"
+                     value="{{ old('title', $dailyMenu->title) }}"
+                     aria-required="true"
+                     aria-describedby="{{ $errors->has('title') ? 'error-title' : '' }}"
+                     class="w-full border rounded-md px-3 py-2 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100
+                            {{ $errors->has('title') ? 'border-red-500' : 'border-gray-300' }}">
+              @error('title')
+                <p id="error-title" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+              @enderror
+            </div>
+
+            {{-- Descripción --}}
+            <div>
+              <label for="description" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Descripción
+              </label>
+              <textarea id="description" name="description" rows="3"
+                        aria-describedby="{{ $errors->has('description') ? 'error-description' : '' }}"
+                        class="w-full border rounded-md px-3 py-2 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100
+                               {{ $errors->has('description') ? 'border-red-500' : 'border-gray-300' }}">{{ old('description', $dailyMenu->description) }}</textarea>
+              @error('description')
+                <p id="error-description" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+              @enderror
+            </div>
+
+            {{-- Precio y Max por día --}}
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label for="price" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Precio (€) <span class="text-red-500" aria-hidden="true">*</span>
+                </label>
+                <input type="number" id="price" name="price"
+                       value="{{ old('price', $dailyMenu->price) }}"
+                       step="0.01" min="0.01"
+                       aria-required="true"
+                       aria-describedby="{{ $errors->has('price') ? 'error-price' : '' }}"
+                       class="w-full border rounded-md px-3 py-2 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100
+                              {{ $errors->has('price') ? 'border-red-500' : 'border-gray-300' }}">
+                @error('price')
+                  <p id="error-price" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+              </div>
+              <div>
+                <label for="max_per_day" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Máximo por día
+                </label>
+                <input type="number" id="max_per_day" name="max_per_day"
+                       value="{{ old('max_per_day', $dailyMenu->max_per_day) }}"
+                       min="1"
+                       aria-describedby="hint-max_per_day {{ $errors->has('max_per_day') ? 'error-max_per_day' : '' }}"
+                       class="w-full border rounded-md px-3 py-2 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100
+                              {{ $errors->has('max_per_day') ? 'border-red-500' : 'border-gray-300' }}">
+                <p id="hint-max_per_day" class="mt-1 text-xs text-gray-400">Vacío = sin límite</p>
+                @error('max_per_day')
+                  <p id="error-max_per_day" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                @enderror
+              </div>
+            </div>
+
+            {{-- Activo --}}
+            <div class="flex items-center gap-3">
+              <input type="hidden" name="is_active" value="0">
+              <input type="checkbox" id="is_active" name="is_active" value="1"
+                     {{ old('is_active', $dailyMenu->is_active) ? 'checked' : '' }}
+                     class="h-4 w-4 text-orange-500 border-gray-300 rounded">
+              <label for="is_active" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                Menú activo
+              </label>
+            </div>
+
+            {{-- Selector de modo: día de semana vs fecha específica --}}
+            @php
+              $currentMode = $dailyMenu->specific_date ? 'date' : 'week';
+              $oldMode     = old('day_of_week') ? 'week' : (old('specific_date') ? 'date' : $currentMode);
+            @endphp
+            <div x-data="{ mode: '{{ $oldMode }}' }">
+              <fieldset>
+                <legend class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Programación <span class="text-red-500" aria-hidden="true">*</span>
+                </legend>
+                <div class="flex gap-4 mb-3">
+                  <label class="flex items-center gap-2 cursor-pointer">
+                    <input type="radio" name="_mode" value="week"
+                           x-model="mode"
+                           class="h-4 w-4 text-orange-500 border-gray-300">
+                    <span class="text-sm text-gray-700 dark:text-gray-300">Día de la semana</span>
+                  </label>
+                  <label class="flex items-center gap-2 cursor-pointer">
+                    <input type="radio" name="_mode" value="date"
+                           x-model="mode"
+                           class="h-4 w-4 text-orange-500 border-gray-300">
+                    <span class="text-sm text-gray-700 dark:text-gray-300">Fecha específica</span>
+                  </label>
+                </div>
+
+                {{-- Selector día de semana --}}
+                <div x-show="mode === 'week'" x-cloak>
+                  <label for="day_of_week" class="block text-sm text-gray-600 dark:text-gray-400 mb-1">
+                    Día de la semana
+                  </label>
+                  <select id="day_of_week" name="day_of_week"
+                          :required="mode === 'week'"
+                          aria-describedby="{{ $errors->has('day_of_week') ? 'error-day_of_week' : '' }}"
+                          class="w-full border rounded-md px-3 py-2 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100
+                                 {{ $errors->has('day_of_week') ? 'border-red-500' : 'border-gray-300' }}">
+                    <option value="">— Seleccionar —</option>
+                    @foreach(['monday' => 'Lunes', 'tuesday' => 'Martes', 'wednesday' => 'Miércoles', 'thursday' => 'Jueves', 'friday' => 'Viernes', 'saturday' => 'Sábado', 'sunday' => 'Domingo'] as $val => $label)
+                      <option value="{{ $val }}" {{ old('day_of_week', $dailyMenu->day_of_week) === $val ? 'selected' : '' }}>
+                        {{ $label }}
+                      </option>
+                    @endforeach
+                  </select>
+                  @error('day_of_week')
+                    <p id="error-day_of_week" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                  @enderror
+                </div>
+
+                {{-- Input fecha específica --}}
+                <div x-show="mode === 'date'" x-cloak>
+                  <label for="specific_date" class="block text-sm text-gray-600 dark:text-gray-400 mb-1">
+                    Fecha
+                  </label>
+                  <input type="date" id="specific_date" name="specific_date"
+                         value="{{ old('specific_date', $dailyMenu->specific_date?->format('Y-m-d')) }}"
+                         :required="mode === 'date'"
+                         aria-describedby="{{ $errors->has('specific_date') ? 'error-specific_date' : '' }}"
+                         class="w-full border rounded-md px-3 py-2 text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100
+                                {{ $errors->has('specific_date') ? 'border-red-500' : 'border-gray-300' }}">
+                  @error('specific_date')
+                    <p id="error-specific_date" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                  @enderror
+                </div>
+              </fieldset>
+            </div>
+
+          </div>
+
+          {{-- Acciones --}}
+          <div class="flex justify-end gap-3 mt-6 pt-4 border-t border-gray-200 dark:border-gray-700">
+            <a href="{{ route('daily-menus.index') }}"
+               class="px-4 py-2 text-sm text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-md">
+              Cancelar
+            </a>
+            <button type="submit"
+                    class="px-4 py-2 text-sm text-white bg-orange-500 hover:bg-orange-700 rounded-md font-medium">
+              Guardar cambios
+            </button>
+          </div>
+
+        </form>
+      </div>
+    </div>
+  </div>
+</x-app-layout>

--- a/resources/views/daily-menus/index.blade.php
+++ b/resources/views/daily-menus/index.blade.php
@@ -128,7 +128,7 @@
                       {{ number_format($menu->price, 2) }} €
                     </td>
                     <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 hidden md:table-cell">
-                      {{ $menu->sections_count ?? '—' }}
+                      {{ $menu->sections_count }}
                     </td>
                     <td class="px-4 py-3">
                       @if($menu->is_active)

--- a/resources/views/daily-menus/index.blade.php
+++ b/resources/views/daily-menus/index.blade.php
@@ -1,0 +1,191 @@
+{{-- @author Ayrtonalania --}}
+<x-app-layout>
+  <x-slot name="header">
+    <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+      Menú del Día
+    </h2>
+  </x-slot>
+
+  <div class="py-12">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div class="p-6 text-gray-900 dark:text-gray-100">
+
+        {{-- Flash messages --}}
+        @if(session('success'))
+          <div role="alert" class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-6">
+            {{ session('success') }}
+          </div>
+        @endif
+        @if(session('error'))
+          <div role="alert" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
+            {{ session('error') }}
+          </div>
+        @endif
+
+        {{-- Botón crear --}}
+        <div class="flex justify-end mb-6">
+          <a href="{{ route('daily-menus.create') }}"
+             class="bg-orange-500 hover:bg-orange-700 text-white font-bold py-2 px-4 rounded">
+            + Nuevo Menú del Día
+          </a>
+        </div>
+
+        {{-- Resumen semanal --}}
+        <section aria-labelledby="resumen-semanal-titulo" class="mb-8">
+          <h3 id="resumen-semanal-titulo" class="text-lg font-semibold mb-3 text-gray-700 dark:text-gray-300">
+            Resumen semanal
+          </h3>
+          <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-2">
+            @php
+              $dayLabels = [
+                'monday'    => 'Lun',
+                'tuesday'   => 'Mar',
+                'wednesday' => 'Mié',
+                'thursday'  => 'Jue',
+                'friday'    => 'Vie',
+                'saturday'  => 'Sáb',
+                'sunday'    => 'Dom',
+              ];
+            @endphp
+            @foreach($weekSummary as $day => $data)
+              <div class="relative border rounded-lg p-3 text-center
+                          {{ $data['menu'] ? 'bg-orange-50 dark:bg-orange-900/20 border-orange-300' : 'bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-600' }}">
+                @if($data['exception'])
+                  <span class="absolute -top-2 -right-2 bg-blue-500 text-white text-xs px-1.5 py-0.5 rounded-full leading-none">
+                    Exc.
+                  </span>
+                @endif
+                <p class="font-bold text-sm text-gray-700 dark:text-gray-200">{{ $dayLabels[$day] }}</p>
+                @if($data['menu'])
+                  <p class="text-xs text-orange-600 dark:text-orange-400 mt-1 truncate" title="{{ $data['menu']->title }}">
+                    {{ $data['menu']->title }}
+                  </p>
+                  <p class="text-xs font-semibold text-gray-600 dark:text-gray-300 mt-0.5">
+                    {{ number_format($data['menu']->price, 2) }} €
+                  </p>
+                @else
+                  <p class="text-xs text-gray-400 mt-1">Sin menú</p>
+                @endif
+              </div>
+            @endforeach
+          </div>
+        </section>
+
+        {{-- Tabla de menús --}}
+        <section aria-labelledby="tabla-menus-titulo">
+          <h3 id="tabla-menus-titulo" class="text-lg font-semibold mb-3 text-gray-700 dark:text-gray-300">
+            Todos los menús
+          </h3>
+          <div class="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+            <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700"
+                   aria-label="Listado de menús del día">
+              <thead class="bg-gray-50 dark:bg-gray-800">
+                <tr>
+                  <th scope="col" class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Día / Fecha
+                  </th>
+                  <th scope="col" class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Título
+                  </th>
+                  <th scope="col" class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden sm:table-cell">
+                    Precio
+                  </th>
+                  <th scope="col" class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider hidden md:table-cell">
+                    Secciones
+                  </th>
+                  <th scope="col" class="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Activo
+                  </th>
+                  <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                    Acciones
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="bg-white dark:bg-gray-900 divide-y divide-gray-100 dark:divide-gray-700">
+                @forelse($menus as $menu)
+                  <tr>
+                    <td class="px-4 py-3 text-sm text-gray-700 dark:text-gray-300">
+                      @if($menu->specific_date)
+                        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                          Fecha específica
+                        </span>
+                        <br>
+                        <span class="text-xs text-gray-500">{{ $menu->specific_date->format('d/m/Y') }}</span>
+                      @else
+                        @php
+                          $dayNames = [
+                            'monday' => 'Lunes', 'tuesday' => 'Martes', 'wednesday' => 'Miércoles',
+                            'thursday' => 'Jueves', 'friday' => 'Viernes', 'saturday' => 'Sábado', 'sunday' => 'Domingo'
+                          ];
+                        @endphp
+                        {{ $dayNames[$menu->day_of_week] ?? $menu->day_of_week }}
+                      @endif
+                    </td>
+                    <td class="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">
+                      {{ $menu->title }}
+                    </td>
+                    <td class="px-4 py-3 text-sm text-gray-700 dark:text-gray-300 hidden sm:table-cell">
+                      {{ number_format($menu->price, 2) }} €
+                    </td>
+                    <td class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400 hidden md:table-cell">
+                      {{ $menu->sections_count ?? '—' }}
+                    </td>
+                    <td class="px-4 py-3">
+                      @if($menu->is_active)
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                          Activo
+                        </span>
+                      @else
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400">
+                          Inactivo
+                        </span>
+                      @endif
+                    </td>
+                    <td class="px-4 py-3 text-right">
+                      <div class="flex flex-col sm:flex-row justify-end gap-2">
+                        <a href="{{ route('daily-menus.sections', $menu) }}"
+                           aria-label="Configurar secciones del menú {{ $menu->title }}"
+                           class="text-sm bg-indigo-50 text-indigo-600 hover:bg-indigo-100 border border-indigo-200 py-1 px-3 rounded dark:bg-indigo-900/30 dark:text-indigo-300 dark:border-indigo-700">
+                          Secciones
+                        </a>
+                        <a href="{{ route('daily-menus.edit', $menu) }}"
+                           aria-label="Editar menú {{ $menu->title }}"
+                           class="text-sm bg-yellow-50 text-yellow-700 hover:bg-yellow-100 border border-yellow-200 py-1 px-3 rounded dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700">
+                          Editar
+                        </a>
+                        <form action="{{ route('daily-menus.destroy', $menu) }}" method="POST"
+                              onsubmit="return confirm('¿Eliminar el menú {{ addslashes($menu->title) }}? Esta acción no se puede deshacer.')">
+                          @csrf
+                          @method('DELETE')
+                          <button type="submit"
+                                  aria-label="Eliminar menú {{ $menu->title }}"
+                                  class="w-full text-sm bg-red-50 text-red-600 hover:bg-red-100 border border-red-200 py-1 px-3 rounded dark:bg-red-900/30 dark:text-red-400 dark:border-red-700">
+                            Eliminar
+                          </button>
+                        </form>
+                      </div>
+                    </td>
+                  </tr>
+                @empty
+                  <tr>
+                    <td colspan="6" class="px-4 py-8 text-center text-gray-400 dark:text-gray-500">
+                      No hay menús del día configurados.
+                      <a href="{{ route('daily-menus.create') }}" class="text-orange-500 hover:underline ml-1">Crear el primero</a>
+                    </td>
+                  </tr>
+                @endforelse
+              </tbody>
+            </table>
+          </div>
+
+          @if($menus->hasPages())
+            <nav aria-label="Paginación de menús del día" class="mt-6">
+              {{ $menus->links() }}
+            </nav>
+          @endif
+        </section>
+
+      </div>
+    </div>
+  </div>
+</x-app-layout>

--- a/resources/views/daily-menus/sections.blade.php
+++ b/resources/views/daily-menus/sections.blade.php
@@ -59,9 +59,8 @@
                   {{ $sectionLabels[$type] }}
                 </h4>
                 @if(!$section)
-                  <form action="{{ route('daily-menus.sections', $dailyMenu) }}" method="POST">
+                  <form action="{{ route('daily-menus.sections.store', $dailyMenu) }}" method="POST">
                     @csrf
-                    <input type="hidden" name="_action" value="create_section">
                     <input type="hidden" name="section_type" value="{{ $type }}">
                     <button type="submit"
                             aria-label="Añadir sección {{ $sectionLabels[$type] }}"
@@ -73,8 +72,20 @@
               </div>
 
               @if($section)
+                {{-- Botón eliminar sección --}}
+                <form action="{{ route('daily-menus.sections.destroy', [$dailyMenu, $section]) }}" method="POST"
+                      onsubmit="return confirm('¿Eliminar la sección {{ addslashes($sectionLabels[$type]) }}? Se perderán los productos asignados.')">
+                  @csrf
+                  @method('DELETE')
+                  <button type="submit"
+                          aria-label="Eliminar sección {{ $sectionLabels[$type] }}"
+                          class="text-sm bg-red-50 text-red-600 hover:bg-red-100 border border-red-200 py-1 px-3 rounded dark:bg-red-900/20 dark:text-red-400 dark:border-red-700">
+                    Eliminar sección
+                  </button>
+                </form>
+
                 {{-- Configuración de la sección existente --}}
-                <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-4">
+                <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-4 mt-4">
                   <div class="flex items-center gap-2">
                     <input type="checkbox" id="is_required_{{ $section->id }}"
                            class="h-4 w-4 text-orange-500 border-gray-300 rounded"

--- a/resources/views/daily-menus/sections.blade.php
+++ b/resources/views/daily-menus/sections.blade.php
@@ -1,0 +1,291 @@
+{{-- @author Ayrtonalania --}}
+<x-app-layout>
+  <x-slot name="header">
+    <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+      Configurar — {{ $dailyMenu->title }}
+    </h2>
+  </x-slot>
+
+  <div class="py-12">
+    <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+
+      {{-- Breadcrumb --}}
+      <nav aria-label="Migas de pan" class="mb-4 text-sm text-gray-500 dark:text-gray-400">
+        <ol class="flex items-center gap-1">
+          <li><a href="{{ route('daily-menus.index') }}" class="hover:underline text-orange-500">Menú del Día</a></li>
+          <li aria-hidden="true">/</li>
+          <li class="text-gray-700 dark:text-gray-300">Configurar secciones</li>
+        </ol>
+      </nav>
+
+      {{-- Flash messages --}}
+      @if(session('success'))
+        <div role="alert" class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-6">
+          {{ session('success') }}
+        </div>
+      @endif
+      @if(session('error'))
+        <div role="alert" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-6">
+          {{ session('error') }}
+        </div>
+      @endif
+
+      {{-- ============================================================
+           BLOQUE A — Secciones del menú
+      ============================================================ --}}
+      <section aria-labelledby="secciones-titulo" class="mb-10">
+        <h3 id="secciones-titulo" class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-4">
+          Secciones del menú
+        </h3>
+
+        @php
+          $sectionLabels = [
+            'first_course'  => 'Primer Plato',
+            'second_course' => 'Segundo Plato',
+            'dessert'       => 'Postre',
+            'coffee'        => 'Café / Infusión',
+            'drink'         => 'Bebida',
+            'bread'         => 'Pan',
+          ];
+          $existingSections = $dailyMenu->sections->keyBy('type');
+        @endphp
+
+        <div class="space-y-4">
+          @foreach($sectionTypes as $type)
+            @php $section = $existingSections->get($type); @endphp
+            <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4 sm:p-5">
+              <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
+                <h4 class="font-semibold text-gray-800 dark:text-gray-200">
+                  {{ $sectionLabels[$type] }}
+                </h4>
+                @if(!$section)
+                  <form action="{{ route('daily-menus.sections', $dailyMenu) }}" method="POST">
+                    @csrf
+                    <input type="hidden" name="_action" value="create_section">
+                    <input type="hidden" name="section_type" value="{{ $type }}">
+                    <button type="submit"
+                            aria-label="Añadir sección {{ $sectionLabels[$type] }}"
+                            class="text-sm bg-orange-50 text-orange-600 hover:bg-orange-100 border border-orange-200 py-1 px-3 rounded dark:bg-orange-900/20 dark:text-orange-300 dark:border-orange-700">
+                      + Añadir sección
+                    </button>
+                  </form>
+                @endif
+              </div>
+
+              @if($section)
+                {{-- Configuración de la sección existente --}}
+                <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-4">
+                  <div class="flex items-center gap-2">
+                    <input type="checkbox" id="is_required_{{ $section->id }}"
+                           class="h-4 w-4 text-orange-500 border-gray-300 rounded"
+                           {{ $section->is_required ? 'checked' : '' }} disabled>
+                    <label for="is_required_{{ $section->id }}" class="text-sm text-gray-600 dark:text-gray-400">
+                      Obligatoria
+                    </label>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <input type="checkbox" id="is_free_{{ $section->id }}"
+                           class="h-4 w-4 text-orange-500 border-gray-300 rounded"
+                           {{ $section->is_free ? 'checked' : '' }} disabled>
+                    <label for="is_free_{{ $section->id }}" class="text-sm text-gray-600 dark:text-gray-400">
+                      Incluida en precio
+                    </label>
+                  </div>
+                  <div class="flex items-center gap-2">
+                    <label for="max_qty_{{ $section->id }}" class="text-sm text-gray-600 dark:text-gray-400 whitespace-nowrap">
+                      Máx. elecciones:
+                    </label>
+                    <input type="number" id="max_qty_{{ $section->id }}" value="{{ $section->max_quantity }}"
+                           min="1" disabled
+                           class="w-16 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm
+                                  dark:bg-gray-700 dark:text-gray-100 bg-gray-50">
+                  </div>
+                </div>
+
+                @if($section->is_free && $type === 'bread')
+                  <p class="text-xs text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded px-3 py-2 mb-3">
+                    El pan aparecerá como ítem gratuito (precio 0,00 €) en el panel de cocina.
+                  </p>
+                @endif
+
+                {{-- Sync de productos --}}
+                <form action="{{ route('daily-menus.sync-products', [$dailyMenu, $section]) }}" method="POST">
+                  @csrf
+                  <div class="mb-3">
+                    <label for="products_{{ $section->id }}"
+                           class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      Productos disponibles en esta sección
+                    </label>
+                    <select id="products_{{ $section->id }}" name="product_ids[]"
+                            multiple size="6"
+                            aria-label="Seleccionar productos para {{ $sectionLabels[$type] }}"
+                            class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1 text-sm
+                                   dark:bg-gray-700 dark:text-gray-100">
+                      @php
+                        $assignedProductIds = $section->products->pluck('id')->toArray();
+                        $grouped = $products->groupBy(fn($p) => $p->category?->name ?? 'Sin categoría');
+                      @endphp
+                      @foreach($grouped as $categoryName => $categoryProducts)
+                        <optgroup label="{{ $categoryName }}">
+                          @foreach($categoryProducts as $product)
+                            <option value="{{ $product->id }}"
+                                    {{ in_array($product->id, $assignedProductIds) ? 'selected' : '' }}>
+                              {{ $product->name }}
+                            </option>
+                          @endforeach
+                        </optgroup>
+                      @endforeach
+                    </select>
+                    <p class="mt-1 text-xs text-gray-400">Mantén Ctrl (o Cmd) para seleccionar múltiples productos.</p>
+                  </div>
+                  <div class="flex justify-end">
+                    <button type="submit"
+                            aria-label="Guardar productos de {{ $sectionLabels[$type] }}"
+                            class="text-sm bg-indigo-600 hover:bg-indigo-700 text-white py-1.5 px-4 rounded">
+                      Guardar productos
+                    </button>
+                  </div>
+                </form>
+
+              @else
+                <p class="text-sm text-gray-400 dark:text-gray-500 italic">
+                  Esta sección no está configurada para este menú.
+                </p>
+              @endif
+            </div>
+          @endforeach
+        </div>
+      </section>
+
+      {{-- ============================================================
+           BLOQUE B — Configuración de tiempos (rondas)
+      ============================================================ --}}
+      <section aria-labelledby="timing-titulo"
+               x-data="{
+                 rounds: {{ json_encode(
+                   $dailyMenu->timingRules->count() > 0
+                     ? $dailyMenu->timingRules->map(fn($r) => [
+                         'round_number'           => $r->round_number,
+                         'default_delay_minutes'  => $r->default_delay_minutes,
+                         'estimated_prep_minutes' => $r->estimated_prep_minutes,
+                         'section_types'          => $r->section_types ?? [],
+                       ])->values()->toArray()
+                     : [['round_number' => 1, 'default_delay_minutes' => 0, 'estimated_prep_minutes' => 15, 'section_types' => []]]
+                 ) }}
+               }">
+        <h3 id="timing-titulo" class="text-lg font-semibold text-gray-800 dark:text-gray-200 mb-4">
+          Rondas de envío a cocina / barra
+        </h3>
+
+        <form action="{{ route('daily-menus.timing', $dailyMenu) }}" method="POST">
+          @csrf
+
+          <div class="space-y-4">
+            <template x-for="(round, index) in rounds" :key="index">
+              <div class="bg-white dark:bg-gray-800 rounded-lg shadow border border-gray-200 dark:border-gray-700 p-4 sm:p-5">
+                <div class="flex items-center justify-between mb-4">
+                  <h4 class="font-semibold text-gray-700 dark:text-gray-300">
+                    Ronda <span x-text="round.round_number"></span>
+                  </h4>
+                  <button type="button"
+                          x-show="rounds.length > 1"
+                          @click="rounds.splice(index, 1); rounds.forEach((r, i) => r.round_number = i + 1)"
+                          aria-label="Eliminar ronda"
+                          class="text-sm text-red-500 hover:text-red-700">
+                    Eliminar ronda
+                  </button>
+                </div>
+
+                <input type="hidden" :name="`rounds[${index}][round_number]`" :value="round.round_number">
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+                  <div>
+                    <label :for="`delay_${index}`"
+                           class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      Tiempo sugerido al cliente (min)
+                    </label>
+                    <input type="number"
+                           :id="`delay_${index}`"
+                           :name="`rounds[${index}][default_delay_minutes]`"
+                           x-model.number="round.default_delay_minutes"
+                           min="0" required
+                           aria-required="true"
+                           class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm
+                                  dark:bg-gray-700 dark:text-gray-100">
+                  </div>
+                  <div>
+                    <label :for="`prep_${index}`"
+                           class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      Tiempo de preparación (min)
+                    </label>
+                    <input type="number"
+                           :id="`prep_${index}`"
+                           :name="`rounds[${index}][estimated_prep_minutes]`"
+                           x-model.number="round.estimated_prep_minutes"
+                           min="1" required
+                           aria-required="true"
+                           class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm
+                                  dark:bg-gray-700 dark:text-gray-100">
+                    <p class="mt-1 text-xs text-gray-400">
+                      El sistema restará este valor al tiempo elegido por el cliente para calcular cuándo despachar a cocina.
+                    </p>
+                  </div>
+                </div>
+
+                <div>
+                  <p class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                    Secciones en esta ronda
+                  </p>
+                  <div class="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                    @foreach($sectionTypes as $st)
+                      <label class="flex items-center gap-2 cursor-pointer">
+                        <input type="checkbox"
+                               :name="`rounds[${index}][section_types][]`"
+                               value="{{ $st }}"
+                               :checked="round.section_types.includes('{{ $st }}')"
+                               @change="round.section_types.includes('{{ $st }}')
+                                 ? round.section_types.splice(round.section_types.indexOf('{{ $st }}'), 1)
+                                 : round.section_types.push('{{ $st }}')"
+                               class="h-4 w-4 text-orange-500 border-gray-300 rounded">
+                        <span class="text-sm text-gray-600 dark:text-gray-400">
+                          {{ $sectionLabels[$st] ?? $st }}
+                        </span>
+                      </label>
+                    @endforeach
+                  </div>
+                </div>
+              </div>
+            </template>
+          </div>
+
+          {{-- Botón añadir ronda --}}
+          <div class="mt-4">
+            <button type="button"
+                    x-show="rounds.length < 4"
+                    @click="rounds.push({
+                      round_number: rounds.length + 1,
+                      default_delay_minutes: 0,
+                      estimated_prep_minutes: 15,
+                      section_types: []
+                    })"
+                    class="text-sm bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600
+                           text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600
+                           py-2 px-4 rounded">
+              + Añadir ronda
+            </button>
+          </div>
+
+          {{-- Guardar tiempos --}}
+          <div class="flex justify-end mt-6">
+            <button type="submit"
+                    class="px-5 py-2 text-sm text-white bg-orange-500 hover:bg-orange-700 rounded-md font-medium">
+              Guardar tiempos
+            </button>
+          </div>
+
+        </form>
+      </section>
+
+    </div>
+  </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -79,6 +79,10 @@ Route::middleware(['auth', 'business.active'])->group(function () {
              ->parameters(['daily-menus' => 'dailyMenu']);
         Route::get('/daily-menus/{dailyMenu}/sections', [DailyMenuController::class, 'sections'])
              ->name('daily-menus.sections');
+        Route::post('/daily-menus/{dailyMenu}/sections', [DailyMenuController::class, 'storeSection'])
+             ->name('daily-menus.sections.store');
+        Route::delete('/daily-menus/{dailyMenu}/sections/{section}', [DailyMenuController::class, 'destroySection'])
+             ->name('daily-menus.sections.destroy');
         Route::post('/daily-menus/{dailyMenu}/sections/{section}/products/sync', [DailyMenuController::class, 'syncProducts'])
              ->name('daily-menus.sync-products');
         Route::post('/daily-menus/{dailyMenu}/timing', [DailyMenuController::class, 'storeTiming'])

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,4 +1,5 @@
 <?php
+use App\Http\Controllers\DailyMenuController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\IngredientController;
 use App\Http\Controllers\StaffController;
@@ -71,6 +72,17 @@ Route::middleware(['auth', 'business.active'])->group(function () {
         Route::post('/zonas', [ZoneController::class, 'store'])->name('zones.store');
         Route::patch('/zonas/{zone}', [ZoneController::class, 'update'])->name('zones.update');
         Route::delete('/zonas/{zone}', [ZoneController::class, 'destroy'])->name('zones.destroy');
+
+        // Menú del Día — gestión del gerente (Bloque 14.2)
+        Route::resource('daily-menus', DailyMenuController::class)
+             ->except(['show'])
+             ->parameters(['daily-menus' => 'dailyMenu']);
+        Route::get('/daily-menus/{dailyMenu}/sections', [DailyMenuController::class, 'sections'])
+             ->name('daily-menus.sections');
+        Route::post('/daily-menus/{dailyMenu}/sections/{section}/products/sync', [DailyMenuController::class, 'syncProducts'])
+             ->name('daily-menus.sync-products');
+        Route::post('/daily-menus/{dailyMenu}/timing', [DailyMenuController::class, 'storeTiming'])
+             ->name('daily-menus.timing');
     });
 
     // Mapa visual — lectura para admin y camarero, edición solo admin


### PR DESCRIPTION
## Qué se implementa

- 11 rutas protegidas con middleware `auth` + `role:admin` bajo `/daily-menus`
- `DailyMenuController` con 10 métodos: `index`, `create`, `store`, `edit`, `update`, `destroy`, `sections`, `storeSection`, `destroySection`, `syncProducts`, `storeTiming`
- Vista `index` con resumen semanal de los 7 días (sin N+1, pre-carga en 2 queries) + tabla paginada con `sections_count`
- Vistas `create` y `edit` con selector Alpine.js para `day_of_week` vs `specific_date`
- Vista `sections` con gestión de secciones (crear/eliminar), sync de productos por sección y configuración de rondas de timing con Alpine.js

## Reglas aplicadas

- `abort_if($dailyMenu->user_id !== Auth::user()->ownerUserId(), 403)` en `edit`, `update`, `destroy`, `sections`, `storeSection`, `destroySection`, `syncProducts` y `storeTiming`
- `syncProducts` verifica propiedad de `product_ids` antes del sync (no solo que existen en la tabla)
- `storeTiming` usa `DB::transaction()` y elimina reglas antiguas antes de insertar nuevas; itera sobre `$validated['rounds']`, no sobre raw input
- Validación de unicidad de `day_of_week` y `specific_date` por usuario activo en `store` y `update`
- `withCount('sections')` + pre-carga de excepciones semanales en 2 queries (N+1 resuelto)
- `paginate(15)` en el listado de menús

## Notas

- Se añadieron `storeSection` y `destroySection` (no en el spec original) porque son necesarios para que el botón "Añadir / Eliminar sección" de la vista sea funcional
- La columna `FIELD()` en `orderByRaw` es MySQL-specific; los tests actuales no ejercitan `DailyMenuController@index` directamente, por lo que no hay conflicto con SQLite en el entorno de test

## Checklist CLAUDE.md

- [x] `php artisan test` pasa al 100% — 556 tests, 0 fallos
- [x] Un commit por archivo
- [x] `@author Ayrtonalania` en cabecera de clase del controller
- [x] `abort_if()` en todos los métodos que lo requieren
- [x] Reviewer ha dado SHIP IT (tras aplicar fixes W1, W2 y S2)