### PR TITLE
[test] bloque14.6 — tests completos del menú del día

### DIFF
--- a/app/Http/Controllers/DailyMenuController.php
+++ b/app/Http/Controllers/DailyMenuController.php
@@ -38,7 +38,15 @@ class DailyMenuController extends Controller
             ->withCount('sections')
             ->orderByRaw("CASE WHEN specific_date IS NOT NULL THEN 0 ELSE 1 END")
             ->orderBy('specific_date')
-            ->orderByRaw("FIELD(day_of_week, 'monday','tuesday','wednesday','thursday','friday','saturday','sunday')")
+            ->orderByRaw("CASE day_of_week
+                WHEN 'monday'    THEN 1
+                WHEN 'tuesday'   THEN 2
+                WHEN 'wednesday' THEN 3
+                WHEN 'thursday'  THEN 4
+                WHEN 'friday'    THEN 5
+                WHEN 'saturday'  THEN 6
+                WHEN 'sunday'    THEN 7
+                ELSE 8 END")
             ->paginate(15);
 
         $weekDays = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
@@ -115,7 +123,7 @@ class DailyMenuController extends Controller
 
         if (!empty($validated['specific_date'])) {
             $exists = DailyMenu::where('user_id', $ownerId)
-                ->where('specific_date', $validated['specific_date'])
+                ->whereDate('specific_date', $validated['specific_date'])
                 ->where('is_active', true)
                 ->exists();
 
@@ -187,7 +195,7 @@ class DailyMenuController extends Controller
 
         if (!empty($validated['specific_date'])) {
             $exists = DailyMenu::where('user_id', $ownerId)
-                ->where('specific_date', $validated['specific_date'])
+                ->whereDate('specific_date', $validated['specific_date'])
                 ->where('is_active', true)
                 ->where('id', '!=', $dailyMenu->id)
                 ->exists();

--- a/tests/Feature/Bloque14/DailyMenuAdminTest.php
+++ b/tests/Feature/Bloque14/DailyMenuAdminTest.php
@@ -1,0 +1,483 @@
+<?php
+
+use App\Models\Category;
+use App\Models\DailyMenu;
+use App\Models\DailyMenuSection;
+use App\Models\Plan;
+use App\Models\Product;
+use App\Models\User;
+
+beforeEach(function () {
+    $plan        = Plan::factory()->create();
+    $this->user  = User::factory()->admin()->create(['plan_id' => $plan->id]);
+    $this->other = User::factory()->admin()->create(['plan_id' => $plan->id]);
+});
+
+// ─── Auth ────────────────────────────────────────────────────────────────────
+
+it('redirects unauthenticated user away from daily menus index', function () {
+    $this->get(route('daily-menus.index'))
+        ->assertRedirect(route('login'));
+});
+
+it('redirects unauthenticated user away from daily menus create', function () {
+    $this->get(route('daily-menus.create'))
+        ->assertRedirect(route('login'));
+});
+
+it('redirects unauthenticated user away from daily menus edit', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+
+    $this->get(route('daily-menus.edit', $menu))
+        ->assertRedirect(route('login'));
+});
+
+// ─── Index ───────────────────────────────────────────────────────────────────
+
+it('shows daily menus index to authenticated user', function () {
+    $this->actingAs($this->user)
+        ->get(route('daily-menus.index'))
+        ->assertOk();
+});
+
+it('shows only the authenticated users daily menus', function () {
+    DailyMenu::factory()->create(['user_id' => $this->user->id, 'title' => 'Mi Menú']);
+    DailyMenu::factory()->create(['user_id' => $this->other->id, 'title' => 'Menú Ajeno']);
+
+    $this->actingAs($this->user)
+        ->get(route('daily-menus.index'))
+        ->assertSee('Mi Menú')
+        ->assertDontSee('Menú Ajeno');
+});
+
+// ─── Store ───────────────────────────────────────────────────────────────────
+
+it('creates a daily menu with a day of week', function () {
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.store'), [
+            'title'       => 'Menú del Lunes',
+            'price'       => 12.50,
+            'day_of_week' => 'monday',
+        ])
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('daily_menus', [
+        'user_id'     => $this->user->id,
+        'title'       => 'Menú del Lunes',
+        'day_of_week' => 'monday',
+    ]);
+});
+
+it('creates a daily menu with a specific date', function () {
+    $date = now()->addDays(3)->toDateString();
+
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.store'), [
+            'title'         => 'Menú Especial',
+            'price'         => 15.00,
+            'specific_date' => $date,
+        ])
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('daily_menus', [
+        'user_id' => $this->user->id,
+        'title'   => 'Menú Especial',
+    ]);
+});
+
+it('assigns the authenticated user id when creating a daily menu', function () {
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.store'), [
+            'title'       => 'Menú',
+            'price'       => 10.00,
+            'day_of_week' => 'tuesday',
+        ]);
+
+    $this->assertDatabaseHas('daily_menus', ['user_id' => $this->user->id]);
+});
+
+it('fails to create a daily menu without title', function () {
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.store'), [
+            'price'       => 10.00,
+            'day_of_week' => 'monday',
+        ])
+        ->assertSessionHasErrors('title');
+});
+
+it('fails to create a daily menu without price', function () {
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.store'), [
+            'title'       => 'Menú',
+            'day_of_week' => 'monday',
+        ])
+        ->assertSessionHasErrors('price');
+});
+
+it('fails to create a daily menu without day or specific date', function () {
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.store'), [
+            'title' => 'Menú',
+            'price' => 10.00,
+        ])
+        ->assertSessionHasErrors(['day_of_week', 'specific_date']);
+});
+
+it('fails to create a daily menu when active one already exists for that day', function () {
+    DailyMenu::factory()->create([
+        'user_id'     => $this->user->id,
+        'day_of_week' => 'friday',
+        'is_active'   => true,
+    ]);
+
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.store'), [
+            'title'       => 'Otro Menú Viernes',
+            'price'       => 11.00,
+            'day_of_week' => 'friday',
+        ])
+        ->assertSessionHasErrors('day_of_week');
+});
+
+it('fails to create a daily menu when active one already exists for that specific date', function () {
+    $date = now()->addDays(2)->toDateString();
+
+    DailyMenu::factory()->create([
+        'user_id'       => $this->user->id,
+        'specific_date' => $date,
+        'day_of_week'   => null,
+        'is_active'     => true,
+    ]);
+
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.store'), [
+            'title'         => 'Menú Duplicado',
+            'price'         => 11.00,
+            'specific_date' => $date,
+        ])
+        ->assertSessionHasErrors('specific_date');
+});
+
+it('flash success message after creating a daily menu', function () {
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.store'), [
+            'title'       => 'Menú Flash',
+            'price'       => 10.00,
+            'day_of_week' => 'saturday',
+        ])
+        ->assertSessionHas('success');
+});
+
+// ─── Edit ────────────────────────────────────────────────────────────────────
+
+it('shows the edit form to the menu owner', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+
+    $this->actingAs($this->user)
+        ->get(route('daily-menus.edit', $menu))
+        ->assertOk();
+});
+
+it('returns 403 when non-owner tries to edit a daily menu', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->other->id]);
+
+    $this->actingAs($this->user)
+        ->get(route('daily-menus.edit', $menu))
+        ->assertForbidden();
+});
+
+// ─── Update ──────────────────────────────────────────────────────────────────
+
+it('updates a daily menu with valid data', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->user->id, 'day_of_week' => 'monday']);
+
+    $this->actingAs($this->user)
+        ->put(route('daily-menus.update', $menu), [
+            'title'       => 'Menú Actualizado',
+            'price'       => 14.00,
+            'day_of_week' => 'monday',
+        ])
+        ->assertRedirect(route('daily-menus.index'));
+
+    $this->assertDatabaseHas('daily_menus', [
+        'id'    => $menu->id,
+        'title' => 'Menú Actualizado',
+    ]);
+});
+
+it('returns 403 when non-owner tries to update a daily menu', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->other->id, 'day_of_week' => 'monday']);
+
+    $this->actingAs($this->user)
+        ->put(route('daily-menus.update', $menu), [
+            'title'       => 'Hack',
+            'price'       => 1.00,
+            'day_of_week' => 'monday',
+        ])
+        ->assertForbidden();
+});
+
+it('flash success message after updating a daily menu', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->user->id, 'day_of_week' => 'monday']);
+
+    $this->actingAs($this->user)
+        ->put(route('daily-menus.update', $menu), [
+            'title'       => 'Menú Actualizado',
+            'price'       => 14.00,
+            'day_of_week' => 'monday',
+        ])
+        ->assertSessionHas('success');
+});
+
+// ─── Destroy ─────────────────────────────────────────────────────────────────
+
+it('deletes a daily menu owned by the user', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+
+    $this->actingAs($this->user)
+        ->delete(route('daily-menus.destroy', $menu))
+        ->assertRedirect(route('daily-menus.index'));
+
+    $this->assertDatabaseMissing('daily_menus', ['id' => $menu->id]);
+});
+
+it('returns 403 when non-owner tries to delete a daily menu', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->other->id]);
+
+    $this->actingAs($this->user)
+        ->delete(route('daily-menus.destroy', $menu))
+        ->assertForbidden();
+});
+
+it('flash success message after deleting a daily menu', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+
+    $this->actingAs($this->user)
+        ->delete(route('daily-menus.destroy', $menu))
+        ->assertSessionHas('success');
+});
+
+// ─── Sections view ───────────────────────────────────────────────────────────
+
+it('shows the sections configuration to the menu owner', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+
+    $this->actingAs($this->user)
+        ->get(route('daily-menus.sections', $menu))
+        ->assertOk();
+});
+
+it('returns 403 when non-owner views sections of a daily menu', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->other->id]);
+
+    $this->actingAs($this->user)
+        ->get(route('daily-menus.sections', $menu))
+        ->assertForbidden();
+});
+
+// ─── storeSection ────────────────────────────────────────────────────────────
+
+it('adds a section to a daily menu', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.sections.store', $menu), [
+            'section_type' => 'first_course',
+        ])
+        ->assertRedirect(route('daily-menus.sections', $menu));
+
+    $this->assertDatabaseHas('daily_menu_sections', [
+        'daily_menu_id' => $menu->id,
+        'type'          => 'first_course',
+    ]);
+});
+
+it('prevents adding a duplicate section type to a daily menu', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+    DailyMenuSection::factory()->create([
+        'daily_menu_id' => $menu->id,
+        'type'          => 'dessert',
+    ]);
+
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.sections.store', $menu), [
+            'section_type' => 'dessert',
+        ])
+        ->assertSessionHas('error');
+});
+
+it('returns 403 when non-owner adds a section', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->other->id]);
+
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.sections.store', $menu), [
+            'section_type' => 'first_course',
+        ])
+        ->assertForbidden();
+});
+
+// ─── destroySection ──────────────────────────────────────────────────────────
+
+it('removes a section from a daily menu', function () {
+    $menu    = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+    $section = DailyMenuSection::factory()->create(['daily_menu_id' => $menu->id]);
+
+    $this->actingAs($this->user)
+        ->delete(route('daily-menus.sections.destroy', [$menu, $section]))
+        ->assertRedirect(route('daily-menus.sections', $menu));
+
+    $this->assertDatabaseMissing('daily_menu_sections', ['id' => $section->id]);
+});
+
+it('returns 403 when non-owner deletes a section', function () {
+    $menu    = DailyMenu::factory()->create(['user_id' => $this->other->id]);
+    $section = DailyMenuSection::factory()->create(['daily_menu_id' => $menu->id]);
+
+    $this->actingAs($this->user)
+        ->delete(route('daily-menus.sections.destroy', [$menu, $section]))
+        ->assertForbidden();
+});
+
+it('returns 403 when section does not belong to the given daily menu', function () {
+    $menu      = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+    $otherMenu = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+    $section   = DailyMenuSection::factory()->create(['daily_menu_id' => $otherMenu->id]);
+
+    $this->actingAs($this->user)
+        ->delete(route('daily-menus.sections.destroy', [$menu, $section]))
+        ->assertForbidden();
+});
+
+// ─── syncProducts ────────────────────────────────────────────────────────────
+
+it('syncs products to a section', function () {
+    $menu     = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+    $section  = DailyMenuSection::factory()->create(['daily_menu_id' => $menu->id]);
+    $category = Category::factory()->create(['user_id' => $this->user->id]);
+    $product  = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $category->id]);
+
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.sync-products', [$menu, $section]), [
+            'product_ids' => [$product->id],
+        ])
+        ->assertRedirect(route('daily-menus.sections', $menu));
+
+    $this->assertDatabaseHas('daily_menu_section_products', [
+        'daily_menu_section_id' => $section->id,
+        'product_id'            => $product->id,
+    ]);
+});
+
+it('returns 403 when syncing products from another user', function () {
+    $menu        = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+    $section     = DailyMenuSection::factory()->create(['daily_menu_id' => $menu->id]);
+    $otherCat    = Category::factory()->create(['user_id' => $this->other->id]);
+    $otherProduct = Product::factory()->create(['user_id' => $this->other->id, 'category_id' => $otherCat->id]);
+
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.sync-products', [$menu, $section]), [
+            'product_ids' => [$otherProduct->id],
+        ])
+        ->assertForbidden();
+});
+
+it('returns 403 when non-owner syncs products', function () {
+    $menu    = DailyMenu::factory()->create(['user_id' => $this->other->id]);
+    $section = DailyMenuSection::factory()->create(['daily_menu_id' => $menu->id]);
+
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.sync-products', [$menu, $section]), [
+            'product_ids' => [],
+        ])
+        ->assertForbidden();
+});
+
+it('flash success message after syncing products', function () {
+    $menu    = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+    $section = DailyMenuSection::factory()->create(['daily_menu_id' => $menu->id]);
+
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.sync-products', [$menu, $section]), [
+            'product_ids' => [],
+        ])
+        ->assertSessionHas('success');
+});
+
+// ─── storeTiming ─────────────────────────────────────────────────────────────
+
+it('saves timing rules for a daily menu', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.timing', $menu), [
+            'rounds' => [
+                [
+                    'round_number'           => 1,
+                    'default_delay_minutes'  => 0,
+                    'estimated_prep_minutes' => 10,
+                    'section_types'          => ['first_course'],
+                ],
+                [
+                    'round_number'           => 2,
+                    'default_delay_minutes'  => 30,
+                    'estimated_prep_minutes' => 10,
+                    'section_types'          => ['second_course', 'dessert'],
+                ],
+            ],
+        ])
+        ->assertRedirect(route('daily-menus.sections', $menu));
+
+    $this->assertDatabaseHas('daily_menu_timing_rules', [
+        'daily_menu_id' => $menu->id,
+        'round_number'  => 1,
+    ]);
+    $this->assertDatabaseHas('daily_menu_timing_rules', [
+        'daily_menu_id' => $menu->id,
+        'round_number'  => 2,
+    ]);
+});
+
+it('replaces existing timing rules on save', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->user->id]);
+    $menu->timingRules()->create([
+        'round_number'           => 1,
+        'default_delay_minutes'  => 5,
+        'estimated_prep_minutes' => 5,
+        'section_types'          => ['bread'],
+    ]);
+
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.timing', $menu), [
+            'rounds' => [
+                [
+                    'round_number'           => 1,
+                    'default_delay_minutes'  => 20,
+                    'estimated_prep_minutes' => 15,
+                    'section_types'          => ['first_course'],
+                ],
+            ],
+        ]);
+
+    $this->assertEquals(1, $menu->timingRules()->count());
+    $this->assertDatabaseHas('daily_menu_timing_rules', [
+        'daily_menu_id'         => $menu->id,
+        'default_delay_minutes' => 20,
+    ]);
+});
+
+it('returns 403 when non-owner saves timing', function () {
+    $menu = DailyMenu::factory()->create(['user_id' => $this->other->id]);
+
+    $this->actingAs($this->user)
+        ->post(route('daily-menus.timing', $menu), [
+            'rounds' => [
+                [
+                    'round_number'           => 1,
+                    'default_delay_minutes'  => 0,
+                    'estimated_prep_minutes' => 10,
+                    'section_types'          => ['first_course'],
+                ],
+            ],
+        ])
+        ->assertForbidden();
+});

--- a/tests/Feature/Bloque14/DailyMenuOrderTest.php
+++ b/tests/Feature/Bloque14/DailyMenuOrderTest.php
@@ -217,29 +217,3 @@ it('creates order items with queued status', function () {
     $item = OrderItem::where('order_id', $this->order->id)->first();
     expect($item->status)->toBe('queued');
 });
-
-// ─── Timing calculation ──────────────────────────────────────────────────────
-
-it('delay is zero when client delay equals estimated prep time', function () {
-    $clientDelay   = 10;
-    $estimatedPrep = 10;
-    $delaySeconds  = max(0, ($clientDelay - $estimatedPrep) * 60);
-
-    expect($delaySeconds)->toBe(0);
-});
-
-it('delay is zero when client delay is less than estimated prep time', function () {
-    $clientDelay   = 5;
-    $estimatedPrep = 10;
-    $delaySeconds  = max(0, ($clientDelay - $estimatedPrep) * 60);
-
-    expect($delaySeconds)->toBe(0);
-});
-
-it('delay is positive when client delay exceeds estimated prep time', function () {
-    $clientDelay   = 30;
-    $estimatedPrep = 10;
-    $delaySeconds  = max(0, ($clientDelay - $estimatedPrep) * 60);
-
-    expect($delaySeconds)->toBe(1200);
-});

--- a/tests/Feature/Bloque14/DailyMenuOrderTest.php
+++ b/tests/Feature/Bloque14/DailyMenuOrderTest.php
@@ -1,0 +1,245 @@
+<?php
+
+use App\Jobs\SendDailyMenuRound;
+use App\Models\Category;
+use App\Models\DailyMenu;
+use App\Models\DailyMenuOrder;
+use App\Models\DailyMenuOrderSelection;
+use App\Models\DailyMenuSection;
+use App\Models\DailyMenuTimingRule;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Plan;
+use App\Models\Product;
+use App\Models\Table;
+use App\Models\User;
+use App\Services\DailyMenuOrderService;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(function () {
+    $plan        = Plan::factory()->create();
+    $this->user  = User::factory()->admin()->create(['plan_id' => $plan->id]);
+
+    $this->table = Table::factory()->create(['user_id' => $this->user->id]);
+
+    $today = strtolower(now()->englishDayOfWeek);
+
+    $this->menu = DailyMenu::factory()->create([
+        'user_id'     => $this->user->id,
+        'day_of_week' => $today,
+        'is_active'   => true,
+        'price'       => 12.00,
+    ]);
+
+    $this->category = Category::factory()->create([
+        'user_id'     => $this->user->id,
+        'destination' => 'kitchen',
+    ]);
+
+    $this->product = Product::factory()->create([
+        'user_id'     => $this->user->id,
+        'category_id' => $this->category->id,
+        'price'       => 8.00,
+    ]);
+
+    $this->section = DailyMenuSection::factory()->create([
+        'daily_menu_id' => $this->menu->id,
+        'type'          => 'first_course',
+        'is_required'   => true,
+        'is_free'       => false,
+    ]);
+
+    $this->section->products()->attach($this->product->id);
+
+    $this->timingRule = DailyMenuTimingRule::factory()->create([
+        'daily_menu_id'          => $this->menu->id,
+        'round_number'           => 1,
+        'default_delay_minutes'  => 0,
+        'estimated_prep_minutes' => 10,
+        'section_types'          => ['first_course'],
+    ]);
+
+    $this->order = Order::factory()->create([
+        'table_id' => $this->table->id,
+        'status'   => 'pending',
+        'total'    => $this->menu->price,
+    ]);
+
+    $this->dailyMenuOrder = DailyMenuOrder::factory()->create([
+        'order_id'      => $this->order->id,
+        'daily_menu_id' => $this->menu->id,
+        'rounds_total'  => 1,
+        'current_round' => 0,
+        'status'        => 'pending',
+    ]);
+
+    DailyMenuOrderSelection::factory()->create([
+        'daily_menu_order_id'   => $this->dailyMenuOrder->id,
+        'daily_menu_section_id' => $this->section->id,
+        'product_id'            => $this->product->id,
+        'quantity'              => 1,
+    ]);
+});
+
+// ─── DailyMenuOrderService::dispatchRounds ───────────────────────────────────
+
+it('dispatches one job per timing rule', function () {
+    Queue::fake();
+
+    $rules = $this->menu->timingRules;
+    DailyMenuOrderService::dispatchRounds($this->dailyMenuOrder, $rules, []);
+
+    Queue::assertPushed(SendDailyMenuRound::class, 1);
+});
+
+it('dispatches a job with the correct round number', function () {
+    Queue::fake();
+
+    $rules = $this->menu->timingRules;
+    DailyMenuOrderService::dispatchRounds($this->dailyMenuOrder, $rules, []);
+
+    Queue::assertPushed(SendDailyMenuRound::class, function ($job) {
+        return $job->round === 1;
+    });
+});
+
+it('dispatches two jobs for two timing rules', function () {
+    Queue::fake();
+
+    DailyMenuTimingRule::factory()->create([
+        'daily_menu_id'          => $this->menu->id,
+        'round_number'           => 2,
+        'default_delay_minutes'  => 30,
+        'estimated_prep_minutes' => 10,
+        'section_types'          => ['second_course'],
+    ]);
+
+    $rules = $this->menu->timingRules()->orderBy('round_number')->get();
+    DailyMenuOrderService::dispatchRounds($this->dailyMenuOrder, $rules, []);
+
+    Queue::assertPushed(SendDailyMenuRound::class, 2);
+});
+
+// ─── SendDailyMenuRound Job ──────────────────────────────────────────────────
+
+it('creates order items when the job runs', function () {
+    $job = new SendDailyMenuRound($this->dailyMenuOrder, 1);
+    $job->handle();
+
+    $this->assertDatabaseHas('order_items', [
+        'order_id'      => $this->order->id,
+        'product_id'    => $this->product->id,
+        'is_daily_menu' => 1,
+    ]);
+});
+
+it('sets is_daily_menu to true on the created order item', function () {
+    $job = new SendDailyMenuRound($this->dailyMenuOrder, 1);
+    $job->handle();
+
+    $item = OrderItem::where('order_id', $this->order->id)->first();
+    expect($item->is_daily_menu)->toBeTrue();
+});
+
+it('sets the destination from the product category', function () {
+    $job = new SendDailyMenuRound($this->dailyMenuOrder, 1);
+    $job->handle();
+
+    $item = OrderItem::where('order_id', $this->order->id)->first();
+    expect($item->destination)->toBe('kitchen');
+});
+
+it('sets price to product price when section is not free', function () {
+    $job = new SendDailyMenuRound($this->dailyMenuOrder, 1);
+    $job->handle();
+
+    $item = OrderItem::where('order_id', $this->order->id)->first();
+    expect((float) $item->price)->toBe(8.00);
+});
+
+it('sets price to 0 when section is free', function () {
+    $this->section->update(['is_free' => true]);
+
+    $job = new SendDailyMenuRound($this->dailyMenuOrder, 1);
+    $job->handle();
+
+    $item = OrderItem::where('order_id', $this->order->id)->first();
+    expect((float) $item->price)->toBe(0.0);
+});
+
+it('updates current_round after the job runs', function () {
+    $job = new SendDailyMenuRound($this->dailyMenuOrder, 1);
+    $job->handle();
+
+    $this->dailyMenuOrder->refresh();
+    expect($this->dailyMenuOrder->current_round)->toBe(1);
+});
+
+it('marks the daily menu order as completed when the last round runs', function () {
+    $job = new SendDailyMenuRound($this->dailyMenuOrder, 1);
+    $job->handle();
+
+    $this->dailyMenuOrder->refresh();
+    expect($this->dailyMenuOrder->status)->toBe('completed');
+});
+
+it('does not mark as completed when there are more rounds pending', function () {
+    $this->dailyMenuOrder->update(['rounds_total' => 2]);
+
+    $job = new SendDailyMenuRound($this->dailyMenuOrder, 1);
+    $job->handle();
+
+    $this->dailyMenuOrder->refresh();
+    expect($this->dailyMenuOrder->status)->toBe('pending');
+});
+
+it('skips processing when the daily menu order is cancelled', function () {
+    $this->dailyMenuOrder->update(['status' => 'cancelled']);
+
+    $job = new SendDailyMenuRound($this->dailyMenuOrder, 1);
+    $job->handle();
+
+    $this->assertDatabaseMissing('order_items', ['order_id' => $this->order->id]);
+});
+
+it('does not create order items when the timing rule does not match', function () {
+    // Round 2 does not exist in timing rules → job skips
+    $job = new SendDailyMenuRound($this->dailyMenuOrder, 99);
+    $job->handle();
+
+    $this->assertDatabaseMissing('order_items', ['order_id' => $this->order->id]);
+});
+
+it('creates order items with queued status', function () {
+    $job = new SendDailyMenuRound($this->dailyMenuOrder, 1);
+    $job->handle();
+
+    $item = OrderItem::where('order_id', $this->order->id)->first();
+    expect($item->status)->toBe('queued');
+});
+
+// ─── Timing calculation ──────────────────────────────────────────────────────
+
+it('delay is zero when client delay equals estimated prep time', function () {
+    $clientDelay   = 10;
+    $estimatedPrep = 10;
+    $delaySeconds  = max(0, ($clientDelay - $estimatedPrep) * 60);
+
+    expect($delaySeconds)->toBe(0);
+});
+
+it('delay is zero when client delay is less than estimated prep time', function () {
+    $clientDelay   = 5;
+    $estimatedPrep = 10;
+    $delaySeconds  = max(0, ($clientDelay - $estimatedPrep) * 60);
+
+    expect($delaySeconds)->toBe(0);
+});
+
+it('delay is positive when client delay exceeds estimated prep time', function () {
+    $clientDelay   = 30;
+    $estimatedPrep = 10;
+    $delaySeconds  = max(0, ($clientDelay - $estimatedPrep) * 60);
+
+    expect($delaySeconds)->toBe(1200);
+});

--- a/tests/Feature/Bloque14/DailyMenuPublicTest.php
+++ b/tests/Feature/Bloque14/DailyMenuPublicTest.php
@@ -323,6 +323,8 @@ it('returns 422 when timing override is below the estimated prep time', function
     ])->assertStatus(422);
 });
 
+// Note: lockForUpdate() is a no-op on SQLite, so this test verifies the count
+// threshold logic only. The race-condition guard is exercised only on MySQL/MariaDB.
 it('returns 409 when the menu is sold out', function () {
     ['menu' => $menu, 'section' => $section, 'product' => $product] = buildTodayMenu($this->user->id);
     $menu->update(['max_per_day' => 1]);

--- a/tests/Feature/Bloque14/DailyMenuPublicTest.php
+++ b/tests/Feature/Bloque14/DailyMenuPublicTest.php
@@ -1,0 +1,394 @@
+<?php
+
+use App\Models\Category;
+use App\Models\DailyMenu;
+use App\Models\DailyMenuOrder;
+use App\Models\DailyMenuSection;
+use App\Models\DailyMenuTimingRule;
+use App\Models\Order;
+use App\Models\Plan;
+use App\Models\Product;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Support\Facades\Queue;
+
+beforeEach(function () {
+    $plan        = Plan::factory()->create();
+    $this->user  = User::factory()->admin()->create(['plan_id' => $plan->id]);
+    $this->other = User::factory()->admin()->create(['plan_id' => $plan->id]);
+
+    $this->table = Table::factory()->create(['user_id' => $this->user->id]);
+});
+
+// ─── Helper ──────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a fully configured daily menu for today with one section and one product.
+ * Returns an array with menu, section, and product.
+ */
+function buildTodayMenu($userId): array
+{
+    $today = strtolower(now()->englishDayOfWeek);
+
+    $menu = DailyMenu::factory()->create([
+        'user_id'     => $userId,
+        'day_of_week' => $today,
+        'is_active'   => true,
+        'price'       => 12.00,
+    ]);
+
+    $section = DailyMenuSection::factory()->create([
+        'daily_menu_id' => $menu->id,
+        'type'          => 'first_course',
+        'is_required'   => true,
+        'is_free'       => false,
+    ]);
+
+    $category = Category::factory()->create(['user_id' => $userId, 'destination' => 'kitchen']);
+    $product  = Product::factory()->create(['user_id' => $userId, 'category_id' => $category->id]);
+
+    $section->products()->attach($product->id);
+
+    return compact('menu', 'section', 'product');
+}
+
+// ─── GET /api/v1/menu/{hash}/daily-menu ──────────────────────────────────────
+
+it('returns 404 for an invalid table hash on show', function () {
+    $this->getJson('/api/v1/menu/invalid-hash/daily-menu')
+        ->assertStatus(404);
+});
+
+it('returns data null when no daily menu is active today', function () {
+    $this->getJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu")
+        ->assertOk()
+        ->assertJson(['success' => true, 'data' => null]);
+});
+
+it('returns the active daily menu for today', function () {
+    ['menu' => $menu] = buildTodayMenu($this->user->id);
+
+    $this->getJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu")
+        ->assertOk()
+        ->assertJsonPath('data.menu.id', $menu->id)
+        ->assertJsonPath('data.menu.title', $menu->title);
+});
+
+it('includes sections in the response', function () {
+    ['section' => $section] = buildTodayMenu($this->user->id);
+
+    $response = $this->getJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu");
+
+    $response->assertOk();
+    $sections = $response->json('data.sections');
+    expect($sections)->toHaveCount(1);
+    expect($sections[0]['id'])->toBe($section->id);
+});
+
+it('embeds timing_rule inside each section', function () {
+    ['menu' => $menu, 'section' => $section] = buildTodayMenu($this->user->id);
+
+    DailyMenuTimingRule::factory()->create([
+        'daily_menu_id'          => $menu->id,
+        'round_number'           => 1,
+        'default_delay_minutes'  => 0,
+        'estimated_prep_minutes' => 10,
+        'section_types'          => ['first_course'],
+    ]);
+
+    $response = $this->getJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu");
+
+    $response->assertOk();
+    $sections = $response->json('data.sections');
+    expect($sections[0]['timing_rule'])->not->toBeNull();
+    expect($sections[0]['timing_rule']['round_number'])->toBe(1);
+});
+
+it('returns timing_rule null for sections without a timing rule', function () {
+    buildTodayMenu($this->user->id);
+
+    $response = $this->getJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu");
+
+    $response->assertOk();
+    $sections = $response->json('data.sections');
+    expect($sections[0]['timing_rule'])->toBeNull();
+});
+
+it('returns available count when max_per_day is set', function () {
+    ['menu' => $menu] = buildTodayMenu($this->user->id);
+    $menu->update(['max_per_day' => 5]);
+
+    $order = Order::factory()->create(['table_id' => $this->table->id, 'status' => 'pending']);
+    DailyMenuOrder::factory()->create([
+        'daily_menu_id' => $menu->id,
+        'order_id'      => $order->id,
+        'status'        => 'pending',
+    ]);
+
+    $this->getJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu")
+        ->assertOk()
+        ->assertJsonPath('data.menu.available_count', 4);
+});
+
+it('returns available count null when max_per_day is not set', function () {
+    buildTodayMenu($this->user->id);
+
+    $this->getJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu")
+        ->assertOk()
+        ->assertJsonPath('data.menu.available_count', null);
+});
+
+it('does not return a daily menu from another restaurant', function () {
+    buildTodayMenu($this->other->id);
+
+    $this->getJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu")
+        ->assertOk()
+        ->assertJsonPath('data', null);
+});
+
+it('does not return an inactive daily menu', function () {
+    $today = strtolower(now()->englishDayOfWeek);
+    DailyMenu::factory()->create([
+        'user_id'     => $this->user->id,
+        'day_of_week' => $today,
+        'is_active'   => false,
+    ]);
+
+    $this->getJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu")
+        ->assertOk()
+        ->assertJsonPath('data', null);
+});
+
+// ─── POST /api/v1/menu/{hash}/daily-menu/order ───────────────────────────────
+
+it('returns 404 when ordering with an invalid table hash', function () {
+    $this->postJson('/api/v1/menu/invalid-hash/daily-menu/order', [
+        'selections' => [['section_id' => 1, 'product_id' => 1, 'quantity' => 1]],
+    ])->assertStatus(404);
+});
+
+it('returns 404 when no daily menu is available today', function () {
+    $this->postJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu/order", [
+        'selections' => [['section_id' => 1, 'product_id' => 1, 'quantity' => 1]],
+    ])->assertStatus(404);
+});
+
+it('returns 409 when the table has a la carte orders pending', function () {
+    ['menu' => $menu, 'section' => $section, 'product' => $product] = buildTodayMenu($this->user->id);
+
+    $order = Order::factory()->create(['table_id' => $this->table->id, 'status' => 'pending']);
+
+    $this->postJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu/order", [
+        'selections' => [[
+            'section_id' => $section->id,
+            'product_id' => $product->id,
+            'quantity'   => 1,
+        ]],
+    ])->assertStatus(409);
+});
+
+it('creates a daily menu order successfully', function () {
+    Queue::fake();
+    ['menu' => $menu, 'section' => $section, 'product' => $product] = buildTodayMenu($this->user->id);
+
+    $this->postJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu/order", [
+        'selections' => [[
+            'section_id' => $section->id,
+            'product_id' => $product->id,
+            'quantity'   => 1,
+        ]],
+    ])->assertCreated()
+      ->assertJsonPath('success', true);
+
+    $this->assertDatabaseHas('orders', [
+        'table_id' => $this->table->id,
+        'status'   => 'pending',
+    ]);
+});
+
+it('creates a daily_menu_order record linked to the order', function () {
+    Queue::fake();
+    ['menu' => $menu, 'section' => $section, 'product' => $product] = buildTodayMenu($this->user->id);
+
+    $this->postJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu/order", [
+        'selections' => [[
+            'section_id' => $section->id,
+            'product_id' => $product->id,
+            'quantity'   => 1,
+        ]],
+    ])->assertCreated();
+
+    $this->assertDatabaseHas('daily_menu_orders', [
+        'daily_menu_id' => $menu->id,
+        'status'        => 'pending',
+    ]);
+});
+
+it('stores the customer selections in daily_menu_order_selections', function () {
+    Queue::fake();
+    ['section' => $section, 'product' => $product] = buildTodayMenu($this->user->id);
+
+    $this->postJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu/order", [
+        'selections' => [[
+            'section_id' => $section->id,
+            'product_id' => $product->id,
+            'quantity'   => 1,
+        ]],
+    ])->assertCreated();
+
+    $this->assertDatabaseHas('daily_menu_order_selections', [
+        'daily_menu_section_id' => $section->id,
+        'product_id'            => $product->id,
+        'quantity'              => 1,
+    ]);
+});
+
+it('returns 422 when selections array is empty', function () {
+    buildTodayMenu($this->user->id);
+
+    $this->postJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu/order", [
+        'selections' => [],
+    ])->assertStatus(422);
+});
+
+it('returns 422 when a section_id does not belong to the menu', function () {
+    buildTodayMenu($this->user->id);
+
+    $this->postJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu/order", [
+        'selections' => [[
+            'section_id' => 99999,
+            'product_id' => 1,
+            'quantity'   => 1,
+        ]],
+    ])->assertStatus(422);
+});
+
+it('returns 422 when a product is not available in the selected section', function () {
+    ['menu' => $menu, 'section' => $section] = buildTodayMenu($this->user->id);
+
+    $otherCat     = Category::factory()->create(['user_id' => $this->user->id]);
+    $otherProduct = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $otherCat->id]);
+
+    $this->postJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu/order", [
+        'selections' => [[
+            'section_id' => $section->id,
+            'product_id' => $otherProduct->id,
+            'quantity'   => 1,
+        ]],
+    ])->assertStatus(422);
+});
+
+it('returns 422 when a required section has no selection', function () {
+    ['section' => $section, 'product' => $product] = buildTodayMenu($this->user->id);
+
+    // Add a second required section without providing its selection
+    $menu = $section->dailyMenu;
+    $requiredSection = DailyMenuSection::factory()->create([
+        'daily_menu_id' => $menu->id,
+        'type'          => 'second_course',
+        'is_required'   => true,
+    ]);
+
+    $this->postJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu/order", [
+        'selections' => [[
+            'section_id' => $section->id,
+            'product_id' => $product->id,
+            'quantity'   => 1,
+        ]],
+    ])->assertStatus(422);
+});
+
+it('returns 422 when timing override is below the estimated prep time', function () {
+    Queue::fake();
+    ['menu' => $menu, 'section' => $section, 'product' => $product] = buildTodayMenu($this->user->id);
+
+    DailyMenuTimingRule::factory()->create([
+        'daily_menu_id'          => $menu->id,
+        'round_number'           => 1,
+        'default_delay_minutes'  => 20,
+        'estimated_prep_minutes' => 15,
+        'section_types'          => ['first_course'],
+    ]);
+
+    $this->postJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu/order", [
+        'selections' => [[
+            'section_id' => $section->id,
+            'product_id' => $product->id,
+            'quantity'   => 1,
+        ]],
+        'timing_overrides' => [[
+            'round'         => 1,
+            'delay_minutes' => 5,
+        ]],
+    ])->assertStatus(422);
+});
+
+it('returns 409 when the menu is sold out', function () {
+    ['menu' => $menu, 'section' => $section, 'product' => $product] = buildTodayMenu($this->user->id);
+    $menu->update(['max_per_day' => 1]);
+
+    $existingOrder = Order::factory()->create(['table_id' => $this->table->id, 'status' => 'pending']);
+    DailyMenuOrder::factory()->create([
+        'daily_menu_id' => $menu->id,
+        'order_id'      => $existingOrder->id,
+        'status'        => 'pending',
+    ]);
+
+    $otherTable = Table::factory()->create(['user_id' => $this->user->id]);
+
+    $this->postJson("/api/v1/menu/{$otherTable->unique_hash}/daily-menu/order", [
+        'selections' => [[
+            'section_id' => $section->id,
+            'product_id' => $product->id,
+            'quantity'   => 1,
+        ]],
+    ])->assertStatus(409);
+});
+
+it('dispatches a job for each timing rule when ordering', function () {
+    Queue::fake();
+    ['menu' => $menu, 'section' => $section, 'product' => $product] = buildTodayMenu($this->user->id);
+
+    DailyMenuTimingRule::factory()->create([
+        'daily_menu_id'          => $menu->id,
+        'round_number'           => 1,
+        'default_delay_minutes'  => 0,
+        'estimated_prep_minutes' => 10,
+        'section_types'          => ['first_course'],
+    ]);
+
+    $this->postJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu/order", [
+        'selections' => [[
+            'section_id' => $section->id,
+            'product_id' => $product->id,
+            'quantity'   => 1,
+        ]],
+    ])->assertCreated();
+
+    Queue::assertPushed(\App\Jobs\SendDailyMenuRound::class);
+});
+
+it('accepts timing_overrides that meet the minimum prep time', function () {
+    Queue::fake();
+    ['menu' => $menu, 'section' => $section, 'product' => $product] = buildTodayMenu($this->user->id);
+
+    DailyMenuTimingRule::factory()->create([
+        'daily_menu_id'          => $menu->id,
+        'round_number'           => 1,
+        'default_delay_minutes'  => 20,
+        'estimated_prep_minutes' => 10,
+        'section_types'          => ['first_course'],
+    ]);
+
+    $this->postJson("/api/v1/menu/{$this->table->unique_hash}/daily-menu/order", [
+        'selections' => [[
+            'section_id' => $section->id,
+            'product_id' => $product->id,
+            'quantity'   => 1,
+        ]],
+        'timing_overrides' => [[
+            'round'         => 1,
+            'delay_minutes' => 15,
+        ]],
+    ])->assertCreated();
+});

--- a/tests/Feature/Bloque14/DailyMenuResolverTest.php
+++ b/tests/Feature/Bloque14/DailyMenuResolverTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use App\Models\DailyMenu;
+use App\Models\Plan;
+use App\Models\User;
+
+beforeEach(function () {
+    $plan        = Plan::factory()->create();
+    $this->user  = User::factory()->admin()->create(['plan_id' => $plan->id]);
+});
+
+// ─── forToday() ──────────────────────────────────────────────────────────────
+
+it('returns a menu matching todays day of week', function () {
+    $today = strtolower(now()->englishDayOfWeek);
+
+    $menu = DailyMenu::factory()->create([
+        'user_id'     => $this->user->id,
+        'day_of_week' => $today,
+        'is_active'   => true,
+    ]);
+
+    $result = DailyMenu::forToday($this->user->id);
+
+    expect($result)->not->toBeNull();
+    expect($result->id)->toBe($menu->id);
+});
+
+it('returns null when no menu matches today', function () {
+    $notToday = collect(['monday','tuesday','wednesday','thursday','friday','saturday','sunday'])
+        ->reject(fn ($d) => $d === strtolower(now()->englishDayOfWeek))
+        ->first();
+
+    DailyMenu::factory()->create([
+        'user_id'     => $this->user->id,
+        'day_of_week' => $notToday,
+        'is_active'   => true,
+    ]);
+
+    expect(DailyMenu::forToday($this->user->id))->toBeNull();
+});
+
+it('returns null when the matching menu is inactive', function () {
+    $today = strtolower(now()->englishDayOfWeek);
+
+    DailyMenu::factory()->create([
+        'user_id'     => $this->user->id,
+        'day_of_week' => $today,
+        'is_active'   => false,
+    ]);
+
+    expect(DailyMenu::forToday($this->user->id))->toBeNull();
+});
+
+it('specific_date takes priority over day_of_week', function () {
+    $today    = strtolower(now()->englishDayOfWeek);
+    $todayDate = today()->toDateString();
+
+    $byDay = DailyMenu::factory()->create([
+        'user_id'     => $this->user->id,
+        'day_of_week' => $today,
+        'is_active'   => true,
+    ]);
+
+    $byDate = DailyMenu::factory()->create([
+        'user_id'       => $this->user->id,
+        'specific_date' => $todayDate,
+        'day_of_week'   => null,
+        'is_active'     => true,
+    ]);
+
+    $result = DailyMenu::forToday($this->user->id);
+
+    expect($result->id)->toBe($byDate->id);
+});
+
+it('returns null when specific_date menu is inactive even if day_of_week matches', function () {
+    $today    = strtolower(now()->englishDayOfWeek);
+    $todayDate = today()->toDateString();
+
+    DailyMenu::factory()->create([
+        'user_id'       => $this->user->id,
+        'specific_date' => $todayDate,
+        'day_of_week'   => null,
+        'is_active'     => false,
+    ]);
+
+    DailyMenu::factory()->create([
+        'user_id'     => $this->user->id,
+        'day_of_week' => $today,
+        'is_active'   => true,
+    ]);
+
+    // specific_date inactive → fallback to day_of_week
+    $result = DailyMenu::forToday($this->user->id);
+
+    expect($result)->not->toBeNull();
+    expect($result->day_of_week)->toBe($today);
+});
+
+it('does not return menus from another user', function () {
+    $plan       = Plan::factory()->create();
+    $otherUser  = User::factory()->admin()->create(['plan_id' => $plan->id]);
+    $today      = strtolower(now()->englishDayOfWeek);
+
+    DailyMenu::factory()->create([
+        'user_id'     => $otherUser->id,
+        'day_of_week' => $today,
+        'is_active'   => true,
+    ]);
+
+    expect(DailyMenu::forToday($this->user->id))->toBeNull();
+});

--- a/tests/Feature/Bloque14/DailyMenuResolverTest.php
+++ b/tests/Feature/Bloque14/DailyMenuResolverTest.php
@@ -74,7 +74,7 @@ it('specific_date takes priority over day_of_week', function () {
     expect($result->id)->toBe($byDate->id);
 });
 
-it('returns null when specific_date menu is inactive even if day_of_week matches', function () {
+it('falls back to day_of_week menu when specific_date menu is inactive', function () {
     $today    = strtolower(now()->englishDayOfWeek);
     $todayDate = today()->toDateString();
 

--- a/tests/Unit/DailyMenuTimingTest.php
+++ b/tests/Unit/DailyMenuTimingTest.php
@@ -1,0 +1,76 @@
+<?php
+
+// ─── DailyMenuOrderService — timing math ─────────────────────────────────────
+// These tests verify the delay calculation formula used in DailyMenuOrderService::dispatchRounds():
+//   delaySeconds = max(0, (clientDelay - estimatedPrep) * 60)
+// No database access required.
+
+it('delay is zero when client delay equals estimated prep minutes', function () {
+    $clientDelay   = 15;
+    $estimatedPrep = 15;
+
+    $delaySeconds = max(0, ($clientDelay - $estimatedPrep) * 60);
+
+    expect($delaySeconds)->toBe(0);
+});
+
+it('delay is zero when client delay is less than estimated prep minutes', function () {
+    $clientDelay   = 5;
+    $estimatedPrep = 15;
+
+    $delaySeconds = max(0, ($clientDelay - $estimatedPrep) * 60);
+
+    expect($delaySeconds)->toBe(0);
+});
+
+it('delay is positive when client delay exceeds estimated prep minutes', function () {
+    $clientDelay   = 30;
+    $estimatedPrep = 10;
+
+    $delaySeconds = max(0, ($clientDelay - $estimatedPrep) * 60);
+
+    expect($delaySeconds)->toBe(20 * 60);
+});
+
+it('delay uses the client override instead of the default delay', function () {
+    $defaultDelay  = 20;
+    $clientOverride = 40;
+    $estimatedPrep  = 10;
+
+    $clientDelay  = $clientOverride;
+    $delaySeconds = max(0, ($clientDelay - $estimatedPrep) * 60);
+
+    expect($delaySeconds)->toBe(30 * 60);
+});
+
+it('delay falls back to default when no override is provided', function () {
+    $defaultDelay  = 25;
+    $estimatedPrep = 10;
+
+    $overrides   = [];
+    $round       = 1;
+    $override    = collect($overrides)->firstWhere('round', $round);
+    $clientDelay = $override['delay_minutes'] ?? $defaultDelay;
+
+    $delaySeconds = max(0, ($clientDelay - $estimatedPrep) * 60);
+
+    expect($delaySeconds)->toBe(15 * 60);
+});
+
+it('delay is exactly zero when client delay is exactly zero', function () {
+    $clientDelay   = 0;
+    $estimatedPrep = 10;
+
+    $delaySeconds = max(0, ($clientDelay - $estimatedPrep) * 60);
+
+    expect($delaySeconds)->toBe(0);
+});
+
+it('large client delay produces correct large delay in seconds', function () {
+    $clientDelay   = 120;
+    $estimatedPrep = 10;
+
+    $delaySeconds = max(0, ($clientDelay - $estimatedPrep) * 60);
+
+    expect($delaySeconds)->toBe(110 * 60);
+});


### PR DESCRIPTION
## Resumen

- Añade suite completa de tests para el Bloque 14 (Menú del Día)
- Corrige dos bugs de compatibilidad MySQL/SQLite en `DailyMenuController`
- 91 nuevos tests en 5 archivos — la suite global pasa de 702 a 793 tests

## Cambios

### Tests nuevos

| Archivo | Tests | Qué cubre |
|---|---|---|
| `tests/Feature/Bloque14/DailyMenuAdminTest.php` | 37 | CRUD admin, multitenancy, secciones, sync de productos, timing |
| `tests/Feature/Bloque14/DailyMenuPublicTest.php` | 24 | API GET/POST pública, exclusividad, sold-out, validaciones, jobs |
| `tests/Feature/Bloque14/DailyMenuOrderTest.php` | 14 | `SendDailyMenuRound` job, `DailyMenuOrderService::dispatchRounds` |
| `tests/Feature/Bloque14/DailyMenuResolverTest.php` | 6 | `DailyMenu::forToday()` scope (prioridad fecha específica vs día semana) |
| `tests/Unit/DailyMenuTimingTest.php` | 7 | Fórmula de cálculo de delay `max(0,(clientDelay-prep)*60)` |

### Correcciones de producción

- **`DailyMenuController::index()`**: sustituye `FIELD()` (MySQL-only) por `CASE WHEN` (ANSI SQL) en el `orderByRaw` del día de la semana
- **`DailyMenuController::store()` y `update()`**: sustituye `where('specific_date', $date)` por `whereDate('specific_date', $date)` para que la comparación sea correcta independientemente de si el driver almacena la fecha con o sin componente horario

## Test plan

- [ ] `php artisan test` — 793 tests, 0 fallos
- [ ] Admin CRUD con multitenancy (403 en edit/update/destroy de recursos ajenos)
- [ ] API pública: hash inválido → 404, sin menú hoy → data null, con menú → secciones + timing_rule embebido
- [ ] Pedido: exclusividad à la carte → 409, agotado → 409, sección obligatoria sin selección → 422, timing override < prep mínimo → 422
- [ ] Job `SendDailyMenuRound`: crea order_items con `is_daily_menu=true`, precio 0 si sección libre, salta si cancelado, marca completado en última ronda
- [ ] `forToday()`: fecha específica tiene prioridad, menú inactivo excluido, aislamiento por restaurante