### PR TITLE
fix(zones): add missing floor column migration

### DIFF
--- a/database/migrations/2026_05_17_000005_add_floor_to_zones.php
+++ b/database/migrations/2026_05_17_000005_add_floor_to_zones.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('zones', function (Blueprint $table) {
+            $table->unsignedTinyInteger('floor')->default(1)->after('rotation');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('zones', function (Blueprint $table) {
+            $table->dropColumn('floor');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- La migración `2026_05_17_000005_add_floor_to_zones.php` estaba en la rama `feat/bloque15-3-frontend-alpine` pero no fue incluida en el PR #190 al hacer merge.
- Esto causaba `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'floor' in zones` al intentar crear zonas en el mapa multi-planta.

## Test plan
- [ ] Ejecutar `php artisan migrate` — debe aplicar la migración sin errores
- [ ] Crear una zona en el mapa de mesas — no debe lanzar error de columna
- [ ] `php artisan test` pasa al 100%