### PR TITLE
Audit/seguridad soft deletes

### DIFF
--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -24,6 +24,7 @@ use SimpleSoftwareIO\QrCode\Facades\QrCode;
  *
  * @author AyrtonAlania
  * @author SebastianBCF
+ * @author BenjaminDTS
  */
 class TableController extends Controller
 {
@@ -277,7 +278,7 @@ class TableController extends Controller
      */
     public function updatePosition(Request $request, Table $table): JsonResponse
     {
-        abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $data = $request->validate([
             'position_x' => 'required|integer|min:-3000',
@@ -305,7 +306,7 @@ class TableController extends Controller
      */
     public function updateName(Request $request, Table $table): JsonResponse
     {
-        abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $data = $request->validate([
             'name' => 'required|string|max:50',
@@ -329,7 +330,7 @@ class TableController extends Controller
      */
     public function updateZone(Request $request, Table $table): JsonResponse
     {
-        abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $data = $request->validate([
             'zone_id' => ['nullable', Rule::exists('zones', 'id')->where('user_id', Auth::id())],
@@ -360,7 +361,7 @@ class TableController extends Controller
      */
     public function updateShape(Request $request, Table $table): JsonResponse
     {
-        abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $data = $request->validate([
             'shape' => 'required|in:square,round,rectangle,bar,stool',
@@ -392,7 +393,7 @@ class TableController extends Controller
      */
     public function updateFloor(Request $request, Table $table): JsonResponse
     {
-        abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $data = $request->validate([
             'floor' => 'required|integer|min:1|max:5',
@@ -421,7 +422,7 @@ class TableController extends Controller
      */
     public function destroy(Table $table): JsonResponse
     {
-        abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $name  = $table->name;
         $shape = $table->shape;
@@ -447,7 +448,7 @@ class TableController extends Controller
      */
     public function showQr(Table $table): Response
     {
-        abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $url = route('menu.show', $table->unique_hash);
         $svg = QrCode::format('svg')
@@ -466,7 +467,7 @@ class TableController extends Controller
      */
     public function downloadQr(Table $table): Response
     {
-        abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $url      = route('menu.show', $table->unique_hash);
         $svg      = QrCode::format('svg')
@@ -490,7 +491,7 @@ class TableController extends Controller
      */
     public function regenerateHash(Table $table): RedirectResponse
     {
-        abort_if($table->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $table->update(['unique_hash' => Str::uuid()->toString()]);
 

--- a/app/Http/Controllers/ZoneController.php
+++ b/app/Http/Controllers/ZoneController.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Auth;
  * Solo accesible para el gerente (admin). Todas las operaciones son AJAX/JSON.
  *
  * @author AyrtonAlania
+ * @author BenjaminDTS
  */
 class ZoneController extends Controller
 {
@@ -57,7 +58,7 @@ class ZoneController extends Controller
      */
     public function update(Request $request, Zone $zone): JsonResponse
     {
-        abort_if($zone->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($zone->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $data = $request->validate([
             'name'       => 'sometimes|string|max:50',
@@ -87,7 +88,7 @@ class ZoneController extends Controller
      */
     public function destroy(Zone $zone): JsonResponse
     {
-        abort_if($zone->user_id !== Auth::id(), 403, 'Acceso denegado.');
+        abort_if($zone->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $name = $zone->name;
         $zone->delete();

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * Class Category
@@ -14,10 +15,11 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * Define a qué impresora debe enviarse (Bar o Cocina).
  *
  * @property string $destination  'kitchen' o 'bar'
+ * @author BenjaminDTS
  */
 class Category extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = ['user_id', 'name', 'destination'];
 

--- a/app/Models/Ingredient.php
+++ b/app/Models/Ingredient.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * Class Ingredient
@@ -18,10 +19,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string|null $allergen_type Tipo de alérgeno según Reglamento UE 1169/2011
  *
  * @author AyrtonAlania
+ * @author BenjaminDTS
  */
 class Ingredient extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = ['user_id', 'name', 'is_allergen', 'allergen_type'];
 

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * Class Product
@@ -13,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  * Representa un plato o bebida de la carta.
  *
  * @author SebastianBCF
+ * @author BenjaminDTS
  *
  * @property string $image       Ruta relativa de la imagen almacenada en storage/app/public/products
  * @property float $price      Precio base del producto
@@ -20,7 +22,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
  */
 class Product extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'user_id',

--- a/database/migrations/2026_05_18_173101_add_soft_deletes_to_categories_table.php
+++ b/database/migrations/2026_05_18_173101_add_soft_deletes_to_categories_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2026_05_18_173101_add_soft_deletes_to_products_table.php
+++ b/database/migrations/2026_05_18_173101_add_soft_deletes_to_products_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2026_05_18_173102_add_soft_deletes_to_ingredients_table.php
+++ b/database/migrations/2026_05_18_173102_add_soft_deletes_to_ingredients_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/tests/Feature/Bloque1/CategoryTest.php
+++ b/tests/Feature/Bloque1/CategoryTest.php
@@ -209,7 +209,7 @@ it('deletes a category owned by the user', function () {
         ->delete(route('categories.destroy', $category))
         ->assertRedirect(route('categories.index'));
 
-    $this->assertDatabaseMissing('categories', ['id' => $category->id]);
+    $this->assertSoftDeleted('categories', ['id' => $category->id]);
 });
 
 it('returns 403 when user tries to delete another users category', function () {

--- a/tests/Feature/Bloque1/IngredientTest.php
+++ b/tests/Feature/Bloque1/IngredientTest.php
@@ -186,7 +186,7 @@ it('deletes an ingredient owned by the user', function () {
         ->delete(route('ingredients.destroy', $ingredient))
         ->assertRedirect(route('ingredients.index'));
 
-    $this->assertDatabaseMissing('ingredients', ['id' => $ingredient->id]);
+    $this->assertSoftDeleted('ingredients', ['id' => $ingredient->id]);
 });
 
 it('returns 403 when user tries to delete another users ingredient', function () {

--- a/tests/Feature/Bloque1/ProductTest.php
+++ b/tests/Feature/Bloque1/ProductTest.php
@@ -295,7 +295,7 @@ it('deletes a product and removes its image from storage', function () {
         ->delete(route('products.destroy', $product))
         ->assertRedirect(route('products.index'));
 
-    $this->assertDatabaseMissing('products', ['id' => $product->id]);
+    $this->assertSoftDeleted('products', ['id' => $product->id]);
 });
 
 it('returns 403 when user tries to delete another users product', function () {

--- a/tests/Feature/Bloque6/TapasTest.php
+++ b/tests/Feature/Bloque6/TapasTest.php
@@ -1091,7 +1091,7 @@ it('allows deleting Tapas category when tapas_disabled', function () {
          ->delete(route('categories.destroy', $tapasCategory))
          ->assertRedirect(route('categories.index'));
 
-    $this->assertDatabaseMissing('categories', ['id' => $tapasCategory->id]);
+    $this->assertSoftDeleted('categories', ['id' => $tapasCategory->id]);
 });
 
 it('tapas category products are not shown in main menu listing when tapas enabled', function () {

--- a/tests/Feature/Menu/CategoryTest.php
+++ b/tests/Feature/Menu/CategoryTest.php
@@ -209,7 +209,7 @@ it('deletes a category owned by the user', function () {
         ->delete(route('categories.destroy', $category))
         ->assertRedirect(route('categories.index'));
 
-    $this->assertDatabaseMissing('categories', ['id' => $category->id]);
+    $this->assertSoftDeleted('categories', ['id' => $category->id]);
 });
 
 it('returns 403 when user tries to delete another users category', function () {

--- a/tests/Feature/Menu/IngredientTest.php
+++ b/tests/Feature/Menu/IngredientTest.php
@@ -186,7 +186,7 @@ it('deletes an ingredient owned by the user', function () {
         ->delete(route('ingredients.destroy', $ingredient))
         ->assertRedirect(route('ingredients.index'));
 
-    $this->assertDatabaseMissing('ingredients', ['id' => $ingredient->id]);
+    $this->assertSoftDeleted('ingredients', ['id' => $ingredient->id]);
 });
 
 it('returns 403 when user tries to delete another users ingredient', function () {

--- a/tests/Feature/Menu/ProductTest.php
+++ b/tests/Feature/Menu/ProductTest.php
@@ -295,7 +295,7 @@ it('deletes a product and removes its image from storage', function () {
         ->delete(route('products.destroy', $product))
         ->assertRedirect(route('products.index'));
 
-    $this->assertDatabaseMissing('products', ['id' => $product->id]);
+    $this->assertSoftDeleted('products', ['id' => $product->id]);
 });
 
 it('returns 403 when user tries to delete another users product', function () {

--- a/tests/Feature/SecurityTest.php
+++ b/tests/Feature/SecurityTest.php
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * @author BenjaminDTS
+ */
+
+use App\Models\Category;
+use App\Models\Ingredient;
+use App\Models\Plan;
+use App\Models\Product;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\CreatesTenants;
+
+uses(RefreshDatabase::class);
+uses(CreatesTenants::class);
+
+beforeEach(function () {
+    $this->setupTenants();
+});
+
+// ──────────────────────────────────────────────
+// RUTAS PROTEGIDAS — requieren autenticación
+// ──────────────────────────────────────────────
+
+it('all admin routes require authentication', function () {
+    $routes = [
+        ['GET', route('categories.index')],
+        ['GET', route('products.index')],
+        ['GET', route('ingredients.index')],
+        ['GET', route('tables.index')],
+        ['GET', route('dashboard')],
+        ['GET', route('staff.index')],
+        ['GET', route('manager.income')],
+    ];
+
+    foreach ($routes as [$method, $url]) {
+        $response = $this->call($method, $url);
+        expect($response->getStatusCode())
+            ->toBeIn([302, 401], "Route {$url} should redirect unauthenticated users");
+
+        if ($response->getStatusCode() === 302) {
+            expect($response->headers->get('Location'))->toContain('login');
+        }
+    }
+});
+
+// ──────────────────────────────────────────────
+// RUTAS SUPERADMIN — requieren rol superadmin
+// ──────────────────────────────────────────────
+
+it('all superadmin routes require superadmin role', function () {
+    $admin = User::factory()->admin()->withBusiness()->create([
+        'plan_id' => Plan::factory()->create()->id,
+    ]);
+
+    $routes = [
+        ['GET', route('superadmin.businesses.index')],
+        ['GET', route('superadmin.dashboard')],
+        ['GET', route('superadmin.plans.index')],
+    ];
+
+    foreach ($routes as [$method, $url]) {
+        $this->actingAs($admin)
+             ->call($method, $url)
+             ->assertForbidden();
+    }
+});
+
+it('waiter cannot access admin-only routes', function () {
+    $admin  = User::factory()->admin()->withBusiness()->create();
+    $waiter = User::factory()->waiter()->staffOf($admin)->create();
+
+    // Rutas protegidas por role:admin que un camarero no puede ver
+    $this->actingAs($waiter)
+         ->get(route('manager.income'))
+         ->assertForbidden();
+
+    $this->actingAs($waiter)
+         ->get(route('staff.index'))
+         ->assertForbidden();
+
+    $this->actingAs($waiter)
+         ->get(route('dashboard'))
+         ->assertForbidden();
+});
+
+// ──────────────────────────────────────────────
+// SOFT DELETES — visibilidad post-eliminación
+// ──────────────────────────────────────────────
+
+it('soft deleted categories are not visible in index', function () {
+    $category = Category::factory()->create(['user_id' => $this->user->id]);
+
+    $category->delete();
+
+    $response = $this->actingAs($this->user)
+                     ->get(route('categories.index'));
+
+    $categories = $response->viewData('categories');
+    expect($categories->contains('id', $category->id))->toBeFalse();
+});
+
+it('soft deleted products do not appear in public menu', function () {
+    $plan     = Plan::factory()->create();
+    $owner    = User::factory()->admin()->create(['plan_id' => $plan->id]);
+    $table    = Table::factory()->create(['user_id' => $owner->id]);
+    $category = Category::factory()->create(['user_id' => $owner->id, 'destination' => 'kitchen']);
+    $product  = Product::factory()->create([
+        'user_id'     => $owner->id,
+        'category_id' => $category->id,
+        'is_active'   => true,
+    ]);
+
+    $product->delete();
+
+    $this->get(route('menu.show', $table->unique_hash))
+         ->assertOk()
+         ->assertDontSee($product->name);
+});
+
+it('soft deleted ingredients are not assignable to products', function () {
+    $ingredient = Ingredient::factory()->create(['user_id' => $this->user->id]);
+    $product    = Product::factory()->create([
+        'user_id'     => $this->user->id,
+        'category_id' => Category::factory()->create(['user_id' => $this->user->id])->id,
+    ]);
+
+    $ingredient->delete();
+
+    // El ingrediente eliminado no debe aparecer en el listado de ingredientes
+    $remaining = Ingredient::where('user_id', $this->user->id)->get();
+    expect($remaining->contains('id', $ingredient->id))->toBeFalse();
+
+    // Intentar sincronizar con el ingrediente eliminado no debe incluirlo
+    $this->actingAs($this->user)
+         ->post(route('products.ingredients.sync', $product), [
+             'ingredients' => [
+                 $ingredient->id => ['included' => '1', 'quantity_base' => 1],
+             ],
+         ]);
+
+    expect($product->fresh()->ingredients->contains('id', $ingredient->id))->toBeFalse();
+});
+
+it('soft deleted category is not accessible via edit route', function () {
+    $category = Category::factory()->create(['user_id' => $this->user->id]);
+    $category->delete();
+
+    $this->actingAs($this->user)
+         ->get(route('categories.edit', $category->id))
+         ->assertNotFound();
+});
+
+it('soft deleted product is not accessible via edit route', function () {
+    $product = Product::factory()->create([
+        'user_id'     => $this->user->id,
+        'category_id' => Category::factory()->create(['user_id' => $this->user->id])->id,
+    ]);
+    $product->delete();
+
+    $this->actingAs($this->user)
+         ->get(route('products.edit', $product->id))
+         ->assertNotFound();
+});
+
+// ──────────────────────────────────────────────
+// MULTITENANCY — protección cross-user
+// ──────────────────────────────────────────────
+
+it('user cannot access soft deleted resources of other users', function () {
+    $categoryOther = Category::factory()->create(['user_id' => $this->other->id]);
+    $categoryOther->delete();
+
+    // El usuario propio no puede ver el recurso (soft-deleted + de otro usuario)
+    $this->actingAs($this->user)
+         ->get(route('categories.edit', $categoryOther->id))
+         ->assertNotFound();
+});
+
+it('all destroy methods have multitenancy protection', function () {
+    $category   = Category::factory()->create(['user_id' => $this->other->id]);
+    $product    = Product::factory()->create([
+        'user_id'     => $this->other->id,
+        'category_id' => $category->id,
+    ]);
+    $ingredient = Ingredient::factory()->create(['user_id' => $this->other->id]);
+
+    $this->actingAs($this->user)
+         ->delete(route('categories.destroy', $category))
+         ->assertForbidden();
+
+    $this->actingAs($this->user)
+         ->delete(route('products.destroy', $product))
+         ->assertForbidden();
+
+    $this->actingAs($this->user)
+         ->delete(route('ingredients.destroy', $ingredient))
+         ->assertForbidden();
+
+    // Recursos intactos en BD
+    $this->assertDatabaseHas('categories',  ['id' => $category->id,   'deleted_at' => null]);
+    $this->assertDatabaseHas('products',    ['id' => $product->id,    'deleted_at' => null]);
+    $this->assertDatabaseHas('ingredients', ['id' => $ingredient->id, 'deleted_at' => null]);
+});
+
+it('table QR is accessible to restaurant staff via ownerUserId', function () {
+    $admin  = User::factory()->admin()->alsoWaiter()->create();
+    $table  = Table::factory()->create(['user_id' => $admin->id]);
+    $waiter = User::factory()->waiter()->staffOf($admin)->create();
+
+    $this->actingAs($waiter)
+         ->get(route('tables.qr.show', $table))
+         ->assertOk();
+});
+
+it('table QR is not accessible to staff of a different restaurant', function () {
+    $admin1 = User::factory()->admin()->create();
+    $admin2 = User::factory()->admin()->create();
+    $table  = Table::factory()->create(['user_id' => $admin1->id]);
+    $waiter = User::factory()->waiter()->staffOf($admin2)->create();
+
+    $this->actingAs($waiter)
+         ->get(route('tables.qr.show', $table))
+         ->assertForbidden();
+});


### PR DESCRIPTION
## 📝 Descripción
<!-- Resumen claro de los cambios introducidos en este PR -->


## 🔗 Issue Relacionado
<!-- Enlaza el issue o tarea que resuelve este PR -->
Closes #...

## 🔢 Bloque del Roadmap
<!-- Indica el bloque al que pertenece, ej: Bloque 1.6 -->
**Bloque:** X.X

## 🧩 Tipo de Cambio
- [ ] `feat` — Nueva funcionalidad
- [ ] `fix` — Corrección de bug
- [ ] `refactor` — Refactorización sin cambio de comportamiento
- [ ] `style` — Cambios visuales sin lógica
- [ ] `docs` — Solo documentación
- [ ] `test` — Pruebas

---

## ✅ Checklist — Backend (BenjaminDTS)
- [ ] La rama parte de `main` actualizado
- [ ] Un commit por acción concreta (rutas, controlador, vista por separado)
- [ ] Todos los métodos tienen PHPDoc completo (`@param`, `@return`)
- [ ] `@author` solo en la cabecera de la clase, nunca en los métodos
- [ ] `abort_if($model->user_id !== Auth::id(), 403)` en `edit`, `update` y `destroy`
- [ ] Validaciones con `$request->validate([...])` en `store` y `update`
- [ ] Mensajes flash implementados (`->with('success', '...')`)
- [ ] Si hay imágenes: se borra la vieja antes de guardar la nueva
- [ ] Migraciones documentadas si hay cambios en BBDD
- [ ] La aplicación arranca sin errores (`php artisan serve`)

## ✅ Checklist — Frontend (SebastianBCF)
- [ ] `npm run build` ejecutado con los cambios de Tailwind
- [ ] Vistas muestran correctamente los mensajes flash (`@if(session('success'))`)
- [ ] HTML5 semántico y Mobile-First
- [ ] Sin `console.log` en el código

## ✅ Checklist — QA (Ayrton)
- [ ] Happy path probado y funciona correctamente
- [ ] Validaciones del formulario verificadas (campos requeridos, formatos)
- [ ] Multitenancy verificado: un usuario no accede a datos de otro
- [ ] Mensajes flash de éxito y error aparecen correctamente
- [ ] No hay regresiones en funcionalidades existentes

---

## 📸 Capturas de Pantalla
<!-- Si aplica, añade capturas antes/después de los cambios visuales -->

## 🔗 Contexto Adicional
<!-- Cualquier información relevante para el revisor -->
