### PR TITLE
fix(bloque8): multifloor map fixes and improvements

### DIFF
--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -280,9 +280,12 @@ class TableController extends Controller
 
         $table->update($data);
 
-        $message = $data['zone_id']
-            ? "Zona asignada a \"{$table->name}\"."
-            : "Zona eliminada de \"{$table->name}\".";
+        if ($data['zone_id']) {
+            $zoneName = Zone::find($data['zone_id'])?->name ?? 'desconocida';
+            $message  = "Zona \"{$zoneName}\" asignada a \"{$table->name}\".";
+        } else {
+            $message = "Zona eliminada de \"{$table->name}\".";
+        }
 
         return response()->json([
             'success' => true,

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -162,6 +162,7 @@ class TableController extends Controller
             'width'            => 'required|integer|min:40|max:800',
             'height'           => 'required|integer|min:40|max:400',
             'is_service_point' => 'sometimes|boolean',
+            'floor'            => 'sometimes|integer|min:1|max:5',
             'zone_id'          => ['sometimes', 'nullable', Rule::exists('zones', 'id')->where('user_id', Auth::id())],
         ]);
 

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -62,13 +62,28 @@ class TableController extends Controller
                            ->orderBy('name')
                            ->get();
         $zones       = Zone::where('user_id', $ownerId)->orderBy('name')->get();
-        $owner       = Auth::user()->isAdmin() ? Auth::user() : Auth::user()->admin;
-        $maxTables   = $owner?->plan?->max_tables ?? 10;
-        $floorWidth  = $owner?->floor_width  ?? 1200;
-        $floorHeight = $owner?->floor_height ?? 800;
-        $readonly    = ! Auth::user()->isAdmin();
+        $owner         = Auth::user()->isAdmin() ? Auth::user() : Auth::user()->admin;
+        $maxTables     = $owner?->plan?->max_tables ?? 10;
+        $floorWidth    = $owner?->floor_width    ?? 1200;
+        $floorHeight   = $owner?->floor_height   ?? 800;
+        $floorCount    = $owner?->floor_count    ?? 1;
+        $floorsEnabled = $owner?->floors_enabled ?? false;
+        $readonly      = ! Auth::user()->isAdmin();
 
-        return view('tables.map', compact('tables', 'elements', 'zones', 'maxTables', 'floorWidth', 'floorHeight', 'readonly'));
+        $savedSizes       = $owner?->floor_canvas_sizes ?? [];
+        $floorCanvasSizes = [];
+        for ($f = 1; $f <= $floorCount; $f++) {
+            $floorCanvasSizes[$f] = [
+                'width'  => $savedSizes[$f]['width']  ?? $floorWidth,
+                'height' => $savedSizes[$f]['height'] ?? $floorHeight,
+            ];
+        }
+
+        return view('tables.map', compact(
+            'tables', 'elements', 'zones', 'maxTables',
+            'floorWidth', 'floorHeight', 'floorCount', 'floorsEnabled',
+            'floorCanvasSizes', 'readonly'
+        ));
     }
 
     /**
@@ -107,9 +122,23 @@ class TableController extends Controller
         $data = $request->validate([
             'floor_width'  => 'required|integer|min:800|max:3000',
             'floor_height' => 'required|integer|min:600|max:2000',
+            'floor'        => 'sometimes|integer|min:1|max:5',
         ]);
 
-        Auth::user()->update($data);
+        $user  = Auth::user();
+        $floor = $data['floor'] ?? 1;
+
+        $sizes          = $user->floor_canvas_sizes ?? [];
+        $sizes[$floor]  = ['width' => $data['floor_width'], 'height' => $data['floor_height']];
+
+        $updatePayload = ['floor_canvas_sizes' => $sizes];
+
+        if ($floor === 1) {
+            $updatePayload['floor_width']  = $data['floor_width'];
+            $updatePayload['floor_height'] = $data['floor_height'];
+        }
+
+        $user->update($updatePayload);
 
         return response()->json([
             'success' => true,

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -324,6 +324,36 @@ class TableController extends Controller
     }
 
     /**
+     * Mueve una mesa o elemento a una planta diferente.
+     *
+     * @param  Request  $request
+     * @param  Table    $table
+     * @return JsonResponse
+     */
+    public function updateFloor(Request $request, Table $table): JsonResponse
+    {
+        abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+
+        $data = $request->validate([
+            'floor' => 'required|integer|min:1|max:5',
+        ]);
+
+        $table->update($data);
+
+        $label = match ($table->shape) {
+            'bar'   => 'Barra',
+            'stool' => 'Taburete',
+            default => "Mesa \"{$table->name}\"",
+        };
+
+        return response()->json([
+            'success' => true,
+            'data'    => $table,
+            'message' => "{$label} movida a Planta {$table->floor}.",
+        ]);
+    }
+
+    /**
      * Elimina una mesa del mapa y de la base de datos.
      *
      * @param  Table  $table

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -147,6 +147,63 @@ class TableController extends Controller
     }
 
     /**
+     * Actualiza la configuración de plantas del restaurante (número de plantas y toggle).
+     *
+     * @param  Request  $request
+     * @return JsonResponse
+     */
+    public function updateFloorSettings(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'floor_count'    => 'sometimes|integer|min:1|max:5',
+            'floors_enabled' => 'sometimes|boolean',
+        ]);
+
+        Auth::user()->update($data);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Configuración de plantas guardada.',
+        ]);
+    }
+
+    /**
+     * Elimina la última planta y todas las estructuras que contiene.
+     *
+     * @param  int  $floor
+     * @return JsonResponse
+     */
+    public function destroyFloor(int $floor): JsonResponse
+    {
+        $user = Auth::user();
+
+        if ($floor < 2 || $floor > ($user->floor_count ?? 1)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Planta no válida.',
+            ], 422);
+        }
+
+        $ownerId = $user->ownerUserId();
+
+        Table::where('user_id', $ownerId)->where('floor', $floor)->delete();
+        Zone::where('user_id', $ownerId)->where('floor', $floor)->delete();
+
+        $newCount = $floor - 1;
+        $sizes    = $user->floor_canvas_sizes ?? [];
+        unset($sizes[$floor]);
+        $user->update([
+            'floor_count'        => $newCount,
+            'floor_canvas_sizes' => $sizes,
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'message' => "Planta {$floor} eliminada.",
+        ]);
+    }
+
+    /**
      * Crea una nueva mesa desde el mapa visual.
      *
      * @param  Request  $request

--- a/app/Http/Controllers/ZoneController.php
+++ b/app/Http/Controllers/ZoneController.php
@@ -32,6 +32,7 @@ class ZoneController extends Controller
             'position_y' => 'required|integer|min:0',
             'width'      => 'required|integer|min:80|max:2000',
             'height'     => 'required|integer|min:60|max:1500',
+            'floor'      => 'sometimes|integer|min:1|max:5',
         ]);
 
         $zone = Zone::create([
@@ -66,6 +67,7 @@ class ZoneController extends Controller
             'width'      => 'sometimes|integer|min:80|max:2000',
             'height'     => 'sometimes|integer|min:60|max:1500',
             'rotation'   => 'sometimes|integer|min:0|max:359',
+            'floor'      => 'sometimes|integer|min:1|max:5',
         ]);
 
         $zone->update($data);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -71,6 +71,7 @@ class User extends Authenticatable
         'floor_height',
         'floor_count',
         'floors_enabled',
+        'floor_canvas_sizes',
     ];
 
     /**
@@ -96,8 +97,9 @@ class User extends Authenticatable
             'active'            => 'boolean',
             'is_waiter'         => 'boolean',
             'is_kitchen'        => 'boolean',
-            'floor_count'       => 'integer',
-            'floors_enabled'    => 'boolean',
+            'floor_count'        => 'integer',
+            'floors_enabled'     => 'boolean',
+            'floor_canvas_sizes' => 'array',
         ];
     }
 

--- a/app/Models/Zone.php
+++ b/app/Models/Zone.php
@@ -38,6 +38,7 @@ class Zone extends Model
         'width',
         'height',
         'rotation',
+        'floor',
     ];
 
     /**

--- a/database/migrations/2026_05_17_000006_add_floor_canvas_sizes_to_users.php
+++ b/database/migrations/2026_05_17_000006_add_floor_canvas_sizes_to_users.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->json('floor_canvas_sizes')->nullable()->after('floors_enabled');
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('floor_canvas_sizes');
+        });
+    }
+};

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1122,6 +1122,20 @@
             </a>
         </div>
     </div>
+
+    {{-- Toast fijo — siempre visible sin importar scroll ni zoom del canvas --}}
+    <div x-show="toast.show"
+         x-transition:enter="transition ease-out duration-200"
+         x-transition:enter-start="opacity-0 translate-y-2"
+         x-transition:enter-end="opacity-100 translate-y-0"
+         x-transition:leave="transition ease-in duration-150"
+         x-transition:leave-end="opacity-0 translate-y-2"
+         :class="toast.error ? 'bg-red-100 text-red-700 border-red-300' : 'bg-green-100 text-green-700 border-green-300'"
+         class="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] border rounded-lg px-4 py-2 text-sm font-medium shadow-lg pointer-events-none"
+         x-text="toast.msg"
+         role="alert"
+         aria-live="polite">
+    </div>
 </div>
 
 {{-- Modal de confirmación de eliminación --}}
@@ -1273,20 +1287,6 @@
                 Crear
             </button>
         </div>
-    </div>
-
-    {{-- Toast fijo — siempre visible sin importar scroll ni zoom del canvas --}}
-    <div x-show="toast.show"
-         x-transition:enter="transition ease-out duration-200"
-         x-transition:enter-start="opacity-0 translate-y-2"
-         x-transition:enter-end="opacity-100 translate-y-0"
-         x-transition:leave="transition ease-in duration-150"
-         x-transition:leave-end="opacity-0 translate-y-2"
-         :class="toast.error ? 'bg-red-100 text-red-700 border-red-300' : 'bg-green-100 text-green-700 border-green-300'"
-         class="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] border rounded-lg px-4 py-2 text-sm font-medium shadow-lg pointer-events-none"
-         x-text="toast.msg"
-         role="alert"
-         aria-live="polite">
     </div>
 </div>
 

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -68,20 +68,6 @@
         </div>
 
         <div class="flex items-center gap-3 flex-wrap">
-            {{-- Toast --}}
-            <div x-show="toast.show"
-                 x-transition:enter="transition ease-out duration-200"
-                 x-transition:enter-start="opacity-0 translate-y-1"
-                 x-transition:enter-end="opacity-100 translate-y-0"
-                 x-transition:leave="transition ease-in duration-150"
-                 x-transition:leave-end="opacity-0"
-                 :class="toast.error ? 'bg-red-100 text-red-700 border-red-300' : 'bg-green-100 text-green-700 border-green-300'"
-                 class="border rounded-lg px-3 py-1.5 text-sm font-medium"
-                 x-text="toast.msg"
-                 role="alert"
-                 aria-live="polite">
-            </div>
-
             {{-- ── Control de tamaño del lienzo — solo admin ──────────────── --}}
             <div x-show="!readonly" class="flex items-center gap-2">
                 <span class="text-xs font-medium text-gray-500 dark:text-gray-400 hidden sm:block"
@@ -1287,6 +1273,20 @@
                 Crear
             </button>
         </div>
+    </div>
+
+    {{-- Toast fijo — siempre visible sin importar scroll ni zoom del canvas --}}
+    <div x-show="toast.show"
+         x-transition:enter="transition ease-out duration-200"
+         x-transition:enter-start="opacity-0 translate-y-2"
+         x-transition:enter-end="opacity-100 translate-y-0"
+         x-transition:leave="transition ease-in duration-150"
+         x-transition:leave-end="opacity-0 translate-y-2"
+         :class="toast.error ? 'bg-red-100 text-red-700 border-red-300' : 'bg-green-100 text-green-700 border-green-300'"
+         class="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] border rounded-lg px-4 py-2 text-sm font-medium shadow-lg pointer-events-none"
+         x-text="toast.msg"
+         role="alert"
+         aria-live="polite">
     </div>
 </div>
 

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -131,6 +131,88 @@
                 </div>
             </div>
 
+            {{-- ── Toggle + selector de plantas — solo admin ──────────────── --}}
+            <template x-if="!readonly">
+                <div class="flex items-center gap-2">
+                    {{-- Toggle activar/desactivar sistema de plantas --}}
+                    <label class="flex items-center gap-1.5 text-xs font-medium text-gray-500 dark:text-gray-400 cursor-pointer select-none"
+                           id="floors-toggle-desc">
+                        <button type="button"
+                                role="switch"
+                                :aria-checked="floorsEnabled"
+                                @click="toggleFloorsEnabled(!floorsEnabled)"
+                                aria-describedby="floors-toggle-desc"
+                                :class="floorsEnabled
+                                    ? 'bg-indigo-600'
+                                    : 'bg-gray-300 dark:bg-gray-600'"
+                                class="relative inline-flex w-9 h-5 rounded-full transition-colors
+                                       focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-1">
+                            <span :class="floorsEnabled ? 'translate-x-4' : 'translate-x-0.5'"
+                                  class="inline-block w-4 h-4 mt-0.5 bg-white rounded-full shadow transition-transform">
+                            </span>
+                        </button>
+                        Plantas
+                    </label>
+
+                    {{-- Selector de plantas — solo si floorsEnabled --}}
+                    <template x-if="floorsEnabled">
+                        <div class="flex items-center gap-1"
+                             role="group"
+                             aria-label="Selector de planta">
+
+                            {{-- Botón por cada planta --}}
+                            <template x-for="n in floorCount" :key="n">
+                                <button type="button"
+                                        @click="switchFloor(n)"
+                                        :aria-pressed="currentView === 'floor' && currentFloor === n"
+                                        :aria-label="`Planta ${n}`"
+                                        :class="currentView === 'floor' && currentFloor === n
+                                            ? 'bg-indigo-600 text-white'
+                                            : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
+                                        class="px-2.5 py-1.5 rounded text-xs font-semibold border border-gray-200 dark:border-gray-600 transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-400"
+                                        x-text="`P${n}`">
+                                </button>
+                            </template>
+
+                            {{-- Botón Vista General --}}
+                            <button type="button"
+                                    @click="switchView('general')"
+                                    :aria-pressed="currentView === 'general'"
+                                    :class="currentView === 'general'
+                                        ? 'bg-indigo-600 text-white'
+                                        : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
+                                    class="px-2.5 py-1.5 rounded text-xs font-semibold border border-gray-200 dark:border-gray-600 transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-400">
+                                General
+                            </button>
+
+                            {{-- Añadir planta --}}
+                            <button type="button"
+                                    x-show="floorCount < 5"
+                                    @click="addFloor()"
+                                    aria-label="Añadir planta"
+                                    class="px-2 py-1.5 rounded text-xs font-semibold border border-gray-200 dark:border-gray-600
+                                           bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300
+                                           hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors
+                                           focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-400">
+                                + P
+                            </button>
+
+                            {{-- Eliminar última planta --}}
+                            <button type="button"
+                                    x-show="floorCount > 1"
+                                    @click="confirmDeleteFloor(floorCount)"
+                                    :aria-label="`Eliminar Planta ${floorCount}`"
+                                    class="px-2 py-1.5 rounded text-xs font-semibold border border-red-300 dark:border-red-700
+                                           bg-white dark:bg-gray-700 text-red-500 dark:text-red-400
+                                           hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors
+                                           focus:outline-none focus:ring-2 focus:ring-inset focus:ring-red-400">
+                                − P<span x-text="floorCount"></span>
+                            </button>
+                        </div>
+                    </template>
+                </div>
+            </template>
+
             <a href="{{ route('tables.index') }}"
                class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-white
                       bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -464,7 +464,7 @@
 
                         {{-- Botón editar zona --}}
                         <button type="button"
-                                @click.stop="if (editingZoneId === zone.id) { editingZoneId = null; editingZone = null; } else { editingZoneId = zone.id; editingZone = zone; const r = $el.getBoundingClientRect(); const panelW = 220; const panelH = 180; const vpW = window.innerWidth; const vpH = window.innerHeight; const px = Math.min(Math.max(8, r.left + r.width / 2 - panelW / 2), vpW - panelW - 8); const py = Math.min(r.bottom + 8, vpH - panelH - 8); editZonePanelPos = { x: px, y: py }; }"
+                                @click.stop="if (editingZoneId === zone.id) { editingZoneId = null; editingZone = null; _zoneBtnEl = null; } else { editingZoneId = zone.id; editingZone = zone; _zoneBtnEl = $el; editZonePanelPos = panelPosFromBtn($el, 220); editingTableId = null; editingTable = null; _editBtnEl = null; }"
                                 class="absolute -top-2.5 -right-9
                                        w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
                                        flex items-center justify-center transition-opacity
@@ -770,7 +770,7 @@
                             {{-- Botón editar forma — solo admin --}}
                             <button type="button"
                                     x-show="!readonly && !(isRotating && rotatingId === table.id)"
-                                    @click.stop="if (editingTableId === table.id) { editingTableId = null; editingTable = null; } else { editingTableId = table.id; editingTable = table; const r = $el.getBoundingClientRect(); const panelW = 220; const panelH = 260; const vpW = window.innerWidth; const vpH = window.innerHeight; const px = Math.min(Math.max(8, r.left + r.width / 2 - panelW / 2), vpW - panelW - 8); const py = Math.min(r.bottom + 8, vpH - panelH - 8); editPanelPos = { x: px, y: py }; }"
+                                    @click.stop="if (editingTableId === table.id) { editingTableId = null; editingTable = null; _editBtnEl = null; } else { editingTableId = table.id; editingTable = table; _editBtnEl = $el; editPanelPos = panelPosFromBtn($el, 220); editingZoneId = null; editingZone = null; _zoneBtnEl = null; }"
                                     class="absolute -top-2.5 -right-16
                                            w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
                                            flex items-center justify-center transition-opacity
@@ -874,8 +874,8 @@
              x-transition:enter-start="opacity-0 scale-95"
              x-transition:enter-end="opacity-100 scale-100"
              @click.stop
-             @keydown.escape.window="editingZoneId = null; editingZone = null"
-             class="fixed z-[200] bg-white dark:bg-gray-800 rounded-xl shadow-xl
+             @keydown.escape.window="editingZoneId = null; editingZone = null; _zoneBtnEl = null"
+             class="absolute z-[200] bg-white dark:bg-gray-800 rounded-xl shadow-xl
                     border border-gray-200 dark:border-gray-700 p-3 min-w-[200px]"
              :style="`left:${editZonePanelPos.x}px; top:${editZonePanelPos.y}px`"
              role="dialog"
@@ -896,6 +896,22 @@
                                       px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
                                :aria-label="`Nombre de la zona ${editingZone.name}`">
                     </div>
+
+                    <template x-if="floorsEnabled && floorCount > 1">
+                        <div>
+                            <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Planta</p>
+                            <select @change.stop="moveZoneToFloor(editingZone, parseInt($event.target.value))"
+                                    @click.stop
+                                    class="w-full rounded-lg border border-gray-300 dark:border-gray-600
+                                           bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                                           px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 mb-3"
+                                    :aria-label="`Planta de la zona ${editingZone.name}`">
+                                <template x-for="n in floorCount" :key="n">
+                                    <option :value="n" :selected="(editingZone.floor ?? 1) === n" x-text="`Planta ${n}`"></option>
+                                </template>
+                            </select>
+                        </div>
+                    </template>
 
                     <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Color</p>
                     <div class="flex items-center gap-2 mb-2">
@@ -918,8 +934,8 @@
              x-transition:enter-start="opacity-0 scale-95"
              x-transition:enter-end="opacity-100 scale-100"
              @click.stop
-             @keydown.escape.window="editingTableId = null; editingTable = null"
-             class="fixed z-[200] bg-white dark:bg-gray-800 rounded-xl shadow-xl
+             @keydown.escape.window="editingTableId = null; editingTable = null; _editBtnEl = null"
+             class="absolute z-[200] bg-white dark:bg-gray-800 rounded-xl shadow-xl
                     border border-gray-200 dark:border-gray-700 p-3 min-w-[200px]"
              :style="`left:${editPanelPos.x}px; top:${editPanelPos.y}px`"
              role="dialog"
@@ -951,12 +967,29 @@
                                    px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 mb-3"
                             :aria-label="`Zona de la mesa ${editingTable.name}`">
                         <option value="">Sin zona</option>
-                        <template x-for="zone in zones" :key="zone.id">
+                        <template x-for="zone in zones.filter(z => !floorsEnabled || (z.floor ?? 1) === (editingTable.floor ?? 1))" :key="zone.id">
                             <option :value="zone.id"
                                     :selected="editingTable.zone_id == zone.id"
                                     x-text="zone.name"></option>
                         </template>
                     </select>
+
+                    {{-- Planta — solo si floorsEnabled y hay más de 1 planta --}}
+                    <template x-if="floorsEnabled && floorCount > 1">
+                        <div>
+                            <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 mt-3 uppercase tracking-wide">Planta</p>
+                            <select @change.stop="moveToFloor(editingTable, parseInt($event.target.value))"
+                                    @click.stop
+                                    class="w-full rounded-lg border border-gray-300 dark:border-gray-600
+                                           bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                                           px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 mb-3"
+                                    :aria-label="`Planta de la mesa ${editingTable.name}`">
+                                <template x-for="n in floorCount" :key="n">
+                                    <option :value="n" :selected="(editingTable.floor ?? 1) === n" x-text="`Planta ${n}`"></option>
+                                </template>
+                            </select>
+                        </div>
+                    </template>
 
                     <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wide">Forma</p>
                     <div class="flex gap-1.5" role="group" aria-label="Seleccionar forma">

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -4,6 +4,16 @@
  | @author AyrtonAlania
  | @author SebastianBCF
 --}}
+<style>
+@keyframes zampa-selected-pulse {
+    0%, 100% { box-shadow: 0 0 0 2px rgba(99,102,241,0.85), 0 0 0 5px rgba(99,102,241,0.25); }
+    50%       { box-shadow: 0 0 0 3px rgba(99,102,241,0.55), 0 0 0 9px rgba(99,102,241,0.08); }
+}
+.zampa-selected {
+    animation: zampa-selected-pulse 1.4s ease-in-out infinite;
+}
+</style>
+
 <x-app-layout>
 <div
     class="flex flex-col h-screen bg-gray-100 dark:bg-gray-900"
@@ -58,6 +68,20 @@
         </div>
 
         <div class="flex items-center gap-3 flex-wrap">
+            {{-- Toast --}}
+            <div x-show="toast.show"
+                 x-transition:enter="transition ease-out duration-200"
+                 x-transition:enter-start="opacity-0 translate-y-1"
+                 x-transition:enter-end="opacity-100 translate-y-0"
+                 x-transition:leave="transition ease-in duration-150"
+                 x-transition:leave-end="opacity-0"
+                 :class="toast.error ? 'bg-red-100 text-red-700 border-red-300' : 'bg-green-100 text-green-700 border-green-300'"
+                 class="border rounded-lg px-3 py-1.5 text-sm font-medium"
+                 x-text="toast.msg"
+                 role="alert"
+                 aria-live="polite">
+            </div>
+
             {{-- ── Control de tamaño del lienzo — solo admin ──────────────── --}}
             <div x-show="!readonly" class="flex items-center gap-2">
                 <span class="text-xs font-medium text-gray-500 dark:text-gray-400 hidden sm:block"
@@ -368,7 +392,7 @@
         </aside>
 
         {{-- ── CANVAS ───────────────────────────────────────── --}}
-        <main id="main-content" class="flex-1 overflow-auto p-4">
+        <main id="main-content" class="flex-1 overflow-auto p-4 relative">
             <div
                 x-ref="canvas"
                 class="relative bg-white dark:bg-gray-800 rounded-xl shadow-inner
@@ -396,21 +420,6 @@
                     </div>
                 </div>
 
-                {{-- Toast de confirmación / error — parte superior del canvas --}}
-                <div x-show="toast.show"
-                     x-transition:enter="transition ease-out duration-200"
-                     x-transition:enter-start="opacity-0 -translate-y-2"
-                     x-transition:enter-end="opacity-100 translate-y-0"
-                     x-transition:leave="transition ease-in duration-150"
-                     x-transition:leave-end="opacity-0"
-                     :class="toast.error ? 'bg-red-100 text-red-700 border-red-300' : 'bg-green-100 text-green-700 border-green-300'"
-                     class="absolute top-3 left-1/2 -translate-x-1/2 z-[300]
-                            border rounded-lg px-4 py-2 text-sm font-medium shadow-md pointer-events-none whitespace-nowrap"
-                     x-text="toast.msg"
-                     role="alert"
-                     aria-live="polite">
-                </div>
-
                 {{-- Banner vista general --}}
                 <div x-show="floorsEnabled && currentView === 'general'"
                      aria-live="polite"
@@ -434,10 +443,11 @@
                 </svg>
 
                 {{-- Zonas (capa de fondo, z-index 5) --}}
-                <template x-for="zone in zones" :key="'z'+zone.id">
+                <template x-for="zone in visibleZones()" :key="'z'+zone.id">
                     <div
                         :data-zone-id="zone.id"
                         class="zone-item absolute group select-none touch-none cursor-grab"
+                        :class="{'zampa-selected': isActive(zone.id)}"
                         :style="`
                             left:${zone.position_x}px;
                             top:${zone.position_y}px;
@@ -493,7 +503,6 @@
                             </svg>
                         </button>
 
-                        {{-- Panel de edición de zona movido fuera del canvas (fixed) para evitar herencia de transform --}}
 
                         {{-- Handle de rotación de zona (color sincronizado con zone.color) --}}
                         <div class="absolute -top-9 left-1/2 -translate-x-1/2
@@ -536,7 +545,7 @@
                 </template>
 
                 {{-- Barras especiales: usa table-item para interact.js, idéntico al sistema de mesas --}}
-                <template x-for="bar in elements.filter(e => e.shape === 'bar')" :key="'b'+bar.id">
+                <template x-for="bar in visibleElements().filter(e => e.shape === 'bar')" :key="'b'+bar.id">
                     <div
                         :data-table-id="bar.id"
                         class="table-item absolute group select-none touch-none"
@@ -555,7 +564,8 @@
                                     bg-amber-100 dark:bg-amber-900
                                     border-2 border-amber-400 dark:border-amber-600
                                     shadow-md cursor-grab active:cursor-grabbing
-                                    transition-shadow hover:shadow-lg">
+                                    transition-shadow hover:shadow-lg"
+                             :class="{'zampa-selected': isActive(bar.id)}">
 
                             <span class="text-xs font-semibold text-amber-800 dark:text-amber-300
                                          text-center px-1 leading-tight pointer-events-none"
@@ -619,7 +629,7 @@
                 </template>
 
                 {{-- Taburetes: drag Alpine-nativo --}}
-                <template x-for="stool in elements.filter(e => e.shape === 'stool')" :key="'s'+stool.id">
+                <template x-for="stool in visibleElements().filter(e => e.shape === 'stool')" :key="'s'+stool.id">
                     <div
                         :data-table-id="stool.id"
                         class="element-item absolute group select-none touch-none"
@@ -639,6 +649,7 @@
                                     border-2 border-amber-400 dark:border-amber-600
                                     shadow-md cursor-grab active:cursor-grabbing
                                     transition-shadow hover:shadow-lg"
+                             :class="{'zampa-selected': isActive(stool.id)}"
                              @mousedown.prevent="startElementDrag($event, stool)">
 
                             <span class="text-xs font-semibold text-amber-800 dark:text-amber-300
@@ -704,7 +715,7 @@
                 </template>
 
                 {{-- Mesas existentes --}}
-                <template x-for="table in tables" :key="table.id">
+                <template x-for="table in visibleTables()" :key="table.id">
                     <div
                         :data-table-id="table.id"
                         class="table-item absolute group select-none touch-none"
@@ -712,7 +723,9 @@
                                  width:${table.width}px; height:${table.height}px;
                                  transform: rotate(${table.rotation ?? 0}deg);
                                  transform-origin: center;
-                                 z-index: ${hoveredId === table.id || selectedId === table.id || rotatingId === table.id || editingTableId === table.id ? 30 : 10};`"
+                                 z-index: ${hoveredId === table.id || selectedId === table.id || rotatingId === table.id || editingTableId === table.id
+                                     ? (floorsEnabled && currentView === 'general' ? 100 : 30)
+                                     : (floorsEnabled && currentView === 'general' ? 10 + ((table.floor ?? 1) - 1) * 10 : 10)};`"
                         @mouseenter="hoveredId = table.id"
                         @mouseleave="hoveredId = null"
                         @click.stop="selectedId = selectedId === table.id ? null : table.id; editingTableId = null; editingTable = null; editingZoneId = null; editingZone = null;"
@@ -725,9 +738,10 @@
                                     shadow-md cursor-grab active:cursor-grabbing
                                     transition-shadow hover:shadow-lg"
                              :class="{
-                                'rounded-full':  table.shape === 'round',
-                                'rounded-xl':    table.shape === 'square',
-                                'rounded-lg':    table.shape === 'rectangle',
+                                'rounded-full':    table.shape === 'round',
+                                'rounded-xl':      table.shape === 'square',
+                                'rounded-lg':      table.shape === 'rectangle',
+                                'zampa-selected':  isActive(table.id),
                              }"
                              :style="zoneFor(table) ? `border-color: ${zoneFor(table).color}` : null">
 
@@ -816,7 +830,6 @@
                                 </svg>
                             </button>
 
-                            {{-- Panel de edición movido fuera del canvas (fixed) para evitar herencia del transform:rotate --}}
                         </div>
 
                         {{-- Handle de rotación — solo admin --}}
@@ -865,165 +878,167 @@
                     <p class="text-indigo-500 font-semibold text-lg"
                        x-text="currentDragShape === 'bar' ? 'Suelta aquí para colocar la barra' : currentDragShape === 'stool' ? 'Suelta aquí para colocar el taburete' : 'Suelta aquí para crear la mesa'"></p>
                 </div>
+                {{-- Panel de edición de zona — absolute dentro del canvas, coordenadas en espacio del canvas --}}
+                <div x-show="editingZoneId !== null && editingZone !== null"
+                     x-transition:enter="transition ease-out duration-150"
+                     x-transition:enter-start="opacity-0 scale-95"
+                     x-transition:enter-end="opacity-100 scale-100"
+                     @click.stop
+                     @keydown.escape.window="editingZoneId = null; editingZone = null; _zoneBtnEl = null"
+                     class="absolute z-[200] bg-white dark:bg-gray-800 rounded-xl shadow-xl
+                            border border-gray-200 dark:border-gray-700 p-3 min-w-[200px]"
+                     :style="`left:${editZonePanelPos.x}px; top:${editZonePanelPos.y}px`"
+                     role="dialog"
+                     :aria-label="editingZone ? `Editar zona ${editingZone.name}` : 'Editar zona'">
+
+                    <template x-if="editingZone">
+                        <div>
+                            <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Nombre</p>
+                            <div class="flex gap-1 mb-3">
+                                <input type="text"
+                                       :value="editingZone.name"
+                                       @keydown.enter.stop="updateZoneName(editingZone, $event.target.value); $event.target.blur()"
+                                       @blur.stop="updateZoneName(editingZone, $event.target.value)"
+                                       @click.stop
+                                       maxlength="50"
+                                       class="w-full rounded-lg border border-gray-300 dark:border-gray-600
+                                              bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                                              px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                       :aria-label="`Nombre de la zona ${editingZone.name}`">
+                            </div>
+
+                            <template x-if="floorsEnabled && floorCount > 1">
+                                <div>
+                                    <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Planta</p>
+                                    <select @change.stop="moveZoneToFloor(editingZone, parseInt($event.target.value))"
+                                            @click.stop
+                                            class="w-full rounded-lg border border-gray-300 dark:border-gray-600
+                                                   bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                                                   px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 mb-3"
+                                            :aria-label="`Planta de la zona ${editingZone.name}`">
+                                        <template x-for="n in floorCount" :key="n">
+                                            <option :value="n"
+                                                    :selected="(editingZone.floor ?? 1) === n"
+                                                    x-text="`Planta ${n}`">
+                                            </option>
+                                        </template>
+                                    </select>
+                                </div>
+                            </template>
+
+                            <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Color</p>
+                            <div class="flex items-center gap-2 mb-2">
+                                <input type="color"
+                                       :value="editingZone.color"
+                                       @input.stop="editingZone.color = $event.target.value"
+                                       @change.stop="updateZoneColor(editingZone, $event.target.value)"
+                                       @click.stop
+                                       class="w-8 h-8 rounded cursor-pointer border border-gray-200 p-0.5"
+                                       :aria-label="`Color de la zona ${editingZone.name}`">
+                                <span class="text-xs text-gray-500 font-mono" x-text="editingZone.color"></span>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+
+                {{-- Panel de edición de mesa — absolute dentro del canvas, coordenadas en espacio del canvas --}}
+                <div x-show="editingTableId !== null && editingTable !== null"
+                     x-transition:enter="transition ease-out duration-150"
+                     x-transition:enter-start="opacity-0 scale-95"
+                     x-transition:enter-end="opacity-100 scale-100"
+                     @click.stop
+                     @keydown.escape.window="editingTableId = null; editingTable = null; _editBtnEl = null"
+                     class="absolute z-[200] bg-white dark:bg-gray-800 rounded-xl shadow-xl
+                            border border-gray-200 dark:border-gray-700 p-3 min-w-[200px]"
+                     :style="`left:${editPanelPos.x}px; top:${editPanelPos.y}px`"
+                     role="dialog"
+                     :aria-label="editingTable ? `Editar mesa ${editingTable.name}` : 'Editar mesa'">
+
+                    <template x-if="editingTable">
+                        <div>
+                            <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Nombre</p>
+                            <div class="flex gap-1 mb-3">
+                                <input type="text"
+                                       :value="editingTable.name"
+                                       @keydown.enter.stop="updateName(editingTable, $event.target.value); $event.target.blur()"
+                                       @blur.stop="updateName(editingTable, $event.target.value)"
+                                       @click.stop
+                                       maxlength="50"
+                                       class="w-full rounded-lg border border-gray-300 dark:border-gray-600
+                                              bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                                              px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                       :aria-label="`Nombre de la mesa ${editingTable.name}`">
+                            </div>
+
+                            <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 mt-3 uppercase tracking-wide">Zona</p>
+                            <select @change.stop="updateZoneAssignment(editingTable, $event.target.value)"
+                                    @click.stop
+                                    class="w-full rounded-lg border border-gray-300 dark:border-gray-600
+                                           bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                                           px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 mb-3"
+                                    :aria-label="`Zona de la mesa ${editingTable.name}`">
+                                <option value="">Sin zona</option>
+                                <template x-for="zone in zones.filter(z => !floorsEnabled || (z.floor ?? 1) === (editingTable.floor ?? 1))" :key="zone.id">
+                                    <option :value="zone.id"
+                                            :selected="editingTable.zone_id == zone.id"
+                                            x-text="zone.name"></option>
+                                </template>
+                            </select>
+
+                            <template x-if="floorsEnabled && floorCount > 1">
+                                <div>
+                                    <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 mt-3 uppercase tracking-wide">Planta</p>
+                                    <select @change.stop="moveToFloor(editingTable, parseInt($event.target.value))"
+                                            @click.stop
+                                            class="w-full rounded-lg border border-gray-300 dark:border-gray-600
+                                                   bg-white dark:bg-gray-700 text-gray-900 dark:text-white
+                                                   px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 mb-3"
+                                            :aria-label="`Planta de la mesa ${editingTable.name}`">
+                                        <template x-for="n in floorCount" :key="n">
+                                            <option :value="n"
+                                                    :selected="(editingTable.floor ?? 1) === n"
+                                                    x-text="`Planta ${n}`">
+                                            </option>
+                                        </template>
+                                    </select>
+                                </div>
+                            </template>
+
+                            <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wide">Forma</p>
+                            <div class="flex gap-1.5" role="group" aria-label="Seleccionar forma">
+                                <button type="button"
+                                        @click.stop="updateShape(editingTable, 'square')"
+                                        :class="editingTable.shape === 'square'
+                                            ? 'bg-indigo-600 text-white ring-2 ring-indigo-400'
+                                            : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/30'"
+                                        class="w-9 h-9 rounded-lg flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                                        aria-label="Forma cuadrada">
+                                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="3"/></svg>
+                                </button>
+                                <button type="button"
+                                        @click.stop="updateShape(editingTable, 'round')"
+                                        :class="editingTable.shape === 'round'
+                                            ? 'bg-indigo-600 text-white ring-2 ring-indigo-400'
+                                            : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/30'"
+                                        class="w-9 h-9 rounded-lg flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                                        aria-label="Forma redonda">
+                                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/></svg>
+                                </button>
+                                <button type="button"
+                                        @click.stop="updateShape(editingTable, 'rectangle')"
+                                        :class="editingTable.shape === 'rectangle'
+                                            ? 'bg-indigo-600 text-white ring-2 ring-indigo-400'
+                                            : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/30'"
+                                        class="w-9 h-9 rounded-lg flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                                        aria-label="Forma rectangular">
+                                    <svg class="w-5 h-3" fill="currentColor" viewBox="0 0 24 14" aria-hidden="true"><rect x="0" y="0" width="24" height="14" rx="3"/></svg>
+                                </button>
+                            </div>
+                        </div>
+                    </template>
+                </div>
             </div>
         </main>
-
-        {{-- Panel de edición de zona — fixed para escapar del transform:rotate del padre --}}
-        <div x-show="editingZoneId !== null && editingZone !== null"
-             x-transition:enter="transition ease-out duration-150"
-             x-transition:enter-start="opacity-0 scale-95"
-             x-transition:enter-end="opacity-100 scale-100"
-             @click.stop
-             @keydown.escape.window="editingZoneId = null; editingZone = null; _zoneBtnEl = null"
-             class="absolute z-[200] bg-white dark:bg-gray-800 rounded-xl shadow-xl
-                    border border-gray-200 dark:border-gray-700 p-3 min-w-[200px]"
-             :style="`left:${editZonePanelPos.x}px; top:${editZonePanelPos.y}px`"
-             role="dialog"
-             :aria-label="editingZone ? `Editar zona ${editingZone.name}` : 'Editar zona'">
-
-            <template x-if="editingZone">
-                <div>
-                    <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Nombre</p>
-                    <div class="flex gap-1 mb-3">
-                        <input type="text"
-                               :value="editingZone.name"
-                               @keydown.enter.stop="updateZoneName(editingZone, $event.target.value); $event.target.blur()"
-                               @blur.stop="updateZoneName(editingZone, $event.target.value)"
-                               @click.stop
-                               maxlength="50"
-                               class="w-full rounded-lg border border-gray-300 dark:border-gray-600
-                                      bg-white dark:bg-gray-700 text-gray-900 dark:text-white
-                                      px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                               :aria-label="`Nombre de la zona ${editingZone.name}`">
-                    </div>
-
-                    <template x-if="floorsEnabled && floorCount > 1">
-                        <div>
-                            <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Planta</p>
-                            <select @change.stop="moveZoneToFloor(editingZone, parseInt($event.target.value))"
-                                    @click.stop
-                                    class="w-full rounded-lg border border-gray-300 dark:border-gray-600
-                                           bg-white dark:bg-gray-700 text-gray-900 dark:text-white
-                                           px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 mb-3"
-                                    :aria-label="`Planta de la zona ${editingZone.name}`">
-                                <template x-for="n in floorCount" :key="n">
-                                    <option :value="n" :selected="(editingZone.floor ?? 1) === n" x-text="`Planta ${n}`"></option>
-                                </template>
-                            </select>
-                        </div>
-                    </template>
-
-                    <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Color</p>
-                    <div class="flex items-center gap-2 mb-2">
-                        <input type="color"
-                               :value="editingZone.color"
-                               @input.stop="editingZone.color = $event.target.value"
-                               @change.stop="updateZoneColor(editingZone, $event.target.value)"
-                               @click.stop
-                               class="w-8 h-8 rounded cursor-pointer border border-gray-200 p-0.5"
-                               :aria-label="`Color de la zona ${editingZone.name}`">
-                        <span class="text-xs text-gray-500 font-mono" x-text="editingZone.color"></span>
-                    </div>
-                </div>
-            </template>
-        </div>
-
-        {{-- Panel de edición de mesa — fixed para escapar del transform:rotate del padre --}}
-        <div x-show="editingTableId !== null && editingTable !== null"
-             x-transition:enter="transition ease-out duration-150"
-             x-transition:enter-start="opacity-0 scale-95"
-             x-transition:enter-end="opacity-100 scale-100"
-             @click.stop
-             @keydown.escape.window="editingTableId = null; editingTable = null; _editBtnEl = null"
-             class="absolute z-[200] bg-white dark:bg-gray-800 rounded-xl shadow-xl
-                    border border-gray-200 dark:border-gray-700 p-3 min-w-[200px]"
-             :style="`left:${editPanelPos.x}px; top:${editPanelPos.y}px`"
-             role="dialog"
-             :aria-label="editingTable ? `Editar mesa ${editingTable.name}` : 'Editar mesa'">
-
-            <template x-if="editingTable">
-                <div>
-                    {{-- Editar nombre --}}
-                    <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wide">Nombre</p>
-                    <div class="flex gap-1 mb-3">
-                        <input type="text"
-                               :value="editingTable.name"
-                               @keydown.enter.stop="updateName(editingTable, $event.target.value); $event.target.blur()"
-                               @blur.stop="updateName(editingTable, $event.target.value)"
-                               @click.stop
-                               maxlength="50"
-                               class="w-full rounded-lg border border-gray-300 dark:border-gray-600
-                                      bg-white dark:bg-gray-700 text-gray-900 dark:text-white
-                                      px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                               :aria-label="`Nombre de la mesa ${editingTable.name}`">
-                    </div>
-
-                    {{-- Zona --}}
-                    <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 mt-3 uppercase tracking-wide">Zona</p>
-                    <select @change.stop="updateZoneAssignment(editingTable, $event.target.value)"
-                            @click.stop
-                            class="w-full rounded-lg border border-gray-300 dark:border-gray-600
-                                   bg-white dark:bg-gray-700 text-gray-900 dark:text-white
-                                   px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 mb-3"
-                            :aria-label="`Zona de la mesa ${editingTable.name}`">
-                        <option value="">Sin zona</option>
-                        <template x-for="zone in zones.filter(z => !floorsEnabled || (z.floor ?? 1) === (editingTable.floor ?? 1))" :key="zone.id">
-                            <option :value="zone.id"
-                                    :selected="editingTable.zone_id == zone.id"
-                                    x-text="zone.name"></option>
-                        </template>
-                    </select>
-
-                    {{-- Planta — solo si floorsEnabled y hay más de 1 planta --}}
-                    <template x-if="floorsEnabled && floorCount > 1">
-                        <div>
-                            <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 mt-3 uppercase tracking-wide">Planta</p>
-                            <select @change.stop="moveToFloor(editingTable, parseInt($event.target.value))"
-                                    @click.stop
-                                    class="w-full rounded-lg border border-gray-300 dark:border-gray-600
-                                           bg-white dark:bg-gray-700 text-gray-900 dark:text-white
-                                           px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 mb-3"
-                                    :aria-label="`Planta de la mesa ${editingTable.name}`">
-                                <template x-for="n in floorCount" :key="n">
-                                    <option :value="n" :selected="(editingTable.floor ?? 1) === n" x-text="`Planta ${n}`"></option>
-                                </template>
-                            </select>
-                        </div>
-                    </template>
-
-                    <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wide">Forma</p>
-                    <div class="flex gap-1.5" role="group" aria-label="Seleccionar forma">
-                        <button type="button"
-                                @click.stop="updateShape(editingTable, 'square')"
-                                :class="editingTable.shape === 'square'
-                                    ? 'bg-indigo-600 text-white ring-2 ring-indigo-400'
-                                    : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/30'"
-                                class="w-9 h-9 rounded-lg flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-400"
-                                aria-label="Forma cuadrada">
-                            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="3" width="18" height="18" rx="3"/></svg>
-                        </button>
-                        <button type="button"
-                                @click.stop="updateShape(editingTable, 'round')"
-                                :class="editingTable.shape === 'round'
-                                    ? 'bg-indigo-600 text-white ring-2 ring-indigo-400'
-                                    : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/30'"
-                                class="w-9 h-9 rounded-lg flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-400"
-                                aria-label="Forma redonda">
-                            <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"/></svg>
-                        </button>
-                        <button type="button"
-                                @click.stop="updateShape(editingTable, 'rectangle')"
-                                :class="editingTable.shape === 'rectangle'
-                                    ? 'bg-indigo-600 text-white ring-2 ring-indigo-400'
-                                    : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/30'"
-                                class="w-9 h-9 rounded-lg flex items-center justify-center transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-400"
-                                aria-label="Forma rectangular">
-                            <svg class="w-5 h-3" fill="currentColor" viewBox="0 0 24 14" aria-hidden="true"><rect x="0" y="0" width="24" height="14" rx="3"/></svg>
-                        </button>
-                    </div>
-                </div>
-            </template>
-        </div>
 
         {{-- Indicador de grados de rotación — fuera del canvas escalado para que fixed funcione correctamente --}}
         <div x-show="rotTooltip.show"
@@ -1155,6 +1170,7 @@
         <h2 id="delete-modal-title"
             class="text-lg font-bold text-center text-gray-900 dark:text-white mb-2"
             x-text="
+                $store.deleteModal.table?._isFloor          ? `Eliminar Planta ${$store.deleteModal.table.name}` :
                 $store.deleteModal.table?.shape === 'bar'   ? 'Eliminar barra' :
                 $store.deleteModal.table?.shape === 'stool' ? 'Eliminar taburete' :
                 $store.deleteModal.table?.shape             ? 'Eliminar mesa' :
@@ -1164,9 +1180,22 @@
 
         <p id="delete-modal-desc"
            class="text-sm text-center text-gray-500 dark:text-gray-400 mb-6">
-            ¿Eliminar <span class="font-semibold text-gray-700 dark:text-gray-200"
-                            x-text="`&quot;${$store.deleteModal.table?.name}&quot;`"></span>?
-            Esta acción no se puede deshacer.
+            <template x-if="$store.deleteModal.table?._isFloor">
+                <span>
+                    Se eliminarán <span class="font-semibold text-gray-700 dark:text-gray-200"
+                                        x-text="$store.deleteModal.table._count"></span>
+                    estructura(s) de la <span class="font-semibold text-gray-700 dark:text-gray-200"
+                                              x-text="`Planta ${$store.deleteModal.table.name}`"></span>.
+                    Esta acción no se puede deshacer.
+                </span>
+            </template>
+            <template x-if="!$store.deleteModal.table?._isFloor">
+                <span>
+                    ¿Eliminar <span class="font-semibold text-gray-700 dark:text-gray-200"
+                                    x-text="`&quot;${$store.deleteModal.table?.name}&quot;`"></span>?
+                    Esta acción no se puede deshacer.
+                </span>
+            </template>
         </p>
 
         <div class="flex gap-3">
@@ -1353,8 +1382,12 @@ document.addEventListener('alpine:init', () => {
         editingZoneId:         null,
         editingZone:           null,
         editZonePanelPos:      { x: 0, y: 0 },
+        _editBtnEl:            null,
+        _zoneBtnEl:            null,
         isRotating:            false,
         rotatingId:            null,
+        draggingId:            null,
+        resizingId:            null,
         hoveredId:             null,
         selectedId:            null,
         isRotatingZone:        false,
@@ -1577,16 +1610,21 @@ document.addEventListener('alpine:init', () => {
         // Devuelve true si el item colisiona con elementos prohibidos.
         // Mesas ↔ mesas: prohibido. Mesas ↔ especiales: prohibido.
         // Especiales ↔ especiales: prohibido. Zonas: siempre permitidas.
+        // En vista general con plantas activas: solapamiento libre entre plantas.
         hasCollision(item) {
+            if (this.floorsEnabled && this.currentView === 'general') return false;
+
             const isSpecial = ['bar', 'stool'].includes(item.shape);
             const selfId    = item.id ?? null;
+            const itemFloor = this.floorsEnabled ? (item.floor ?? this.currentFloor) : null;
+            const sameFloor = (other) => !this.floorsEnabled || (other.floor ?? 1) === (itemFloor ?? 1);
 
             if (isSpecial) {
-                return this.tables.some(t => this.overlaps(item, t)) ||
-                       this.elements.some(e => e.id !== selfId && this.overlaps(item, e));
+                return this.tables.filter(sameFloor).some(t => this.overlaps(item, t)) ||
+                       this.elements.filter(sameFloor).some(e => e.id !== selfId && this.overlaps(item, e));
             }
-            return this.tables.some(t => t.id !== selfId && this.overlaps(item, t)) ||
-                   this.elements.some(e => this.overlaps(item, e));
+            return this.tables.filter(sameFloor).some(t => t.id !== selfId && this.overlaps(item, t)) ||
+                   this.elements.filter(sameFloor).some(e => this.overlaps(item, e));
         },
 
         // ── Interactividad de mesas existentes ────────────────────────────────
@@ -1603,10 +1641,8 @@ document.addEventListener('alpine:init', () => {
                             const el   = event.target;
                             const id   = parseInt(el.dataset.tableId);
                             const item = this.tables.find(t => t.id === id) ?? this.elements.find(e => e.id === id);
-                            // Cierra el panel de edición al iniciar arrastre
-                            this.editingTableId = null;
-                            this.editingTable   = null;
-                            // Marca si el elemento arranca ya en colisión (permite desatascarlo)
+                            this.closeEditPanels();
+                            this.draggingId      = id;
                             el._startedColliding = item ? this.hasCollision(item) : false;
                         },
                         move: (event) => {
@@ -1668,6 +1704,7 @@ document.addEventListener('alpine:init', () => {
                             const y  = Math.round(parseFloat(el.style.top)  || 0);
                             const w  = Math.round(parseFloat(el.style.width)  || 100);
                             const h  = Math.round(parseFloat(el.style.height) || 100);
+                            this.draggingId = null;
                             this.persistPosition(id, x, y, w, h);
                         },
                     },
@@ -1697,6 +1734,8 @@ document.addEventListener('alpine:init', () => {
             const startPx   = zone.position_x;
             const startPy   = zone.position_y;
 
+            this.closeEditPanels();
+            this.draggingId            = zone.id;
             document.body.style.cursor = 'grabbing';
 
             const onMove = (e) => {
@@ -1709,6 +1748,7 @@ document.addEventListener('alpine:init', () => {
             const onUp = async () => {
                 document.removeEventListener('mousemove', onMove);
                 document.removeEventListener('mouseup',   onUp);
+                this.draggingId            = null;
                 document.body.style.cursor = '';
                 await this.persistZonePosition(zone.id, zone.position_x, zone.position_y);
             };
@@ -1723,7 +1763,9 @@ document.addEventListener('alpine:init', () => {
             const centerX    = canvasRect.left + zone.position_x + zone.width  / 2;
             const centerY    = canvasRect.top  + zone.position_y + zone.height / 2;
 
+            this.closeEditPanels();
             this.isRotating            = true;
+            this.rotatingId            = zone.id;
             this.rotTooltip.show       = true;
             document.body.style.cursor = "url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2720%27 height=%2720%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3C/svg%3E') 10 10, grabbing";
 
@@ -1742,6 +1784,7 @@ document.addEventListener('alpine:init', () => {
                 document.removeEventListener('mousemove', onMove);
                 document.removeEventListener('mouseup',   onUp);
                 this.isRotating            = false;
+                this.rotatingId            = null;
                 this.rotTooltip.show       = false;
                 document.body.style.cursor = '';
                 await this.persistZoneRotation(zone.id, zone.rotation ?? 0);
@@ -1758,6 +1801,8 @@ document.addEventListener('alpine:init', () => {
             const startMX = event.clientX;
             const startMY = event.clientY;
 
+            this.closeEditPanels();
+            this.draggingId            = element.id;
             document.body.style.cursor = 'grabbing';
 
             // Si el elemento ya está en colisión al iniciar, permitir movimiento libre hasta salir
@@ -1794,6 +1839,7 @@ document.addEventListener('alpine:init', () => {
             const onUp = async () => {
                 document.removeEventListener('mousemove', onMove);
                 document.removeEventListener('mouseup',   onUp);
+                this.draggingId            = null;
                 document.body.style.cursor = '';
                 await this.persistPosition(element.id, element.position_x, element.position_y, element.width, element.height);
             };
@@ -2023,6 +2069,7 @@ document.addEventListener('alpine:init', () => {
                         width:            w,
                         height:           h,
                         is_service_point: true,
+                        floor:            this.floorsEnabled ? this.currentFloor : 1,
                     }),
                 });
 
@@ -2059,6 +2106,7 @@ document.addEventListener('alpine:init', () => {
                         width:            w,
                         height:           h,
                         is_service_point: false,
+                        floor:            this.floorsEnabled ? this.currentFloor : 1,
                     }),
                 });
 
@@ -2087,7 +2135,7 @@ document.addEventListener('alpine:init', () => {
                         'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
                         'Accept':       'application/json',
                     },
-                    body: JSON.stringify({ name, color, position_x: x, position_y: y, width: w, height: h }),
+                    body: JSON.stringify({ name, color, position_x: x, position_y: y, width: w, height: h, floor: this.floorsEnabled ? this.currentFloor : 1 }),
                 });
 
                 const json = await res.json();
@@ -2180,6 +2228,8 @@ document.addEventListener('alpine:init', () => {
             const startMY = event.clientY;
             const startW  = zone.width;
             const startH  = zone.height;
+            this.closeEditPanels();
+            this.resizingId            = zone.id;
             document.body.style.cursor = 'se-resize';
 
             const onMove = (e) => {
@@ -2192,6 +2242,7 @@ document.addEventListener('alpine:init', () => {
             const onUp = async () => {
                 document.removeEventListener('mousemove', onMove);
                 document.removeEventListener('mouseup',   onUp);
+                this.resizingId            = null;
                 document.body.style.cursor = '';
                 try {
                     await fetch(`/zonas/${zone.id}`, {
@@ -2258,6 +2309,8 @@ document.addEventListener('alpine:init', () => {
             const startPx = table.position_x;
             const startPy = table.position_y;
 
+            this.closeEditPanels();
+            this.resizingId            = table.id;
             document.body.style.cursor = 'se-resize';
 
             const onMove = (e) => {
@@ -2290,6 +2343,7 @@ document.addEventListener('alpine:init', () => {
             const onUp = async () => {
                 document.removeEventListener('mousemove', onMove);
                 document.removeEventListener('mouseup',   onUp);
+                this.resizingId            = null;
                 document.body.style.cursor = '';
                 await this.persistPosition(table.id, table.position_x, table.position_y, table.width, table.height);
             };
@@ -2339,6 +2393,7 @@ document.addEventListener('alpine:init', () => {
             table.shape = shape;
             this.editingTableId = null;
             this.editingTable   = null;
+            this._editBtnEl     = null;
 
             try {
                 const res = await fetch(`/mesas/${table.id}/forma`, {
@@ -2436,8 +2491,7 @@ document.addEventListener('alpine:init', () => {
 
         // ── Rotación libre arrastrando el handle (estilo Canva) ───────────────
         startRotation(event, table) {
-            this.editingTableId = null;
-            this.editingTable   = null;
+            this.closeEditPanels();
             this.rotatingId     = table.id;
 
             const canvasRect = this.$refs.canvas.getBoundingClientRect();
@@ -2735,7 +2789,6 @@ document.addEventListener('alpine:init', () => {
                 this.showToast('Error de red al mover la estructura.', true);
             }
         },
-
 
         // ── AJAX: eliminar mesa ───────────────────────────────────────────────
         async deleteTable(table) {

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1042,6 +1042,20 @@
             </span>
         </div>
     </div>
+
+    {{-- Toast fijo — siempre visible sin importar scroll ni zoom del canvas --}}
+    <div x-show="toast.show"
+         x-transition:enter="transition ease-out duration-200"
+         x-transition:enter-start="opacity-0 translate-y-2"
+         x-transition:enter-end="opacity-100 translate-y-0"
+         x-transition:leave="transition ease-in duration-150"
+         x-transition:leave-end="opacity-0 translate-y-2"
+         :class="toast.error ? 'bg-red-100 text-red-700 border-red-300' : 'bg-green-100 text-green-700 border-green-300'"
+         class="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] border rounded-lg px-4 py-2 text-sm font-medium shadow-lg pointer-events-none"
+         x-text="toast.msg"
+         role="alert"
+         aria-live="polite">
+    </div>
 </div>
 
 {{-- Modal de QR de mesa --}}
@@ -1121,20 +1135,6 @@
                 Descargar SVG
             </a>
         </div>
-    </div>
-
-    {{-- Toast fijo — siempre visible sin importar scroll ni zoom del canvas --}}
-    <div x-show="toast.show"
-         x-transition:enter="transition ease-out duration-200"
-         x-transition:enter-start="opacity-0 translate-y-2"
-         x-transition:enter-end="opacity-100 translate-y-0"
-         x-transition:leave="transition ease-in duration-150"
-         x-transition:leave-end="opacity-0 translate-y-2"
-         :class="toast.error ? 'bg-red-100 text-red-700 border-red-300' : 'bg-green-100 text-green-700 border-green-300'"
-         class="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] border rounded-lg px-4 py-2 text-sm font-medium shadow-lg pointer-events-none"
-         x-text="toast.msg"
-         role="alert"
-         aria-live="polite">
     </div>
 </div>
 

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -58,33 +58,20 @@
         </div>
 
         <div class="flex items-center gap-3 flex-wrap">
-            {{-- Toast --}}
-            <div x-show="toast.show"
-                 x-transition:enter="transition ease-out duration-200"
-                 x-transition:enter-start="opacity-0 translate-y-1"
-                 x-transition:enter-end="opacity-100 translate-y-0"
-                 x-transition:leave="transition ease-in duration-150"
-                 x-transition:leave-end="opacity-0"
-                 :class="toast.error ? 'bg-red-100 text-red-700 border-red-300' : 'bg-green-100 text-green-700 border-green-300'"
-                 class="border rounded-lg px-3 py-1.5 text-sm font-medium"
-                 x-text="toast.msg"
-                 role="alert"
-                 aria-live="polite">
-            </div>
-
             {{-- ── Control de tamaño del lienzo — solo admin ──────────────── --}}
             <div x-show="!readonly" class="flex items-center gap-2">
                 <span class="text-xs font-medium text-gray-500 dark:text-gray-400 hidden sm:block"
                       aria-hidden="true">Plano:</span>
 
-                {{-- Botones S / M / L / XL --}}
-                <div class="flex rounded-lg overflow-hidden border border-gray-200 dark:border-gray-600"
+                {{-- Botones S / M / L / XL — ocultos en vista general (tamaño automático) --}}
+                <div x-show="!(floorsEnabled && currentView === 'general')"
+                     class="flex rounded-lg overflow-hidden border border-gray-200 dark:border-gray-600"
                      role="group"
                      aria-label="Tamaño del lienzo del plano">
                     <button type="button"
                             @click="setCanvasSize(1200, 800)"
-                            :aria-pressed="floorWidth === 1200 && floorHeight === 800"
-                            :class="floorWidth === 1200 && floorHeight === 800
+                            :aria-pressed="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 1200 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 800"
+                            :class="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 1200 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 800
                                 ? 'bg-indigo-600 text-white'
                                 : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
                             class="px-3 py-1.5 text-xs font-semibold border-r border-gray-200 dark:border-gray-600
@@ -92,8 +79,8 @@
                             aria-label="Lienzo pequeño: 1200 × 800 px">S</button>
                     <button type="button"
                             @click="setCanvasSize(1600, 1000)"
-                            :aria-pressed="floorWidth === 1600 && floorHeight === 1000"
-                            :class="floorWidth === 1600 && floorHeight === 1000
+                            :aria-pressed="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 1600 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 1000"
+                            :class="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 1600 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 1000
                                 ? 'bg-indigo-600 text-white'
                                 : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
                             class="px-3 py-1.5 text-xs font-semibold border-r border-gray-200 dark:border-gray-600
@@ -101,8 +88,8 @@
                             aria-label="Lienzo mediano: 1600 × 1000 px">M</button>
                     <button type="button"
                             @click="setCanvasSize(2000, 1200)"
-                            :aria-pressed="floorWidth === 2000 && floorHeight === 1200"
-                            :class="floorWidth === 2000 && floorHeight === 1200
+                            :aria-pressed="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 2000 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 1200"
+                            :class="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 2000 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 1200
                                 ? 'bg-indigo-600 text-white'
                                 : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
                             class="px-3 py-1.5 text-xs font-semibold border-r border-gray-200 dark:border-gray-600
@@ -110,8 +97,8 @@
                             aria-label="Lienzo grande: 2000 × 1200 px">L</button>
                     <button type="button"
                             @click="setCanvasSize(2400, 1500)"
-                            :aria-pressed="floorWidth === 2400 && floorHeight === 1500"
-                            :class="floorWidth === 2400 && floorHeight === 1500
+                            :aria-pressed="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 2400 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 1500"
+                            :class="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 2400 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 1500
                                 ? 'bg-indigo-600 text-white'
                                 : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
                             class="px-3 py-1.5 text-xs font-semibold transition-colors
@@ -325,6 +312,32 @@
                                 whitespace-nowrap pointer-events-none">
                         Ajusta el zoom al 100% para editar el plano
                     </div>
+                </div>
+
+                {{-- Toast de confirmación / error — parte superior del canvas --}}
+                <div x-show="toast.show"
+                     x-transition:enter="transition ease-out duration-200"
+                     x-transition:enter-start="opacity-0 -translate-y-2"
+                     x-transition:enter-end="opacity-100 translate-y-0"
+                     x-transition:leave="transition ease-in duration-150"
+                     x-transition:leave-end="opacity-0"
+                     :class="toast.error ? 'bg-red-100 text-red-700 border-red-300' : 'bg-green-100 text-green-700 border-green-300'"
+                     class="absolute top-3 left-1/2 -translate-x-1/2 z-[300]
+                            border rounded-lg px-4 py-2 text-sm font-medium shadow-md pointer-events-none whitespace-nowrap"
+                     x-text="toast.msg"
+                     role="alert"
+                     aria-live="polite">
+                </div>
+
+                {{-- Banner vista general --}}
+                <div x-show="floorsEnabled && currentView === 'general'"
+                     aria-live="polite"
+                     class="absolute top-2 left-1/2 -translate-x-1/2 z-10 pointer-events-none">
+                    <span class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium
+                                 bg-indigo-100 dark:bg-indigo-900/60 text-indigo-700 dark:text-indigo-300
+                                 border border-indigo-200 dark:border-indigo-700 shadow-sm">
+                        Vista general — todas las plantas visibles · colisión desactivada
+                    </span>
                 </div>
 
                 {{-- Cuadrícula decorativa --}}
@@ -1209,6 +1222,11 @@ document.addEventListener('alpine:init', () => {
         zones:                 @json($zones),
         floorWidth:            {{ $floorWidth }},
         floorHeight:           {{ $floorHeight }},
+        floorsEnabled:         {{ $floorsEnabled ? 'true' : 'false' }},
+        floorCount:            {{ $floorCount }},
+        floorCanvasSizes:      @json($floorCanvasSizes),
+        currentFloor:          1,
+        currentView:           'floor',
         readonly:              {{ $readonly ? 'true' : 'false' }},
         canvasZoom:            1,
         isDraggingFromPalette: false,
@@ -1315,9 +1333,14 @@ document.addEventListener('alpine:init', () => {
 
         // ── Cambiar tamaño del lienzo y persistir en BD ───────────────────────
         async setCanvasSize(w, h) {
-            const prev = { w: this.floorWidth, h: this.floorHeight };
+            const floor    = this.floorsEnabled ? this.currentFloor : 1;
+            const prevW    = this.floorWidth;
+            const prevH    = this.floorHeight;
+            const prevSize = this.floorCanvasSizes[floor] ? { ...this.floorCanvasSizes[floor] } : { width: prevW, height: prevH };
+
             this.floorWidth  = w;
             this.floorHeight = h;
+            this.floorCanvasSizes[floor] = { width: w, height: h };
 
             try {
                 const res = await fetch('{{ route("tables.canvas.update") }}', {
@@ -1327,22 +1350,24 @@ document.addEventListener('alpine:init', () => {
                         'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
                         'Accept':       'application/json',
                     },
-                    body: JSON.stringify({ floor_width: w, floor_height: h }),
+                    body: JSON.stringify({ floor_width: w, floor_height: h, floor }),
                 });
 
                 const json = await res.json();
 
                 if (!res.ok || !json.success) {
-                    this.floorWidth  = prev.w;
-                    this.floorHeight = prev.h;
+                    this.floorWidth  = prevW;
+                    this.floorHeight = prevH;
+                    this.floorCanvasSizes[floor] = prevSize;
                     this.showToast(json.message ?? 'Error al guardar el tamaño.', true);
                     return;
                 }
 
                 this.showToast(`Plano ${w} × ${h} px guardado.`);
             } catch {
-                this.floorWidth  = prev.w;
-                this.floorHeight = prev.h;
+                this.floorWidth  = prevW;
+                this.floorHeight = prevH;
+                this.floorCanvasSizes[floor] = prevSize;
                 this.showToast('Error de red al guardar el tamaño.', true);
             }
         },
@@ -2343,6 +2368,259 @@ document.addEventListener('alpine:init', () => {
             document.addEventListener('mousemove', onMove);
             document.addEventListener('mouseup',   onUp);
         },
+
+        closeEditPanels() {
+            this.editingTableId = null;
+            this.editingTable   = null;
+            this._editBtnEl     = null;
+            this.editingZoneId  = null;
+            this.editingZone    = null;
+            this._zoneBtnEl     = null;
+        },
+
+        isActive(id) {
+            return this.selectedId     === id
+                || this.rotatingId     === id
+                || this.draggingId     === id
+                || this.resizingId     === id
+                || this.editingTableId === id
+                || this.editingZoneId  === id;
+        },
+
+        panelPosFromBtn(btn, panelW) {
+            const canvas = this.$refs.canvas;
+            const cRect  = canvas.getBoundingClientRect();
+            const bRect  = btn.getBoundingClientRect();
+            const zoom   = this.canvasZoom;
+            // Convertir coords de viewport a espacio del canvas (divir por zoom deshace el transform:scale)
+            const left = (bRect.left + bRect.width / 2 - cRect.left) / zoom - panelW / 2;
+            const top  = (bRect.bottom - cRect.top) / zoom + 8;
+            return {
+                x: Math.max(4, left),
+                y: Math.max(4, top),
+            };
+        },
+
+        // ── Filtros de visibilidad por planta ────────────────────────────────
+        visibleTables() {
+            if (!this.floorsEnabled || this.currentView === 'general') return this.tables;
+            return this.tables.filter(t => (t.floor ?? 1) === this.currentFloor);
+        },
+
+        visibleElements() {
+            if (!this.floorsEnabled || this.currentView === 'general') return this.elements;
+            return this.elements.filter(e => (e.floor ?? 1) === this.currentFloor);
+        },
+
+        visibleZones() {
+            if (!this.floorsEnabled || this.currentView === 'general') return this.zones;
+            return this.zones.filter(z => (z.floor ?? 1) === this.currentFloor);
+        },
+
+        // ── Navegación entre plantas y vistas ────────────────────────────────
+        switchFloor(n) {
+            this.currentFloor   = n;
+            this.currentView    = 'floor';
+            const size = this.floorCanvasSizes[n];
+            if (size) {
+                this.floorWidth  = size.width;
+                this.floorHeight = size.height;
+            }
+            this.editingTableId = null;
+            this.editingTable   = null;
+            this._editBtnEl     = null;
+            this.editingZoneId  = null;
+            this.editingZone    = null;
+            this._zoneBtnEl     = null;
+        },
+
+        switchView(view) {
+            this.currentView    = view;
+            if (view === 'general' && this.floorsEnabled) {
+                const sizes = Object.values(this.floorCanvasSizes);
+                if (sizes.length) {
+                    this.floorWidth  = Math.max(...sizes.map(s => s.width));
+                    this.floorHeight = Math.max(...sizes.map(s => s.height));
+                }
+            }
+            this.editingTableId = null;
+            this.editingTable   = null;
+            this._editBtnEl     = null;
+            this.editingZoneId  = null;
+            this.editingZone    = null;
+            this._zoneBtnEl     = null;
+        },
+
+        // ── Mover zona a otra planta ─────────────────────────────────────────
+        async moveZoneToFloor(zone, newFloor) {
+            if (!zone || newFloor === (zone.floor ?? 1)) return;
+            const prev = zone.floor ?? 1;
+            zone.floor = newFloor;
+            try {
+                const res = await fetch(`/zonas/${zone.id}`, {
+                    method:  'PATCH',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                        'Accept':       'application/json',
+                    },
+                    body: JSON.stringify({ floor: newFloor }),
+                });
+                const json = await res.json();
+                if (!res.ok || !json.success) {
+                    zone.floor = prev;
+                    this.showToast(json.message ?? 'Error al mover la zona.', true);
+                    return;
+                }
+                this.editingZoneId = null;
+                this.editingZone   = null;
+                this._zoneBtnEl    = null;
+                this.showToast(json.message);
+            } catch {
+                zone.floor = prev;
+                this.showToast('Error de red al mover la zona.', true);
+            }
+        },
+
+        // ── Toggle sistema de plantas ─────────────────────────────────────────
+        async toggleFloorsEnabled(enabled) {
+            if (!enabled) {
+                const hasUpperStructures =
+                    this.tables.some(t => (t.floor ?? 1) > 1) ||
+                    this.elements.some(e => (e.floor ?? 1) > 1) ||
+                    this.zones.some(z => (z.floor ?? 1) > 1);
+                if (hasUpperStructures) {
+                    this.showToast('Elimina todas las estructuras de las plantas superiores antes de desactivar el sistema.', true);
+                    return;
+                }
+                this.currentView  = 'floor';
+                this.currentFloor = 1;
+            }
+            const prev = this.floorsEnabled;
+            this.floorsEnabled = enabled;
+            try {
+                const res = await fetch('{{ route("tables.floor-settings") }}', {
+                    method:  'PATCH',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                        'Accept':       'application/json',
+                    },
+                    body: JSON.stringify({ floors_enabled: enabled }),
+                });
+                const json = await res.json();
+                if (!res.ok || !json.success) {
+                    this.floorsEnabled = prev;
+                    this.showToast(json.message ?? 'Error al guardar la configuración de plantas.', true);
+                }
+            } catch {
+                this.floorsEnabled = prev;
+                this.showToast('Error al guardar la configuración de plantas.', true);
+            }
+        },
+
+        // ── Añadir planta ─────────────────────────────────────────────────────
+        async addFloor() {
+            if (this.floorCount >= 5) return;
+            const newCount = this.floorCount + 1;
+            try {
+                const res = await fetch('{{ route("tables.floor-settings") }}', {
+                    method:  'PATCH',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                        'Accept':       'application/json',
+                    },
+                    body: JSON.stringify({ floor_count: newCount }),
+                });
+                const json = await res.json();
+                if (res.ok && json.success) {
+                    this.floorCount = newCount;
+                    const floor1Size = this.floorCanvasSizes[1] ?? { width: this.floorWidth, height: this.floorHeight };
+                    this.floorCanvasSizes[newCount] = { ...floor1Size };
+                    this.switchFloor(newCount);
+                    this.showToast(`Planta ${newCount} creada.`);
+                }
+            } catch {
+                this.showToast('Error al crear la planta.', true);
+            }
+        },
+
+        // ── Confirmar y eliminar última planta ───────────────────────────────
+        async confirmDeleteFloor(floor) {
+            const structuresOnFloor = [
+                ...this.tables.filter(t => (t.floor ?? 1) === floor),
+                ...this.elements.filter(e => (e.floor ?? 1) === floor),
+            ];
+
+            const confirmed = await Alpine.store('deleteModal').prompt({
+                name:     String(floor),
+                shape:    null,
+                _isFloor: true,
+                _count:   structuresOnFloor.length,
+            });
+
+            if (!confirmed) return;
+
+            try {
+                const res = await fetch(`/mesas/mapa/plantas/${floor}`, {
+                    method:  'DELETE',
+                    headers: {
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                        'Accept':       'application/json',
+                    },
+                });
+                const json = await res.json();
+                if (!res.ok || !json.success) {
+                    this.showToast(json.message ?? 'Error al eliminar la planta.', true);
+                    return;
+                }
+                this.tables   = this.tables.filter(t => (t.floor ?? 1) !== floor);
+                this.elements = this.elements.filter(e => (e.floor ?? 1) !== floor);
+                this.floorCount = floor - 1;
+                if (this.currentFloor >= floor) this.switchFloor(floor - 1);
+                this.$nextTick(() => {
+                    this.initTableInteract();
+                    this.initCanvasDropzone();
+                });
+                this.showToast(`Planta ${floor} eliminada.`);
+            } catch {
+                this.showToast('Error de red al eliminar la planta.', true);
+            }
+        },
+
+        // ── Mover estructura a otra planta ───────────────────────────────────
+        async moveToFloor(item, newFloor) {
+            if (!item || newFloor === (item.floor ?? 1)) return;
+            const prev = item.floor ?? 1;
+            item.floor = newFloor;
+            try {
+                const res = await fetch(`/mesas/${item.id}/planta`, {
+                    method:  'PATCH',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                        'Accept':       'application/json',
+                    },
+                    body: JSON.stringify({ floor: newFloor }),
+                });
+                const json = await res.json();
+                if (!res.ok || !json.success) {
+                    item.floor = prev;
+                    this.showToast(json.message ?? 'Error al mover la estructura.', true);
+                    return;
+                }
+                this.editingTableId = null;
+                this.editingTable   = null;
+                this._editBtnEl     = null;
+                this.$nextTick(() => this.initTableInteract());
+                this.showToast(json.message);
+            } catch {
+                item.floor = prev;
+                this.showToast('Error de red al mover la estructura.', true);
+            }
+        },
+
 
         // ── AJAX: eliminar mesa ───────────────────────────────────────────────
         async deleteTable(table) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,10 +63,13 @@ Route::middleware(['auth', 'business.active'])->group(function () {
         // Mapa visual de mesas (Bloques 8.1 y 8.3) — solo admin puede editar
         Route::post('/mesas', [TableController::class, 'store'])->name('tables.store');
         Route::patch('/mesas/mapa/canvas', [TableController::class, 'updateCanvas'])->name('tables.canvas.update');
+        Route::patch('/mesas/mapa/plantas/config', [TableController::class, 'updateFloorSettings'])->name('tables.floor-settings');
+        Route::delete('/mesas/mapa/plantas/{floor}', [TableController::class, 'destroyFloor'])->name('tables.floor-destroy');
         Route::patch('/mesas/{table}/posicion', [TableController::class, 'updatePosition'])->name('tables.updatePosition');
         Route::patch('/mesas/{table}/forma', [TableController::class, 'updateShape'])->name('tables.updateShape');
         Route::patch('/mesas/{table}/nombre', [TableController::class, 'updateName'])->name('tables.updateName');
         Route::patch('/mesas/{table}/zona', [TableController::class, 'updateZone'])->name('tables.updateZone');
+        Route::patch('/mesas/{table}/planta', [TableController::class, 'updateFloor'])->name('tables.update-floor');
         Route::delete('/mesas/{table}', [TableController::class, 'destroy'])->name('tables.destroy');
 
         // Gestión de zonas del plano — solo admin


### PR DESCRIPTION
## Summary

- Tamaño de canvas independiente por planta (`floor_canvas_sizes` en usuarios)
- Las estructuras arrastradas desde la paleta ahora se crean en la planta activa, no siempre en planta 1
- Implementados métodos faltantes: `destroyFloor`, `updateFloorSettings`, `updateFloor`
- Zonas: columna `floor` añadida a `fillable` y aceptada en `store`/`update`
- Mensaje de movimiento de estructura incluye nombre de planta destino
- Mensaje de asignación de zona incluye nombre de zona y mesa
- Toast de confirmación/error reubicado como elemento `fixed` siempre visible (independiente del scroll y zoom del canvas)

## Test plan

- [ ] Arrastrar mesa/elemento/zona al canvas → se crea en la planta seleccionada
- [ ] Mover estructura a otra planta desde el panel de edición → mensaje "X movida a Planta N"
- [ ] Asignar zona a mesa → mensaje "Zona 'X' asignada a 'Y'"
- [ ] Eliminar última planta → estructuras eliminadas, `floor_count` decrementado
- [ ] Cambiar tamaño de canvas en planta 2 → no afecta a planta 1
- [ ] Toast visible en canvas grande con scroll o zoom reducido

🤖 Generated with [Claude Code](https://claude.com/claude-code)