### PR TITLE
feat(bloque16.1): add split payment fields to users

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -38,6 +38,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property int         $floor_height   Alto del canvas del plano (px)
  * @property int         $floor_count    Número de plantas activas del local (1–5)
  * @property bool        $floors_enabled Si el sistema de plantas está activo
+ * @property bool        $split_payment_enabled   Si el cobro partido está activo para este restaurante
+ * @property int|null    $split_payment_max_parts Máximo de partes en que se puede dividir la cuenta (null = sin límite)
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
@@ -72,6 +74,8 @@ class User extends Authenticatable
         'floor_count',
         'floors_enabled',
         'floor_canvas_sizes',
+        'split_payment_enabled',
+        'split_payment_max_parts',
     ];
 
     /**
@@ -97,9 +101,11 @@ class User extends Authenticatable
             'active'            => 'boolean',
             'is_waiter'         => 'boolean',
             'is_kitchen'        => 'boolean',
-            'floor_count'        => 'integer',
-            'floors_enabled'     => 'boolean',
-            'floor_canvas_sizes' => 'array',
+            'floor_count'             => 'integer',
+            'floors_enabled'          => 'boolean',
+            'floor_canvas_sizes'      => 'array',
+            'split_payment_enabled'   => 'boolean',
+            'split_payment_max_parts' => 'integer',
         ];
     }
 
@@ -305,6 +311,16 @@ class User extends Authenticatable
     public function ownerUserId(): int
     {
         return $this->admin_id ?? $this->id;
+    }
+
+    /**
+     * Indica si el cobro partido está habilitado para este restaurante.
+     *
+     * @return bool
+     */
+    public function isSplitPaymentEnabled(): bool
+    {
+        return (bool) $this->split_payment_enabled;
     }
 
     /**

--- a/database/migrations/2026_05_20_211150_add_split_payment_to_users_table.php
+++ b/database/migrations/2026_05_20_211150_add_split_payment_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('split_payment_enabled')->default(false)->after('floors_enabled');
+            $table->integer('split_payment_max_parts')->nullable()->after('split_payment_enabled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['split_payment_enabled', 'split_payment_max_parts']);
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -79,8 +79,9 @@ class DatabaseSeeder extends Seeder
                 'address'       => 'Calle Mayor 1, Madrid',
                 'lat'           => 40.4168,
                 'lng'           => -3.7038,
-                'is_waiter'     => true,
-                'is_kitchen'    => true,
+                'is_waiter'              => true,
+                'is_kitchen'             => true,
+                'split_payment_enabled'  => false,
             ]
         );
 


### PR DESCRIPTION
## Resumen

- Migración que añade `split_payment_enabled` (boolean, default `false`) y `split_payment_max_parts` (integer nullable) a la tabla `users`
- Modelo `User` actualizado: campos en `$fillable`, casts y helper `isSplitPaymentEnabled()`
- Seeder del admin demo con `split_payment_enabled = false` explícito

## Notas para bloques siguientes

El campo `split_payment_max_parts` es nullable. Al consumirlo en los Bloques 16.3/16.4, usar `> 0` para detectar "sin límite" (el cast `integer` convierte `NULL` a `0`).

## Test plan

- [x] `php artisan migrate:fresh --seed` sin errores
- [x] `php artisan test` — 821 passed, 0 failed
- [x] Reviewer: SHIP IT