### PR TITLE
[feat] bloque14.5 — componente Blade del menú del día en carta digital

### DIFF
--- a/resources/views/components/daily-menu-availability.blade.php
+++ b/resources/views/components/daily-menu-availability.blade.php
@@ -1,4 +1,5 @@
 {{-- @author SebastianBCF --}}
+{{-- @author Ayrtonalania --}}
 {{-- Indicador de disponibilidad del menú del día.
      Se renderiza dentro del banner (sin x-data propio), hereda el scope Alpine del banner. --}}
 

--- a/resources/views/components/daily-menu-banner.blade.php
+++ b/resources/views/components/daily-menu-banner.blade.php
@@ -1,4 +1,5 @@
 {{-- @author SebastianBCF --}}
+{{-- @author Ayrtonalania --}}
 {{-- Banner del Menú del Día en la carta digital pública.
      Se inserta al inicio del <main> de la carta, antes de las categorías. --}}
 @props(['hash'])
@@ -15,7 +16,6 @@ window.dailyMenuBanner = function (hash) {
         drink:         'Bebida',
         bread:         'Pan',
     };
-    const OPTIONAL_TYPES = ['dessert', 'coffee', 'drink', 'bread'];
 
     return {
         hash,
@@ -35,6 +35,7 @@ window.dailyMenuBanner = function (hash) {
         enviado:       false,
         errorMsg:      null,
         intentoAvanzar: false,
+        timingRules:   [],
 
         /* ── Computed ───────────────────────────────────────────────── */
         get pasoActualObj() {
@@ -115,46 +116,83 @@ window.dailyMenuBanner = function (hash) {
 
         /* ── Construcción del stepper ───────────────────────────────── */
         _buildFromData(data) {
-            const rules  = data.timing_rules ?? [];
-            const pasos  = [];
-            const timings = {};
+            const sections = data.sections ?? [];
+            const pasos    = [];
+            const timings  = {};
 
-            rules.forEach((rule, idx) => {
-                const roundSecs = (data.sections ?? []).filter(
-                    s => rule.section_types.includes(s.type)
-                );
-                roundSecs.forEach(section => {
+            // Agrupar secciones por round_number de su timing_rule embebida.
+            // La API no devuelve un array timing_rules raíz; cada sección
+            // lleva su regla embebida como section.timing_rule.
+            const byRound = new Map();
+            const noRound = [];
+
+            sections.forEach(section => {
+                const rn = section.timing_rule?.round_number ?? null;
+                if (rn !== null) {
+                    if (!byRound.has(rn)) {
+                        byRound.set(rn, {
+                            round:    rn,
+                            minDelay: section.timing_rule.estimated_prep_minutes,
+                            sections: [],
+                        });
+                        timings[rn] = section.timing_rule.default_delay_minutes;
+                    }
+                    byRound.get(rn).sections.push(section);
+                } else {
+                    noRound.push(section);
+                }
+            });
+
+            const rounds = [...byRound.values()].sort((a, b) => a.round - b.round);
+
+            // Secciones sin regla de timing van primero
+            noRound.forEach(section => {
+                pasos.push({
+                    tipo:      'seleccion',
+                    sectionId: section.id,
+                    label:     SECTION_LABELS[section.type] ?? section.type,
+                    required:  section.is_required,
+                    round:     null,
+                    section,
+                });
+            });
+
+            // Secciones con timing, intercaladas con pasos de timing
+            rounds.forEach((group, idx) => {
+                group.sections.forEach(section => {
                     pasos.push({
                         tipo:      'seleccion',
                         sectionId: section.id,
                         label:     SECTION_LABELS[section.type] ?? section.type,
-                        required:  !OPTIONAL_TYPES.includes(section.type),
-                        round:     rule.round_number,
+                        required:  section.is_required,
+                        round:     group.round,
                         section,
                     });
                 });
-                timings[rule.round_number] = rule.default_delay_minutes;
 
-                if (idx < rules.length - 1) {
-                    const nextRule = rules[idx + 1];
-                    const nextSec  = (data.sections ?? []).find(
-                        s => nextRule.section_types.includes(s.type)
-                    );
-                    const nextName = nextSec
+                if (idx < rounds.length - 1) {
+                    const nextGroup = rounds[idx + 1];
+                    const nextSec   = nextGroup.sections[0];
+                    const nextName  = nextSec
                         ? (SECTION_LABELS[nextSec.type] ?? nextSec.type).toLowerCase()
                         : 'el siguiente plato';
                     pasos.push({
                         tipo:     'timing',
-                        round:    nextRule.round_number,
+                        round:    nextGroup.round,
                         label:    `¿Cuándo quieres ${nextName}?`,
-                        minDelay: nextRule.estimated_prep_minutes,
+                        minDelay: nextGroup.minDelay,
                     });
                 }
             });
 
             pasos.push({ tipo: 'confirmacion', label: 'Confirmar pedido' });
-            this.pasos   = pasos;
-            this.timings = timings;
+            this.pasos       = pasos;
+            this.timings     = timings;
+            this.timingRules = rounds;
+        },
+
+        sectionLabel(type) {
+            return SECTION_LABELS[type] ?? type;
         },
 
         /* ── Navegación del stepper ─────────────────────────────────── */
@@ -237,7 +275,7 @@ window.dailyMenuBanner = function (hash) {
                             product_id: sel.product_id,
                             quantity:   1,
                         })),
-                    timing_preferences: Object.entries(this.timings).map(([round, delay]) => ({
+                    timing_overrides: Object.entries(this.timings).map(([round, delay]) => ({
                         round:         parseInt(round),
                         delay_minutes: delay,
                     })),
@@ -309,7 +347,7 @@ window.dailyMenuBanner = function (hash) {
                               :key="section.id">
                         <span class="text-xs px-2 py-0.5 rounded-full
                                      bg-white/10 text-blue-100">
-                            <span x-text="section.type_label"></span>
+                            <span x-text="sectionLabel(section.type)"></span>
                             <span x-show="section.is_free"
                                   class="text-yellow-300"> · incluido</span>
                         </span>

--- a/resources/views/components/daily-menu-exclusivity-dialog.blade.php
+++ b/resources/views/components/daily-menu-exclusivity-dialog.blade.php
@@ -9,7 +9,7 @@
     aria-labelledby="exclusivity-title"
     aria-describedby="exclusivity-desc"
     x-show="showExclusivityWarning"
-    @keydown.escape.window="if (showExclusivityWarning) showExclusivityWarning = false"
+    @keydown.escape.window="if (showExclusivityWarning) { showExclusivityWarning = false; $nextTick(() => $refs.openButton?.focus()); }"
     @keydown.tab.window="
         if (!showExclusivityWarning || !$el.contains(document.activeElement)) return;
         $event.preventDefault();

--- a/resources/views/components/daily-menu-exclusivity-dialog.blade.php
+++ b/resources/views/components/daily-menu-exclusivity-dialog.blade.php
@@ -1,4 +1,5 @@
 {{-- @author SebastianBCF --}}
+{{-- @author Ayrtonalania --}}
 {{-- Dialog de exclusividad: se muestra cuando el usuario tiene ítems en el carrito
      y quiere abrir el menú del día. Hereda el scope Alpine del banner (sin x-data propio). --}}
 

--- a/resources/views/components/daily-menu-stepper.blade.php
+++ b/resources/views/components/daily-menu-stepper.blade.php
@@ -1,4 +1,5 @@
 {{-- @author SebastianBCF --}}
+{{-- @author Ayrtonalania --}}
 {{-- Stepper modal del menú del día.
      Sin x-data propio: hereda todo el scope Alpine del banner.
      Se usa con: <x-daily-menu-stepper :hash="$hash" x-show="open" @close.window="close()" /> --}}
@@ -235,15 +236,15 @@
 
                     {{-- Horarios estimados por ronda --}}
                     <div class="mt-4 pt-4 border-t border-blue-800/40"
-                         x-show="Object.keys(timings).length > 1">
+                         x-show="timingRules.length > 1">
                         <p class="text-blue-400 text-xs font-semibold uppercase tracking-wider mb-2">
                             Horarios estimados
                         </p>
-                        <template x-for="rule in menuData?.timing_rules ?? []" :key="rule.round_number">
+                        <template x-for="rule in timingRules" :key="rule.round">
                             <div class="flex items-center justify-between text-xs text-blue-300 mb-1.5">
-                                <span x-text="`Ronda ${rule.round_number}`"></span>
+                                <span x-text="`Ronda ${rule.round}`"></span>
                                 <span class="font-semibold text-blue-100"
-                                      x-text="horasEstimadas[rule.round_number] ?? '--:--'"></span>
+                                      x-text="horasEstimadas[rule.round] ?? '--:--'"></span>
                             </div>
                         </template>
                     </div>

--- a/resources/views/components/daily-menu-timing-control.blade.php
+++ b/resources/views/components/daily-menu-timing-control.blade.php
@@ -38,7 +38,7 @@
         <div class="text-center min-w-[80px]"
              role="spinbutton"
              :aria-valuemin="pasoActualObj?.minDelay"
-             aria-valuemax="120"
+             :aria-valuemax="120"
              :aria-valuenow="timings[pasoActualObj?.round]"
              :aria-valuetext="timings[pasoActualObj?.round] + ' minutos'">
             <span class="text-5xl font-bold text-white"

--- a/resources/views/components/daily-menu-timing-control.blade.php
+++ b/resources/views/components/daily-menu-timing-control.blade.php
@@ -1,4 +1,5 @@
 {{-- @author SebastianBCF --}}
+{{-- @author Ayrtonalania --}}
 {{-- Control de timing [−] X min [+] para el stepper del menú del día.
      Sin x-data propio: hereda el scope Alpine del banner (pasoActualObj, timings, horasEstimadas). --}}
 


### PR DESCRIPTION
## Qué se implementa

- Corrección de tres bugs críticos en los componentes Blade del Menú del Día creados en el Bloque 14.2:
  - `_buildFromData` leía `data.timing_rules` (campo inexistente en la API); ahora extrae las reglas de timing de `section.timing_rule` agrupando por `round_number`
  - `submitOrder` enviaba `timing_preferences` al servidor; la API valida `timing_overrides`
  - El template usaba `section.type_label` (no existe en la respuesta de la API); ahora usa `sectionLabel(type)` con el mapa `SECTION_LABELS`
- Corrección del loop de horarios estimados en el paso de confirmación del stepper: usaba `menuData?.timing_rules` (inexistente) en lugar del array `timingRules` construido localmente
- Fix de accesibilidad: `aria-valuemax` pasa a ser binding dinámico (`:aria-valuemax`) para consistencia con `aria-valuemin` y `aria-valuenow`
- Fix de accesibilidad: Escape en el dialog de exclusividad ahora devuelve el foco al botón de apertura (`$refs.openButton`)
- `@author Ayrtonalania` añadido a los 5 componentes Blade

## Decisiones de diseño aplicadas

- Patrón de presentación: Card destacada full-width con gradiente Zampa (`#2E50B0` → `#1A3380`), según aprobado en Bloque 14.0
- Control de timing: `[−] X min [+]` con `aria-spinbutton` completo y hora estimada en tiempo real con `aria-live="polite"`
- Exclusividad: `alertdialog` de advertencia antes de abrir el stepper si hay ítems à la carte; focus trap + Escape funcionan correctamente

## Checklist CLAUDE.md

- [x] `php artisan test --parallel` pasa al 100% (702 tests, 0 fallos)
- [x] `npm run build` sin errores ni warnings
- [x] Un commit por archivo modificado
- [x] `@author Ayrtonalania` añadido según regla CASO B (ya existía `@author SebastianBCF`)
- [x] Reviewer ha dado SHIP IT