### PR TITLE
feat(bloque16.2): split payment config panel for admin

### DIFF
--- a/app/Http/Controllers/SplitPaymentConfigController.php
+++ b/app/Http/Controllers/SplitPaymentConfigController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+
+/**
+ * Class SplitPaymentConfigController
+ *
+ * Permite al gerente activar o desactivar el cobro partido en su restaurante
+ * y configurar el número máximo de partes en que se puede dividir la cuenta por mesa.
+ *
+ * @author BenjaminDTS
+ */
+class SplitPaymentConfigController extends Controller
+{
+    /**
+     * Muestra el formulario de configuración de cobro partido.
+     *
+     * @return View
+     */
+    public function edit(): View
+    {
+        $user = Auth::user();
+
+        return view('split-payment.edit', compact('user'));
+    }
+
+    /**
+     * Guarda la configuración de cobro partido del restaurante.
+     *
+     * Cuando split_payment_enabled es false, split_payment_max_parts
+     * se normaliza a null para evitar estado fantasma.
+     *
+     * @param  Request $request
+     * @return RedirectResponse
+     */
+    public function update(Request $request): RedirectResponse
+    {
+        $enabled = $request->boolean('split_payment_enabled');
+
+        $request->validate([
+            'split_payment_enabled'   => ['sometimes', 'boolean'],
+            'split_payment_max_parts' => ['nullable', 'integer', 'min:2', 'max:20'],
+        ]);
+
+        Auth::user()->update([
+            'split_payment_enabled'   => $enabled,
+            'split_payment_max_parts' => $enabled
+                ? ($request->input('split_payment_max_parts') ?: null)
+                : null,
+        ]);
+
+        return redirect()->route('split-payment.edit')
+                         ->with('success', 'Configuración de cobro partido guardada correctamente.');
+    }
+}

--- a/app/Http/Controllers/SplitPaymentConfigController.php
+++ b/app/Http/Controllers/SplitPaymentConfigController.php
@@ -40,12 +40,12 @@ class SplitPaymentConfigController extends Controller
      */
     public function update(Request $request): RedirectResponse
     {
-        $enabled = $request->boolean('split_payment_enabled');
-
-        $request->validate([
+        $validated = $request->validate([
             'split_payment_enabled'   => ['sometimes', 'boolean'],
             'split_payment_max_parts' => ['nullable', 'integer', 'min:2', 'max:20'],
         ]);
+
+        $enabled = (bool) ($validated['split_payment_enabled'] ?? false);
 
         Auth::user()->update([
             'split_payment_enabled'   => $enabled,

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -3,7 +3,7 @@
     @php
         $cartaActive   = request()->routeIs('categories.*', 'ingredients.*', 'products.*', 'daily-menus.*');
         $localActive   = request()->routeIs('tables.*', 'zones.*', 'staff.*');
-        $negocioActive = request()->routeIs('tapas.*', 'manager.*');
+        $negocioActive = request()->routeIs('tapas.*', 'manager.*', 'split-payment.*');
     @endphp
 
     <!-- Primary Navigation Menu -->
@@ -153,6 +153,9 @@
                                 <x-dropdown-link role="menuitem" :href="route('tapas.edit')" :active="request()->routeIs('tapas.*')">
                                     {{ __('Tapas') }}
                                 </x-dropdown-link>
+                                <x-dropdown-link role="menuitem" :href="route('split-payment.edit')" :active="request()->routeIs('split-payment.*')">
+                                    {{ __('Cobro Partido') }}
+                                </x-dropdown-link>
                                 <x-dropdown-link role="menuitem" :href="route('manager.income')" :active="request()->routeIs('manager.*')">
                                     {{ __('Ingresos') }}
                                 </x-dropdown-link>
@@ -284,6 +287,9 @@
                 <h3 class="px-3 pt-3 pb-1 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500" role="presentation">{{ __('Negocio') }}</h3>
                 <x-responsive-nav-link :href="route('tapas.edit')" :active="request()->routeIs('tapas.*')">
                     {{ __('Tapas') }}
+                </x-responsive-nav-link>
+                <x-responsive-nav-link :href="route('split-payment.edit')" :active="request()->routeIs('split-payment.*')">
+                    {{ __('Cobro Partido') }}
                 </x-responsive-nav-link>
                 <x-responsive-nav-link :href="route('manager.income')" :active="request()->routeIs('manager.*')">
                     {{ __('Ingresos') }}

--- a/resources/views/split-payment/edit.blade.php
+++ b/resources/views/split-payment/edit.blade.php
@@ -1,0 +1,97 @@
+{{-- @author BenjaminDTS --}}
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Cobro Partido') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
+
+            @if(session('success'))
+            <div role="alert" class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-6">
+                {{ session('success') }}
+            </div>
+            @endif
+
+            <div class="bg-white dark:bg-gray-800 shadow sm:rounded-lg p-6 sm:p-8">
+
+                <form
+                    method="POST"
+                    action="{{ route('split-payment.update') }}"
+                    x-data="{
+                        split_enabled: {{ $user->split_payment_enabled ? 'true' : 'false' }}
+                    }"
+                >
+                    @csrf
+                    @method('PUT')
+
+                    {{-- ── Toggle: Activar cobro partido ───────────────────── --}}
+                    <div class="flex items-center justify-between mb-6">
+                        <div>
+                            <label for="split_enabled_btn" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                {{ __('Activar cobro partido') }}
+                            </label>
+                            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                {{ __('Permite a los clientes dividir la cuenta entre varios comensales desde la carta digital.') }}
+                            </p>
+                        </div>
+                        <button
+                            id="split_enabled_btn"
+                            type="button"
+                            role="switch"
+                            :aria-checked="split_enabled.toString()"
+                            @click="split_enabled = !split_enabled"
+                            :class="split_enabled ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+                            class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                        >
+                            <span
+                                :class="split_enabled ? 'translate-x-6' : 'translate-x-1'"
+                                class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform"
+                            ></span>
+                        </button>
+                        <input type="hidden" name="split_payment_enabled" :value="split_enabled ? '1' : '0'">
+                    </div>
+
+                    {{-- ── Campo: Máximo de partes (visible solo si activo) ── --}}
+                    <div x-show="split_enabled" x-transition class="border-t border-gray-200 dark:border-gray-700 pt-6">
+                        <label for="split_payment_max_parts" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            {{ __('Máximo de partes por mesa') }}
+                        </label>
+                        <p id="max-parts-desc" class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                            {{ __('Deja vacío para no limitar el número de partes en que se puede dividir la cuenta.') }}
+                        </p>
+                        <input
+                            type="number"
+                            id="split_payment_max_parts"
+                            name="split_payment_max_parts"
+                            value="{{ old('split_payment_max_parts', $user->split_payment_max_parts > 0 ? $user->split_payment_max_parts : '') }}"
+                            min="2"
+                            max="20"
+                            :disabled="!split_enabled"
+                            :aria-required="split_enabled ? 'false' : undefined"
+                            aria-describedby="max-parts-desc error-split_payment_max_parts"
+                            class="mt-1 block w-32 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                            placeholder="{{ __('Sin límite') }}"
+                        >
+                        @error('split_payment_max_parts')
+                            <p id="error-split_payment_max_parts" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div class="mt-8 flex justify-end">
+                        <button
+                            type="submit"
+                            class="inline-flex items-center px-5 py-2 bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 text-white text-sm font-medium rounded-md transition-colors"
+                        >
+                            {{ __('Guardar configuración') }}
+                        </button>
+                    </div>
+
+                </form>
+            </div>
+
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\StaffController;
 use App\Http\Controllers\BarPanelController;
 use App\Http\Controllers\ManagerRevenueController;
 use App\Http\Controllers\PaymentController;
+use App\Http\Controllers\SplitPaymentConfigController;
 use App\Http\Controllers\TapasController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\KitchenController;
@@ -51,6 +52,9 @@ Route::middleware(['auth', 'business.active'])->group(function () {
     Route::middleware('role:admin')->group(function () {
         Route::get('/tapas/config', [TapasController::class, 'edit'])->name('tapas.edit');
         Route::put('/tapas/config', [TapasController::class, 'update'])->name('tapas.update');
+
+        Route::get('/split-payment/config', [SplitPaymentConfigController::class, 'edit'])->name('split-payment.edit');
+        Route::put('/split-payment/config', [SplitPaymentConfigController::class, 'update'])->name('split-payment.update');
 
         Route::get('/manager/income', [ManagerRevenueController::class, 'index'])->name('manager.income');
 

--- a/tests/Feature/Bloque16/SplitPaymentConfigTest.php
+++ b/tests/Feature/Bloque16/SplitPaymentConfigTest.php
@@ -1,0 +1,163 @@
+<?php
+
+use App\Models\User;
+use App\Models\Plan;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    $plan = Plan::factory()->create();
+
+    $this->admin = User::factory()->create([
+        'role'                   => 'admin',
+        'plan_id'                => $plan->id,
+        'split_payment_enabled'  => false,
+        'split_payment_max_parts'=> null,
+    ]);
+
+    $this->other = User::factory()->create([
+        'role'                   => 'admin',
+        'plan_id'                => $plan->id,
+        'split_payment_enabled'  => false,
+        'split_payment_max_parts'=> null,
+    ]);
+
+    $this->waiter = User::factory()->create([
+        'role'     => 'waiter',
+        'admin_id' => $this->admin->id,
+    ]);
+});
+
+it('redirects unauthenticated user from split payment config', function () {
+    $this->get(route('split-payment.edit'))->assertRedirect(route('login'));
+    $this->put(route('split-payment.update'))->assertRedirect(route('login'));
+});
+
+it('waiter cannot access split payment config', function () {
+    $this->actingAs($this->waiter)
+         ->get(route('split-payment.edit'))
+         ->assertForbidden();
+});
+
+it('admin can view split payment config', function () {
+    $this->actingAs($this->admin)
+         ->get(route('split-payment.edit'))
+         ->assertOk()
+         ->assertViewIs('split-payment.edit')
+         ->assertViewHas('user', $this->admin);
+});
+
+it('admin can enable split payment', function () {
+    $this->actingAs($this->admin)
+         ->put(route('split-payment.update'), [
+             'split_payment_enabled' => '1',
+         ])
+         ->assertRedirect(route('split-payment.edit'));
+
+    expect($this->admin->fresh()->split_payment_enabled)->toBeTrue();
+});
+
+it('admin can disable split payment', function () {
+    $this->admin->update(['split_payment_enabled' => true, 'split_payment_max_parts' => 4]);
+
+    $this->actingAs($this->admin)
+         ->put(route('split-payment.update'), [
+             'split_payment_enabled' => '0',
+         ])
+         ->assertRedirect(route('split-payment.edit'));
+
+    $fresh = $this->admin->fresh();
+    expect($fresh->split_payment_enabled)->toBeFalse();
+});
+
+it('admin can set max parts limit', function () {
+    $this->actingAs($this->admin)
+         ->put(route('split-payment.update'), [
+             'split_payment_enabled'   => '1',
+             'split_payment_max_parts' => '5',
+         ])
+         ->assertRedirect(route('split-payment.edit'));
+
+    expect($this->admin->fresh()->split_payment_max_parts)->toBe(5);
+});
+
+it('max parts must be at least 2', function () {
+    $this->actingAs($this->admin)
+         ->put(route('split-payment.update'), [
+             'split_payment_enabled'   => '1',
+             'split_payment_max_parts' => '1',
+         ])
+         ->assertSessionHasErrors('split_payment_max_parts');
+});
+
+it('max parts cannot exceed 20', function () {
+    $this->actingAs($this->admin)
+         ->put(route('split-payment.update'), [
+             'split_payment_enabled'   => '1',
+             'split_payment_max_parts' => '21',
+         ])
+         ->assertSessionHasErrors('split_payment_max_parts');
+});
+
+it('max parts must be an integer', function () {
+    $this->actingAs($this->admin)
+         ->put(route('split-payment.update'), [
+             'split_payment_enabled'   => '1',
+             'split_payment_max_parts' => 'abc',
+         ])
+         ->assertSessionHasErrors('split_payment_max_parts');
+});
+
+it('max parts is cleared when split payment is disabled', function () {
+    $this->admin->update(['split_payment_enabled' => true, 'split_payment_max_parts' => 6]);
+
+    $this->actingAs($this->admin)
+         ->put(route('split-payment.update'), [
+             'split_payment_enabled'   => '0',
+             'split_payment_max_parts' => '6',
+         ])
+         ->assertRedirect(route('split-payment.edit'));
+
+    expect($this->admin->fresh()->split_payment_max_parts)->toBeNull();
+});
+
+it('max parts can be left empty for no limit', function () {
+    $this->actingAs($this->admin)
+         ->put(route('split-payment.update'), [
+             'split_payment_enabled'   => '1',
+             'split_payment_max_parts' => '',
+         ])
+         ->assertRedirect(route('split-payment.edit'));
+
+    expect($this->admin->fresh()->split_payment_max_parts)->toBeNull();
+});
+
+it('shows success flash after saving config', function () {
+    $this->actingAs($this->admin)
+         ->put(route('split-payment.update'), [
+             'split_payment_enabled' => '1',
+         ])
+         ->assertSessionHas('success');
+});
+
+it('split payment config is scoped to the restaurant', function () {
+    $this->admin->update(['split_payment_enabled' => true, 'split_payment_max_parts' => 3]);
+
+    $this->actingAs($this->other)
+         ->put(route('split-payment.update'), [
+             'split_payment_enabled'   => '0',
+             'split_payment_max_parts' => null,
+         ]);
+
+    expect($this->admin->fresh()->split_payment_enabled)->toBeTrue()
+        ->and($this->admin->fresh()->split_payment_max_parts)->toBe(3);
+});
+
+it('other admin cannot change another admins split payment config', function () {
+    $this->admin->update(['split_payment_enabled' => true]);
+
+    $this->actingAs($this->other)
+         ->put(route('split-payment.update'), ['split_payment_enabled' => '0']);
+
+    expect($this->admin->fresh()->split_payment_enabled)->toBeTrue();
+});

--- a/tests/Feature/Bloque16/SplitPaymentConfigTest.php
+++ b/tests/Feature/Bloque16/SplitPaymentConfigTest.php
@@ -67,7 +67,8 @@ it('admin can disable split payment', function () {
          ->assertRedirect(route('split-payment.edit'));
 
     $fresh = $this->admin->fresh();
-    expect($fresh->split_payment_enabled)->toBeFalse();
+    expect($fresh->split_payment_enabled)->toBeFalse()
+        ->and($fresh->split_payment_max_parts)->toBeNull();
 });
 
 it('admin can set max parts limit', function () {


### PR DESCRIPTION
## Resumen

- `SplitPaymentConfigController` con `edit()` y `update()` — validación, normalización y guardado de `split_payment_enabled` y `split_payment_max_parts` en el usuario autenticado
- Rutas `GET/PUT /split-payment/config` dentro de `middleware('role:admin')`
- Vista `split-payment/edit.blade.php` con toggle Alpine.js + campo de partes máximas (visible solo si el toggle está activo)
- Enlace "Cobro Partido" en el menú Negocio (desktop y responsive)

## Decisión de arquitectura

Vista y controlador propios (no acoplados a tapas): el cobro partido es un dominio de pagos independiente. Evita choque de nombres con el futuro `SplitPaymentController` del Bloque 16.3/16.4 (sufijo `Config` distingue configuración de operación).

## Nota para Bloque 16.3/16.4

`split_payment_max_parts` nullable — el cast `integer` de Laravel devuelve `null` cuando el valor en BD es NULL. Comprobar con `> 0` para detectar "sin límite", no con `=== null`.

## Test plan

- [x] 14 tests en `tests/Feature/Bloque16/SplitPaymentConfigTest.php` — todos pasando
- [x] Suite completa: 835 passed, 0 failed
- [x] Cubre: redirect sin auth, waiter 403, enable/disable, min:2, max:20, null=sin límite, max_parts cleared on disable, flash, multitenancy