### PR TITLE
feat(bloque15.2): backend TableController — floor settings, update y destroy

### DIFF
--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -62,13 +62,19 @@ class TableController extends Controller
                            ->orderBy('name')
                            ->get();
         $zones       = Zone::where('user_id', $ownerId)->orderBy('name')->get();
-        $owner       = Auth::user()->isAdmin() ? Auth::user() : Auth::user()->admin;
-        $maxTables   = $owner?->plan?->max_tables ?? 10;
-        $floorWidth  = $owner?->floor_width  ?? 1200;
-        $floorHeight = $owner?->floor_height ?? 800;
-        $readonly    = ! Auth::user()->isAdmin();
+        $owner         = Auth::user()->isAdmin() ? Auth::user() : Auth::user()->admin;
+        $maxTables     = $owner?->plan?->max_tables ?? 10;
+        $floorWidth    = $owner?->floor_width    ?? 1200;
+        $floorHeight   = $owner?->floor_height   ?? 800;
+        $floorCount    = $owner?->floor_count    ?? 1;
+        $floorsEnabled = $owner?->floors_enabled ?? false;
+        $readonly      = ! Auth::user()->isAdmin();
 
-        return view('tables.map', compact('tables', 'elements', 'zones', 'maxTables', 'floorWidth', 'floorHeight', 'readonly'));
+        return view('tables.map', compact(
+            'tables', 'elements', 'zones', 'maxTables',
+            'floorWidth', 'floorHeight', 'floorCount', 'floorsEnabled',
+            'readonly'
+        ));
     }
 
     /**
@@ -118,6 +124,33 @@ class TableController extends Controller
     }
 
     /**
+     * Actualiza la configuración del sistema de plantas del mapa.
+     *
+     * @param  Request $request
+     * @return JsonResponse
+     */
+    public function updateFloorSettings(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'floors_enabled' => 'sometimes|boolean',
+            'floor_count'    => 'sometimes|integer|min:1|max:5',
+        ]);
+
+        Auth::user()->update($data);
+
+        $user = Auth::user()->fresh();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Configuración de plantas guardada.',
+            'data'    => [
+                'floors_enabled' => $user->floors_enabled,
+                'floor_count'    => $user->floor_count,
+            ],
+        ]);
+    }
+
+    /**
      * Crea una nueva mesa desde el mapa visual.
      *
      * @param  Request  $request
@@ -134,6 +167,7 @@ class TableController extends Controller
             'height'           => 'required|integer|min:40|max:400',
             'is_service_point' => 'sometimes|boolean',
             'zone_id'          => ['sometimes', 'nullable', Rule::exists('zones', 'id')->where('user_id', Auth::id())],
+            'floor'            => 'sometimes|integer|min:1|max:5',
         ]);
 
         $isServicePoint = in_array($data['shape'], ['bar', 'stool'])
@@ -166,6 +200,7 @@ class TableController extends Controller
             'unique_hash'      => Str::uuid()->toString(),
             'status'           => 'free',
             'is_service_point' => $isServicePoint,
+            'floor'            => $data['floor'] ?? 1,
         ]);
 
         $message = match ($table->shape) {
@@ -262,6 +297,39 @@ class TableController extends Controller
     }
 
     /**
+     * Mueve una mesa o elemento a una planta diferente.
+     *
+     * @param  Request $request
+     * @param  Table   $table
+     * @return JsonResponse
+     */
+    public function updateFloor(Request $request, Table $table): JsonResponse
+    {
+        abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+
+        $data = $request->validate([
+            'floor' => 'required|integer|min:1|max:5',
+        ]);
+
+        $floorCount = Auth::user()->floor_count ?? 1;
+
+        if ($data['floor'] > $floorCount) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Planta inexistente.',
+            ], 422);
+        }
+
+        $table->update(['floor' => $data['floor']]);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $table,
+            'message' => "Mesa movida a la Planta {$data['floor']}.",
+        ]);
+    }
+
+    /**
      * Actualiza la forma visual de una mesa existente en el mapa.
      *
      * @param  Request  $request
@@ -290,6 +358,43 @@ class TableController extends Controller
             'success' => true,
             'data'    => $table,
             'message' => "Forma de \"{$table->name}\" cambiada a {$label}.",
+        ]);
+    }
+
+    /**
+     * Elimina todas las mesas y elementos de una planta específica
+     * y reduce floor_count en 1. Solo se puede eliminar la última planta.
+     *
+     * @param  int $floor
+     * @return JsonResponse
+     */
+    public function destroyFloor(int $floor): JsonResponse
+    {
+        $user       = Auth::user();
+        $floorCount = $user->floor_count ?? 1;
+
+        if ($floor <= 1) {
+            return response()->json([
+                'success' => false,
+                'message' => 'La planta 1 no puede eliminarse.',
+            ], 422);
+        }
+
+        if ($floor !== $floorCount) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Solo se puede eliminar la última planta.',
+            ], 422);
+        }
+
+        Table::where('user_id', Auth::id())->where('floor', $floor)->delete();
+
+        $user->update(['floor_count' => $floorCount - 1]);
+
+        return response()->json([
+            'success' => true,
+            'message' => "Planta {$floor} eliminada.",
+            'data'    => ['floor_count' => $floorCount - 1],
         ]);
     }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,10 +63,13 @@ Route::middleware(['auth', 'business.active'])->group(function () {
         // Mapa visual de mesas (Bloques 8.1 y 8.3) — solo admin puede editar
         Route::post('/mesas', [TableController::class, 'store'])->name('tables.store');
         Route::patch('/mesas/mapa/canvas', [TableController::class, 'updateCanvas'])->name('tables.canvas.update');
+        Route::patch('/mesas/mapa/plantas/config', [TableController::class, 'updateFloorSettings'])->name('tables.floor-settings');
+        Route::delete('/mesas/mapa/plantas/{floor}', [TableController::class, 'destroyFloor'])->name('tables.floor-destroy')->where('floor', '[1-5]');
         Route::patch('/mesas/{table}/posicion', [TableController::class, 'updatePosition'])->name('tables.updatePosition');
         Route::patch('/mesas/{table}/forma', [TableController::class, 'updateShape'])->name('tables.updateShape');
         Route::patch('/mesas/{table}/nombre', [TableController::class, 'updateName'])->name('tables.updateName');
         Route::patch('/mesas/{table}/zona', [TableController::class, 'updateZone'])->name('tables.updateZone');
+        Route::patch('/mesas/{table}/planta', [TableController::class, 'updateFloor'])->name('tables.update-floor');
         Route::delete('/mesas/{table}', [TableController::class, 'destroy'])->name('tables.destroy');
 
         // Gestión de zonas del plano — solo admin


### PR DESCRIPTION
## Resumen

- `TableController::map()`: pasa `floorCount` y `floorsEnabled` a la vista
- `TableController::store()`: acepta y persiste campo `floor` (default 1)
- Nuevo método `updateFloorSettings()`: activa/desactiva plantas y ajusta `floor_count` (1–5)
- Nuevo método `updateFloor()`: mueve mesa/elemento a otra planta; rechaza planta > `floor_count`
- Nuevo método `destroyFloor()`: elimina todas las mesas y zonas de la última planta y reduce `floor_count`
- Rutas: `PATCH /mesas/mapa/plantas/config`, `DELETE /mesas/mapa/plantas/{floor}`, `PATCH /mesas/{table}/planta`

## Test plan

- [ ] `php artisan test tests/Feature/Bloque15/` pasa al 100%
- [ ] Rutas registradas correctamente (`php artisan route:list`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)