### PR TITLE
fix(map): UI/UX improvements and fixes for floor map editor

### DIFF
--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -424,12 +424,12 @@
         {{-- ── CANVAS ───────────────────────────────────────── --}}
         <main id="main-content"
               class="flex-1 p-4 relative"
-              :class="editMode ? 'overflow-auto' : 'overflow-hidden flex items-center justify-center'">
+              :class="(editMode && currentView !== 'general') ? 'overflow-auto' : 'overflow-hidden flex items-center justify-center'">
             <div
                 x-ref="canvas"
                 class="relative bg-white dark:bg-gray-800 rounded-xl shadow-inner
                        border-2 border-dashed border-gray-200 dark:border-gray-700"
-                :style="editMode
+                :style="(editMode && currentView !== 'general')
                     ? `width:${floorWidth}px; height:${floorHeight}px; transform:scale(${canvasZoom}); transform-origin:top left; margin-bottom:${-floorHeight*(1-canvasZoom)}px; margin-right:${-floorWidth*(1-canvasZoom)}px;`
                     : `width:${floorWidth}px; height:${floorHeight}px; transform:scale(${canvasZoom}); transform-origin:center center; flex-shrink:0;`"
                 aria-label="Plano del restaurante"

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -159,83 +159,76 @@
                 </div>
             </div>
 
-            {{-- ── Toggle + selector de plantas — solo admin ──────────────── --}}
+            {{-- ── Toggle Plantas — solo en modo edición ──────────────────── --}}
             <template x-if="!readonly && editMode">
-                <div class="flex items-center gap-2">
-                    {{-- Toggle activar/desactivar sistema de plantas --}}
-                    <label class="flex items-center gap-1.5 text-xs font-medium text-gray-500 dark:text-gray-400 cursor-pointer select-none"
-                           id="floors-toggle-desc">
+                <label class="flex items-center gap-1.5 text-xs font-medium text-gray-500 dark:text-gray-400 cursor-pointer select-none"
+                       id="floors-toggle-desc">
+                    <button type="button"
+                            role="switch"
+                            :aria-checked="floorsEnabled"
+                            @click="toggleFloorsEnabled(!floorsEnabled)"
+                            aria-describedby="floors-toggle-desc"
+                            :class="floorsEnabled ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+                            class="relative inline-flex w-9 h-5 rounded-full transition-colors
+                                   focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-1">
+                        <span :class="floorsEnabled ? 'translate-x-4' : 'translate-x-0.5'"
+                              class="inline-block w-4 h-4 mt-0.5 bg-white rounded-full shadow transition-transform">
+                        </span>
+                    </button>
+                    Plantas
+                </label>
+            </template>
+
+            {{-- ── Selector de plantas — visible en vista y edición ────────── --}}
+            <template x-if="!readonly && floorsEnabled">
+                <div class="flex items-center gap-1"
+                     role="group"
+                     aria-label="Selector de planta">
+
+                    {{-- Botón por cada planta --}}
+                    <template x-for="n in floorCount" :key="n">
                         <button type="button"
-                                role="switch"
-                                :aria-checked="floorsEnabled"
-                                @click="toggleFloorsEnabled(!floorsEnabled)"
-                                aria-describedby="floors-toggle-desc"
-                                :class="floorsEnabled
-                                    ? 'bg-indigo-600'
-                                    : 'bg-gray-300 dark:bg-gray-600'"
-                                class="relative inline-flex w-9 h-5 rounded-full transition-colors
-                                       focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-1">
-                            <span :class="floorsEnabled ? 'translate-x-4' : 'translate-x-0.5'"
-                                  class="inline-block w-4 h-4 mt-0.5 bg-white rounded-full shadow transition-transform">
-                            </span>
+                                @click="switchFloor(n)"
+                                :aria-pressed="currentView === 'floor' && currentFloor === n"
+                                :aria-label="`Planta ${n}`"
+                                :class="currentView === 'floor' && currentFloor === n
+                                    ? 'bg-indigo-600 text-white'
+                                    : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
+                                class="px-2.5 py-1.5 rounded text-xs font-semibold border border-gray-200 dark:border-gray-600 transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-400"
+                                x-text="`P${n}`">
                         </button>
-                        Plantas
-                    </label>
-
-                    {{-- Selector de plantas — solo si floorsEnabled --}}
-                    <template x-if="floorsEnabled">
-                        <div class="flex items-center gap-1"
-                             role="group"
-                             aria-label="Selector de planta">
-
-                            {{-- Botón por cada planta --}}
-                            <template x-for="n in floorCount" :key="n">
-                                <button type="button"
-                                        @click="switchFloor(n)"
-                                        :aria-pressed="currentView === 'floor' && currentFloor === n"
-                                        :aria-label="`Planta ${n}`"
-                                        :class="currentView === 'floor' && currentFloor === n
-                                            ? 'bg-indigo-600 text-white'
-                                            : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
-                                        class="px-2.5 py-1.5 rounded text-xs font-semibold border border-gray-200 dark:border-gray-600 transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-400"
-                                        x-text="`P${n}`">
-                                </button>
-                            </template>
-
-                            {{-- Botón Vista General --}}
-                            <button type="button"
-                                    @click="switchView('general')"
-                                    :aria-pressed="currentView === 'general'"
-                                    :class="currentView === 'general'
-                                        ? 'bg-indigo-600 text-white'
-                                        : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
-                                    class="px-2.5 py-1.5 rounded text-xs font-semibold border border-gray-200 dark:border-gray-600 transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-400">
-                                General
-                            </button>
-
-                            {{-- Añadir planta --}}
-                            <button type="button"
-                                    x-show="floorCount < 5"
-                                    @click="addFloor()"
-                                    aria-label="Añadir planta"
-                                    class="px-2 py-1.5 rounded text-xs font-semibold
-                                           bg-green-500 hover:bg-green-600 text-white
-                                           transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-green-400">
-                                + P
-                            </button>
-
-                            {{-- Eliminar última planta --}}
-                            <button type="button"
-                                    x-show="floorCount > 1"
-                                    @click="confirmDeleteFloor(floorCount)"
-                                    :aria-label="`Eliminar Planta ${floorCount}`"
-                                    class="px-2 py-1.5 rounded text-xs font-semibold
-                                           bg-red-500 hover:bg-red-600 text-white
-                                           transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-red-400">
-                                − P<span x-text="floorCount"></span>
-                            </button>
-                        </div>
                     </template>
+
+                    {{-- Botón Vista General --}}
+                    <button type="button"
+                            @click="switchView('general')"
+                            :aria-pressed="currentView === 'general'"
+                            :class="currentView === 'general'
+                                ? 'bg-indigo-600 text-white'
+                                : 'bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'"
+                            class="px-2.5 py-1.5 rounded text-xs font-semibold border border-gray-200 dark:border-gray-600 transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-400">
+                        General
+                    </button>
+
+                    {{-- Añadir/Eliminar planta — solo en modo edición --}}
+                    <button type="button"
+                            x-show="editMode && floorCount < 5"
+                            @click="addFloor()"
+                            aria-label="Añadir planta"
+                            class="px-2 py-1.5 rounded text-xs font-semibold
+                                   bg-green-500 hover:bg-green-600 text-white
+                                   transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-green-400">
+                        + P
+                    </button>
+                    <button type="button"
+                            x-show="editMode && floorCount > 1"
+                            @click="confirmDeleteFloor(floorCount)"
+                            :aria-label="`Eliminar Planta ${floorCount}`"
+                            class="px-2 py-1.5 rounded text-xs font-semibold
+                                   bg-red-500 hover:bg-red-600 text-white
+                                   transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-red-400">
+                        − P<span x-text="floorCount"></span>
+                    </button>
                 </div>
             </template>
 
@@ -255,7 +248,7 @@
                     </button>
                     <button type="button"
                             x-show="editMode"
-                            @click="editMode = false; switchView('general')"
+                            @click="editMode = false; $nextTick(() => _applyOverviewZoom())"
                             class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-white
                                    bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
                             aria-label="Confirmar cambios y salir del modo edición">
@@ -1419,7 +1412,7 @@ document.addEventListener('alpine:init', () => {
         floorCount:            {{ $floorCount }},
         floorCanvasSizes:      @json($floorCanvasSizes),
         currentFloor:          1,
-        currentView:           'general',
+        currentView:           'floor',
         readonly:              {{ $readonly ? 'true' : 'false' }},
         editMode:              false,
         canvasZoom:            1,
@@ -1453,14 +1446,6 @@ document.addEventListener('alpine:init', () => {
                     this.initZoneInteract();
                     this.initPaletteInteract();
                     this.clampAllToCanvas();
-                }
-                // Vista inicial: general con zoom auto-fit al canvas completo
-                if (this.floorsEnabled) {
-                    const sizes = Object.values(this.floorCanvasSizes);
-                    if (sizes.length) {
-                        this.floorWidth  = Math.max(...sizes.map(s => s.width));
-                        this.floorHeight = Math.max(...sizes.map(s => s.height));
-                    }
                 }
                 this._applyOverviewZoom();
             });

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -381,7 +381,7 @@
                 x-ref="canvas"
                 class="relative bg-white dark:bg-gray-800 rounded-xl shadow-inner
                        border-2 border-dashed border-gray-200 dark:border-gray-700"
-                :style="`width:${floorWidth}px; height:${floorHeight}px; min-width:100%;
+                :style="`width:${floorWidth}px; height:${floorHeight}px;
                          transform:scale(${canvasZoom}); transform-origin:top left;`"
                 aria-label="Plano del restaurante"
                 @click="if (canvasZoom === 1) { editingTableId = null; editingTable = null; editingZoneId = null; editingZone = null; selectedId = null; }"

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -864,12 +864,12 @@
                 </template>
 
                 {{-- Indicador de zona de soltar --}}
-                <div x-show="isDraggingFromPalette"
+                <div x-show="isDraggingFromPalette || isDraggingZone"
                      class="absolute inset-0 rounded-xl border-4 border-dashed border-indigo-400
                             bg-indigo-50/30 dark:bg-indigo-900/20 pointer-events-none
                             flex items-center justify-center">
                     <p class="text-indigo-500 font-semibold text-lg"
-                       x-text="currentDragShape === 'bar' ? 'Suelta aquí para colocar la barra' : currentDragShape === 'stool' ? 'Suelta aquí para colocar el taburete' : 'Suelta aquí para crear la mesa'"></p>
+                       x-text="isDraggingZone ? 'Suelta aquí para crear la zona' : currentDragShape === 'bar' ? 'Suelta aquí para colocar la barra' : currentDragShape === 'stool' ? 'Suelta aquí para colocar el taburete' : 'Suelta aquí para crear la mesa'"></p>
                 </div>
                 {{-- Panel de edición de zona — absolute dentro del canvas, coordenadas en espacio del canvas --}}
                 <div x-show="editingZoneId !== null && editingZone !== null"

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -248,7 +248,7 @@
                     </button>
                     <button type="button"
                             x-show="editMode"
-                            @click="editMode = false; $nextTick(() => _applyOverviewZoom())"
+                            @click="editMode = false; _applyOverviewZoom()"
                             class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-white
                                    bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
                             aria-label="Confirmar cambios y salir del modo edición">

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1489,6 +1489,34 @@ document.addEventListener('alpine:init', () => {
             this.floorHeight = h;
             this.floorCanvasSizes[floor] = { width: w, height: h };
 
+            // Clamp visual inmediato: empuja estructuras al borde sin esperar al servidor
+            const snapshots = [];
+            if (w < prevW || h < prevH) {
+                for (const item of [...this.tables, ...this.elements]) {
+                    const { width: sw, height: sh } = this.sizeForItem(item);
+                    const { minX, maxX, minY, maxY } = this.canvasBounds(item, sw, sh);
+                    const cx = Math.max(minX, Math.min(maxX, item.position_x));
+                    const cy = Math.max(minY, Math.min(maxY, item.position_y));
+                    if (cx !== item.position_x || cy !== item.position_y) {
+                        snapshots.push({ item, prevX: item.position_x, prevY: item.position_y });
+                        item.position_x = cx;
+                        item.position_y = cy;
+                    }
+                }
+                for (const zone of this.zones) {
+                    const { width: sw, height: sh } = this.sizeForItem(zone);
+                    const maxX = Math.max(0, sw - zone.width);
+                    const maxY = Math.max(0, sh - zone.height);
+                    const cx   = Math.max(0, Math.min(maxX, zone.position_x));
+                    const cy   = Math.max(0, Math.min(maxY, zone.position_y));
+                    if (cx !== zone.position_x || cy !== zone.position_y) {
+                        snapshots.push({ item: zone, prevX: zone.position_x, prevY: zone.position_y, isZone: true });
+                        zone.position_x = cx;
+                        zone.position_y = cy;
+                    }
+                }
+            }
+
             try {
                 const res = await fetch('{{ route("tables.canvas.update") }}', {
                     method:  'PATCH',
@@ -1506,16 +1534,31 @@ document.addEventListener('alpine:init', () => {
                     this.floorWidth  = prevW;
                     this.floorHeight = prevH;
                     this.floorCanvasSizes[floor] = prevSize;
+                    for (const { item, prevX, prevY } of snapshots) {
+                        item.position_x = prevX;
+                        item.position_y = prevY;
+                    }
                     this.showToast(json.message ?? 'Error al guardar el tamaño.', true);
                     return;
                 }
 
                 this.showToast(`Plano ${w} × ${h} px guardado.`);
-                if (w < prevW || h < prevH) await this.clampAllToCanvas();
+                // Persistir en BD las posiciones ya aplicadas visualmente
+                for (const { item, isZone } of snapshots) {
+                    if (isZone) {
+                        await this.persistZonePosition(item.id, item.position_x, item.position_y);
+                    } else {
+                        await this.persistPosition(item.id, item.position_x, item.position_y, item.width, item.height);
+                    }
+                }
             } catch {
                 this.floorWidth  = prevW;
                 this.floorHeight = prevH;
                 this.floorCanvasSizes[floor] = prevSize;
+                for (const { item, prevX, prevY } of snapshots) {
+                    item.position_x = prevX;
+                    item.position_y = prevY;
+                }
                 this.showToast('Error de red al guardar el tamaño.', true);
             }
         },

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -386,25 +386,8 @@
                          margin-bottom:${-floorHeight*(1-canvasZoom)}px;
                          margin-right:${-floorWidth*(1-canvasZoom)}px;`"
                 aria-label="Plano del restaurante"
-                @click="if (canvasZoom === 1) { editingTableId = null; editingTable = null; editingZoneId = null; editingZone = null; selectedId = null; }"
+                @click="editingTableId = null; editingTable = null; editingZoneId = null; editingZone = null; selectedId = null;"
             >
-                {{-- Overlay de zoom: bloquea edición cuando canvasZoom < 1 --}}
-                <div x-show="canvasZoom < 1 && !(floorsEnabled && currentView === 'general')"
-                     x-transition:enter="transition ease-out duration-150"
-                     x-transition:enter-start="opacity-0"
-                     x-transition:enter-end="opacity-100"
-                     class="absolute inset-0 z-40 rounded-xl cursor-not-allowed select-none"
-                     role="status"
-                     aria-live="polite">
-                    <div class="absolute bottom-4 left-1/2 -translate-x-1/2
-                                bg-amber-50 dark:bg-amber-900/80
-                                border border-amber-300 dark:border-amber-600
-                                text-amber-800 dark:text-amber-300
-                                text-sm font-medium px-4 py-2 rounded-full shadow-md
-                                whitespace-nowrap pointer-events-none">
-                        Ajusta el zoom al 100% para editar el plano
-                    </div>
-                </div>
 
                 {{-- Overlay vista general: bloquea toda interacción con estructuras --}}
                 <div x-show="floorsEnabled && currentView === 'general'"
@@ -1664,8 +1647,8 @@ document.addEventListener('alpine:init', () => {
                             const { minX, maxX, minY, maxY } = item
                                 ? this.canvasBounds(item)
                                 : { minX: 0, maxX: this.floorWidth - 100, minY: 0, maxY: this.floorHeight - 100 };
-                            const propX = Math.max(minX, Math.min(maxX, Math.round(curX + event.dx)));
-                            const propY = Math.max(minY, Math.min(maxY, Math.round(curY + event.dy)));
+                            const propX = Math.max(minX, Math.min(maxX, Math.round(curX + event.dx / this.canvasZoom)));
+                            const propY = Math.max(minY, Math.min(maxY, Math.round(curY + event.dy / this.canvasZoom)));
 
                             if (!item) {
                                 el.style.left = `${propX}px`;
@@ -1748,8 +1731,8 @@ document.addEventListener('alpine:init', () => {
             const onMove = (e) => {
                 const maxX = Math.max(0, this.floorWidth  - zone.width);
                 const maxY = Math.max(0, this.floorHeight - zone.height);
-                zone.position_x = Math.max(0, Math.min(maxX, Math.round(startPx + (e.clientX - startMX))));
-                zone.position_y = Math.max(0, Math.min(maxY, Math.round(startPy + (e.clientY - startMY))));
+                zone.position_x = Math.max(0, Math.min(maxX, Math.round(startPx + (e.clientX - startMX) / this.canvasZoom)));
+                zone.position_y = Math.max(0, Math.min(maxY, Math.round(startPy + (e.clientY - startMY) / this.canvasZoom)));
             };
 
             const onUp = async () => {
@@ -1767,8 +1750,8 @@ document.addEventListener('alpine:init', () => {
         // ── Rotación libre de zona arrastrando el handle ─────────────────────
         startZoneRotation(event, zone) {
             const canvasRect = this.$refs.canvas.getBoundingClientRect();
-            const centerX    = canvasRect.left + zone.position_x + zone.width  / 2;
-            const centerY    = canvasRect.top  + zone.position_y + zone.height / 2;
+            const centerX    = canvasRect.left + (zone.position_x + zone.width  / 2) * this.canvasZoom;
+            const centerY    = canvasRect.top  + (zone.position_y + zone.height / 2) * this.canvasZoom;
 
             this.closeEditPanels();
             this.isRotating            = true;
@@ -1819,8 +1802,8 @@ document.addEventListener('alpine:init', () => {
             const onMove = (e) => {
                 const { minX, maxX, minY, maxY } = this.canvasBounds(element);
 
-                const propX = Math.max(minX, Math.min(maxX, Math.round(startPx + (e.clientX - startMX))));
-                const propY = Math.max(minY, Math.min(maxY, Math.round(startPy + (e.clientY - startMY))));
+                const propX = Math.max(minX, Math.min(maxX, Math.round(startPx + (e.clientX - startMX) / this.canvasZoom)));
+                const propY = Math.max(minY, Math.min(maxY, Math.round(startPy + (e.clientY - startMY) / this.canvasZoom)));
 
                 if (startedColliding) {
                     element.position_x = propX;
@@ -1870,12 +1853,6 @@ document.addEventListener('alpine:init', () => {
                 inertia: false,
                 listeners: {
                     start: (event) => {
-                        if (this.canvasZoom < 1) {
-                            event.interaction.stop();
-                            this.showToast('Ajusta el zoom al 100% para añadir mesas.', true);
-                            return;
-                        }
-
                         if (this.tables.length >= {{ $maxTables }}) {
                             this.showToast(`Límite de {{ $maxTables }} mesas alcanzado.`, true);
                             return;
@@ -1946,12 +1923,6 @@ document.addEventListener('alpine:init', () => {
                 inertia: false,
                 listeners: {
                     start: (event) => {
-                        if (this.canvasZoom < 1) {
-                            event.interaction.stop();
-                            this.showToast('Ajusta el zoom al 100% para añadir elementos.', true);
-                            return;
-                        }
-
                         const shape = event.target.dataset.shape;
                         const dropW = parseInt(event.target.dataset.width)  || 80;
                         const dropH = parseInt(event.target.dataset.height) || 50;
@@ -2009,12 +1980,6 @@ document.addEventListener('alpine:init', () => {
                 inertia: false,
                 listeners: {
                     start: (event) => {
-                        if (this.canvasZoom < 1) {
-                            event.interaction.stop();
-                            this.showToast('Ajusta el zoom al 100% para añadir zonas.', true);
-                            return;
-                        }
-
                         const w = parseInt(event.target.dataset.width)  || 300;
                         const h = parseInt(event.target.dataset.height) || 200;
                         ghost.style.width        = `${w}px`;
@@ -2323,8 +2288,8 @@ document.addEventListener('alpine:init', () => {
             document.body.style.cursor = 'se-resize';
 
             const onMove = (e) => {
-                const dx = e.clientX - startMX;
-                const dy = e.clientY - startMY;
+                const dx = (e.clientX - startMX) / this.canvasZoom;
+                const dy = (e.clientY - startMY) / this.canvasZoom;
 
                 // Proyectar delta de pantalla al espacio local del elemento (rotación inversa)
                 const localDX =  dx * cosθ + dy * sinθ;
@@ -2505,8 +2470,8 @@ document.addEventListener('alpine:init', () => {
             this.rotatingId     = table.id;
 
             const canvasRect = this.$refs.canvas.getBoundingClientRect();
-            const centerX    = canvasRect.left + table.position_x + table.width  / 2;
-            const centerY    = canvasRect.top  + table.position_y + table.height / 2;
+            const centerX    = canvasRect.left + (table.position_x + table.width  / 2) * this.canvasZoom;
+            const centerY    = canvasRect.top  + (table.position_y + table.height / 2) * this.canvasZoom;
 
             this.isRotating            = true;
             this.rotTooltip.show       = true;

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -20,6 +20,7 @@
     x-data="tableMap()"
     x-init="init()"
     @mouseup.window="if(isRotating||isRotatingZone){}"
+    @keydown.ctrl.z.window.prevent="undo()"
 >
 
     {{-- ══════════════════════════════════════════════════════
@@ -116,12 +117,29 @@
                             aria-label="Lienzo extra grande: 2400 × 1500 px">XL</button>
                 </div>
 
+                {{-- Botón Deshacer --}}
+                <button type="button"
+                        @click="undo()"
+                        :disabled="undoStack.length === 0"
+                        :class="undoStack.length === 0
+                            ? 'opacity-40 cursor-not-allowed'
+                            : 'hover:bg-gray-100 dark:hover:bg-gray-600'"
+                        class="p-1.5 rounded-lg text-gray-500 dark:text-gray-400 transition-colors
+                               focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                        aria-label="Deshacer último cambio (Ctrl+Z)"
+                        title="Deshacer (Ctrl+Z)">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3"/>
+                    </svg>
+                </button>
+
                 {{-- Zoom slider (solo visual, sin persistencia en BD) --}}
                 <div class="hidden sm:flex items-center gap-1.5">
                     <label for="canvas-zoom" class="sr-only">Zoom del plano</label>
                     <input id="canvas-zoom"
                            type="range"
                            min="0.5"
+                           @mousedown="pushUndo()"
                            max="1"
                            step="0.05"
                            x-model.number="canvasZoom"
@@ -1383,6 +1401,7 @@ document.addEventListener('alpine:init', () => {
         zoneColor:             '#6366f1',
         toast:                 { show: false, msg: '', error: false, _timer: null },
         rotTooltip:            { show: false, x: 0, y: 0, deg: 0 },
+        undoStack:             [],
 
         init() {
             // El tamaño del canvas viene de BD (floorWidth/floorHeight).
@@ -1480,6 +1499,7 @@ document.addEventListener('alpine:init', () => {
 
         // ── Cambiar tamaño del lienzo y persistir en BD ───────────────────────
         async setCanvasSize(w, h) {
+            this.pushUndo();
             const floor    = this.floorsEnabled ? this.currentFloor : 1;
             const prevW    = this.floorWidth;
             const prevH    = this.floorHeight;
@@ -1670,6 +1690,102 @@ document.addEventListener('alpine:init', () => {
                    this.elements.filter(sameFloor).some(e => this.overlaps(item, e));
         },
 
+        // ── Historial de cambios (Undo) ───────────────────────────────────────
+        snapshot() {
+            return {
+                floorWidth:       this.floorWidth,
+                floorHeight:      this.floorHeight,
+                floorCanvasSizes: JSON.parse(JSON.stringify(this.floorCanvasSizes)),
+                canvasZoom:       this.canvasZoom,
+                tables:   this.tables.map(t  => ({ id: t.id,  position_x: t.position_x,  position_y: t.position_y,  width: t.width,  height: t.height,  rotation: t.rotation  ?? 0 })),
+                elements: this.elements.map(e => ({ id: e.id,  position_x: e.position_x,  position_y: e.position_y,  width: e.width,  height: e.height,  rotation: e.rotation  ?? 0 })),
+                zones:    this.zones.map(z    => ({ id: z.id,  position_x: z.position_x,  position_y: z.position_y,  width: z.width,  height: z.height,  rotation: z.rotation  ?? 0, color: z.color })),
+            };
+        },
+
+        pushUndo() {
+            this.undoStack.push(this.snapshot());
+            if (this.undoStack.length > 20) this.undoStack.shift();
+        },
+
+        async undo() {
+            if (!this.undoStack.length) return;
+            const prev  = this.undoStack.pop();
+            const floor = this.floorsEnabled ? this.currentFloor : 1;
+
+            const canvasSizeChanged =
+                prev.floorWidth  !== this.floorWidth  ||
+                prev.floorHeight !== this.floorHeight  ||
+                JSON.stringify(prev.floorCanvasSizes) !== JSON.stringify(this.floorCanvasSizes);
+
+            // Restaurar estado reactivo inmediatamente
+            this.canvasZoom       = prev.canvasZoom;
+            this.floorWidth       = prev.floorWidth;
+            this.floorHeight      = prev.floorHeight;
+            this.floorCanvasSizes = prev.floorCanvasSizes;
+
+            const toPersistItems = [];
+            const toPersistZones = [];
+
+            for (const snap of prev.tables) {
+                const t = this.tables.find(t => t.id === snap.id);
+                if (!t) continue;
+                if (t.position_x !== snap.position_x || t.position_y !== snap.position_y ||
+                    t.width !== snap.width || t.height !== snap.height || (t.rotation ?? 0) !== snap.rotation) {
+                    t.position_x = snap.position_x; t.position_y = snap.position_y;
+                    t.width      = snap.width;       t.height     = snap.height;
+                    t.rotation   = snap.rotation;
+                    toPersistItems.push(t);
+                }
+            }
+            for (const snap of prev.elements) {
+                const e = this.elements.find(e => e.id === snap.id);
+                if (!e) continue;
+                if (e.position_x !== snap.position_x || e.position_y !== snap.position_y ||
+                    e.width !== snap.width || e.height !== snap.height || (e.rotation ?? 0) !== snap.rotation) {
+                    e.position_x = snap.position_x; e.position_y = snap.position_y;
+                    e.width      = snap.width;       e.height     = snap.height;
+                    e.rotation   = snap.rotation;
+                    toPersistItems.push(e);
+                }
+            }
+            for (const snap of prev.zones) {
+                const z = this.zones.find(z => z.id === snap.id);
+                if (!z) continue;
+                if (z.position_x !== snap.position_x || z.position_y !== snap.position_y ||
+                    z.width !== snap.width || z.height !== snap.height ||
+                    (z.rotation ?? 0) !== snap.rotation || z.color !== snap.color) {
+                    z.position_x = snap.position_x; z.position_y = snap.position_y;
+                    z.width      = snap.width;       z.height     = snap.height;
+                    z.rotation   = snap.rotation;    z.color      = snap.color;
+                    toPersistZones.push(z);
+                }
+            }
+
+            // Persistir en BD
+            if (canvasSizeChanged) {
+                try {
+                    await fetch('{{ route("tables.canvas.update") }}', {
+                        method:  'PATCH',
+                        headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
+                        body: JSON.stringify({ floor_width: prev.floorWidth, floor_height: prev.floorHeight, floor }),
+                    });
+                } catch {}
+            }
+            for (const item of toPersistItems) {
+                await this.persistPosition(item.id, item.position_x, item.position_y, item.width, item.height);
+            }
+            for (const z of toPersistZones) {
+                try {
+                    await fetch(`/zonas/${z.id}`, {
+                        method:  'PATCH',
+                        headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
+                        body: JSON.stringify({ position_x: z.position_x, position_y: z.position_y, width: z.width, height: z.height, rotation: z.rotation }),
+                    });
+                } catch {}
+            }
+        },
+
         // ── Interactividad de mesas existentes ────────────────────────────────
         initTableInteract() {
             interact('.table-item').unset();
@@ -1682,6 +1798,7 @@ document.addEventListener('alpine:init', () => {
                     listeners: {
                         start: (event) => {
                             if (this.floorsEnabled && this.currentView === 'general') { event.interaction.stop(); return; }
+                            this.pushUndo();
                             const el   = event.target;
                             const id   = parseInt(el.dataset.tableId);
                             const item = this.tables.find(t => t.id === id) ?? this.elements.find(e => e.id === id);
@@ -1772,6 +1889,7 @@ document.addEventListener('alpine:init', () => {
 
         // ── Drag nativo de zona: actualiza zone.position_x/y reactivamente ───
         startZoneDrag(event, zone) {
+            this.pushUndo();
             const canvasEl  = this.$refs.canvas;
             const startMX   = event.clientX;
             const startMY   = event.clientY;
@@ -1803,6 +1921,7 @@ document.addEventListener('alpine:init', () => {
 
         // ── Rotación libre de zona arrastrando el handle ─────────────────────
         startZoneRotation(event, zone) {
+            this.pushUndo();
             const canvasRect = this.$refs.canvas.getBoundingClientRect();
             const centerX    = canvasRect.left + (zone.position_x + zone.width  / 2) * this.canvasZoom;
             const centerY    = canvasRect.top  + (zone.position_y + zone.height / 2) * this.canvasZoom;
@@ -1841,6 +1960,7 @@ document.addEventListener('alpine:init', () => {
         // ── Drag nativo de elemento especial (barra/taburete) ────────────────
         startElementDrag(event, element) {
             if (this.floorsEnabled && this.currentView === 'general') return;
+            this.pushUndo();
             const startPx = element.position_x;
             const startPy = element.position_y;
             const startMX = event.clientX;
@@ -2251,6 +2371,7 @@ document.addEventListener('alpine:init', () => {
 
         // ── Resize de zona ────────────────────────────────────────────────────
         startZoneResize(event, zone) {
+            this.pushUndo();
             const startMX = event.clientX;
             const startMY = event.clientY;
             const startW  = zone.width;
@@ -2327,6 +2448,7 @@ document.addEventListener('alpine:init', () => {
         // ── Resize libre en espacio local del elemento rotado ────────────────
         startResize(event, table) {
             if (this.floorsEnabled && this.currentView === 'general') return;
+            this.pushUndo();
             const θRad    = (table.rotation ?? 0) * Math.PI / 180;
             const cosθ    = Math.cos(θRad);
             const sinθ    = Math.sin(θRad);
@@ -2520,6 +2642,7 @@ document.addEventListener('alpine:init', () => {
         // ── Rotación libre arrastrando el handle (estilo Canva) ───────────────
         startRotation(event, table) {
             if (this.floorsEnabled && this.currentView === 'general') return;
+            this.pushUndo();
             this.closeEditPanels();
             this.rotatingId     = table.id;
 

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -2954,6 +2954,7 @@ document.addEventListener('alpine:init', () => {
                 }
                 this.tables   = this.tables.filter(t => (t.floor ?? 1) !== floor);
                 this.elements = this.elements.filter(e => (e.floor ?? 1) !== floor);
+                this.zones    = this.zones.filter(z => (z.floor ?? 1) !== floor);
                 this.floorCount = floor - 1;
                 if (this.currentFloor >= floor) this.switchFloor(floor - 1);
                 this.$nextTick(() => {

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -1411,7 +1411,9 @@ document.addEventListener('alpine:init', () => {
 
         // Devuelve los límites de posición válidos para un item considerando su rotación.
         // position_x/y pueden ser negativos en elementos más altos que anchos rotados 90°.
-        canvasBounds(item) {
+        canvasBounds(item, w, h) {
+            const canvasW = w ?? this.floorWidth;
+            const canvasH = h ?? this.floorHeight;
             const rad   = (item.rotation ?? 0) * Math.PI / 180;
             const cos   = Math.abs(Math.cos(rad));
             const sin   = Math.abs(Math.sin(rad));
@@ -1421,16 +1423,23 @@ document.addEventListener('alpine:init', () => {
             const halfH = hw * sin + hh * cos;
             return {
                 minX: halfW - hw,
-                maxX: this.floorWidth  - hw - halfW,
+                maxX: canvasW - hw - halfW,
                 minY: halfH - hh,
-                maxY: this.floorHeight - hh - halfH,
+                maxY: canvasH - hh - halfH,
             };
+        },
+
+        // Devuelve el tamaño del canvas de la planta de un item.
+        sizeForItem(item) {
+            const floor = this.floorsEnabled ? (item.floor ?? 1) : 1;
+            return this.floorCanvasSizes[floor] ?? { width: this.floorWidth, height: this.floorHeight };
         },
 
         // Recupera estructuras y zonas que hayan quedado fuera del canvas y persiste la corrección.
         async clampAllToCanvas() {
             for (const item of [...this.tables, ...this.elements]) {
-                const { minX, maxX, minY, maxY } = this.canvasBounds(item);
+                const { width: w, height: h } = this.sizeForItem(item);
+                const { minX, maxX, minY, maxY } = this.canvasBounds(item, w, h);
                 const cx = Math.max(minX, Math.min(maxX, item.position_x));
                 const cy = Math.max(minY, Math.min(maxY, item.position_y));
                 if (cx !== item.position_x || cy !== item.position_y) {
@@ -1438,8 +1447,9 @@ document.addEventListener('alpine:init', () => {
                 }
             }
             for (const zone of this.zones) {
-                const maxX = Math.max(0, this.floorWidth  - zone.width);
-                const maxY = Math.max(0, this.floorHeight - zone.height);
+                const { width: w, height: h } = this.sizeForItem(zone);
+                const maxX = Math.max(0, w - zone.width);
+                const maxY = Math.max(0, h - zone.height);
                 const cx   = Math.max(0, Math.min(maxX, zone.position_x));
                 const cy   = Math.max(0, Math.min(maxY, zone.position_y));
                 if (cx !== zone.position_x || cy !== zone.position_y) {
@@ -1501,6 +1511,7 @@ document.addEventListener('alpine:init', () => {
                 }
 
                 this.showToast(`Plano ${w} × ${h} px guardado.`);
+                if (w < prevW || h < prevH) await this.clampAllToCanvas();
             } catch {
                 this.floorWidth  = prevW;
                 this.floorHeight = prevH;

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -483,6 +483,8 @@
                     ? `width:${floorWidth}px; height:${floorHeight}px; transform:scale(${canvasZoom}); transform-origin:top left; margin-bottom:${-floorHeight*(1-canvasZoom)}px; margin-right:${-floorWidth*(1-canvasZoom)}px;`
                     : `width:${floorWidth}px; height:${floorHeight}px; transform:scale(${canvasZoom}); transform-origin:center center; flex-shrink:0;`"
                 aria-label="Plano del restaurante"
+                :class="(editMode && currentView !== 'general' && !isPanning) ? 'cursor-grab' : ''"
+                @mousedown.self="startPan($event)"
                 @click="editingTableId = null; editingTable = null; editingZoneId = null; editingZone = null; selectedId = null;"
             >
 
@@ -1574,6 +1576,7 @@ document.addEventListener('alpine:init', () => {
         rotTooltip:            { show: false, x: 0, y: 0, deg: 0 },
         undoStack:             [],
         redoStack:             [],
+        isPanning:             false,
 
         init() {
             this.$nextTick(() => {
@@ -2882,6 +2885,33 @@ document.addEventListener('alpine:init', () => {
                 await this.persistPosition(table.id, table.position_x, table.position_y, table.width, table.height);
             };
 
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup',   onUp);
+        },
+
+        startPan(event) {
+            if (!this.editMode || this.currentView === 'general') return;
+            if (event.button !== 0) return;
+            const main = this.$refs.canvas?.parentElement;
+            if (!main) return;
+            this.isPanning = true;
+            const startX   = event.clientX;
+            const startY   = event.clientY;
+            const scrollX  = main.scrollLeft;
+            const scrollY  = main.scrollTop;
+            document.body.style.cursor = 'grabbing';
+
+            const onMove = (e) => {
+                if (!this.isPanning) return;
+                main.scrollLeft = scrollX - (e.clientX - startX);
+                main.scrollTop  = scrollY - (e.clientY - startY);
+            };
+            const onUp = () => {
+                this.isPanning             = false;
+                document.body.style.cursor = '';
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup',   onUp);
+            };
             document.addEventListener('mousemove', onMove);
             document.addEventListener('mouseup',   onUp);
         },

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -404,14 +404,20 @@
                     </div>
                 </div>
 
+                {{-- Overlay vista general: bloquea toda interacción con estructuras --}}
+                <div x-show="floorsEnabled && currentView === 'general'"
+                     class="absolute inset-0 z-[100] rounded-xl cursor-default select-none"
+                     aria-hidden="true">
+                </div>
+
                 {{-- Banner vista general --}}
                 <div x-show="floorsEnabled && currentView === 'general'"
                      aria-live="polite"
-                     class="absolute top-2 left-1/2 -translate-x-1/2 z-10 pointer-events-none">
+                     class="absolute top-2 left-1/2 -translate-x-1/2 z-[110] pointer-events-none">
                     <span class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium
                                  bg-indigo-100 dark:bg-indigo-900/60 text-indigo-700 dark:text-indigo-300
                                  border border-indigo-200 dark:border-indigo-700 shadow-sm">
-                        Vista general — todas las plantas visibles · colisión desactivada
+                        Vista general — todas las plantas visibles · interacción con estructuras desactivada
                     </span>
                 </div>
 
@@ -1636,6 +1642,7 @@ document.addEventListener('alpine:init', () => {
                     autoScroll: true,
                     listeners: {
                         start: (event) => {
+                            if (this.floorsEnabled && this.currentView === 'general') { event.interaction.stop(); return; }
                             const el   = event.target;
                             const id   = parseInt(el.dataset.tableId);
                             const item = this.tables.find(t => t.id === id) ?? this.elements.find(e => e.id === id);
@@ -1794,6 +1801,7 @@ document.addEventListener('alpine:init', () => {
 
         // ── Drag nativo de elemento especial (barra/taburete) ────────────────
         startElementDrag(event, element) {
+            if (this.floorsEnabled && this.currentView === 'general') return;
             const startPx = element.position_x;
             const startPy = element.position_y;
             const startMX = event.clientX;
@@ -2297,6 +2305,7 @@ document.addEventListener('alpine:init', () => {
 
         // ── Resize libre en espacio local del elemento rotado ────────────────
         startResize(event, table) {
+            if (this.floorsEnabled && this.currentView === 'general') return;
             const θRad    = (table.rotation ?? 0) * Math.PI / 180;
             const cosθ    = Math.cos(θRad);
             const sinθ    = Math.sin(θRad);
@@ -2489,6 +2498,7 @@ document.addEventListener('alpine:init', () => {
 
         // ── Rotación libre arrastrando el handle (estilo Canva) ───────────────
         startRotation(event, table) {
+            if (this.floorsEnabled && this.currentView === 'general') return;
             this.closeEditPanels();
             this.rotatingId     = table.id;
 

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -2834,6 +2834,9 @@ document.addEventListener('alpine:init', () => {
             const scaleX  = availW  / this.floorWidth;
             const scaleY  = availH  / this.floorHeight;
             this.canvasZoom = Math.max(0.5, Math.min(1, Math.min(scaleX, scaleY)));
+            // Resetear scroll del contenedor para que el canvas aparezca centrado correctamente
+            const main = this.$refs.canvas?.parentElement;
+            if (main) { main.scrollTop = 0; main.scrollLeft = 0; }
         },
 
         // ── Mover zona a otra planta ─────────────────────────────────────────

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -80,7 +80,7 @@
                      role="group"
                      aria-label="Tamaño del lienzo del plano">
                     <button type="button"
-                            @click="setCanvasSize(1200, 800)"
+                            @click="requestCanvasSize(1200, 800, 'S')"
                             :aria-pressed="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 1200 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 800"
                             :class="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 1200 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 800
                                 ? 'bg-indigo-600 text-white'
@@ -89,7 +89,7 @@
                                    transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-400"
                             aria-label="Lienzo pequeño: 1200 × 800 px">S</button>
                     <button type="button"
-                            @click="setCanvasSize(1600, 1000)"
+                            @click="requestCanvasSize(1600, 1000, 'M')"
                             :aria-pressed="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 1600 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 1000"
                             :class="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 1600 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 1000
                                 ? 'bg-indigo-600 text-white'
@@ -98,7 +98,7 @@
                                    transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-400"
                             aria-label="Lienzo mediano: 1600 × 1000 px">M</button>
                     <button type="button"
-                            @click="setCanvasSize(2000, 1200)"
+                            @click="requestCanvasSize(2000, 1200, 'L')"
                             :aria-pressed="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 2000 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 1200"
                             :class="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 2000 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 1200
                                 ? 'bg-indigo-600 text-white'
@@ -107,7 +107,7 @@
                                    transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-400"
                             aria-label="Lienzo grande: 2000 × 1200 px">L</button>
                     <button type="button"
-                            @click="setCanvasSize(2400, 1500)"
+                            @click="requestCanvasSize(2400, 1500, 'XL')"
                             :aria-pressed="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 2400 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 1500"
                             :class="(floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).width === 2400 && (floorCanvasSizes[currentFloor] ?? {width:floorWidth,height:floorHeight}).height === 1500
                                 ? 'bg-indigo-600 text-white'
@@ -1282,6 +1282,80 @@
     </div>
 </div>
 
+{{-- Modal de confirmación de cambio de tamaño del plano --}}
+<div x-data
+     x-show="$store.sizeModal.show"
+     x-transition:enter="transition ease-out duration-200"
+     x-transition:enter-start="opacity-0"
+     x-transition:enter-end="opacity-100"
+     x-transition:leave="transition ease-in duration-150"
+     x-transition:leave-end="opacity-0"
+     class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+     aria-modal="true"
+     role="alertdialog"
+     aria-labelledby="size-modal-title"
+     aria-describedby="size-modal-desc"
+     @keydown.escape.window="$store.sizeModal.resolve(false)">
+
+    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl p-6 w-full max-w-md mx-4"
+         x-transition:enter="transition ease-out duration-200"
+         x-transition:enter-start="opacity-0 scale-95"
+         x-transition:enter-end="opacity-100 scale-100"
+         @click.stop>
+
+        {{-- Icono de precaución --}}
+        <div class="flex items-center justify-center w-12 h-12 mx-auto mb-4
+                    rounded-full bg-amber-100 dark:bg-amber-900/30">
+            <svg class="w-6 h-6 text-amber-600 dark:text-amber-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"/>
+            </svg>
+        </div>
+
+        <h2 id="size-modal-title"
+            class="text-lg font-bold text-center text-gray-900 dark:text-white mb-3">
+            Cambiar tamaño del plano a <span x-text="$store.sizeModal.label" class="text-amber-600 dark:text-amber-400"></span>
+        </h2>
+
+        <div id="size-modal-desc" class="text-sm text-gray-600 dark:text-gray-400 space-y-2 mb-6">
+            <template x-if="$store.sizeModal.isShrink">
+                <div class="space-y-2">
+                    <p>Estás reduciendo el tamaño del plano. Ten en cuenta lo siguiente:</p>
+                    <ul class="list-disc list-inside space-y-1 text-gray-500 dark:text-gray-400">
+                        <li>Las estructuras que queden fuera del nuevo borde serán <span class="font-semibold text-amber-600 dark:text-amber-400">desplazadas automáticamente</span> hacia dentro del plano.</li>
+                        <li>El diseño actual puede verse <span class="font-semibold text-amber-600 dark:text-amber-400">alterado</span> si hay mesas, barras o zonas cerca de los bordes.</li>
+                        <li>Puedes usar <kbd class="px-1 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-xs font-mono">Ctrl+Z</kbd> para deshacer si el resultado no es el esperado.</li>
+                    </ul>
+                </div>
+            </template>
+            <template x-if="!$store.sizeModal.isShrink">
+                <p>El plano se ampliará al tamaño <span class="font-semibold" x-text="$store.sizeModal.label"></span>. Las estructuras existentes no se moverán.</p>
+            </template>
+        </div>
+
+        <div class="flex gap-3">
+            <button type="button"
+                    @click="$store.sizeModal.resolve(false)"
+                    class="flex-1 px-4 py-2 rounded-xl text-sm font-medium
+                           text-gray-700 dark:text-gray-200
+                           bg-gray-100 dark:bg-gray-700
+                           hover:bg-gray-200 dark:hover:bg-gray-600
+                           focus:outline-none focus:ring-2 focus:ring-gray-400
+                           transition-colors">
+                Cancelar
+            </button>
+            <button type="button"
+                    @click="$store.sizeModal.resolve(true)"
+                    x-init="$watch('$store.sizeModal.show', v => v && $nextTick(() => $el.focus()))"
+                    class="flex-1 px-4 py-2 rounded-xl text-sm font-medium text-white
+                           bg-amber-500 hover:bg-amber-600
+                           focus:outline-none focus:ring-2 focus:ring-amber-400
+                           transition-colors">
+                Cambiar tamaño
+            </button>
+        </div>
+    </div>
+</div>
+
 {{-- Ghost element — sigue al cursor mientras se arrastra desde la paleta --}}
 <div id="palette-ghost"
      class="fixed pointer-events-none z-50 hidden opacity-70
@@ -1419,6 +1493,27 @@ document.addEventListener('alpine:init', () => {
         },
     });
 
+    // ── Store para el modal de confirmación de cambio de tamaño ─────────────
+    Alpine.store('sizeModal', {
+        show:     false,
+        label:    '',
+        isShrink: false,
+        _resolve: null,
+
+        prompt(label, isShrink) {
+            this.label    = label;
+            this.isShrink = isShrink;
+            this.show     = true;
+            return new Promise(resolve => { this._resolve = resolve; });
+        },
+
+        resolve(confirmed) {
+            this.show     = false;
+            this._resolve?.(confirmed);
+            this._resolve = null;
+        },
+    });
+
     // ── Componente principal del mapa ─────────────────────────────────────────
     Alpine.data('tableMap', () => ({
         tables:                @json($tables),
@@ -1541,6 +1636,17 @@ document.addEventListener('alpine:init', () => {
                     }
                 });
             } catch {}
+        },
+
+        // ── Solicitar cambio de tamaño con confirmación previa ───────────────
+        async requestCanvasSize(w, h, label) {
+            const cur      = this.floorCanvasSizes[this.floorsEnabled ? this.currentFloor : 1]
+                             ?? { width: this.floorWidth, height: this.floorHeight };
+            if (w === cur.width && h === cur.height) return;
+            const isShrink = w < cur.width || h < cur.height;
+            const confirmed = await Alpine.store('sizeModal').prompt(label, isShrink);
+            if (!confirmed) return;
+            this.setCanvasSize(w, h);
         },
 
         // ── Cambiar tamaño del lienzo y persistir en BD ───────────────────────

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -244,7 +244,7 @@
                 <div class="flex items-center gap-2">
                     <button type="button"
                             x-show="!editMode"
-                            @click="editMode = true"
+                            @click="editMode = true; switchFloor(currentFloor)"
                             class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-white
                                    bg-amber-500 hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 transition-colors"
                             aria-label="Entrar en modo edición del mapa">
@@ -255,7 +255,7 @@
                     </button>
                     <button type="button"
                             x-show="editMode"
-                            @click="editMode = false"
+                            @click="editMode = false; switchView('general')"
                             class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-white
                                    bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
                             aria-label="Confirmar cambios y salir del modo edición">
@@ -1418,7 +1418,7 @@ document.addEventListener('alpine:init', () => {
         floorCount:            {{ $floorCount }},
         floorCanvasSizes:      @json($floorCanvasSizes),
         currentFloor:          1,
-        currentView:           'floor',
+        currentView:           'general',
         readonly:              {{ $readonly ? 'true' : 'false' }},
         editMode:              false,
         canvasZoom:            1,
@@ -1446,21 +1446,26 @@ document.addEventListener('alpine:init', () => {
         undoStack:             [],
 
         init() {
-            // El tamaño del canvas viene de BD (floorWidth/floorHeight).
-            // Solo el zoom es local (visual), keyed por usuario para evitar mezcla entre cuentas.
-            const lsZoom   = 'zampa:mapZoom:user:{{ auth()->id() }}';
-            const savedZoom = parseFloat(localStorage.getItem(lsZoom));
-            if (!isNaN(savedZoom) && savedZoom >= 0.5 && savedZoom <= 1) {
-                this.canvasZoom = savedZoom;
-            }
-            this.$watch('canvasZoom', val => localStorage.setItem(lsZoom, val));
-
             this.$nextTick(() => {
                 if (!this.readonly) {
                     this.initTableInteract();
                     this.initZoneInteract();
                     this.initPaletteInteract();
                     this.clampAllToCanvas();
+                }
+                // Vista inicial: general con zoom auto-fit al canvas completo
+                if (this.floorsEnabled) {
+                    const sizes = Object.values(this.floorCanvasSizes);
+                    if (sizes.length) {
+                        this.floorWidth  = Math.max(...sizes.map(s => s.width));
+                        this.floorHeight = Math.max(...sizes.map(s => s.height));
+                    }
+                }
+                const container = this.$refs.canvas?.parentElement;
+                if (container) {
+                    const scaleX = (container.clientWidth  - 32) / this.floorWidth;
+                    const scaleY = (container.clientHeight - 32) / this.floorHeight;
+                    this.canvasZoom = Math.max(0.5, Math.min(1, Math.min(scaleX, scaleY)));
                 }
             });
 
@@ -2807,11 +2812,13 @@ document.addEventListener('alpine:init', () => {
 
         switchView(view) {
             this.currentView    = view;
-            if (view === 'general' && this.floorsEnabled) {
-                const sizes = Object.values(this.floorCanvasSizes);
-                if (sizes.length) {
-                    this.floorWidth  = Math.max(...sizes.map(s => s.width));
-                    this.floorHeight = Math.max(...sizes.map(s => s.height));
+            if (view === 'general') {
+                if (this.floorsEnabled) {
+                    const sizes = Object.values(this.floorCanvasSizes);
+                    if (sizes.length) {
+                        this.floorWidth  = Math.max(...sizes.map(s => s.width));
+                        this.floorHeight = Math.max(...sizes.map(s => s.height));
+                    }
                 }
                 this.$nextTick(() => {
                     const container = this.$refs.canvas?.parentElement;

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -2777,11 +2777,15 @@ document.addEventListener('alpine:init', () => {
         switchFloor(n) {
             this.currentFloor   = n;
             this.currentView    = 'floor';
-            this.canvasZoom     = 1;
             const size = this.floorCanvasSizes[n];
             if (size) {
                 this.floorWidth  = size.width;
                 this.floorHeight = size.height;
+            }
+            if (this.editMode) {
+                this.canvasZoom = 1;
+            } else {
+                this._applyOverviewZoom();
             }
             this.editingTableId = null;
             this.editingTable   = null;

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -460,6 +460,23 @@
                     </span>
                 </div>
 
+                {{-- Badge planta activa --}}
+                <div x-show="floorsEnabled && currentView === 'floor'"
+                     aria-live="polite"
+                     class="absolute top-2 left-1/2 -translate-x-1/2 z-[110] pointer-events-none">
+                    <span class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium
+                                 bg-gray-100 dark:bg-gray-700/80 text-gray-600 dark:text-gray-300
+                                 border border-gray-200 dark:border-gray-600 shadow-sm">
+                        <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M3 21h18M3 10h18M3 7l9-4 9 4M4 10v11M20 10v11M8 10v11M16 10v11M12 10v11"/>
+                        </svg>
+                        Planta <span x-text="currentFloor"></span>
+                        <template x-if="!editMode">
+                            <span class="text-gray-400 dark:text-gray-500">· solo vista</span>
+                        </template>
+                    </span>
+                </div>
+
                 {{-- Cuadrícula decorativa --}}
                 <svg class="absolute inset-0 w-full h-full pointer-events-none opacity-30 dark:opacity-10"
                      xmlns="http://www.w3.org/2000/svg">

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -422,15 +422,16 @@
         </aside>
 
         {{-- ── CANVAS ───────────────────────────────────────── --}}
-        <main id="main-content" class="flex-1 overflow-auto p-4 relative">
+        <main id="main-content"
+              class="flex-1 p-4 relative"
+              :class="editMode ? 'overflow-auto' : 'overflow-hidden flex items-center justify-center'">
             <div
                 x-ref="canvas"
                 class="relative bg-white dark:bg-gray-800 rounded-xl shadow-inner
                        border-2 border-dashed border-gray-200 dark:border-gray-700"
-                :style="`width:${floorWidth}px; height:${floorHeight}px;
-                         transform:scale(${canvasZoom}); transform-origin:top left;
-                         margin-bottom:${-floorHeight*(1-canvasZoom)}px;
-                         margin-right:${-floorWidth*(1-canvasZoom)}px;`"
+                :style="editMode
+                    ? `width:${floorWidth}px; height:${floorHeight}px; transform:scale(${canvasZoom}); transform-origin:top left; margin-bottom:${-floorHeight*(1-canvasZoom)}px; margin-right:${-floorWidth*(1-canvasZoom)}px;`
+                    : `width:${floorWidth}px; height:${floorHeight}px; transform:scale(${canvasZoom}); transform-origin:center center; flex-shrink:0;`"
                 aria-label="Plano del restaurante"
                 @click="editingTableId = null; editingTable = null; editingZoneId = null; editingZone = null; selectedId = null;"
             >
@@ -1461,12 +1462,7 @@ document.addEventListener('alpine:init', () => {
                         this.floorHeight = Math.max(...sizes.map(s => s.height));
                     }
                 }
-                const container = this.$refs.canvas?.parentElement;
-                if (container) {
-                    const scaleX = (container.clientWidth  - 32) / this.floorWidth;
-                    const scaleY = (container.clientHeight - 32) / this.floorHeight;
-                    this.canvasZoom = Math.max(0.5, Math.min(1, Math.min(scaleX, scaleY)));
-                }
+                this._applyOverviewZoom();
             });
 
 
@@ -2820,14 +2816,7 @@ document.addEventListener('alpine:init', () => {
                         this.floorHeight = Math.max(...sizes.map(s => s.height));
                     }
                 }
-                this.$nextTick(() => {
-                    const container = this.$refs.canvas?.parentElement;
-                    if (container) {
-                        const scaleX = (container.clientWidth  - 32) / this.floorWidth;
-                        const scaleY = (container.clientHeight - 32) / this.floorHeight;
-                        this.canvasZoom = Math.max(0.5, Math.min(1, Math.min(scaleX, scaleY)));
-                    }
-                });
+                this.$nextTick(() => this._applyOverviewZoom());
             }
             this.editingTableId = null;
             this.editingTable   = null;
@@ -2835,6 +2824,16 @@ document.addEventListener('alpine:init', () => {
             this.editingZoneId  = null;
             this.editingZone    = null;
             this._zoneBtnEl     = null;
+        },
+
+        // Calcula y aplica zoom para que el canvas quepa en pantalla (modo vista general).
+        _applyOverviewZoom() {
+            const headerH = document.querySelector('header')?.offsetHeight ?? 65;
+            const availW  = window.innerWidth  - 48;
+            const availH  = window.innerHeight - headerH - 48;
+            const scaleX  = availW  / this.floorWidth;
+            const scaleY  = availH  / this.floorHeight;
+            this.canvasZoom = Math.max(0.5, Math.min(1, Math.min(scaleX, scaleY)));
         },
 
         // ── Mover zona a otra planta ─────────────────────────────────────────

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -200,10 +200,9 @@
                                     x-show="floorCount < 5"
                                     @click="addFloor()"
                                     aria-label="Añadir planta"
-                                    class="px-2 py-1.5 rounded text-xs font-semibold border border-gray-200 dark:border-gray-600
-                                           bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300
-                                           hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors
-                                           focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-400">
+                                    class="px-2 py-1.5 rounded text-xs font-semibold
+                                           bg-green-500 hover:bg-green-600 text-white
+                                           transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-green-400">
                                 + P
                             </button>
 
@@ -212,10 +211,9 @@
                                     x-show="floorCount > 1"
                                     @click="confirmDeleteFloor(floorCount)"
                                     :aria-label="`Eliminar Planta ${floorCount}`"
-                                    class="px-2 py-1.5 rounded text-xs font-semibold border border-red-300 dark:border-red-700
-                                           bg-white dark:bg-gray-700 text-red-500 dark:text-red-400
-                                           hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors
-                                           focus:outline-none focus:ring-2 focus:ring-inset focus:ring-red-400">
+                                    class="px-2 py-1.5 rounded text-xs font-semibold
+                                           bg-red-500 hover:bg-red-600 text-white
+                                           transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-red-400">
                                 − P<span x-text="floorCount"></span>
                             </button>
                         </div>

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -21,6 +21,7 @@
     x-init="init()"
     @mouseup.window="if(isRotating||isRotatingZone){}"
     @keydown.ctrl.z.window.prevent="undo()"
+    @keydown.ctrl.y.window.prevent="redo()"
 >
 
     {{-- ══════════════════════════════════════════════════════
@@ -117,21 +118,37 @@
                             aria-label="Lienzo extra grande: 2400 × 1500 px">XL</button>
                 </div>
 
-                {{-- Botón Deshacer --}}
-                <button type="button"
-                        @click="undo()"
-                        :disabled="undoStack.length === 0"
-                        :class="undoStack.length === 0
-                            ? 'opacity-40 cursor-not-allowed'
-                            : 'hover:bg-gray-100 dark:hover:bg-gray-600'"
-                        class="p-1.5 rounded-lg text-gray-500 dark:text-gray-400 transition-colors
-                               focus:outline-none focus:ring-2 focus:ring-indigo-400"
-                        aria-label="Deshacer último cambio (Ctrl+Z)"
-                        title="Deshacer (Ctrl+Z)">
-                    <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3"/>
-                    </svg>
-                </button>
+                {{-- Botones Deshacer / Rehacer --}}
+                <div class="flex items-center gap-1">
+                    <button type="button"
+                            @click="undo()"
+                            :disabled="undoStack.length === 0"
+                            :class="undoStack.length === 0
+                                ? 'opacity-40 cursor-not-allowed'
+                                : 'hover:bg-gray-100 dark:hover:bg-gray-600'"
+                            class="p-1.5 rounded-lg text-gray-500 dark:text-gray-400 transition-colors
+                                   focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                            aria-label="Deshacer último cambio (Ctrl+Z)"
+                            title="Deshacer (Ctrl+Z)">
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3"/>
+                        </svg>
+                    </button>
+                    <button type="button"
+                            @click="redo()"
+                            :disabled="redoStack.length === 0"
+                            :class="redoStack.length === 0
+                                ? 'opacity-40 cursor-not-allowed'
+                                : 'hover:bg-gray-100 dark:hover:bg-gray-600'"
+                            class="p-1.5 rounded-lg text-gray-500 dark:text-gray-400 transition-colors
+                                   focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                            aria-label="Rehacer cambio (Ctrl+Y)"
+                            title="Rehacer (Ctrl+Y)">
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15 15l6-6m0 0l-6-6m6 6H9a6 6 0 000 12h3"/>
+                        </svg>
+                    </button>
+                </div>
 
                 {{-- Zoom slider (solo visual, sin persistencia en BD) --}}
                 <div class="hidden sm:flex items-center gap-1.5">
@@ -256,7 +273,7 @@
                         <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/>
                         </svg>
-                        Confirmar
+                        Guardar
                     </button>
                 </div>
             </template>
@@ -419,6 +436,45 @@
         <main id="main-content"
               class="flex-1 p-4 relative"
               :class="(editMode && currentView !== 'general') ? 'overflow-auto' : 'overflow-hidden flex items-center justify-center'">
+
+            {{-- Mensaje inferior modo vista — fuera del canvas para no escalar con él --}}
+            <div x-show="!readonly && !editMode"
+                 class="absolute bottom-3 left-1/2 -translate-x-1/2 z-20 pointer-events-none">
+                <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium
+                             bg-amber-100 dark:bg-amber-900/60 text-amber-700 dark:text-amber-300
+                             border border-amber-300 dark:border-amber-600 shadow-sm whitespace-nowrap">
+                    Pulsa "Editar mapa" para mover o modificar estructuras
+                </span>
+            </div>
+
+            {{-- Banner vista general — fuera del canvas para no escalar con él --}}
+            <div x-show="floorsEnabled && currentView === 'general'"
+                 aria-live="polite"
+                 class="absolute top-3 left-1/2 -translate-x-1/2 z-20 pointer-events-none">
+                <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium
+                             bg-indigo-100 dark:bg-indigo-900/60 text-indigo-700 dark:text-indigo-300
+                             border border-indigo-200 dark:border-indigo-700 shadow-sm whitespace-nowrap">
+                    Vista general — todas las plantas visibles · interacción desactivada
+                </span>
+            </div>
+
+            {{-- Badge planta activa — fuera del canvas para no escalar con él --}}
+            <div x-show="floorsEnabled && currentView === 'floor'"
+                 aria-live="polite"
+                 class="absolute top-3 left-1/2 -translate-x-1/2 z-20 pointer-events-none">
+                <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium
+                             bg-gray-100 dark:bg-gray-700/80 text-gray-600 dark:text-gray-300
+                             border border-gray-200 dark:border-gray-600 shadow-sm whitespace-nowrap">
+                    <svg aria-hidden="true" class="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M3 21h18M3 10h18M3 7l9-4 9 4M4 10v11M20 10v11M8 10v11M16 10v11M12 10v11"/>
+                    </svg>
+                    Planta <span x-text="currentFloor"></span>
+                    <template x-if="!editMode">
+                        <span class="text-gray-400 dark:text-gray-500">· solo vista</span>
+                    </template>
+                </span>
+            </div>
+
             <div
                 x-ref="canvas"
                 class="relative bg-white dark:bg-gray-800 rounded-xl shadow-inner
@@ -434,13 +490,6 @@
                 <div x-show="!readonly && !editMode"
                      class="absolute inset-0 z-[90] rounded-xl cursor-default select-none"
                      aria-hidden="true">
-                    <div class="absolute bottom-4 left-1/2 -translate-x-1/2 pointer-events-none">
-                        <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium
-                                     bg-amber-100 dark:bg-amber-900/60 text-amber-700 dark:text-amber-300
-                                     border border-amber-300 dark:border-amber-600 shadow-sm">
-                            Pulsa "Editar mapa" para mover o modificar estructuras
-                        </span>
-                    </div>
                 </div>
 
                 {{-- Overlay vista general: bloquea toda interacción con estructuras --}}
@@ -449,33 +498,6 @@
                      aria-hidden="true">
                 </div>
 
-                {{-- Banner vista general --}}
-                <div x-show="floorsEnabled && currentView === 'general'"
-                     aria-live="polite"
-                     class="absolute top-2 left-1/2 -translate-x-1/2 z-[110] pointer-events-none">
-                    <span class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium
-                                 bg-indigo-100 dark:bg-indigo-900/60 text-indigo-700 dark:text-indigo-300
-                                 border border-indigo-200 dark:border-indigo-700 shadow-sm">
-                        Vista general — todas las plantas visibles · interacción con estructuras desactivada
-                    </span>
-                </div>
-
-                {{-- Badge planta activa --}}
-                <div x-show="floorsEnabled && currentView === 'floor'"
-                     aria-live="polite"
-                     class="absolute top-2 left-1/2 -translate-x-1/2 z-[110] pointer-events-none">
-                    <span class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium
-                                 bg-gray-100 dark:bg-gray-700/80 text-gray-600 dark:text-gray-300
-                                 border border-gray-200 dark:border-gray-600 shadow-sm">
-                        <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M3 21h18M3 10h18M3 7l9-4 9 4M4 10v11M20 10v11M8 10v11M16 10v11M12 10v11"/>
-                        </svg>
-                        Planta <span x-text="currentFloor"></span>
-                        <template x-if="!editMode">
-                            <span class="text-gray-400 dark:text-gray-500">· solo vista</span>
-                        </template>
-                    </span>
-                </div>
 
                 {{-- Cuadrícula decorativa --}}
                 <svg class="absolute inset-0 w-full h-full pointer-events-none opacity-30 dark:opacity-10"
@@ -1551,6 +1573,7 @@ document.addEventListener('alpine:init', () => {
         toast:                 { show: false, msg: '', error: false, _timer: null },
         rotTooltip:            { show: false, x: 0, y: 0, deg: 0 },
         undoStack:             [],
+        redoStack:             [],
 
         init() {
             this.$nextTick(() => {
@@ -1858,69 +1881,80 @@ document.addEventListener('alpine:init', () => {
         pushUndo() {
             this.undoStack.push(this.snapshot());
             if (this.undoStack.length > 20) this.undoStack.shift();
+            this.redoStack = [];
         },
 
         async undo() {
             if (!this.undoStack.length) return;
-            const prev  = this.undoStack.pop();
+            this.redoStack.push(this.snapshot());
+            if (this.redoStack.length > 20) this.redoStack.shift();
+            await this._applySnapshot(this.undoStack.pop());
+        },
+
+        async redo() {
+            if (!this.redoStack.length) return;
+            this.undoStack.push(this.snapshot());
+            if (this.undoStack.length > 20) this.undoStack.shift();
+            await this._applySnapshot(this.redoStack.pop());
+        },
+
+        async _applySnapshot(snap) {
             const floor = this.floorsEnabled ? this.currentFloor : 1;
 
             const canvasSizeChanged =
-                prev.floorWidth  !== this.floorWidth  ||
-                prev.floorHeight !== this.floorHeight  ||
-                JSON.stringify(prev.floorCanvasSizes) !== JSON.stringify(this.floorCanvasSizes);
+                snap.floorWidth  !== this.floorWidth  ||
+                snap.floorHeight !== this.floorHeight  ||
+                JSON.stringify(snap.floorCanvasSizes) !== JSON.stringify(this.floorCanvasSizes);
 
-            // Restaurar estado reactivo inmediatamente
-            this.canvasZoom       = prev.canvasZoom;
-            this.floorWidth       = prev.floorWidth;
-            this.floorHeight      = prev.floorHeight;
-            this.floorCanvasSizes = prev.floorCanvasSizes;
+            this.canvasZoom       = snap.canvasZoom;
+            this.floorWidth       = snap.floorWidth;
+            this.floorHeight      = snap.floorHeight;
+            this.floorCanvasSizes = snap.floorCanvasSizes;
 
             const toPersistItems = [];
             const toPersistZones = [];
 
-            for (const snap of prev.tables) {
-                const t = this.tables.find(t => t.id === snap.id);
+            for (const s of snap.tables) {
+                const t = this.tables.find(t => t.id === s.id);
                 if (!t) continue;
-                if (t.position_x !== snap.position_x || t.position_y !== snap.position_y ||
-                    t.width !== snap.width || t.height !== snap.height || (t.rotation ?? 0) !== snap.rotation) {
-                    t.position_x = snap.position_x; t.position_y = snap.position_y;
-                    t.width      = snap.width;       t.height     = snap.height;
-                    t.rotation   = snap.rotation;
+                if (t.position_x !== s.position_x || t.position_y !== s.position_y ||
+                    t.width !== s.width || t.height !== s.height || (t.rotation ?? 0) !== s.rotation) {
+                    t.position_x = s.position_x; t.position_y = s.position_y;
+                    t.width      = s.width;       t.height     = s.height;
+                    t.rotation   = s.rotation;
                     toPersistItems.push(t);
                 }
             }
-            for (const snap of prev.elements) {
-                const e = this.elements.find(e => e.id === snap.id);
+            for (const s of snap.elements) {
+                const e = this.elements.find(e => e.id === s.id);
                 if (!e) continue;
-                if (e.position_x !== snap.position_x || e.position_y !== snap.position_y ||
-                    e.width !== snap.width || e.height !== snap.height || (e.rotation ?? 0) !== snap.rotation) {
-                    e.position_x = snap.position_x; e.position_y = snap.position_y;
-                    e.width      = snap.width;       e.height     = snap.height;
-                    e.rotation   = snap.rotation;
+                if (e.position_x !== s.position_x || e.position_y !== s.position_y ||
+                    e.width !== s.width || e.height !== s.height || (e.rotation ?? 0) !== s.rotation) {
+                    e.position_x = s.position_x; e.position_y = s.position_y;
+                    e.width      = s.width;       e.height     = s.height;
+                    e.rotation   = s.rotation;
                     toPersistItems.push(e);
                 }
             }
-            for (const snap of prev.zones) {
-                const z = this.zones.find(z => z.id === snap.id);
+            for (const s of snap.zones) {
+                const z = this.zones.find(z => z.id === s.id);
                 if (!z) continue;
-                if (z.position_x !== snap.position_x || z.position_y !== snap.position_y ||
-                    z.width !== snap.width || z.height !== snap.height ||
-                    (z.rotation ?? 0) !== snap.rotation || z.color !== snap.color) {
-                    z.position_x = snap.position_x; z.position_y = snap.position_y;
-                    z.width      = snap.width;       z.height     = snap.height;
-                    z.rotation   = snap.rotation;    z.color      = snap.color;
+                if (z.position_x !== s.position_x || z.position_y !== s.position_y ||
+                    z.width !== s.width || z.height !== s.height ||
+                    (z.rotation ?? 0) !== s.rotation || z.color !== s.color) {
+                    z.position_x = s.position_x; z.position_y = s.position_y;
+                    z.width      = s.width;       z.height     = s.height;
+                    z.rotation   = s.rotation;    z.color      = s.color;
                     toPersistZones.push(z);
                 }
             }
 
-            // Persistir en BD
             if (canvasSizeChanged) {
                 try {
                     await fetch('{{ route("tables.canvas.update") }}', {
                         method:  'PATCH',
                         headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
-                        body: JSON.stringify({ floor_width: prev.floorWidth, floor_height: prev.floorHeight, floor }),
+                        body: JSON.stringify({ floor_width: snap.floorWidth, floor_height: snap.floorHeight, floor }),
                     });
                 } catch {}
             }
@@ -2183,6 +2217,7 @@ document.addEventListener('alpine:init', () => {
                 inertia: false,
                 listeners: {
                     start: (event) => {
+                        if (this.floorsEnabled && this.currentView === 'general') { event.interaction.stop(); return; }
                         if (this.tables.length >= {{ $maxTables }}) {
                             this.showToast(`Límite de {{ $maxTables }} mesas alcanzado.`, true);
                             return;
@@ -2253,6 +2288,7 @@ document.addEventListener('alpine:init', () => {
                 inertia: false,
                 listeners: {
                     start: (event) => {
+                        if (this.floorsEnabled && this.currentView === 'general') { event.interaction.stop(); return; }
                         const shape = event.target.dataset.shape;
                         const dropW = parseInt(event.target.dataset.width)  || 80;
                         const dropH = parseInt(event.target.dataset.height) || 50;
@@ -2310,6 +2346,7 @@ document.addEventListener('alpine:init', () => {
                 inertia: false,
                 listeners: {
                     start: (event) => {
+                        if (this.floorsEnabled && this.currentView === 'general') { event.interaction.stop(); return; }
                         const w = parseInt(event.target.dataset.width)  || 300;
                         const h = parseInt(event.target.dataset.height) || 200;
                         ghost.style.width        = `${w}px`;

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -387,7 +387,7 @@
                 @click="if (canvasZoom === 1) { editingTableId = null; editingTable = null; editingZoneId = null; editingZone = null; selectedId = null; }"
             >
                 {{-- Overlay de zoom: bloquea edición cuando canvasZoom < 1 --}}
-                <div x-show="canvasZoom < 1"
+                <div x-show="canvasZoom < 1 && !(floorsEnabled && currentView === 'general')"
                      x-transition:enter="transition ease-out duration-150"
                      x-transition:enter-start="opacity-0"
                      x-transition:enter-end="opacity-100"
@@ -2598,6 +2598,7 @@ document.addEventListener('alpine:init', () => {
         switchFloor(n) {
             this.currentFloor   = n;
             this.currentView    = 'floor';
+            this.canvasZoom     = 1;
             const size = this.floorCanvasSizes[n];
             if (size) {
                 this.floorWidth  = size.width;
@@ -2619,6 +2620,14 @@ document.addEventListener('alpine:init', () => {
                     this.floorWidth  = Math.max(...sizes.map(s => s.width));
                     this.floorHeight = Math.max(...sizes.map(s => s.height));
                 }
+                this.$nextTick(() => {
+                    const container = this.$refs.canvas?.parentElement;
+                    if (container) {
+                        const scaleX = (container.clientWidth  - 32) / this.floorWidth;
+                        const scaleY = (container.clientHeight - 32) / this.floorHeight;
+                        this.canvasZoom = Math.max(0.5, Math.min(1, Math.min(scaleX, scaleY)));
+                    }
+                });
             }
             this.editingTableId = null;
             this.editingTable   = null;

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -382,7 +382,9 @@
                 class="relative bg-white dark:bg-gray-800 rounded-xl shadow-inner
                        border-2 border-dashed border-gray-200 dark:border-gray-700"
                 :style="`width:${floorWidth}px; height:${floorHeight}px;
-                         transform:scale(${canvasZoom}); transform-origin:top left;`"
+                         transform:scale(${canvasZoom}); transform-origin:top left;
+                         margin-bottom:${-floorHeight*(1-canvasZoom)}px;
+                         margin-right:${-floorWidth*(1-canvasZoom)}px;`"
                 aria-label="Plano del restaurante"
                 @click="if (canvasZoom === 1) { editingTableId = null; editingTable = null; editingZoneId = null; editingZone = null; selectedId = null; }"
             >

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -70,7 +70,7 @@
 
         <div class="flex items-center gap-3 flex-wrap">
             {{-- ── Control de tamaño del lienzo — solo admin ──────────────── --}}
-            <div x-show="!readonly" class="flex items-center gap-2">
+            <div x-show="!readonly && editMode" class="flex items-center gap-2">
                 <span class="text-xs font-medium text-gray-500 dark:text-gray-400 hidden sm:block"
                       aria-hidden="true">Plano:</span>
 
@@ -160,7 +160,7 @@
             </div>
 
             {{-- ── Toggle + selector de plantas — solo admin ──────────────── --}}
-            <template x-if="!readonly">
+            <template x-if="!readonly && editMode">
                 <div class="flex items-center gap-2">
                     {{-- Toggle activar/desactivar sistema de plantas --}}
                     <label class="flex items-center gap-1.5 text-xs font-medium text-gray-500 dark:text-gray-400 cursor-pointer select-none"
@@ -239,6 +239,34 @@
                 </div>
             </template>
 
+            {{-- Botón Editar / Confirmar — solo propietario --}}
+            <template x-if="!readonly">
+                <div class="flex items-center gap-2">
+                    <button type="button"
+                            x-show="!editMode"
+                            @click="editMode = true"
+                            class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-white
+                                   bg-amber-500 hover:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 transition-colors"
+                            aria-label="Entrar en modo edición del mapa">
+                        <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z"/>
+                        </svg>
+                        Editar mapa
+                    </button>
+                    <button type="button"
+                            x-show="editMode"
+                            @click="editMode = false"
+                            class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-white
+                                   bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
+                            aria-label="Confirmar cambios y salir del modo edición">
+                        <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5"/>
+                        </svg>
+                        Confirmar
+                    </button>
+                </div>
+            </template>
+
             <a href="{{ route('tables.index') }}"
                class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-white
                       bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
@@ -257,7 +285,7 @@
     <div class="flex flex-1 overflow-hidden">
 
         {{-- ── PALETA LATERAL — solo visible para admin ─────── --}}
-        <aside x-show="!readonly"
+        <aside x-show="!readonly && editMode"
                class="flex-shrink-0 w-44 bg-white dark:bg-gray-800
                       border-r border-gray-200 dark:border-gray-700
                       flex flex-col p-3 gap-4 overflow-y-auto">
@@ -406,6 +434,19 @@
                 aria-label="Plano del restaurante"
                 @click="editingTableId = null; editingTable = null; editingZoneId = null; editingZone = null; selectedId = null;"
             >
+
+                {{-- Overlay modo visualización: bloquea interacción cuando no se está editando --}}
+                <div x-show="!readonly && !editMode"
+                     class="absolute inset-0 z-[90] rounded-xl cursor-default select-none"
+                     aria-hidden="true">
+                    <div class="absolute bottom-4 left-1/2 -translate-x-1/2 pointer-events-none">
+                        <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium
+                                     bg-amber-100 dark:bg-amber-900/60 text-amber-700 dark:text-amber-300
+                                     border border-amber-300 dark:border-amber-600 shadow-sm">
+                            Pulsa "Editar mapa" para mover o modificar estructuras
+                        </span>
+                    </div>
+                </div>
 
                 {{-- Overlay vista general: bloquea toda interacción con estructuras --}}
                 <div x-show="floorsEnabled && currentView === 'general'"
@@ -776,7 +817,7 @@
 
                             {{-- Botón editar forma — solo admin --}}
                             <button type="button"
-                                    x-show="!readonly && !(isRotating && rotatingId === table.id)"
+                                    x-show="!readonly && editMode && !(isRotating && rotatingId === table.id)"
                                     @click.stop="if (editingTableId === table.id) { editingTableId = null; editingTable = null; _editBtnEl = null; } else { editingTableId = table.id; editingTable = table; _editBtnEl = $el; editPanelPos = panelPosFromBtn($el, 220); editingZoneId = null; editingZone = null; _zoneBtnEl = null; }"
                                     class="absolute -top-2.5 -right-16
                                            w-6 h-6 rounded-full bg-gray-600 dark:bg-gray-500 text-white
@@ -809,7 +850,7 @@
 
                             {{-- Botón eliminar — solo admin --}}
                             <button type="button"
-                                    x-show="!readonly && !(isRotating && rotatingId === table.id)"
+                                    x-show="!readonly && editMode && !(isRotating && rotatingId === table.id)"
                                     @click.stop="deleteTable(table)"
                                     class="absolute -top-2.5 -right-2.5
                                            w-6 h-6 rounded-full bg-red-500 text-white
@@ -826,7 +867,7 @@
                         </div>
 
                         {{-- Handle de rotación — solo admin --}}
-                        <div x-show="!readonly" class="rotation-handle absolute -top-9 left-1/2 -translate-x-1/2
+                        <div x-show="!readonly && editMode" class="rotation-handle absolute -top-9 left-1/2 -translate-x-1/2
                                     flex flex-col items-center gap-0
                                     transition-opacity z-10"
                              :class="selectedId === table.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'"
@@ -849,7 +890,7 @@
                         </div>
 
                         {{-- Handle de redimensionado — solo admin --}}
-                        <div x-show="!readonly"
+                        <div x-show="!readonly && editMode"
                              class="resize-handle absolute bottom-0 right-0
                                     w-4 h-4 cursor-se-resize transition-opacity"
                              :class="selectedId === table.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'"
@@ -1379,6 +1420,7 @@ document.addEventListener('alpine:init', () => {
         currentFloor:          1,
         currentView:           'floor',
         readonly:              {{ $readonly ? 'true' : 'false' }},
+        editMode:              false,
         canvasZoom:            1,
         isDraggingFromPalette: false,
         currentDragShape:      null,
@@ -1798,6 +1840,7 @@ document.addEventListener('alpine:init', () => {
                     listeners: {
                         start: (event) => {
                             if (this.floorsEnabled && this.currentView === 'general') { event.interaction.stop(); return; }
+                            if (!this.editMode) { event.interaction.stop(); return; }
                             this.pushUndo();
                             const el   = event.target;
                             const id   = parseInt(el.dataset.tableId);
@@ -1889,6 +1932,7 @@ document.addEventListener('alpine:init', () => {
 
         // ── Drag nativo de zona: actualiza zone.position_x/y reactivamente ───
         startZoneDrag(event, zone) {
+            if (!this.editMode) return;
             this.pushUndo();
             const canvasEl  = this.$refs.canvas;
             const startMX   = event.clientX;
@@ -1921,6 +1965,7 @@ document.addEventListener('alpine:init', () => {
 
         // ── Rotación libre de zona arrastrando el handle ─────────────────────
         startZoneRotation(event, zone) {
+            if (!this.editMode) return;
             this.pushUndo();
             const canvasRect = this.$refs.canvas.getBoundingClientRect();
             const centerX    = canvasRect.left + (zone.position_x + zone.width  / 2) * this.canvasZoom;
@@ -1960,6 +2005,7 @@ document.addEventListener('alpine:init', () => {
         // ── Drag nativo de elemento especial (barra/taburete) ────────────────
         startElementDrag(event, element) {
             if (this.floorsEnabled && this.currentView === 'general') return;
+            if (!this.editMode) return;
             this.pushUndo();
             const startPx = element.position_x;
             const startPy = element.position_y;
@@ -2371,6 +2417,7 @@ document.addEventListener('alpine:init', () => {
 
         // ── Resize de zona ────────────────────────────────────────────────────
         startZoneResize(event, zone) {
+            if (!this.editMode) return;
             this.pushUndo();
             const startMX = event.clientX;
             const startMY = event.clientY;
@@ -2448,6 +2495,7 @@ document.addEventListener('alpine:init', () => {
         // ── Resize libre en espacio local del elemento rotado ────────────────
         startResize(event, table) {
             if (this.floorsEnabled && this.currentView === 'general') return;
+            if (!this.editMode) return;
             this.pushUndo();
             const θRad    = (table.rotation ?? 0) * Math.PI / 180;
             const cosθ    = Math.cos(θRad);
@@ -2642,6 +2690,7 @@ document.addEventListener('alpine:init', () => {
         // ── Rotación libre arrastrando el handle (estilo Canva) ───────────────
         startRotation(event, table) {
             if (this.floorsEnabled && this.currentView === 'general') return;
+            if (!this.editMode) return;
             this.pushUndo();
             this.closeEditPanels();
             this.rotatingId     = table.id;

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -199,8 +199,9 @@
                         </button>
                     </template>
 
-                    {{-- Botón Vista General --}}
+                    {{-- Botón Vista General — solo cuando hay más de una planta --}}
                     <button type="button"
+                            x-show="floorCount > 1"
                             @click="switchView('general')"
                             :aria-pressed="currentView === 'general'"
                             :class="currentView === 'general'

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -266,7 +266,7 @@
                     </button>
                     <button type="button"
                             x-show="editMode"
-                            @click="editMode = false; _applyOverviewZoom()"
+                            @click="exitEditMode()"
                             class="inline-flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-white
                                    bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
                             aria-label="Confirmar cambios y salir del modo edición">
@@ -2895,6 +2895,18 @@ document.addEventListener('alpine:init', () => {
             this._zoneBtnEl     = null;
         },
 
+        exitEditMode() {
+            this.editMode  = false;
+            this.closeEditPanels();
+            this.selectedId = null;
+            this.hoveredId  = null;
+            Alpine.store('qrModal').close();
+            Alpine.store('tableModal').cancel();
+            Alpine.store('deleteModal').resolve(false);
+            Alpine.store('sizeModal').resolve(false);
+            this._applyOverviewZoom();
+        },
+
         isActive(id) {
             return this.selectedId     === id
                 || this.rotatingId     === id
@@ -2957,7 +2969,7 @@ document.addEventListener('alpine:init', () => {
         },
 
         switchView(view) {
-            this.currentView    = view;
+            this.currentView = view;
             if (view === 'general') {
                 if (this.floorsEnabled) {
                     const sizes = Object.values(this.floorCanvasSizes);
@@ -2968,12 +2980,13 @@ document.addEventListener('alpine:init', () => {
                 }
                 this.$nextTick(() => this._applyOverviewZoom());
             }
-            this.editingTableId = null;
-            this.editingTable   = null;
-            this._editBtnEl     = null;
-            this.editingZoneId  = null;
-            this.editingZone    = null;
-            this._zoneBtnEl     = null;
+            this.closeEditPanels();
+            this.selectedId = null;
+            this.hoveredId  = null;
+            Alpine.store('qrModal').close();
+            Alpine.store('tableModal').cancel();
+            Alpine.store('deleteModal').resolve(false);
+            Alpine.store('sizeModal').resolve(false);
         },
 
         // Calcula y aplica zoom para que el canvas quepa en pantalla (modo vista general).


### PR DESCRIPTION
## Summary

- Modo edición con toggle Editar mapa / Guardar: al guardar se cierran todos los paneles, modales QR, confirmación y selección activa
- Auto-fit zoom en modo vista y al cambiar de planta; canvas centrado con `flex items-center justify-center`
- Selector de planta persistente en modo vista; botón General oculto cuando solo hay una planta
- Badge informativo de planta activa y banner de vista general fuera del canvas (no escalan con el zoom)
- Sistema de deshacer (Ctrl+Z) y rehacer (Ctrl+Y) con historial de hasta 20 snapshots
- Drag & drop de paleta bloqueado en vista general para evitar crear estructuras sin planta asignada
- Modal de precaución al reducir el tamaño del canvas con descripción de consecuencias
- Zonas eliminadas correctamente al borrar una planta del frontend
- Panning del canvas arrastrando el fondo en modo edición (cursor grab/grabbing), independiente del zoom
- Compensación de coordenadas en drag/resize para cualquier nivel de zoom
- Márgenes negativos para eliminar espacio vacío de scroll al hacer zoom out

## Test plan

- [ ] Entrar al mapa → verificar auto-fit en modo vista
- [ ] Pulsar "Editar mapa" → mover mesas, zonas y elementos → pulsar "Guardar" → confirmar que todo se cierra
- [ ] Con panel de edición o modal QR abierto → pulsar "Guardar" → confirmar que se cierra
- [ ] Activar plantas → cambiar entre plantas en modo vista → verificar auto-fit por planta
- [ ] Con una sola planta → verificar que el botón General no aparece
- [ ] Eliminar plantas → verificar que sus estructuras y zonas desaparecen de vista general
- [ ] Ctrl+Z / Ctrl+Y → verificar undo/redo
- [ ] Arrastrar desde paleta en vista general → verificar que no crea estructuras
- [ ] Cambiar tamaño del canvas a uno menor → confirmar modal de precaución
- [ ] En modo edición → arrastrar fondo del canvas → verificar panning libre