### PR TITLE
feat(bloque15.1): migraciones y modelos — sistema de plantas

### DIFF
--- a/app/Models/Table.php
+++ b/app/Models/Table.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property int      $position_y       Coordenada Y en el plano
  * @property int      $width            Ancho de la mesa (px)
  * @property int      $height           Alto de la mesa (px)
+ * @property int      $floor            Planta en la que se encuentra la mesa (1–5)
  * @property bool     $is_service_point Si genera QR y acepta pedidos
  * @author AyrtonAlania
  */
@@ -47,10 +48,12 @@ class Table extends Model
         'height',
         'shape',
         'rotation',
+        'floor',
         'is_service_point',
     ];
 
     protected $casts = [
+        'floor'            => 'integer',
         'is_service_point' => 'boolean',
     ];
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -36,6 +36,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property float|null  $lng            Longitud del negocio
  * @property int         $floor_width    Ancho del canvas del plano (px)
  * @property int         $floor_height   Alto del canvas del plano (px)
+ * @property int         $floor_count    Número de plantas activas del local (1–5)
+ * @property bool        $floors_enabled Si el sistema de plantas está activo
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
@@ -67,6 +69,8 @@ class User extends Authenticatable
         'lng',
         'floor_width',
         'floor_height',
+        'floor_count',
+        'floors_enabled',
     ];
 
     /**
@@ -92,6 +96,8 @@ class User extends Authenticatable
             'active'            => 'boolean',
             'is_waiter'         => 'boolean',
             'is_kitchen'        => 'boolean',
+            'floor_count'       => 'integer',
+            'floors_enabled'    => 'boolean',
         ];
     }
 

--- a/database/migrations/2026_05_17_000003_add_floor_to_tables.php
+++ b/database/migrations/2026_05_17_000003_add_floor_to_tables.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('tables', function (Blueprint $table) {
+            $table->unsignedTinyInteger('floor')->default(1)->after('rotation');
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('tables', function (Blueprint $table) {
+            $table->dropColumn('floor');
+        });
+    }
+};

--- a/database/migrations/2026_05_17_000004_add_floor_columns_to_users.php
+++ b/database/migrations/2026_05_17_000004_add_floor_columns_to_users.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedTinyInteger('floor_count')->default(1)->after('floor_height');
+            $table->boolean('floors_enabled')->default(false)->after('floor_count');
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['floor_count', 'floors_enabled']);
+        });
+    }
+};


### PR DESCRIPTION
## Resumen

- Migración `add_floor_to_tables`: columna `floor` (tinyInt, default 1) en `tables`
- Migración `add_floor_columns_to_users`: columnas `floor_count` (tinyInt, default 1) y `floors_enabled` (bool, default false) en `users`
- `Table`: `floor` añadido a `$fillable` y `$casts`
- `User`: `floor_count` y `floors_enabled` añadidos a `$fillable` y `casts()`

## Test plan

- [ ] `php artisan migrate` sin errores
- [ ] Las columnas existen en BD tras migrar
- [ ] `php artisan test` pasa al 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)