### PR TITLE
feat(bloque16.4): split payment backend

### DIFF
--- a/app/Http/Controllers/Api/SplitPaymentController.php
+++ b/app/Http/Controllers/Api/SplitPaymentController.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\OrderItemPayment;
+use App\Models\Table;
+use App\Services\StripeService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Gestiona el flujo de cobro partido desde la carta pública.
+ * Soporta dos modos: por ítems (items) y reparto equitativo (equitative).
+ * Cada comensal genera un PaymentIntent independiente en Stripe.
+ *
+ * @author BenjaminDTS
+ */
+class SplitPaymentController extends Controller
+{
+    public function __construct(private readonly StripeService $stripe) {}
+
+    /**
+     * Devuelve los ítems del pedido activo indicando cuáles están ya reclamados.
+     *
+     * @param  string  $hash
+     * @return JsonResponse
+     */
+    public function claimedItems(string $hash): JsonResponse
+    {
+        $table = Table::where('unique_hash', $hash)->firstOrFail();
+
+        $order = $this->activeOrder($table->id);
+
+        if (! $order) {
+            return response()->json(['success' => false, 'message' => 'No hay pedido activo.'], 404);
+        }
+
+        $items = $order->items()->with('splitPayments')->get()
+            ->map(fn (OrderItem $item) => [
+                'id'      => $item->id,
+                'name'    => $item->product?->name ?? 'Producto',
+                'price'   => (float) $item->price,
+                'total'   => round((float) $item->price * $item->quantity, 2),
+                'claimed' => $item->isClaimed(),
+            ]);
+
+        return response()->json(['success' => true, 'items' => $items]);
+    }
+
+    /**
+     * Crea un PaymentIntent de Stripe para los ítems seleccionados por el comensal.
+     * Verifica atómicamente que ninguno de los ítems esté ya reclamado.
+     *
+     * @param  Request  $request
+     * @param  string   $hash
+     * @return JsonResponse
+     */
+    public function payItems(Request $request, string $hash): JsonResponse
+    {
+        $validated = $request->validate([
+            'item_ids'   => 'required|array|min:1',
+            'item_ids.*' => 'required|integer',
+        ]);
+
+        $table = Table::where('unique_hash', $hash)->firstOrFail();
+        $order = $this->activeOrder($table->id);
+
+        if (! $order) {
+            return response()->json(['success' => false, 'message' => 'No hay pedido activo.'], 404);
+        }
+
+        return DB::transaction(function () use ($order, $validated, $table) {
+            $items = $order->items()
+                ->whereIn('id', $validated['item_ids'])
+                ->lockForUpdate()
+                ->get();
+
+            if ($items->count() !== count($validated['item_ids'])) {
+                return response()->json(['success' => false, 'message' => 'Uno o más ítems no pertenecen a este pedido.'], 422);
+            }
+
+            $alreadyClaimed = $items->filter(fn (OrderItem $i) => $i->isClaimed());
+            if ($alreadyClaimed->isNotEmpty()) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Uno o más ítems ya han sido reclamados por otro comensal.',
+                    'claimed_ids' => $alreadyClaimed->pluck('id'),
+                ], 409);
+            }
+
+            $amount = $items->sum(fn (OrderItem $i) => round($i->price * $i->quantity, 2));
+
+            $result = $this->stripe->createSplitPaymentIntent(
+                amount:      (int) round($amount * 100),
+                mode:        'items',
+                partNumber:  1,
+                partsTotal:  1,
+                metadata:    ['order_id' => $order->id, 'table_name' => $table->name],
+            );
+
+            foreach ($items as $item) {
+                OrderItemPayment::create([
+                    'order_id'                  => $order->id,
+                    'order_item_id'             => $item->id,
+                    'amount'                    => round($item->price * $item->quantity, 2),
+                    'stripe_payment_intent_id'  => $result['id'],
+                    'status'                    => 'pending',
+                    'mode'                      => 'items',
+                    'parts_total'               => null,
+                    'part_number'               => null,
+                ]);
+            }
+
+            return response()->json([
+                'success'       => true,
+                'client_secret' => $result['client_secret'],
+                'amount'        => $amount,
+            ]);
+        });
+    }
+
+    /**
+     * Crea un PaymentIntent de Stripe para la parte equitativa de un comensal.
+     *
+     * @param  Request  $request
+     * @param  string   $hash
+     * @return JsonResponse
+     */
+    public function payEquitative(Request $request, string $hash): JsonResponse
+    {
+        $validated = $request->validate([
+            'people'      => 'required|integer|min:2|max:50',
+            'part_number' => 'required|integer|min:1',
+        ]);
+
+        $table = Table::where('unique_hash', $hash)->firstOrFail();
+        $order = $this->activeOrder($table->id);
+
+        if (! $order) {
+            return response()->json(['success' => false, 'message' => 'No hay pedido activo.'], 404);
+        }
+
+        $people     = (int) $validated['people'];
+        $partNumber = (int) $validated['part_number'];
+
+        if ($partNumber > $people) {
+            return response()->json(['success' => false, 'message' => 'El número de parte excede el total de personas.'], 422);
+        }
+
+        $part = round((float) $order->total / $people, 2);
+
+        $result = $this->stripe->createSplitPaymentIntent(
+            amount:     (int) round($part * 100),
+            mode:       'equitative',
+            partNumber: $partNumber,
+            partsTotal: $people,
+            metadata:   ['order_id' => $order->id, 'table_name' => $table->name],
+        );
+
+        OrderItemPayment::create([
+            'order_id'                 => $order->id,
+            'order_item_id'            => null,
+            'amount'                   => $part,
+            'stripe_payment_intent_id' => $result['id'],
+            'status'                   => 'pending',
+            'mode'                     => 'equitative',
+            'parts_total'              => $people,
+            'part_number'              => $partNumber,
+        ]);
+
+        return response()->json([
+            'success'       => true,
+            'client_secret' => $result['client_secret'],
+            'amount'        => $part,
+            'part_number'   => $partNumber,
+            'parts_total'   => $people,
+        ]);
+    }
+
+    /**
+     * Verifica el pago con Stripe y marca el OrderItemPayment como pagado.
+     * Si el pedido queda completamente cubierto, lo cierra automáticamente.
+     *
+     * @param  Request  $request
+     * @param  string   $hash
+     * @return JsonResponse
+     */
+    public function confirm(Request $request, string $hash): JsonResponse
+    {
+        $validated = $request->validate([
+            'payment_intent_id' => 'required|string',
+        ]);
+
+        $table = Table::where('unique_hash', $hash)->firstOrFail();
+        $order = $this->activeOrder($table->id);
+
+        if (! $order) {
+            return response()->json(['success' => false, 'message' => 'No hay pedido activo.'], 404);
+        }
+
+        $splitPayment = OrderItemPayment::where('stripe_payment_intent_id', $validated['payment_intent_id'])
+            ->where('order_id', $order->id)
+            ->first();
+
+        if (! $splitPayment) {
+            return response()->json(['success' => false, 'message' => 'Pago parcial no encontrado.'], 404);
+        }
+
+        $intent = $this->stripe->confirmPayment($validated['payment_intent_id']);
+
+        if ($intent['status'] !== 'succeeded') {
+            $splitPayment->update(['status' => 'failed']);
+            return response()->json(['success' => false, 'message' => 'El pago no se ha completado.'], 422);
+        }
+
+        $splitPayment->update(['status' => 'paid']);
+
+        $fullyPaid = $this->checkOrderFullyPaid($order);
+
+        return response()->json([
+            'success'    => true,
+            'fully_paid' => $fullyPaid,
+        ]);
+    }
+
+    /**
+     * Cierra el pedido si el importe pagado via split cubre el total.
+     *
+     * @param  Order  $order
+     * @return bool   true si el pedido fue cerrado
+     */
+    private function checkOrderFullyPaid(Order $order): bool
+    {
+        $order->refresh();
+
+        if (! $order->isFullyPaidViaSplit()) {
+            return false;
+        }
+
+        $order->update([
+            'payment_method' => 'card',
+            'payment_status' => 'paid',
+            'status'         => 'closed',
+            'bill_requested' => false,
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Busca el pedido activo de una mesa.
+     *
+     * @param  int  $tableId
+     * @return Order|null
+     */
+    private function activeOrder(int $tableId): ?Order
+    {
+        return Order::where('table_id', $tableId)
+            ->whereIn('status', ['pending', 'cooking', 'ready'])
+            ->where('payment_status', 'pending')
+            ->latest()
+            ->first();
+    }
+}

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -116,11 +116,29 @@ class MenuController extends Controller
 
         $stripePublicKey = config('services.stripe.key');
 
+        $splitPaymentEnabled  = $table->user->isSplitPaymentEnabled();
+        $splitPaymentMaxParts = $table->user->split_payment_max_parts;
+
+        $activeOrderItemsForAlpine = $activeOrder
+            ? $activeOrder->items()->with(['product:id,name', 'splitPayments'])->get()
+                ->map(fn (OrderItem $item) => [
+                    'id'       => $item->id,
+                    'name'     => $item->product?->name ?? 'Producto',
+                    'quantity' => $item->quantity,
+                    'price'    => (float) $item->price,
+                    'total'    => round((float) $item->price * $item->quantity, 2),
+                    'claimed'  => $item->isClaimed(),
+                ])
+                ->values()
+                ->toArray()
+            : [];
+
         return view('menu.show', compact(
             'table', 'categories', 'allergens',
             'tapaConfig', 'barItemsCount', 'kitchenOpen', 'nextOpeningTime',
             'tapaVariantsUsed', 'tapaProducts', 'shouldSuggest',
-            'hasActiveOrder', 'activeOrderTotal', 'billRequested', 'stripePublicKey'
+            'hasActiveOrder', 'activeOrderTotal', 'billRequested', 'stripePublicKey',
+            'splitPaymentEnabled', 'splitPaymentMaxParts', 'activeOrderItemsForAlpine'
         ));
     }
 }

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Class Order
@@ -85,5 +86,35 @@ class Order extends Model
     public function dailyMenuOrder(): HasOne
     {
         return $this->hasOne(DailyMenuOrder::class);
+    }
+
+    /**
+     * Todos los pagos parciales realizados sobre este pedido.
+     *
+     * @return HasMany
+     */
+    public function splitPayments(): HasMany
+    {
+        return $this->hasMany(OrderItemPayment::class);
+    }
+
+    /**
+     * Suma de los pagos parciales con status 'paid'.
+     *
+     * @return float
+     */
+    public function getPaidAmountViaSplit(): float
+    {
+        return (float) $this->splitPayments()->where('status', 'paid')->sum('amount');
+    }
+
+    /**
+     * Indica si el total del pedido está completamente cubierto por pagos parciales pagados.
+     *
+     * @return bool
+     */
+    public function isFullyPaidViaSplit(): bool
+    {
+        return $this->getPaidAmountViaSplit() >= (float) $this->total;
     }
 }

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -55,4 +55,34 @@ class OrderItem extends Model
     {
         return $this->hasMany(OrderItemModification::class);
     }
+
+    /**
+     * Pagos parciales que cubren este ítem.
+     *
+     * @return HasMany
+     */
+    public function splitPayments(): HasMany
+    {
+        return $this->hasMany(OrderItemPayment::class);
+    }
+
+    /**
+     * Indica si este ítem ha sido reclamado (hay algún pago parcial pendiente o pagado).
+     *
+     * @return bool
+     */
+    public function isClaimed(): bool
+    {
+        return $this->splitPayments()->whereIn('status', ['pending', 'paid'])->exists();
+    }
+
+    /**
+     * Indica si este ítem está completamente cubierto por pagos parciales pagados.
+     *
+     * @return bool
+     */
+    public function isPaidViaSplit(): bool
+    {
+        return $this->splitPayments()->where('status', 'paid')->exists();
+    }
 }

--- a/app/Models/OrderItemPayment.php
+++ b/app/Models/OrderItemPayment.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Class OrderItemPayment
+ *
+ * Registra cada pago parcial realizado sobre un pedido en el modo de cobro partido.
+ * En modo 'items' se vincula a un order_item concreto; en modo 'equitative' order_item_id es null.
+ *
+ * @property int         $order_id
+ * @property int|null    $order_item_id
+ * @property float       $amount
+ * @property string      $stripe_payment_intent_id
+ * @property string      $status              'pending', 'paid', 'failed'
+ * @property string      $mode                'items', 'equitative'
+ * @property int|null    $parts_total
+ * @property int|null    $part_number
+ *
+ * @author BenjaminDTS
+ */
+class OrderItemPayment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'order_id',
+        'order_item_id',
+        'amount',
+        'stripe_payment_intent_id',
+        'status',
+        'mode',
+        'parts_total',
+        'part_number',
+    ];
+
+    protected $casts = [
+        'amount'      => 'float',
+        'parts_total' => 'integer',
+        'part_number' => 'integer',
+    ];
+
+    /**
+     * El pedido al que pertenece este pago parcial.
+     *
+     * @return BelongsTo
+     */
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    /**
+     * El ítem concreto que cubre este pago (null en modo equitativo).
+     *
+     * @return BelongsTo
+     */
+    public function orderItem(): BelongsTo
+    {
+        return $this->belongsTo(OrderItem::class);
+    }
+}

--- a/app/Services/StripeService.php
+++ b/app/Services/StripeService.php
@@ -44,6 +44,42 @@ class StripeService
     }
 
     /**
+     * Crea un PaymentIntent parcial para cobro partido.
+     * Igual que createPaymentIntent pero incluye metadata de split.
+     *
+     * @param  int     $amount      Importe en céntimos
+     * @param  string  $mode        'items' o 'equitative'
+     * @param  int     $partNumber  Número de esta parte (1-based)
+     * @param  int     $partsTotal  Total de partes de la división
+     * @param  array   $metadata    Metadatos adicionales
+     * @return array{id: string, client_secret: string, status: string}
+     */
+    public function createSplitPaymentIntent(
+        int $amount,
+        string $mode,
+        int $partNumber,
+        int $partsTotal,
+        array $metadata = [],
+    ): array {
+        $intent = $this->client->paymentIntents->create([
+            'amount'                    => $amount,
+            'currency'                  => 'eur',
+            'metadata'                  => array_merge($metadata, [
+                'split_mode'        => $mode,
+                'split_part_number' => $partNumber,
+                'split_parts_total' => $partsTotal,
+            ]),
+            'automatic_payment_methods' => ['enabled' => true],
+        ]);
+
+        return [
+            'id'            => $intent->id,
+            'client_secret' => $intent->client_secret,
+            'status'        => $intent->status,
+        ];
+    }
+
+    /**
      * Recupera un PaymentIntent y devuelve su estado actual.
      * Se usa para verificar el pago en el servidor tras la confirmación del cliente.
      *

--- a/database/factories/OrderItemPaymentFactory.php
+++ b/database/factories/OrderItemPaymentFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\OrderItemPayment;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<OrderItemPayment>
+ */
+class OrderItemPaymentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'order_id'                 => \App\Models\Order::factory(),
+            'order_item_id'            => null,
+            'amount'                   => $this->faker->randomFloat(2, 1, 50),
+            'stripe_payment_intent_id' => 'pi_test_' . $this->faker->unique()->lexify('??????????????????'),
+            'status'                   => 'pending',
+            'mode'                     => $this->faker->randomElement(['items', 'equitative']),
+            'parts_total'              => null,
+            'part_number'              => null,
+        ];
+    }
+}

--- a/database/migrations/2026_05_21_190659_create_order_item_payments_table.php
+++ b/database/migrations/2026_05_21_190659_create_order_item_payments_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('order_item_payments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('order_item_id')->nullable()->constrained()->nullOnDelete();
+            $table->decimal('amount', 10, 2);
+            $table->string('stripe_payment_intent_id')->unique();
+            $table->enum('status', ['pending', 'paid', 'failed'])->default('pending');
+            $table->enum('mode', ['items', 'equitative']);
+            $table->unsignedSmallInteger('parts_total')->nullable();
+            $table->unsignedSmallInteger('part_number')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('order_item_payments');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\BillRequestController;
 use App\Http\Controllers\Api\CardPaymentController;
 use App\Http\Controllers\Api\OrderController;
+use App\Http\Controllers\Api\SplitPaymentController;
 use App\Http\Controllers\ChatController;
 use App\Http\Controllers\DailyMenuPublicController;
 use Illuminate\Support\Facades\Route;
@@ -23,6 +24,20 @@ Route::post('/v1/payment/{hash}/intent',  [CardPaymentController::class, 'intent
 Route::post('/v1/payment/{hash}/confirm', [CardPaymentController::class, 'confirm'])
     ->middleware('throttle:10,1')
     ->name('api.payment.confirm');
+
+// Cobro partido — rutas públicas (sin autenticación, contexto por table_hash)
+Route::get('/v1/payment/{hash}/split/items',       [SplitPaymentController::class, 'claimedItems'])
+    ->middleware('throttle:30,1')
+    ->name('api.split.items');
+Route::post('/v1/payment/{hash}/split/pay-items',  [SplitPaymentController::class, 'payItems'])
+    ->middleware('throttle:10,1')
+    ->name('api.split.pay-items');
+Route::post('/v1/payment/{hash}/split/pay-eq',     [SplitPaymentController::class, 'payEquitative'])
+    ->middleware('throttle:10,1')
+    ->name('api.split.pay-eq');
+Route::post('/v1/payment/{hash}/split/confirm',    [SplitPaymentController::class, 'confirm'])
+    ->middleware('throttle:10,1')
+    ->name('api.split.confirm');
 
 // Chatbot IA — rutas públicas (sin autenticación, contexto por table_hash)
 Route::get('/v1/menu/{tableHash}',             [ChatController::class, 'menu'])->middleware('throttle:60,1')->name('api.chat.menu');

--- a/tests/Feature/Bloque16/SplitPaymentTest.php
+++ b/tests/Feature/Bloque16/SplitPaymentTest.php
@@ -1,0 +1,425 @@
+<?php
+
+/**
+ * @author BenjaminDTS
+ */
+
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\OrderItemPayment;
+use App\Models\Product;
+use App\Models\Table;
+use App\Models\User;
+use App\Services\StripeService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Support\CreatesTenants;
+
+uses(RefreshDatabase::class);
+uses(CreatesTenants::class);
+
+beforeEach(function () {
+    $this->setupTenants();
+
+    // Stripe SDK no está instalado en el entorno de tests — siempre mocked.
+    $this->mock(StripeService::class);
+
+    $this->user->update([
+        'split_payment_enabled'   => true,
+        'split_payment_max_parts' => 10,
+    ]);
+
+    $this->table = Table::factory()->for($this->user)->create();
+
+    $this->order = Order::factory()->create([
+        'table_id'       => $this->table->id,
+        'status'         => 'pending',
+        'payment_status' => 'pending',
+        'total'          => 30.00,
+    ]);
+
+    $this->item1 = OrderItem::factory()->create([
+        'order_id' => $this->order->id,
+        'price'    => 10.00,
+        'quantity' => 1,
+    ]);
+
+    $this->item2 = OrderItem::factory()->create([
+        'order_id' => $this->order->id,
+        'price'    => 20.00,
+        'quantity' => 1,
+    ]);
+});
+
+// ─── claimedItems ─────────────────────────────────────────────────────────────
+
+it('claimedItems returns all items with claimed=false when no payments exist', function () {
+    $this->getJson("/api/v1/payment/{$this->table->unique_hash}/split/items")
+        ->assertOk()
+        ->assertJson(['success' => true])
+        ->assertJsonCount(2, 'items')
+        ->assertJsonPath('items.0.claimed', false)
+        ->assertJsonPath('items.1.claimed', false);
+});
+
+it('claimedItems marks item as claimed when a pending payment exists', function () {
+    OrderItemPayment::factory()->create([
+        'order_id'      => $this->order->id,
+        'order_item_id' => $this->item1->id,
+        'status'        => 'pending',
+        'mode'          => 'items',
+    ]);
+
+    $response = $this->getJson("/api/v1/payment/{$this->table->unique_hash}/split/items")
+        ->assertOk();
+
+    $items = collect($response->json('items'));
+    expect($items->firstWhere('id', $this->item1->id)['claimed'])->toBeTrue();
+    expect($items->firstWhere('id', $this->item2->id)['claimed'])->toBeFalse();
+});
+
+it('claimedItems returns 404 with invalid table hash', function () {
+    $this->getJson('/api/v1/payment/invalid-hash/split/items')
+        ->assertNotFound();
+});
+
+it('claimedItems returns 404 when no active order exists', function () {
+    $this->order->update(['status' => 'closed']);
+
+    $this->getJson("/api/v1/payment/{$this->table->unique_hash}/split/items")
+        ->assertNotFound();
+});
+
+// ─── payItems ─────────────────────────────────────────────────────────────────
+
+it('payItems creates a pending OrderItemPayment per selected item', function () {
+    $this->mock(StripeService::class)
+        ->shouldReceive('createSplitPaymentIntent')
+        ->once()
+        ->andReturn([
+            'id'            => 'pi_test_items_001',
+            'client_secret' => 'secret_items_001',
+            'status'        => 'requires_payment_method',
+        ]);
+
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/pay-items", [
+        'item_ids' => [$this->item1->id],
+    ])->assertOk()
+      ->assertJsonPath('success', true)
+      ->assertJsonStructure(['client_secret', 'amount']);
+
+    $this->assertDatabaseHas('order_item_payments', [
+        'order_id'                 => $this->order->id,
+        'order_item_id'            => $this->item1->id,
+        'stripe_payment_intent_id' => 'pi_test_items_001',
+        'status'                   => 'pending',
+        'mode'                     => 'items',
+    ]);
+});
+
+it('payItems returns 409 when an item is already claimed', function () {
+    OrderItemPayment::factory()->create([
+        'order_id'      => $this->order->id,
+        'order_item_id' => $this->item1->id,
+        'status'        => 'pending',
+        'mode'          => 'items',
+    ]);
+
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/pay-items", [
+        'item_ids' => [$this->item1->id],
+    ])->assertStatus(409)
+      ->assertJsonPath('success', false);
+});
+
+it('payItems returns 422 when item_ids is empty', function () {
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/pay-items", [
+        'item_ids' => [],
+    ])->assertUnprocessable();
+});
+
+it('payItems returns 422 when item belongs to a different order', function () {
+    $otherTable = Table::factory()->for($this->other)->create();
+    $otherOrder = Order::factory()->create(['table_id' => $otherTable->id]);
+    $otherItem  = OrderItem::factory()->create(['order_id' => $otherOrder->id]);
+
+    $this->mock(StripeService::class)
+        ->shouldReceive('createSplitPaymentIntent')
+        ->never();
+
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/pay-items", [
+        'item_ids' => [$otherItem->id],
+    ])->assertUnprocessable();
+});
+
+it('payItems returns 404 with invalid table hash', function () {
+    $this->postJson('/api/v1/payment/invalid-hash/split/pay-items', [
+        'item_ids' => [$this->item1->id],
+    ])->assertNotFound();
+});
+
+it('payItems returns 404 when no active order exists', function () {
+    $this->order->update(['status' => 'closed']);
+
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/pay-items", [
+        'item_ids' => [$this->item1->id],
+    ])->assertNotFound();
+});
+
+// ─── payEquitative ────────────────────────────────────────────────────────────
+
+it('payEquitative creates an OrderItemPayment for the diner\'s part', function () {
+    $this->mock(StripeService::class)
+        ->shouldReceive('createSplitPaymentIntent')
+        ->once()
+        ->andReturn([
+            'id'            => 'pi_test_eq_001',
+            'client_secret' => 'secret_eq_001',
+            'status'        => 'requires_payment_method',
+        ]);
+
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/pay-eq", [
+        'people'      => 3,
+        'part_number' => 1,
+    ])->assertOk()
+      ->assertJsonPath('success', true)
+      ->assertJsonPath('parts_total', 3)
+      ->assertJsonPath('part_number', 1);
+
+    $this->assertDatabaseHas('order_item_payments', [
+        'order_id'     => $this->order->id,
+        'order_item_id'=> null,
+        'status'       => 'pending',
+        'mode'         => 'equitative',
+        'parts_total'  => 3,
+        'part_number'  => 1,
+    ]);
+});
+
+it('payEquitative calculates the correct per-person amount', function () {
+    $this->mock(StripeService::class)
+        ->shouldReceive('createSplitPaymentIntent')
+        ->once()
+        ->andReturn(['id' => 'pi_test_eq_002', 'client_secret' => 'secret_eq_002', 'status' => 'requires_payment_method']);
+
+    $response = $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/pay-eq", [
+        'people'      => 3,
+        'part_number' => 1,
+    ])->assertOk();
+
+    expect(round($response->json('amount'), 2))->toBe(round(30 / 3, 2));
+});
+
+it('payEquitative returns 422 when part_number exceeds people', function () {
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/pay-eq", [
+        'people'      => 3,
+        'part_number' => 5,
+    ])->assertUnprocessable();
+});
+
+it('payEquitative returns 422 when people is less than 2', function () {
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/pay-eq", [
+        'people'      => 1,
+        'part_number' => 1,
+    ])->assertUnprocessable();
+});
+
+it('payEquitative returns 404 with invalid table hash', function () {
+    $this->postJson('/api/v1/payment/invalid-hash/split/pay-eq', [
+        'people'      => 2,
+        'part_number' => 1,
+    ])->assertNotFound();
+});
+
+it('payEquitative returns 404 when no active order exists', function () {
+    $this->order->update(['status' => 'closed']);
+
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/pay-eq", [
+        'people'      => 2,
+        'part_number' => 1,
+    ])->assertNotFound();
+});
+
+// ─── confirm ──────────────────────────────────────────────────────────────────
+
+it('confirm marks split payment as paid when Stripe succeeds', function () {
+    $splitPayment = OrderItemPayment::factory()->create([
+        'order_id'                 => $this->order->id,
+        'order_item_id'            => $this->item1->id,
+        'amount'                   => 10.00,
+        'stripe_payment_intent_id' => 'pi_test_confirm_001',
+        'status'                   => 'pending',
+        'mode'                     => 'items',
+    ]);
+
+    $this->mock(StripeService::class)
+        ->shouldReceive('confirmPayment')
+        ->once()
+        ->andReturn(['id' => 'pi_test_confirm_001', 'status' => 'succeeded']);
+
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/confirm", [
+        'payment_intent_id' => 'pi_test_confirm_001',
+    ])->assertOk()->assertJsonPath('success', true);
+
+    $this->assertDatabaseHas('order_item_payments', [
+        'id'     => $splitPayment->id,
+        'status' => 'paid',
+    ]);
+});
+
+it('confirm marks split payment as failed when Stripe does not succeed', function () {
+    $splitPayment = OrderItemPayment::factory()->create([
+        'order_id'                 => $this->order->id,
+        'stripe_payment_intent_id' => 'pi_test_fail_001',
+        'status'                   => 'pending',
+        'mode'                     => 'equitative',
+    ]);
+
+    $this->mock(StripeService::class)
+        ->shouldReceive('confirmPayment')
+        ->once()
+        ->andReturn(['id' => 'pi_test_fail_001', 'status' => 'requires_payment_method']);
+
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/confirm", [
+        'payment_intent_id' => 'pi_test_fail_001',
+    ])->assertUnprocessable();
+
+    $this->assertDatabaseHas('order_item_payments', [
+        'id'     => $splitPayment->id,
+        'status' => 'failed',
+    ]);
+});
+
+it('confirm closes order automatically when fully paid via split', function () {
+    // Item1 ya pagado; Item2 es el que confirmamos ahora
+    OrderItemPayment::factory()->create([
+        'order_id'                 => $this->order->id,
+        'order_item_id'            => $this->item1->id,
+        'amount'                   => 10.00,
+        'stripe_payment_intent_id' => 'pi_test_partial_001',
+        'status'                   => 'paid',
+        'mode'                     => 'items',
+    ]);
+
+    OrderItemPayment::factory()->create([
+        'order_id'                 => $this->order->id,
+        'order_item_id'            => $this->item2->id,
+        'amount'                   => 20.00,
+        'stripe_payment_intent_id' => 'pi_test_partial_002',
+        'status'                   => 'pending',
+        'mode'                     => 'items',
+    ]);
+
+    $this->mock(StripeService::class)
+        ->shouldReceive('confirmPayment')
+        ->once()
+        ->andReturn(['id' => 'pi_test_partial_002', 'status' => 'succeeded']);
+
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/confirm", [
+        'payment_intent_id' => 'pi_test_partial_002',
+    ])->assertOk()
+      ->assertJsonPath('success', true)
+      ->assertJsonPath('fully_paid', true);
+
+    $this->assertDatabaseHas('orders', [
+        'id'             => $this->order->id,
+        'payment_status' => 'paid',
+        'status'         => 'closed',
+    ]);
+});
+
+it('confirm does not close order when partially paid', function () {
+    OrderItemPayment::factory()->create([
+        'order_id'                 => $this->order->id,
+        'order_item_id'            => $this->item1->id,
+        'amount'                   => 10.00,
+        'stripe_payment_intent_id' => 'pi_test_partial_003',
+        'status'                   => 'pending',
+        'mode'                     => 'items',
+    ]);
+
+    $this->mock(StripeService::class)
+        ->shouldReceive('confirmPayment')
+        ->once()
+        ->andReturn(['id' => 'pi_test_partial_003', 'status' => 'succeeded']);
+
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/confirm", [
+        'payment_intent_id' => 'pi_test_partial_003',
+    ])->assertOk()
+      ->assertJsonPath('fully_paid', false);
+
+    $this->assertDatabaseHas('orders', [
+        'id'             => $this->order->id,
+        'payment_status' => 'pending',
+        'status'         => 'pending',
+    ]);
+});
+
+it('confirm returns 404 when payment_intent_id does not belong to the order', function () {
+    $this->mock(StripeService::class)
+        ->shouldReceive('confirmPayment')
+        ->never();
+
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/confirm", [
+        'payment_intent_id' => 'pi_completely_unknown',
+    ])->assertNotFound();
+});
+
+it('confirm returns 422 when payment_intent_id is missing', function () {
+    $this->postJson("/api/v1/payment/{$this->table->unique_hash}/split/confirm", [])
+        ->assertUnprocessable();
+});
+
+it('confirm returns 404 with invalid table hash', function () {
+    $this->postJson('/api/v1/payment/invalid-hash/split/confirm', [
+        'payment_intent_id' => 'pi_test_xyz',
+    ])->assertNotFound();
+});
+
+// ─── Model helpers ────────────────────────────────────────────────────────────
+
+it('OrderItem isClaimed returns true when a pending payment exists', function () {
+    OrderItemPayment::factory()->create([
+        'order_id'      => $this->order->id,
+        'order_item_id' => $this->item1->id,
+        'status'        => 'pending',
+        'mode'          => 'items',
+    ]);
+
+    expect($this->item1->fresh()->isClaimed())->toBeTrue();
+});
+
+it('OrderItem isClaimed returns false when no payment exists', function () {
+    expect($this->item1->fresh()->isClaimed())->toBeFalse();
+});
+
+it('OrderItem isClaimed returns false when only failed payment exists', function () {
+    OrderItemPayment::factory()->create([
+        'order_id'      => $this->order->id,
+        'order_item_id' => $this->item1->id,
+        'status'        => 'failed',
+        'mode'          => 'items',
+    ]);
+
+    expect($this->item1->fresh()->isClaimed())->toBeFalse();
+});
+
+it('Order isFullyPaidViaSplit returns true when paid amount covers total', function () {
+    OrderItemPayment::factory()->create([
+        'order_id' => $this->order->id,
+        'amount'   => 30.00,
+        'status'   => 'paid',
+        'mode'     => 'equitative',
+    ]);
+
+    expect($this->order->fresh()->isFullyPaidViaSplit())->toBeTrue();
+});
+
+it('Order isFullyPaidViaSplit returns false when paid amount is below total', function () {
+    OrderItemPayment::factory()->create([
+        'order_id' => $this->order->id,
+        'amount'   => 10.00,
+        'status'   => 'paid',
+        'mode'     => 'equitative',
+    ]);
+
+    expect($this->order->fresh()->isFullyPaidViaSplit())->toBeFalse();
+});


### PR DESCRIPTION
## Summary

- Adds `order_item_payments` migration and model (`OrderItemPayment`) to track each partial payment
- Extends `Order` with `splitPayments()`, `getPaidAmountViaSplit()`, `isFullyPaidViaSplit()`
- Extends `OrderItem` with `splitPayments()`, `isClaimed()`, `isPaidViaSplit()`
- Adds `createSplitPaymentIntent()` to `StripeService` with split metadata
- Implements `SplitPaymentController` with four public endpoints:
  - `GET  /api/v1/payment/{hash}/split/items` — returns items with `claimed` flag
  - `POST /api/v1/payment/{hash}/split/pay-items` — atomic claim + PaymentIntent per item selection
  - `POST /api/v1/payment/{hash}/split/pay-eq` — equitative split PaymentIntent
  - `POST /api/v1/payment/{hash}/split/confirm` — verifies payment, auto-closes order when fully paid
- `MenuController` now hydrates `claimed` from `order_item_payments` (replaces the `false` placeholder from B16.3)

## Test plan

- [ ] `php artisan test` passes at 100% (863 tests)
- [ ] `claimedItems` returns all items unclaimed when no payments exist
- [ ] `claimedItems` marks item as claimed when a pending payment row exists
- [ ] `payItems` creates `order_item_payments` rows and returns `client_secret`
- [ ] `payItems` returns 409 when an item is already claimed by another diner
- [ ] `payEquitative` calculates correct per-person amount and stores `parts_total`/`part_number`
- [ ] `confirm` marks split payment as paid/failed according to Stripe response
- [ ] `confirm` closes the order automatically when `getPaidAmountViaSplit() >= total`
- [ ] `confirm` does NOT close the order when only partially paid
- [ ] Stripe is always mocked — no real API calls in tests