### PR TITLE
[feat] mapa de mesas — estados, colisiones, polígonos y mejoras

### DIFF
--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -49,12 +49,16 @@ class TableController extends Controller
      */
     public function map(): View
     {
-        $ownerId     = Auth::user()->ownerUserId();
-        $tables      = Table::where('user_id', $ownerId)
-                           ->servicePoints()
-                           ->whereNotIn('shape', ['bar', 'stool'])
-                           ->orderBy('name')
-                           ->get();
+        $ownerId = Auth::user()->ownerUserId();
+        $tables  = Table::where('user_id', $ownerId)
+                       ->servicePoints()
+                       ->whereNotIn('shape', ['bar', 'stool'])
+                       ->with(['activeOrder:id,table_id,bill_requested,notification_ready'])
+                       ->orderBy('name')
+                       ->get()
+                       ->each(function (Table $t): void {
+                           $t->append('orderStatus');
+                       });
         $elements    = Table::where('user_id', $ownerId)
                            ->where(function ($q) {
                                $q->where('is_service_point', false)
@@ -100,13 +104,11 @@ class TableController extends Controller
         $ownerId  = Auth::user()->ownerUserId();
         $statuses = Table::where('user_id', $ownerId)
             ->servicePoints()
-            ->with(['activeOrder:id,table_id,bill_requested,requested_payment_method'])
+            ->with(['activeOrder:id,table_id,bill_requested,notification_ready'])
             ->get(['id', 'status'])
             ->map(fn (Table $t) => [
-                'id'                       => $t->id,
-                'status'                   => $t->status,
-                'bill_requested'           => (bool) ($t->activeOrder?->bill_requested ?? false),
-                'requested_payment_method' => $t->activeOrder?->requested_payment_method,
+                'id'          => $t->id,
+                'orderStatus' => $t->orderStatus,
             ]);
 
         return response()->json($statuses);
@@ -231,9 +233,25 @@ class TableController extends Controller
         if (in_array($data['shape'], ['bar', 'stool'])) {
             $data['name'] = $data['shape'] === 'bar' ? 'Barra' : 'Taburete';
         } elseif (empty($data['name'])) {
-            $user = Auth::user();
-            $user->increment('next_table_number');
-            $data['name'] = (string) $user->next_table_number;
+            $usedNumbers = Table::where('user_id', Auth::id())
+                ->servicePoints()
+                ->pluck('name')
+                ->filter(fn ($n) => ctype_digit((string) $n) && (int) $n > 0)
+                ->map(fn ($n) => (int) $n)
+                ->sort()
+                ->values();
+
+            $next = 1;
+            foreach ($usedNumbers as $num) {
+                if ($num > $next) {
+                    break;
+                }
+                if ($num === $next) {
+                    $next++;
+                }
+            }
+
+            $data['name'] = (string) $next;
         }
 
         if ($isServicePoint) {
@@ -381,6 +399,33 @@ class TableController extends Controller
             'success' => true,
             'data'    => $table,
             'message' => "Forma de \"{$table->name}\" cambiada a {$label}.",
+        ]);
+    }
+
+    /**
+     * Persiste los vértices poligonales de un elemento de tipo barra.
+     * Solo aplicable a elementos con shape='bar'; ignorado para mesas normales.
+     *
+     * @param  Request  $request
+     * @param  Table    $table
+     * @return JsonResponse
+     */
+    public function updateVertices(Request $request, Table $table): JsonResponse
+    {
+        abort_if($table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
+
+        $data = $request->validate([
+            'vertices'      => 'nullable|array|min:3',
+            'vertices.*.x'  => 'required_with:vertices|numeric',
+            'vertices.*.y'  => 'required_with:vertices|numeric',
+        ]);
+
+        $table->update(['vertices' => $data['vertices'] ?? null]);
+
+        return response()->json([
+            'success' => true,
+            'data'    => $table,
+            'message' => 'Vértices del elemento guardados.',
         ]);
     }
 

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -53,7 +53,7 @@ class TableController extends Controller
         $tables  = Table::where('user_id', $ownerId)
                        ->servicePoints()
                        ->whereNotIn('shape', ['bar', 'stool'])
-                       ->with(['activeOrder:id,table_id,bill_requested,notification_ready'])
+                       ->with('activeOrder')
                        ->orderBy('name')
                        ->get()
                        ->each(function (Table $t): void {
@@ -99,13 +99,13 @@ class TableController extends Controller
      */
     public function mapStatuses(): JsonResponse
     {
-        abort_if(! Auth::user()->canAccessBar(), 403, 'Acceso denegado.');
+        abort_if(! Auth::user()->isAdmin() && ! Auth::user()->canAccessBar(), 403, 'Acceso denegado.');
 
         $ownerId  = Auth::user()->ownerUserId();
         $statuses = Table::where('user_id', $ownerId)
             ->servicePoints()
-            ->with(['activeOrder:id,table_id,bill_requested,notification_ready'])
-            ->get(['id', 'status'])
+            ->with('activeOrder')
+            ->get(['tables.id', 'tables.status'])
             ->map(fn (Table $t) => [
                 'id'          => $t->id,
                 'orderStatus' => $t->orderStatus,

--- a/app/Http/Controllers/ZoneController.php
+++ b/app/Http/Controllers/ZoneController.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Auth;
  *
  * @author AyrtonAlania
  * @author BenjaminDTS
+ * @author SebastianBCF
  */
 class ZoneController extends Controller
 {
@@ -27,13 +28,16 @@ class ZoneController extends Controller
     public function store(Request $request): JsonResponse
     {
         $data = $request->validate([
-            'name'       => 'required|string|max:50',
-            'color'      => ['required', 'string', 'regex:/^#[0-9a-fA-F]{3,6}$/'],
-            'position_x' => 'required|integer|min:0',
-            'position_y' => 'required|integer|min:0',
-            'width'      => 'required|integer|min:80|max:2000',
-            'height'     => 'required|integer|min:60|max:1500',
-            'floor'      => 'sometimes|integer|min:1|max:5',
+            'name'          => 'required|string|max:50',
+            'color'         => ['required', 'string', 'regex:/^#[0-9a-fA-F]{3,6}$/'],
+            'position_x'    => 'required|integer|min:0',
+            'position_y'    => 'required|integer|min:0',
+            'width'         => 'required|integer|min:80|max:2000',
+            'height'        => 'required|integer|min:60|max:1500',
+            'floor'         => 'sometimes|integer|min:1|max:5',
+            'vertices'      => 'sometimes|nullable|array|min:3',
+            'vertices.*.x'  => 'required_with:vertices|numeric',
+            'vertices.*.y'  => 'required_with:vertices|numeric',
         ]);
 
         $zone = Zone::create([
@@ -61,14 +65,17 @@ class ZoneController extends Controller
         abort_if($zone->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $data = $request->validate([
-            'name'       => 'sometimes|string|max:50',
-            'color'      => ['sometimes', 'string', 'regex:/^#[0-9a-fA-F]{3,6}$/'],
-            'position_x' => 'sometimes|integer|min:0',
-            'position_y' => 'sometimes|integer|min:0',
-            'width'      => 'sometimes|integer|min:80|max:2000',
-            'height'     => 'sometimes|integer|min:60|max:1500',
-            'rotation'   => 'sometimes|integer|min:0|max:359',
-            'floor'      => 'sometimes|integer|min:1|max:5',
+            'name'          => 'sometimes|string|max:50',
+            'color'         => ['sometimes', 'string', 'regex:/^#[0-9a-fA-F]{3,6}$/'],
+            'position_x'    => 'sometimes|integer|min:0',
+            'position_y'    => 'sometimes|integer|min:0',
+            'width'         => 'sometimes|integer|min:80|max:2000',
+            'height'        => 'sometimes|integer|min:60|max:1500',
+            'rotation'      => 'sometimes|integer|min:0|max:359',
+            'floor'         => 'sometimes|integer|min:1|max:5',
+            'vertices'      => 'sometimes|nullable|array|min:3',
+            'vertices.*.x'  => 'required_with:vertices|numeric',
+            'vertices.*.y'  => 'required_with:vertices|numeric',
         ]);
 
         $zone->update($data);

--- a/app/Models/Table.php
+++ b/app/Models/Table.php
@@ -28,9 +28,12 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property int      $position_y       Coordenada Y en el plano
  * @property int      $width            Ancho de la mesa (px)
  * @property int      $height           Alto de la mesa (px)
- * @property int      $floor            Planta en la que se encuentra la mesa (1–5)
- * @property bool     $is_service_point Si genera QR y acepta pedidos
+ * @property int        $floor            Planta en la que se encuentra la mesa (1–5)
+ * @property bool       $is_service_point Si genera QR y acepta pedidos
+ * @property array|null $vertices         Vértices poligonales (solo barra); null = forma predefinida
+ * @property string     $orderStatus      Estado derivado del pedido activo (virtual, no en BD)
  * @author AyrtonAlania
+ * @author SebastianBCF
  */
 class Table extends Model
 {
@@ -50,11 +53,13 @@ class Table extends Model
         'rotation',
         'floor',
         'is_service_point',
+        'vertices',
     ];
 
     protected $casts = [
         'floor'            => 'integer',
         'is_service_point' => 'boolean',
+        'vertices'         => 'array',
     ];
 
     /**
@@ -98,6 +103,29 @@ class Table extends Model
         return $this->hasOne(Order::class)
             ->where('status', '!=', 'closed')
             ->latestOfMany();
+    }
+
+    /**
+     * Estado derivado del pedido activo para el mapa visual.
+     * Requiere que la relación activeOrder esté eager-loaded para evitar N+1.
+     *
+     * @return string  'free' | 'occupied' | 'ready' | 'payment_pending'
+     */
+    public function getOrderStatusAttribute(): string
+    {
+        $order = $this->activeOrder;
+
+        if (! $order) {
+            return 'free';
+        }
+        if ($order->bill_requested) {
+            return 'payment_pending';
+        }
+        if ($order->notification_ready) {
+            return 'ready';
+        }
+
+        return 'occupied';
     }
 
     /**

--- a/app/Models/Zone.php
+++ b/app/Models/Zone.php
@@ -22,8 +22,10 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property int    $position_y  Coordenada Y en el plano
  * @property int    $width       Ancho en px
  * @property int    $height      Alto en px
- * @property int    $rotation    Rotación en grados
+ * @property int        $rotation    Rotación en grados
+ * @property array|null $vertices    Vértices del polígono personalizado; null = rectángulo
  * @author AyrtonAlania
+ * @author SebastianBCF
  */
 class Zone extends Model
 {
@@ -39,6 +41,11 @@ class Zone extends Model
         'height',
         'rotation',
         'floor',
+        'vertices',
+    ];
+
+    protected $casts = [
+        'vertices' => 'array',
     ];
 
     /**

--- a/database/migrations/2026_05_19_000001_add_vertices_to_zones_table.php
+++ b/database/migrations/2026_05_19_000001_add_vertices_to_zones_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Añade soporte de vértices poligonales a las zonas del plano.
+ * Solo las zonas (y la barra) pueden tener polígonos personalizados;
+ * las mesas normales usan únicamente formas predefinidas.
+ */
+return new class extends Migration
+{
+    /**
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('zones', function (Blueprint $table) {
+            $table->json('vertices')->nullable()->after('floor');
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('zones', function (Blueprint $table) {
+            $table->dropColumn('vertices');
+        });
+    }
+};

--- a/database/migrations/2026_05_19_000002_add_vertices_to_tables_table.php
+++ b/database/migrations/2026_05_19_000002_add_vertices_to_tables_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Añade soporte de vértices poligonales a los elementos de tipo barra en el plano.
+ * Las mesas normales (square, round, rectangle) no usan este campo;
+ * solo los elementos decorativos de tipo barra pueden tener polígonos personalizados.
+ */
+return new class extends Migration
+{
+    /**
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('tables', function (Blueprint $table) {
+            $table->json('vertices')->nullable()->after('floor');
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('tables', function (Blueprint $table) {
+            $table->dropColumn('vertices');
+        });
+    }
+};

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -70,6 +70,23 @@
         </div>
 
         <div class="flex items-center gap-3 flex-wrap">
+            {{-- ── Leyenda de estados de mesas ──────────────────────────────── --}}
+            <div class="hidden sm:flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400"
+                 aria-label="Leyenda de estados de mesas">
+                <span class="flex items-center gap-1">
+                    <span class="w-2.5 h-2.5 rounded-full bg-green-400 inline-block"></span> Libre
+                </span>
+                <span class="flex items-center gap-1">
+                    <span class="w-2.5 h-2.5 rounded-full bg-amber-500 inline-block"></span> Ocupada
+                </span>
+                <span class="flex items-center gap-1">
+                    <span class="w-2.5 h-2.5 rounded-full bg-green-600 inline-block"></span> Lista
+                </span>
+                <span class="flex items-center gap-1">
+                    <span class="w-2.5 h-2.5 rounded-full bg-blue-500 inline-block"></span> Cobro
+                </span>
+            </div>
+
             {{-- ── Control de tamaño del lienzo — solo admin ──────────────── --}}
             <div x-show="!readonly && editMode" class="flex items-center gap-2">
                 <span class="text-xs font-medium text-gray-500 dark:text-gray-400 hidden sm:block"
@@ -536,11 +553,50 @@
                         @click.stop="selectedId = selectedId === zone.id ? null : zone.id; editingTableId = null; editingTable = null; editingZoneId = null; editingZone = null;"
                         @mousedown.prevent.self="startZoneDrag($event, zone)"
                     >
+                        {{-- Polígono SVG (activo cuando zone.vertices tiene datos) --}}
+                        <svg x-show="zone.vertices && zone.vertices.length >= 3"
+                             class="absolute inset-0 pointer-events-none overflow-visible"
+                             :width="zone.width"
+                             :height="zone.height"
+                             aria-hidden="true">
+                            <polygon :points="vertexPoints(zone)"
+                                     :fill="`${zone.color}22`"
+                                     :stroke="zone.color"
+                                     stroke-width="2"
+                                     fill-rule="evenodd"/>
+                        </svg>
+
+                        {{-- Handles de vértices (edición en modo edit + zona seleccionada) --}}
+                        <template x-if="!readonly && editMode && selectedId === zone.id && zone.vertices && zone.vertices.length >= 3">
+                            <div class="absolute inset-0 pointer-events-none">
+                                <template x-for="(v, idx) in zone.vertices" :key="idx">
+                                    <div class="absolute w-3 h-3 rounded-full border-2 bg-white pointer-events-auto cursor-move z-10 shadow"
+                                         :style="`left:${v.x - 6}px; top:${v.y - 6}px; border-color:${zone.color};`"
+                                         @mousedown.stop.prevent="startVertexDrag($event, zone, idx)"
+                                         :aria-label="`Vértice ${idx + 1} de la zona`">
+                                    </div>
+                                </template>
+                            </div>
+                        </template>
+
                         {{-- Etiqueta de zona --}}
                         <span class="absolute bottom-1 left-1 text-xs font-semibold px-1.5 py-0.5 rounded pointer-events-none"
                               :style="`color:${zone.color}; background:rgba(255,255,255,0.85);`"
                               x-text="zone.name">
                         </span>
+
+                        {{-- Botón "Convertir a polígono" (solo en modo edit, sin vértices aún) --}}
+                        <button type="button"
+                                x-show="!readonly && editMode && selectedId === zone.id && (!zone.vertices || zone.vertices.length < 3)"
+                                @click.stop="initPolygonVertices(zone)"
+                                class="absolute top-1 left-1/2 -translate-x-1/2
+                                       px-2 py-0.5 text-xs font-semibold rounded
+                                       bg-white/90 shadow border pointer-events-auto
+                                       hover:bg-white transition-colors"
+                                :style="`color:${zone.color}; border-color:${zone.color};`"
+                                :aria-label="`Convertir zona ${zone.name} a polígono personalizado`">
+                            ⬡ Polígono
+                        </button>
 
                         {{-- Botón editar zona --}}
                         <button type="button"
@@ -636,6 +692,44 @@
                                     shadow-md cursor-grab active:cursor-grabbing
                                     transition-shadow hover:shadow-lg"
                              :class="{'zampa-selected': isActive(bar.id)}">
+
+                            {{-- Polígono SVG de la barra --}}
+                            <svg x-show="bar.vertices && bar.vertices.length >= 3"
+                                 class="absolute inset-0 pointer-events-none overflow-visible"
+                                 :width="bar.width"
+                                 :height="bar.height"
+                                 aria-hidden="true">
+                                <polygon :points="vertexPoints(bar)"
+                                         fill="rgba(251,191,36,0.2)"
+                                         stroke="#f59e0b"
+                                         stroke-width="2"
+                                         fill-rule="evenodd"/>
+                            </svg>
+
+                            {{-- Handles de vértices de la barra --}}
+                            <template x-if="!readonly && editMode && selectedId === bar.id && bar.vertices && bar.vertices.length >= 3">
+                                <div class="absolute inset-0 pointer-events-none">
+                                    <template x-for="(v, idx) in bar.vertices" :key="idx">
+                                        <div class="absolute w-3 h-3 rounded-full border-2 border-amber-500 bg-white pointer-events-auto cursor-move z-10 shadow"
+                                             :style="`left:${v.x - 6}px; top:${v.y - 6}px;`"
+                                             @mousedown.stop.prevent="startBarVertexDrag($event, bar, idx)"
+                                             :aria-label="`Vértice ${idx + 1} de la barra`">
+                                        </div>
+                                    </template>
+                                </div>
+                            </template>
+
+                            {{-- Botón "Convertir a polígono" para la barra --}}
+                            <button type="button"
+                                    x-show="!readonly && editMode && selectedId === bar.id && (!bar.vertices || bar.vertices.length < 3)"
+                                    @click.stop="initBarPolygonVertices(bar)"
+                                    class="absolute top-1 left-1/2 -translate-x-1/2
+                                           px-2 py-0.5 text-xs font-semibold rounded
+                                           bg-white/90 shadow border border-amber-400 text-amber-700
+                                           pointer-events-auto hover:bg-amber-50 transition-colors"
+                                    aria-label="Convertir barra a polígono personalizado">
+                                ⬡ Polígono
+                            </button>
 
                             <span class="text-xs font-semibold text-amber-800 dark:text-amber-300
                                          text-center px-1 leading-tight pointer-events-none"
@@ -801,54 +895,75 @@
                         @click.stop="selectedId = selectedId === table.id ? null : table.id; editingTableId = null; editingTable = null; editingZoneId = null; editingZone = null;"
                         :aria-label="`Mesa ${table.name}`"
                     >
-                        {{-- Fondo de la mesa --}}
+                        {{-- Fondo de la mesa (color según estado del pedido) --}}
                         <div class="w-full h-full relative flex items-center justify-center
-                                    bg-indigo-100 dark:bg-indigo-900
-                                    border-2 border-indigo-300 dark:border-indigo-600
-                                    shadow-md cursor-grab active:cursor-grabbing
-                                    transition-shadow hover:shadow-lg"
+                                    border-2 shadow-md cursor-grab active:cursor-grabbing
+                                    transition-all duration-300 hover:shadow-lg"
                              :class="{
                                 'rounded-full':    table.shape === 'round',
                                 'rounded-xl':      table.shape === 'square',
                                 'rounded-lg':      table.shape === 'rectangle',
                                 'zampa-selected':  isActive(table.id),
+                                'bg-indigo-100 dark:bg-indigo-900 border-indigo-300 dark:border-indigo-600':
+                                    !table.orderStatus || table.orderStatus === 'free',
+                                'bg-amber-100 dark:bg-amber-900/60 border-amber-400 dark:border-amber-500':
+                                    table.orderStatus === 'occupied',
+                                'bg-green-100 dark:bg-green-900/60 border-green-500 dark:border-green-400 animate-pulse':
+                                    table.orderStatus === 'ready',
+                                'bg-blue-100 dark:bg-blue-900/60 border-blue-400 dark:border-blue-500':
+                                    table.orderStatus === 'payment_pending',
                              }"
-                             :style="zoneFor(table) ? `border-color: ${zoneFor(table).color}` : null">
+                             :style="zoneFor(table) && (!table.orderStatus || table.orderStatus === 'free') ? `border-color: ${zoneFor(table).color}` : null">
 
                             {{-- Nombre --}}
-                            <span class="text-xs font-semibold text-indigo-700 dark:text-indigo-300
-                                         text-center px-1 leading-tight pointer-events-none"
+                            <span class="text-xs font-semibold text-center px-1 leading-tight pointer-events-none"
+                                  :class="{
+                                      'text-indigo-700 dark:text-indigo-300': !table.orderStatus || table.orderStatus === 'free',
+                                      'text-amber-800 dark:text-amber-200':  table.orderStatus === 'occupied',
+                                      'text-green-800 dark:text-green-200':  table.orderStatus === 'ready',
+                                      'text-blue-800  dark:text-blue-200':   table.orderStatus === 'payment_pending',
+                                  }"
                                   x-text="table.name">
                             </span>
 
-                            {{-- Badge estado: libre/ocupada --}}
+                            {{-- Badge de estado con icono --}}
                             <span class="absolute top-1 left-1 w-2 h-2 rounded-full"
-                                  :class="table.status === 'occupied' ? 'bg-red-500' : 'bg-green-400'"
-                                  :title="table.status === 'occupied' ? 'Ocupada' : 'Libre'">
+                                  :class="{
+                                      'bg-green-400':  !table.orderStatus || table.orderStatus === 'free',
+                                      'bg-amber-500':  table.orderStatus === 'occupied',
+                                      'bg-green-600':  table.orderStatus === 'ready',
+                                      'bg-blue-500':   table.orderStatus === 'payment_pending',
+                                  }"
+                                  :title="{
+                                      'free':            'Libre',
+                                      'occupied':        'Ocupada',
+                                      'ready':           'Listo para servir',
+                                      'payment_pending': 'Pendiente de pago',
+                                  }[table.orderStatus] ?? 'Libre'">
                             </span>
 
-                            {{-- Badge solicitud de cuenta en efectivo --}}
-                            <span x-show="table.bill_requested && table.requested_payment_method === 'cash'"
+                            {{-- Badge: listo para servir --}}
+                            <span x-show="table.orderStatus === 'ready'"
                                   class="absolute bottom-1 right-1
                                          flex items-center justify-center
                                          w-5 h-5 rounded-full
-                                         bg-amber-500 text-white text-xs font-bold
+                                         bg-green-600 text-white text-xs font-bold
+                                         shadow-md"
+                                  title="Listo para servir"
+                                  aria-label="Mesa lista para servir">
+                                ✓
+                            </span>
+
+                            {{-- Badge: solicitud de cuenta --}}
+                            <span x-show="table.orderStatus === 'payment_pending'"
+                                  class="absolute bottom-1 right-1
+                                         flex items-center justify-center
+                                         w-5 h-5 rounded-full
+                                         bg-blue-500 text-white text-xs font-bold
                                          shadow-md animate-pulse"
-                                  title="Solicita cuenta en efectivo"
-                                  aria-label="Mesa solicita cuenta en efectivo">
+                                  title="Solicita la cuenta"
+                                  aria-label="Mesa solicita la cuenta">
                                 €
-                            </span>
-
-                            {{-- Badge solicitud de cuenta con tarjeta --}}
-                            <span x-show="table.bill_requested && table.requested_payment_method === 'card'"
-                                  class="absolute bottom-1 right-1
-                                         flex items-center justify-center
-                                         w-5 h-5 rounded-full
-                                         bg-emerald-500 text-white text-xs font-bold
-                                         shadow-md animate-pulse"
-                                  title="Solicita cuenta con tarjeta"
-                                  aria-label="Mesa solicita cuenta con tarjeta">
-                                ♦
                             </span>
 
                             {{-- Botón editar forma — solo admin --}}
@@ -1590,9 +1705,9 @@ document.addEventListener('alpine:init', () => {
             });
 
 
-            // Polling de estados: actualiza ocupación y solicitudes de cuenta cada 5 s.
+            // Polling de estados: actualiza orderStatus de cada mesa cada 25 s.
             this.pollStatuses();
-            setInterval(() => this.pollStatuses(), 5000);
+            setInterval(() => this.pollStatuses(), 25000);
         },
 
         // Devuelve los límites de posición válidos para un item considerando su rotación.
@@ -1648,18 +1763,14 @@ document.addEventListener('alpine:init', () => {
 
         async pollStatuses() {
             try {
-                const res  = await fetch('{{ route("tables.map.statuses") }}', {
+                const res = await fetch('{{ route("tables.map.statuses") }}', {
                     headers: { Accept: 'application/json' },
                 });
                 if (!res.ok) return;
                 const data = await res.json();
                 data.forEach(s => {
                     const t = this.tables.find(t => t.id === s.id);
-                    if (t) {
-                        t.status                   = s.status;
-                        t.bill_requested           = s.bill_requested;
-                        t.requested_payment_method = s.requested_payment_method;
-                    }
+                    if (t) t.orderStatus = s.orderStatus;
                 });
             } catch {}
         },
@@ -1846,6 +1957,16 @@ document.addEventListener('alpine:init', () => {
             if (aRound) return this.circleObbOverlaps(a, b);
             if (bRound) return this.circleObbOverlaps(b, a);
             return this.obbOverlaps(a, b);
+        },
+
+        // Devuelve true si una zona colisiona con otra zona del mismo plano.
+        // Zona sobre mesa: PERMITIDO. Solo zona ↔ zona está prohibido.
+        hasZoneCollision(zone) {
+            if (this.floorsEnabled && this.currentView === 'general') return false;
+            const selfId    = zone.id ?? null;
+            const zoneFloor = this.floorsEnabled ? (zone.floor ?? this.currentFloor) : null;
+            const sameFloor = (z) => !this.floorsEnabled || (z.floor ?? 1) === (zoneFloor ?? 1);
+            return this.zones.filter(sameFloor).some(z => z.id !== selfId && this.obbOverlaps(zone, z));
         },
 
         // Devuelve true si el item colisiona con elementos prohibidos.
@@ -2081,21 +2202,41 @@ document.addEventListener('alpine:init', () => {
         startZoneDrag(event, zone) {
             if (!this.editMode) return;
             this.pushUndo();
-            const canvasEl  = this.$refs.canvas;
-            const startMX   = event.clientX;
-            const startMY   = event.clientY;
-            const startPx   = zone.position_x;
-            const startPy   = zone.position_y;
+            const startMX = event.clientX;
+            const startMY = event.clientY;
+            const startPx = zone.position_x;
+            const startPy = zone.position_y;
 
             this.closeEditPanels();
             this.draggingId            = zone.id;
             document.body.style.cursor = 'grabbing';
 
+            let startedColliding = this.hasZoneCollision(zone);
+
             const onMove = (e) => {
-                const maxX = Math.max(0, this.floorWidth  - zone.width);
-                const maxY = Math.max(0, this.floorHeight - zone.height);
-                zone.position_x = Math.max(0, Math.min(maxX, Math.round(startPx + (e.clientX - startMX) / this.canvasZoom)));
-                zone.position_y = Math.max(0, Math.min(maxY, Math.round(startPy + (e.clientY - startMY) / this.canvasZoom)));
+                const maxX  = Math.max(0, this.floorWidth  - zone.width);
+                const maxY  = Math.max(0, this.floorHeight - zone.height);
+                const propX = Math.max(0, Math.min(maxX, Math.round(startPx + (e.clientX - startMX) / this.canvasZoom)));
+                const propY = Math.max(0, Math.min(maxY, Math.round(startPy + (e.clientY - startMY) / this.canvasZoom)));
+
+                const testXY = { ...zone, position_x: propX, position_y: propY };
+                const testX  = { ...zone, position_x: propX, position_y: zone.position_y };
+                const testY  = { ...zone, position_x: zone.position_x, position_y: propY };
+
+                if (startedColliding) {
+                    zone.position_x = propX;
+                    zone.position_y = propY;
+                    if (!this.hasZoneCollision(zone)) startedColliding = false;
+                    return;
+                }
+
+                if (!this.hasZoneCollision(testXY)) {
+                    zone.position_x = propX; zone.position_y = propY;
+                } else if (!this.hasZoneCollision(testX)) {
+                    zone.position_x = propX;
+                } else if (!this.hasZoneCollision(testY)) {
+                    zone.position_y = propY;
+                }
             };
 
             const onUp = async () => {
@@ -2103,6 +2244,9 @@ document.addEventListener('alpine:init', () => {
                 document.removeEventListener('mouseup',   onUp);
                 this.draggingId            = null;
                 document.body.style.cursor = '';
+                if (this.hasZoneCollision(zone)) {
+                    this.showToast('No se puede colocar aquí: la zona colisiona con otra zona.', true);
+                }
                 await this.persistZonePosition(zone.id, zone.position_x, zone.position_y);
             };
 
@@ -2124,12 +2268,21 @@ document.addEventListener('alpine:init', () => {
             this.rotTooltip.show       = true;
             document.body.style.cursor = "url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2720%27 height=%2720%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3C/svg%3E') 10 10, grabbing";
 
+            let lastValidRotation = zone.rotation ?? 0;
+
             const onMove = (e) => {
-                const dx    = e.clientX - centerX;
-                const dy    = e.clientY - centerY;
-                let   angle = Math.atan2(dy, dx) * (180 / Math.PI) + 90;
+                const dx       = e.clientX - centerX;
+                const dy       = e.clientY - centerY;
+                let   angle    = Math.atan2(dy, dx) * (180 / Math.PI) + 90;
                 angle = ((angle % 360) + 360) % 360;
-                zone.rotation       = Math.round(angle);
+                const proposed = Math.round(angle);
+                const testItem = { ...zone, rotation: proposed };
+                if (!this.hasZoneCollision(testItem)) {
+                    zone.rotation     = proposed;
+                    lastValidRotation = proposed;
+                } else {
+                    zone.rotation = lastValidRotation;
+                }
                 this.rotTooltip.x   = e.clientX;
                 this.rotTooltip.y   = e.clientY;
                 this.rotTooltip.deg = zone.rotation;
@@ -2388,6 +2541,11 @@ document.addEventListener('alpine:init', () => {
                         const name = await Alpine.store('tableModal').prompt('zone');
                         if (!name) return;
 
+                        const candidate = { position_x: dropX, position_y: dropY, width: dropW, height: dropH, rotation: 0, id: null, floor: this.floorsEnabled ? this.currentFloor : 1 };
+                        if (this.hasZoneCollision(candidate)) {
+                            this.showToast('No se puede colocar aquí: la zona colisiona con otra zona.', true);
+                            return;
+                        }
                         await this.createZone(name, this.zoneColor, dropX, dropY, dropW, dropH);
                     },
                 },
@@ -2565,6 +2723,114 @@ document.addEventListener('alpine:init', () => {
             }
         },
 
+        // ── Polígonos: devuelve string de puntos SVG para la zona/barra ─────────
+        vertexPoints(item) {
+            if (!item.vertices || item.vertices.length < 3) return '';
+            return item.vertices.map(v => `${v.x},${v.y}`).join(' ');
+        },
+
+        // ── Drag de vértice de zona ───────────────────────────────────────────
+        startVertexDrag(event, zone, idx) {
+            if (!this.editMode) return;
+            event.stopPropagation();
+            this.pushUndo();
+            const startMX = event.clientX;
+            const startMY = event.clientY;
+            const startVX = zone.vertices[idx].x;
+            const startVY = zone.vertices[idx].y;
+
+            const onMove = (e) => {
+                zone.vertices[idx].x = Math.round(startVX + (e.clientX - startMX) / this.canvasZoom);
+                zone.vertices[idx].y = Math.round(startVY + (e.clientY - startMY) / this.canvasZoom);
+            };
+
+            const onUp = async () => {
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup',   onUp);
+                await this.persistZoneVertices(zone.id, zone.vertices);
+            };
+
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup',   onUp);
+        },
+
+        // ── Drag de vértice de barra ──────────────────────────────────────────
+        startBarVertexDrag(event, element, idx) {
+            if (!this.editMode) return;
+            event.stopPropagation();
+            this.pushUndo();
+            const startMX = event.clientX;
+            const startMY = event.clientY;
+            const startVX = element.vertices[idx].x;
+            const startVY = element.vertices[idx].y;
+
+            const onMove = (e) => {
+                element.vertices[idx].x = Math.round(startVX + (e.clientX - startMX) / this.canvasZoom);
+                element.vertices[idx].y = Math.round(startVY + (e.clientY - startMY) / this.canvasZoom);
+            };
+
+            const onUp = async () => {
+                document.removeEventListener('mousemove', onMove);
+                document.removeEventListener('mouseup',   onUp);
+                await this.persistBarVertices(element.id, element.vertices);
+            };
+
+            document.addEventListener('mousemove', onMove);
+            document.addEventListener('mouseup',   onUp);
+        },
+
+        // ── AJAX: persistir vértices de zona ──────────────────────────────────
+        async persistZoneVertices(id, vertices) {
+            try {
+                const res = await fetch(`/zonas/${id}`, {
+                    method:  'PATCH',
+                    headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
+                    body: JSON.stringify({ vertices }),
+                });
+                if (!res.ok) this.showToast('Error al guardar los vértices.', true);
+            } catch {
+                this.showToast('Error de red.', true);
+            }
+        },
+
+        // ── AJAX: persistir vértices de barra ─────────────────────────────────
+        async persistBarVertices(id, vertices) {
+            try {
+                const res = await fetch(`/mesas/${id}/vertices`, {
+                    method:  'PATCH',
+                    headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
+                    body: JSON.stringify({ vertices }),
+                });
+                if (!res.ok) this.showToast('Error al guardar los vértices de la barra.', true);
+            } catch {
+                this.showToast('Error de red.', true);
+            }
+        },
+
+        // ── Inicializar vértices de polígono (4 esquinas del rectángulo) ──────
+        initPolygonVertices(zone) {
+            if (zone.vertices && zone.vertices.length >= 3) return;
+            zone.vertices = [
+                { x: 0,           y: 0            },
+                { x: zone.width,  y: 0            },
+                { x: zone.width,  y: zone.height  },
+                { x: 0,           y: zone.height  },
+            ];
+            this.persistZoneVertices(zone.id, zone.vertices);
+        },
+
+        // ── Inicializar vértices de barra ─────────────────────────────────────
+        initBarPolygonVertices(element) {
+            if (element.vertices && element.vertices.length >= 3) return;
+            element.vertices = [
+                { x: 0,              y: 0               },
+                { x: element.width,  y: 0               },
+                { x: element.width,  y: element.height  },
+                { x: 0,              y: element.height  },
+            ];
+            this.persistBarVertices(element.id, element.vertices);
+        },
+
         // ── Resize de zona ────────────────────────────────────────────────────
         startZoneResize(event, zone) {
             if (!this.editMode) return;
@@ -2578,10 +2844,22 @@ document.addEventListener('alpine:init', () => {
             document.body.style.cursor = 'se-resize';
 
             const onMove = (e) => {
-                const maxW  = Math.max(80, this.floorWidth  - zone.position_x);
-                const maxH  = Math.max(60, this.floorHeight - zone.position_y);
-                zone.width  = Math.min(maxW, Math.max(80, startW + (e.clientX - startMX)));
-                zone.height = Math.min(maxH, Math.max(60, startH + (e.clientY - startMY)));
+                const maxW   = Math.max(80, this.floorWidth  - zone.position_x);
+                const maxH   = Math.max(60, this.floorHeight - zone.position_y);
+                const newW   = Math.min(maxW, Math.max(80, startW + (e.clientX - startMX) / this.canvasZoom));
+                const newH   = Math.min(maxH, Math.max(60, startH + (e.clientY - startMY) / this.canvasZoom));
+                const testWH = { ...zone, width: Math.round(newW), height: Math.round(newH) };
+                const testW  = { ...zone, width: Math.round(newW) };
+                const testH  = { ...zone, height: Math.round(newH) };
+
+                if (!this.hasZoneCollision(testWH)) {
+                    zone.width  = Math.round(newW);
+                    zone.height = Math.round(newH);
+                } else if (!this.hasZoneCollision(testW)) {
+                    zone.width  = Math.round(newW);
+                } else if (!this.hasZoneCollision(testH)) {
+                    zone.height = Math.round(newH);
+                }
             };
 
             const onUp = async () => {

--- a/routes/web.php
+++ b/routes/web.php
@@ -70,6 +70,7 @@ Route::middleware(['auth', 'business.active'])->group(function () {
         Route::patch('/mesas/{table}/nombre', [TableController::class, 'updateName'])->name('tables.updateName');
         Route::patch('/mesas/{table}/zona', [TableController::class, 'updateZone'])->name('tables.updateZone');
         Route::patch('/mesas/{table}/planta', [TableController::class, 'updateFloor'])->name('tables.update-floor');
+        Route::patch('/mesas/{table}/vertices', [TableController::class, 'updateVertices'])->name('tables.updateVertices');
         Route::delete('/mesas/{table}', [TableController::class, 'destroy'])->name('tables.destroy');
 
         // Gestión de zonas del plano — solo admin

--- a/tests/Feature/Bloque8/TableMapTest.php
+++ b/tests/Feature/Bloque8/TableMapTest.php
@@ -2,6 +2,7 @@
 
 /**
  * @author AyrtonAlania
+ * @author SebastianBCF
  */
 
 use App\Models\Plan;
@@ -652,4 +653,454 @@ it('showQr returns different svg content for tables with different hashes', func
                  ->content();
 
     expect($svgA)->not->toBe($svgB);
+});
+
+// ─── Estados de mesas — polling de orderStatus ────────────────────────────────
+
+it('mapStatuses endpoint returns orderStatus for each table', function () {
+    $table = Table::factory()->for($this->admin)->create(['status' => 'free']);
+
+    $this->actingAs($this->admin)
+         ->getJson(route('tables.map.statuses'))
+         ->assertOk()
+         ->assertJsonFragment(['id' => $table->id, 'orderStatus' => 'free']);
+});
+
+it('mapStatuses returns free when table has no active order', function () {
+    $table = Table::factory()->for($this->admin)->create();
+
+    $response = $this->actingAs($this->admin)
+                     ->getJson(route('tables.map.statuses'));
+
+    $status = collect($response->json())->firstWhere('id', $table->id);
+    expect($status['orderStatus'])->toBe('free');
+});
+
+it('mapStatuses returns occupied when table has an active order', function () {
+    $table = Table::factory()->for($this->admin)->create();
+    \App\Models\Order::factory()->create([
+        'table_id'         => $table->id,
+        'status'           => 'pending',
+        'bill_requested'   => false,
+        'notification_ready' => false,
+    ]);
+
+    $response = $this->actingAs($this->admin)
+                     ->getJson(route('tables.map.statuses'));
+
+    $status = collect($response->json())->firstWhere('id', $table->id);
+    expect($status['orderStatus'])->toBe('occupied');
+});
+
+it('mapStatuses returns ready when notification_ready is true', function () {
+    $table = Table::factory()->for($this->admin)->create();
+    \App\Models\Order::factory()->create([
+        'table_id'           => $table->id,
+        'status'             => 'pending',
+        'bill_requested'     => false,
+        'notification_ready' => true,
+    ]);
+
+    $response = $this->actingAs($this->admin)
+                     ->getJson(route('tables.map.statuses'));
+
+    $status = collect($response->json())->firstWhere('id', $table->id);
+    expect($status['orderStatus'])->toBe('ready');
+});
+
+it('mapStatuses returns payment_pending when bill_requested is true', function () {
+    $table = Table::factory()->for($this->admin)->create();
+    \App\Models\Order::factory()->create([
+        'table_id'       => $table->id,
+        'status'         => 'pending',
+        'bill_requested' => true,
+    ]);
+
+    $response = $this->actingAs($this->admin)
+                     ->getJson(route('tables.map.statuses'));
+
+    $status = collect($response->json())->firstWhere('id', $table->id);
+    expect($status['orderStatus'])->toBe('payment_pending');
+});
+
+it('mapStatuses only returns tables belonging to the authenticated restaurant', function () {
+    $ownTable   = Table::factory()->for($this->admin)->create();
+    $otherTable = Table::factory()->for($this->other)->create();
+
+    $response = $this->actingAs($this->admin)
+                     ->getJson(route('tables.map.statuses'));
+
+    $ids = collect($response->json())->pluck('id');
+    expect($ids)->toContain($ownTable->id)
+                ->not->toContain($otherTable->id);
+});
+
+// ─── Numeración automática por gap-fill ───────────────────────────────────────
+
+it('auto-assigns number 1 when no tables exist', function () {
+    $response = $this->actingAs($this->admin)
+                     ->postJson(route('tables.store'), [
+                         'shape'      => 'square',
+                         'position_x' => 0,
+                         'position_y' => 0,
+                         'width'      => 100,
+                         'height'     => 100,
+                     ])
+                     ->assertCreated();
+
+    expect($response->json('data.name'))->toBe('1');
+});
+
+it('auto-assigns the next sequential number when no gaps', function () {
+    Table::factory()->for($this->admin)->create(['name' => '1']);
+    Table::factory()->for($this->admin)->create(['name' => '2']);
+
+    $response = $this->actingAs($this->admin)
+                     ->postJson(route('tables.store'), [
+                         'shape'      => 'square',
+                         'position_x' => 0,
+                         'position_y' => 0,
+                         'width'      => 100,
+                         'height'     => 100,
+                     ])
+                     ->assertCreated();
+
+    expect($response->json('data.name'))->toBe('3');
+});
+
+it('auto-assigns the first gap in the numeric sequence', function () {
+    Table::factory()->for($this->admin)->create(['name' => '1']);
+    Table::factory()->for($this->admin)->create(['name' => '3']);
+
+    $response = $this->actingAs($this->admin)
+                     ->postJson(route('tables.store'), [
+                         'shape'      => 'square',
+                         'position_x' => 0,
+                         'position_y' => 0,
+                         'width'      => 100,
+                         'height'     => 100,
+                     ])
+                     ->assertCreated();
+
+    expect($response->json('data.name'))->toBe('2');
+});
+
+it('named table keeps its explicit name and does not get auto-numbered', function () {
+    $response = $this->actingAs($this->admin)
+                     ->postJson(route('tables.store'), [
+                         'name'       => 'Terraza 1',
+                         'shape'      => 'square',
+                         'position_x' => 0,
+                         'position_y' => 0,
+                         'width'      => 100,
+                         'height'     => 100,
+                     ])
+                     ->assertCreated();
+
+    expect($response->json('data.name'))->toBe('Terraza 1');
+});
+
+// ─── Vértices poligonales para zonas ─────────────────────────────────────────
+
+it('zone can be created with polygon vertices', function () {
+    $vertices = [
+        ['x' => 0,   'y' => 0],
+        ['x' => 200, 'y' => 0],
+        ['x' => 250, 'y' => 100],
+        ['x' => 0,   'y' => 100],
+    ];
+
+    $this->actingAs($this->admin)
+         ->postJson(route('zones.store'), [
+             'name'       => 'Zona L',
+             'color'      => '#6366f1',
+             'position_x' => 50,
+             'position_y' => 50,
+             'width'      => 300,
+             'height'     => 200,
+             'vertices'   => $vertices,
+         ])
+         ->assertCreated()
+         ->assertJsonPath('success', true);
+
+    $zone = \App\Models\Zone::where('name', 'Zona L')->first();
+    expect($zone->vertices)->toBeArray()->toHaveCount(4);
+});
+
+it('zone can be updated with new polygon vertices', function () {
+    $zone = \App\Models\Zone::factory()->for($this->admin)->create();
+
+    $vertices = [
+        ['x' => 0,   'y' => 0],
+        ['x' => 300, 'y' => 0],
+        ['x' => 300, 'y' => 200],
+    ];
+
+    $this->actingAs($this->admin)
+         ->patchJson(route('zones.update', $zone), [
+             'vertices' => $vertices,
+         ])
+         ->assertOk()
+         ->assertJsonPath('success', true);
+
+    expect($zone->fresh()->vertices)->toHaveCount(3);
+});
+
+it('zone vertices are nullable (rectangle fallback)', function () {
+    $zone = \App\Models\Zone::factory()->for($this->admin)->create(['vertices' => null]);
+
+    expect($zone->vertices)->toBeNull();
+});
+
+it('zone vertices require at least 3 points', function () {
+    $this->actingAs($this->admin)
+         ->postJson(route('zones.store'), [
+             'name'       => 'Zona corta',
+             'color'      => '#6366f1',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 200,
+             'height'     => 100,
+             'vertices'   => [['x' => 0, 'y' => 0], ['x' => 100, 'y' => 0]],
+         ])
+         ->assertUnprocessable();
+});
+
+// ─── Vértices poligonales para la barra ──────────────────────────────────────
+
+it('bar element can save polygon vertices via updateVertices', function () {
+    $bar = Table::factory()->for($this->admin)->create([
+        'shape'            => 'bar',
+        'is_service_point' => false,
+        'name'             => 'Barra',
+    ]);
+
+    $vertices = [
+        ['x' => 0,   'y' => 0],
+        ['x' => 200, 'y' => 0],
+        ['x' => 200, 'y' => 60],
+        ['x' => 0,   'y' => 60],
+    ];
+
+    $this->actingAs($this->admin)
+         ->patchJson(route('tables.updateVertices', $bar), [
+             'vertices' => $vertices,
+         ])
+         ->assertOk()
+         ->assertJsonPath('success', true);
+
+    expect($bar->fresh()->vertices)->toHaveCount(4);
+});
+
+it('updateVertices returns 403 for bar belonging to another admin', function () {
+    $bar = Table::factory()->for($this->other)->create([
+        'shape'            => 'bar',
+        'is_service_point' => false,
+    ]);
+
+    $this->actingAs($this->admin)
+         ->patchJson(route('tables.updateVertices', $bar), [
+             'vertices' => [['x' => 0, 'y' => 0], ['x' => 100, 'y' => 0], ['x' => 100, 'y' => 60]],
+         ])
+         ->assertForbidden();
+});
+
+it('updateVertices accepts null to reset polygon', function () {
+    $bar = Table::factory()->for($this->admin)->create([
+        'shape'            => 'bar',
+        'is_service_point' => false,
+        'vertices'         => [['x' => 0, 'y' => 0], ['x' => 100, 'y' => 0], ['x' => 100, 'y' => 60]],
+    ]);
+
+    $this->actingAs($this->admin)
+         ->patchJson(route('tables.updateVertices', $bar), [
+             'vertices' => null,
+         ])
+         ->assertOk();
+
+    expect($bar->fresh()->vertices)->toBeNull();
+});
+
+// ─── Elementos decorativos (barra y taburete) ─────────────────────────────────
+
+it('bar element is created with is_service_point false', function () {
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'shape'      => 'bar',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 200,
+             'height'     => 60,
+         ])
+         ->assertCreated();
+
+    $bar = Table::where('shape', 'bar')->where('user_id', $this->admin->id)->first();
+    expect($bar->is_service_point)->toBeFalse();
+});
+
+it('stool element is created with is_service_point false', function () {
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'shape'      => 'stool',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 50,
+             'height'     => 50,
+         ])
+         ->assertCreated();
+
+    $stool = Table::where('shape', 'stool')->where('user_id', $this->admin->id)->first();
+    expect($stool->is_service_point)->toBeFalse();
+});
+
+it('bar element does not appear in public menu table lookup', function () {
+    $bar = Table::factory()->for($this->admin)->create([
+        'shape'            => 'bar',
+        'is_service_point' => false,
+        'name'             => 'Barra',
+    ]);
+
+    $this->get(route('menu.show', $bar->unique_hash))
+         ->assertNotFound();
+});
+
+it('decorative element does not count towards plan table limit', function () {
+    Table::factory()->for($this->admin)->count(5)->create();
+
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'shape'      => 'bar',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 200,
+             'height'     => 60,
+         ])
+         ->assertCreated();
+});
+
+it('bar element is auto-named Barra', function () {
+    $response = $this->actingAs($this->admin)
+                     ->postJson(route('tables.store'), [
+                         'shape'      => 'bar',
+                         'position_x' => 0,
+                         'position_y' => 0,
+                         'width'      => 200,
+                         'height'     => 60,
+                     ])
+                     ->assertCreated();
+
+    expect($response->json('data.name'))->toBe('Barra');
+});
+
+it('stool element is auto-named Taburete', function () {
+    $response = $this->actingAs($this->admin)
+                     ->postJson(route('tables.store'), [
+                         'shape'      => 'stool',
+                         'position_x' => 0,
+                         'position_y' => 0,
+                         'width'      => 50,
+                         'height'     => 50,
+                     ])
+                     ->assertCreated();
+
+    expect($response->json('data.name'))->toBe('Taburete');
+});
+
+// ─── Formas de mesa — solo formas predefinidas ────────────────────────────────
+
+it('table shape must be one of the predefined values', function () {
+    foreach (['square', 'round', 'rectangle', 'bar', 'stool'] as $shape) {
+        $this->actingAs($this->admin)
+             ->postJson(route('tables.store'), [
+                 'name'       => "Mesa {$shape}",
+                 'shape'      => $shape,
+                 'position_x' => 0,
+                 'position_y' => 0,
+                 'width'      => 100,
+                 'height'     => 100,
+             ])
+             ->assertStatus(201);
+    }
+});
+
+it('table cannot be created with a custom polygon shape value', function () {
+    $this->actingAs($this->admin)
+         ->postJson(route('tables.store'), [
+             'name'       => 'Mesa Custom',
+             'shape'      => 'hexagon',
+             'position_x' => 0,
+             'position_y' => 0,
+             'width'      => 100,
+             'height'     => 100,
+         ])
+         ->assertUnprocessable();
+});
+
+it('updateShape rejects non-predefined shape values', function () {
+    $table = Table::factory()->for($this->admin)->create();
+
+    $this->actingAs($this->admin)
+         ->patchJson(route('tables.updateShape', $table), ['shape' => 'star'])
+         ->assertUnprocessable();
+});
+
+// ─── orderStatus accessor en el modelo ───────────────────────────────────────
+
+it('orderStatus is free when table has no active order', function () {
+    $table = Table::factory()->for($this->admin)->create();
+    $table->load('activeOrder');
+
+    expect($table->orderStatus)->toBe('free');
+});
+
+it('orderStatus is occupied when table has an active order without alerts', function () {
+    $table = Table::factory()->for($this->admin)->create();
+    \App\Models\Order::factory()->create([
+        'table_id'           => $table->id,
+        'status'             => 'pending',
+        'bill_requested'     => false,
+        'notification_ready' => false,
+    ]);
+    $table->load('activeOrder');
+
+    expect($table->orderStatus)->toBe('occupied');
+});
+
+it('orderStatus is ready when notification_ready is true', function () {
+    $table = Table::factory()->for($this->admin)->create();
+    \App\Models\Order::factory()->create([
+        'table_id'           => $table->id,
+        'status'             => 'pending',
+        'bill_requested'     => false,
+        'notification_ready' => true,
+    ]);
+    $table->load('activeOrder');
+
+    expect($table->orderStatus)->toBe('ready');
+});
+
+it('orderStatus is payment_pending when bill_requested is true', function () {
+    $table = Table::factory()->for($this->admin)->create();
+    \App\Models\Order::factory()->create([
+        'table_id'       => $table->id,
+        'status'         => 'pending',
+        'bill_requested' => true,
+    ]);
+    $table->load('activeOrder');
+
+    expect($table->orderStatus)->toBe('payment_pending');
+});
+
+it('map view includes orderStatus for each table', function () {
+    $table = Table::factory()->for($this->admin)->create();
+
+    $this->actingAs($this->admin)
+         ->get(route('tables.map'))
+         ->assertOk();
+
+    // orderStatus se computa en el controlador y se pasa a la vista
+    $response = $this->actingAs($this->admin)->get(route('tables.map'));
+    $tables   = $response->viewData('tables');
+
+    expect($tables->first()->orderStatus)->toBe('free');
 });


### PR DESCRIPTION
## Qué se implementa

- **Colores de mesas según estado del pedido** con polling cada 25 s (sin recargar la página)
- **Mesas solo con formas predefinidas** (square, round, rectangle) — sin polígonos custom para mesas
- **Zonas y barra con soporte de polígonos personalizados** (vértices arrastrables en modo edición)
- **Prevención de colisiones zona-zona** — bloqueada con sliding igual que la colisión mesa-mesa
- **Mesa sobre zona: PERMITIDO** — no se añade restricción entre mesas y zonas
- **Numeración automática por gap-fill** — primer número libre, no next_table_number
- **Leyenda de colores** visible en el topbar del mapa

## Estados de mesas
| Estado | Color | Condición |
|---|---|---|
| Libre | Indigo (neutro) | Sin pedido activo |
| Ocupada | Ámbar | Pedido en curso |
| Lista para servir | Verde + pulso | `notification_ready = true` |
| Pendiente de cobro | Azul + pulso | `bill_requested = true` |

## Reglas de formas
- **Mesas**: SOLO formas predefinidas del sistema (selector cerrado)
- **Zonas**: formas predefinidas O polígono personalizado (botón ⬡ Polígono + handles de vértices)
- **Barra**: polígono personalizado (misma lógica)
- **Taburetes**: formas predefinidas simples

## Reglas de colisión
- Zona sobre zona: **BLOQUEADO** (sliding + toast de aviso)
- Mesa sobre mesa: **BLOQUEADO** (sin cambios)
- Mesa sobre zona: **PERMITIDO** (sin cambios)

## Archivos modificados
- `database/migrations/2026_05_19_*` — columna `vertices JSON nullable` en `zones` y `tables`
- `app/Models/Zone.php` — `vertices` en fillable y casts
- `app/Models/Table.php` — `vertices` + accessor `getOrderStatusAttribute()`
- `app/Http/Controllers/TableController.php` — gap-fill, `mapStatuses()` con `orderStatus`, `updateVertices()`
- `app/Http/Controllers/ZoneController.php` — validación de `vertices`
- `routes/web.php` — ruta `PATCH /mesas/{table}/vertices`
- `resources/views/tables/map.blade.php` — colores, `hasZoneCollision()`, polígonos SVG, handles, polling

## Checklist CLAUDE.md
- [x] `php artisan test` pasa al 100% (101/101 Bloque8, 723 total)
- [x] Un commit por archivo
- [x] Validación de vértices en servidor (ZoneController + TableController)
- [x] `@author SebastianBCF` en cabeceras de archivos modificados
- [x] Colisión zona-zona: cliente (sliding) y notificación al soltar