### PR TITLE
feat(bloque6): configuración del negocio — horarios y período de cierre de pedidos

### DIFF
--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -42,7 +42,21 @@ class OrderController extends Controller
         ]);
 
         $table      = Table::where('unique_hash', $validated['table_hash'])->firstOrFail();
-        $tapaConfig = $table->user->tapaConfig?->load('schedules');
+        $tapaConfig = $table->user->tapaConfig?->load(['kitchenSchedules', 'businessSchedules']);
+
+        if ($tapaConfig && ! $tapaConfig->isBusinessOpen()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'El negocio está cerrado. No se pueden realizar pedidos en este momento.',
+            ], 422);
+        }
+
+        if ($tapaConfig && ! $tapaConfig->isOrderingAllowed()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'El tiempo de pedidos ha finalizado. Solo puedes solicitar la cuenta.',
+            ], 422);
+        }
 
         $order = DB::transaction(function () use ($validated, $table, $tapaConfig) {
             $order = Order::create([

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -33,8 +33,13 @@ class MenuController extends Controller
         $config = $table->user->tapaConfig;
 
         if ($config) {
-            $config->load('schedules');
+            $config->load(['kitchenSchedules', 'businessSchedules']);
         }
+
+        $businessOpen           = ! $config || $config->isBusinessOpen();
+        $orderingAllowed        = ! $config || $config->isOrderingAllowed();
+        $businessNextOpening    = ($config && ! $businessOpen) ? $config->getBusinessNextOpeningTime() : null;
+        $minutesUntilClose      = ($config && $businessOpen && ! $orderingAllowed) ? $config->minutesUntilBusinessClose() : null;
 
         $kitchenOpen     = ! ($config && $config->tapas_enabled) || $config->isKitchenOpen();
         $nextOpeningTime = ($config && ! $kitchenOpen) ? $config->nextOpeningTime() : null;
@@ -138,7 +143,8 @@ class MenuController extends Controller
             'tapaConfig', 'barItemsCount', 'kitchenOpen', 'nextOpeningTime',
             'tapaVariantsUsed', 'tapaProducts', 'shouldSuggest',
             'hasActiveOrder', 'activeOrderTotal', 'billRequested', 'stripePublicKey',
-            'splitPaymentEnabled', 'splitPaymentMaxParts', 'activeOrderItemsForAlpine'
+            'splitPaymentEnabled', 'splitPaymentMaxParts', 'activeOrderItemsForAlpine',
+            'businessOpen', 'orderingAllowed', 'businessNextOpening', 'minutesUntilClose'
         ));
     }
 }

--- a/app/Http/Controllers/TapasController.php
+++ b/app/Http/Controllers/TapasController.php
@@ -13,17 +13,15 @@ use Illuminate\View\View;
 /**
  * Class TapasController
  *
- * Permite al gerente configurar el sistema de tapas del restaurante:
- * activar/desactivar, modo gratuito/de pago, modalidad de precio
- * (fijo global o por producto), precio, variantes máximas,
- * tapa extra de pago y tramos horarios de apertura de cocina.
+ * Gestiona la configuración del negocio: horarios de apertura (negocio y cocina),
+ * período de cierre de pedidos, sistema de tapas y tapa extra.
  *
  * @author BenjaminDTS
  */
 class TapasController extends Controller
 {
     /**
-     * Muestra el formulario de configuración de tapas.
+     * Muestra el formulario de configuración del negocio.
      * Crea la configuración con valores por defecto si aún no existe.
      *
      * @return View
@@ -33,64 +31,64 @@ class TapasController extends Controller
         $tapaConfig = TapaConfig::firstOrCreate(
             ['user_id' => Auth::id()],
             [
-                'tapas_enabled'      => false,
-                'tapas_free'         => true,
-                'price_mode'         => 'fixed',
-                'max_tapa_variants'  => 3,
-                'tapa_price'         => null,
-                'extra_tapa_enabled' => false,
-                'extra_tapa_price'   => null,
+                'tapas_enabled'           => false,
+                'tapas_free'              => true,
+                'price_mode'              => 'fixed',
+                'max_tapa_variants'       => 3,
+                'tapa_price'              => null,
+                'extra_tapa_enabled'      => false,
+                'extra_tapa_price'        => null,
+                'ordering_cutoff_minutes' => 0,
             ]
         );
 
-        $tapaConfig->load('schedules');
+        $tapaConfig->load(['kitchenSchedules', 'businessSchedules']);
 
-        return view('tapas.edit', compact('tapaConfig'));
+        return view('negocio.config', compact('tapaConfig'));
     }
 
     /**
-     * Guarda la configuración de tapas del restaurante.
+     * Guarda la configuración del negocio.
      *
-     * Reglas de precio:
-     *  - Si tapas_free = true: precio y modalidad ignorados, tapa_price = null.
-     *  - Si tapas_free = false y price_mode = 'fixed': tapa_price obligatorio.
-     *  - Si tapas_free = false y price_mode = 'per_product': tapa_price = null.
+     * Valida y persiste:
+     *  - Tramos de horario del negocio (type=business, máx. 4)
+     *  - Tramos de horario de cocina (type=kitchen, máx. 4)
+     *  - Minutos de cierre de pedidos antes del fin de tramo
+     *  - Toda la configuración de tapas
      *
-     * Al activar tapas crea automáticamente la categoría 'Tapas' con destination=kitchen.
-     * Reemplaza los tramos horarios de cocina por los enviados en el formulario.
-     *
-     * @param  Request $request
+     * @param  Request  $request
      * @return RedirectResponse
      */
     public function update(Request $request): RedirectResponse
     {
-        $tapasFree  = $request->boolean('tapas_free');
-        $priceMode  = $request->input('price_mode', 'fixed');
+        $tapasFree = $request->boolean('tapas_free');
+        $priceMode = $request->input('price_mode', 'fixed');
 
         $request->validate([
-            'tapas_enabled'            => ['sometimes', 'boolean'],
-            'tapas_free'               => ['sometimes', 'boolean'],
-            'price_mode'               => ['nullable', 'in:fixed,per_product'],
-            'max_tapa_variants'        => ['required', 'integer', 'min:1', 'max:20'],
-            'tapa_price'               => [
+            'tapas_enabled'                       => ['sometimes', 'boolean'],
+            'tapas_free'                          => ['sometimes', 'boolean'],
+            'price_mode'                          => ['nullable', 'in:fixed,per_product'],
+            'max_tapa_variants'                   => ['required', 'integer', 'min:1', 'max:20'],
+            'tapa_price'                          => [
                 Rule::requiredIf(fn () => ! $tapasFree && $priceMode === 'fixed'),
                 'nullable', 'numeric', 'min:0', 'max:999.99',
             ],
-            'extra_tapa_enabled'       => ['sometimes', 'boolean'],
-            'extra_tapa_price'         => ['required_if:extra_tapa_enabled,1', 'nullable', 'numeric', 'min:0', 'max:999.99'],
-            'schedules'                => ['nullable', 'array', 'max:10'],
-            'schedules.*.opens_at'     => ['required', 'date_format:H:i'],
-            'schedules.*.closes_at'    => ['required', 'date_format:H:i'],
+            'extra_tapa_enabled'                  => ['sometimes', 'boolean'],
+            'extra_tapa_price'                    => ['required_if:extra_tapa_enabled,1', 'nullable', 'numeric', 'min:0', 'max:999.99'],
+            'ordering_cutoff_minutes'             => ['nullable', 'integer', 'min:0', 'max:120'],
+            'kitchen_schedules'                   => ['nullable', 'array', 'max:4'],
+            'kitchen_schedules.*.opens_at'        => ['required', 'date_format:H:i'],
+            'kitchen_schedules.*.closes_at'       => ['required', 'date_format:H:i'],
+            'business_schedules'                  => ['nullable', 'array', 'max:4'],
+            'business_schedules.*.opens_at'       => ['required', 'date_format:H:i'],
+            'business_schedules.*.closes_at'      => ['required', 'date_format:H:i'],
         ]);
 
         $userId       = Auth::id();
         $tapasEnabled = $request->boolean('tapas_enabled');
         $extraEnabled = $request->boolean('extra_tapa_enabled');
 
-        // Normalizar modalidad: si tapas son gratuitas el precio_mode es irrelevante
-        $resolvedMode = $tapasFree ? 'fixed' : $priceMode;
-
-        // tapa_price solo aplica en modalidad fija y tapas de pago
+        $resolvedMode  = $tapasFree ? 'fixed' : $priceMode;
         $resolvedPrice = ($tapasFree || $resolvedMode === 'per_product')
             ? null
             : ($request->input('tapa_price') ?? null);
@@ -105,26 +103,38 @@ class TapasController extends Controller
         $config = TapaConfig::updateOrCreate(
             ['user_id' => $userId],
             [
-                'tapas_enabled'      => $tapasEnabled,
-                'tapas_free'         => $tapasFree,
-                'price_mode'         => $resolvedMode,
-                'max_tapa_variants'  => $request->integer('max_tapa_variants'),
-                'tapa_price'         => $resolvedPrice,
-                'extra_tapa_enabled' => $extraEnabled,
-                'extra_tapa_price'   => $extraEnabled ? ($request->input('extra_tapa_price') ?? null) : null,
+                'tapas_enabled'           => $tapasEnabled,
+                'tapas_free'              => $tapasFree,
+                'price_mode'              => $resolvedMode,
+                'max_tapa_variants'       => $request->integer('max_tapa_variants'),
+                'tapa_price'              => $resolvedPrice,
+                'extra_tapa_enabled'      => $extraEnabled,
+                'extra_tapa_price'        => $extraEnabled ? ($request->input('extra_tapa_price') ?? null) : null,
+                'ordering_cutoff_minutes' => (int) ($request->input('ordering_cutoff_minutes') ?? 0),
             ]
         );
 
-        $config->schedules()->delete();
-
-        foreach ($request->input('schedules', []) as $slot) {
-            $config->schedules()->create([
+        // Reemplazar tramos de cocina
+        $config->kitchenSchedules()->delete();
+        foreach ($request->input('kitchen_schedules', []) as $slot) {
+            $config->kitchenSchedules()->create([
+                'type'      => 'kitchen',
                 'opens_at'  => $slot['opens_at'],
                 'closes_at' => $slot['closes_at'],
             ]);
         }
 
-        return redirect()->route('tapas.edit')
-                         ->with('success', 'Configuración de tapas guardada correctamente.');
+        // Reemplazar tramos del negocio
+        $config->businessSchedules()->delete();
+        foreach ($request->input('business_schedules', []) as $slot) {
+            $config->businessSchedules()->create([
+                'type'      => 'business',
+                'opens_at'  => $slot['opens_at'],
+                'closes_at' => $slot['closes_at'],
+            ]);
+        }
+
+        return redirect()->route('negocio.config.edit')
+                         ->with('success', 'Configuración del negocio guardada correctamente.');
     }
 }

--- a/app/Models/KitchenSchedule.php
+++ b/app/Models/KitchenSchedule.php
@@ -27,6 +27,7 @@ class KitchenSchedule extends Model
      */
     protected $fillable = [
         'tapa_config_id',
+        'type',
         'opens_at',
         'closes_at',
     ];

--- a/app/Models/TapaConfig.php
+++ b/app/Models/TapaConfig.php
@@ -11,21 +11,19 @@ use Illuminate\Support\Carbon;
 /**
  * Class TapaConfig
  *
- * Configuración del sistema de tapas de un restaurante (relación 1:1 con User).
- * Permite al gerente activar tapas, definir si son gratuitas o de pago,
- * la modalidad de precio (fijo global o por producto), el número máximo de
- * variantes distintas por pedido, la tapa extra de pago y los tramos horarios
- * de apertura de cocina.
+ * Configuración del negocio: tapas, horarios de apertura (negocio y cocina)
+ * y período de cierre de pedidos. Relación 1:1 con User.
  *
  * @package App\Models
  * @property int        $user_id
- * @property bool       $tapas_enabled       Si el sistema de tapas está activo
- * @property bool       $tapas_free          true = gratuitas, false = de pago
- * @property string     $price_mode          'fixed' = precio global | 'per_product' = precio individual
- * @property int        $max_tapa_variants   Máximo de variantes distintas por mesa
- * @property float|null $tapa_price          Precio fijo global (solo si price_mode = fixed y tapas_free = false)
- * @property bool       $extra_tapa_enabled  Si se permite pedir una tapa extra de pago
- * @property float|null $extra_tapa_price    Precio de la tapa extra (obligatorio si extra_tapa_enabled)
+ * @property bool       $tapas_enabled              Si el sistema de tapas está activo
+ * @property bool       $tapas_free                 true = gratuitas, false = de pago
+ * @property string     $price_mode                 'fixed' | 'per_product'
+ * @property int        $max_tapa_variants          Máximo de variantes distintas por mesa
+ * @property float|null $tapa_price                 Precio fijo global (solo si price_mode=fixed y tapas_free=false)
+ * @property bool       $extra_tapa_enabled         Si se permite pedir una tapa extra de pago
+ * @property float|null $extra_tapa_price           Precio de la tapa extra
+ * @property int        $ordering_cutoff_minutes    Minutos antes del cierre en los que no se admiten nuevos pedidos
  *
  * @author BenjaminDTS
  */
@@ -45,24 +43,24 @@ class TapaConfig extends Model
         'tapa_price',
         'extra_tapa_enabled',
         'extra_tapa_price',
+        'ordering_cutoff_minutes',
     ];
 
     /**
      * @var array<string, string>
      */
     protected $casts = [
-        'tapas_enabled'      => 'boolean',
-        'tapas_free'         => 'boolean',
-        'price_mode'         => 'string',
-        'max_tapa_variants'  => 'integer',
-        'tapa_price'         => 'decimal:2',
-        'extra_tapa_enabled' => 'boolean',
-        'extra_tapa_price'   => 'decimal:2',
+        'tapas_enabled'           => 'boolean',
+        'tapas_free'              => 'boolean',
+        'price_mode'              => 'string',
+        'max_tapa_variants'       => 'integer',
+        'tapa_price'              => 'decimal:2',
+        'extra_tapa_enabled'      => 'boolean',
+        'extra_tapa_price'        => 'decimal:2',
+        'ordering_cutoff_minutes' => 'integer',
     ];
 
     /**
-     * El restaurante (usuario) al que pertenece esta configuración.
-     *
      * @return BelongsTo
      */
     public function user(): BelongsTo
@@ -71,14 +69,40 @@ class TapaConfig extends Model
     }
 
     /**
-     * Tramos horarios de apertura de cocina configurados por el gerente.
+     * Tramos horarios de la cocina.
+     *
+     * @return HasMany
+     */
+    public function kitchenSchedules(): HasMany
+    {
+        return $this->hasMany(KitchenSchedule::class)
+                    ->where('type', 'kitchen')
+                    ->orderBy('opens_at');
+    }
+
+    /**
+     * Tramos horarios de apertura del negocio.
+     *
+     * @return HasMany
+     */
+    public function businessSchedules(): HasMany
+    {
+        return $this->hasMany(KitchenSchedule::class)
+                    ->where('type', 'business')
+                    ->orderBy('opens_at');
+    }
+
+    /**
+     * Alias de kitchenSchedules() para compatibilidad con código y tests anteriores.
      *
      * @return HasMany
      */
     public function schedules(): HasMany
     {
-        return $this->hasMany(KitchenSchedule::class)->orderBy('opens_at');
+        return $this->kitchenSchedules();
     }
+
+    // ─── Helpers: cocina ─────────────────────────────────────────────────────
 
     /**
      * Determina si la cocina está abierta en este momento.
@@ -89,10 +113,101 @@ class TapaConfig extends Model
      */
     public function isKitchenOpen(): bool
     {
-        $schedules = $this->schedules;
+        $schedules = $this->kitchenSchedules;
 
         if ($schedules->isEmpty()) {
             return true;
+        }
+
+        return $this->isNowWithinSlots($schedules);
+    }
+
+    /**
+     * Devuelve la hora de apertura del próximo tramo de cocina (HH:MM).
+     * Null si no hay tramos configurados.
+     *
+     * @return string|null
+     */
+    public function nextOpeningTime(): ?string
+    {
+        return $this->nextSlotOpeningTime($this->kitchenSchedules);
+    }
+
+    // ─── Helpers: negocio ────────────────────────────────────────────────────
+
+    /**
+     * Determina si el negocio está abierto en este momento.
+     * Sin tramos de negocio configurados se considera siempre abierto.
+     *
+     * @return bool
+     */
+    public function isBusinessOpen(): bool
+    {
+        $schedules = $this->businessSchedules;
+
+        if ($schedules->isEmpty()) {
+            return true;
+        }
+
+        return $this->isNowWithinSlots($schedules);
+    }
+
+    /**
+     * Devuelve false si estamos en el período de cierre de pedidos
+     * (dentro de los últimos ordering_cutoff_minutes del tramo activo).
+     * Si ordering_cutoff_minutes = 0 los pedidos se admiten hasta el cierre.
+     * Si el negocio está cerrado siempre devuelve false.
+     *
+     * @return bool
+     */
+    public function isOrderingAllowed(): bool
+    {
+        if (! $this->isBusinessOpen()) {
+            return false;
+        }
+
+        $cutoff = (int) $this->ordering_cutoff_minutes;
+
+        if ($cutoff <= 0) {
+            return true;
+        }
+
+        $schedules = $this->businessSchedules;
+        $now       = Carbon::now()->format('H:i:s');
+
+        foreach ($schedules as $schedule) {
+            $opens  = $schedule->opens_at;
+            $closes = $schedule->closes_at;
+
+            $inSlot = ($opens <= $closes)
+                ? ($now >= $opens && $now <= $closes)
+                : ($now >= $opens || $now <= $closes);
+
+            if ($inSlot) {
+                // Calculamos minutos hasta el cierre del tramo
+                return $this->minutesToTime($closes) > $cutoff;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Minutos que quedan hasta el cierre del tramo de negocio activo.
+     * Null si el negocio está cerrado o no hay tramos.
+     *
+     * @return int|null
+     */
+    public function minutesUntilBusinessClose(): ?int
+    {
+        if (! $this->isBusinessOpen()) {
+            return null;
+        }
+
+        $schedules = $this->businessSchedules;
+
+        if ($schedules->isEmpty()) {
+            return null;
         }
 
         $now = Carbon::now()->format('H:i:s');
@@ -101,49 +216,34 @@ class TapaConfig extends Model
             $opens  = $schedule->opens_at;
             $closes = $schedule->closes_at;
 
-            if ($opens <= $closes) {
-                if ($now >= $opens && $now <= $closes) {
-                    return true;
-                }
-            } else {
-                // Tramo que cruza medianoche (ej: 22:00 – 02:00)
-                if ($now >= $opens || $now <= $closes) {
-                    return true;
-                }
+            $inSlot = ($opens <= $closes)
+                ? ($now >= $opens && $now <= $closes)
+                : ($now >= $opens || $now <= $closes);
+
+            if ($inSlot) {
+                return $this->minutesToTime($closes);
             }
         }
 
-        return false;
+        return null;
     }
 
     /**
-     * Devuelve la hora de apertura del próximo tramo (HH:MM) para mostrarlo
-     * en el aviso de cocina cerrada. Null si no hay tramos configurados.
+     * Devuelve la hora de apertura del próximo tramo de negocio (HH:MM).
+     * Null si no hay tramos configurados.
      *
      * @return string|null
      */
-    public function nextOpeningTime(): ?string
+    public function getBusinessNextOpeningTime(): ?string
     {
-        $schedules = $this->schedules;
-
-        if ($schedules->isEmpty()) {
-            return null;
-        }
-
-        $now  = Carbon::now()->format('H:i:s');
-        $next = $schedules->first(fn ($s) => $s->opens_at > $now);
-
-        // Si no hay tramo posterior hoy, el primero de mañana
-        $schedule = $next ?? $schedules->first();
-
-        return substr($schedule->opens_at, 0, 5);
+        return $this->nextSlotOpeningTime($this->businessSchedules);
     }
 
+    // ─── Lógica de tapas ─────────────────────────────────────────────────────
+
     /**
-     * Determina si se debe mostrar el modal de sugerencia de tapa al cliente.
-     *
-     * @param  int  $barItemsCount     Bebidas de barra en órdenes activas de la mesa
-     * @param  int  $tapaVariantsUsed  Variantes distintas de tapas ya pedidas en la mesa
+     * @param  int  $barItemsCount
+     * @param  int  $tapaVariantsUsed
      * @return bool
      */
     public function shouldSuggestTapa(int $barItemsCount, int $tapaVariantsUsed): bool
@@ -164,14 +264,6 @@ class TapaConfig extends Model
     }
 
     /**
-     * Devuelve el precio que el cliente debe pagar por una tapa según la modalidad activa.
-     *
-     * Si tapas son gratuitas     → 0.0
-     * Si price_mode = 'fixed'    → precio fijo global (tapa_price)
-     * Si price_mode = per_product → precio individual del producto
-     *
-     * La tapa extra tiene siempre su propio precio (extra_tapa_price), independiente de esta lógica.
-     *
      * @param  Product  $product
      * @return float
      */
@@ -189,9 +281,6 @@ class TapaConfig extends Model
     }
 
     /**
-     * Determina si un producto pertenece a la categoría "Tapas" de este restaurante.
-     * Usado para aplicar el precio de tapa en lugar del precio normal del producto.
-     *
      * @param  Product  $product  Debe tener la relación 'category' cargada
      * @return bool
      */
@@ -200,5 +289,70 @@ class TapaConfig extends Model
         return $product->category_id !== null
             && $product->category?->name === 'Tapas'
             && $product->category?->user_id === $this->user_id;
+    }
+
+    // ─── Helpers privados ────────────────────────────────────────────────────
+
+    /**
+     * @param  \Illuminate\Support\Collection  $schedules
+     * @return bool
+     */
+    private function isNowWithinSlots(\Illuminate\Support\Collection $schedules): bool
+    {
+        $now = Carbon::now()->format('H:i:s');
+
+        foreach ($schedules as $schedule) {
+            $opens  = $schedule->opens_at;
+            $closes = $schedule->closes_at;
+
+            if ($opens <= $closes) {
+                if ($now >= $opens && $now <= $closes) {
+                    return true;
+                }
+            } else {
+                if ($now >= $opens || $now <= $closes) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  \Illuminate\Support\Collection  $schedules
+     * @return string|null
+     */
+    private function nextSlotOpeningTime(\Illuminate\Support\Collection $schedules): ?string
+    {
+        if ($schedules->isEmpty()) {
+            return null;
+        }
+
+        $now  = Carbon::now()->format('H:i:s');
+        $next = $schedules->first(fn ($s) => $s->opens_at > $now);
+
+        $schedule = $next ?? $schedules->first();
+
+        return substr($schedule->opens_at, 0, 5);
+    }
+
+    /**
+     * Minutos que quedan desde ahora hasta la hora dada (HH:MM:SS).
+     * Si la hora ya pasó hoy, calcula como si fuera mañana.
+     *
+     * @param  string  $time  Formato HH:MM:SS
+     * @return int
+     */
+    private function minutesToTime(string $time): int
+    {
+        $now    = Carbon::now();
+        $target = Carbon::today()->setTimeFromTimeString($time);
+
+        if ($target <= $now) {
+            $target->addDay();
+        }
+
+        return (int) $now->diffInMinutes($target);
     }
 }

--- a/database/factories/TapaConfigFactory.php
+++ b/database/factories/TapaConfigFactory.php
@@ -24,8 +24,9 @@ class TapaConfigFactory extends Factory
             'price_mode'         => 'fixed',
             'max_tapa_variants'  => 3,
             'tapa_price'         => null,
-            'extra_tapa_enabled' => false,
-            'extra_tapa_price'   => null,
+            'extra_tapa_enabled'      => false,
+            'extra_tapa_price'        => null,
+            'ordering_cutoff_minutes' => 0,
         ];
     }
 }

--- a/database/migrations/2026_05_21_000001_add_business_schedule_to_kitchen_schedules_and_tapa_configs.php
+++ b/database/migrations/2026_05_21_000001_add_business_schedule_to_kitchen_schedules_and_tapa_configs.php
@@ -1,0 +1,51 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Amplía el sistema de horarios para soportar tramos del negocio
+ * (además de cocina) y añade el período de cierre de pedidos.
+ *
+ * - kitchen_schedules.type: diferencia tramos de cocina vs. negocio.
+ *   Todos los registros existentes quedan con type='kitchen'.
+ * - tapa_configs.ordering_cutoff_minutes: minutos antes del cierre de
+ *   cada tramo de negocio en los que se dejan de aceptar nuevos pedidos.
+ *
+ * @author BenjaminDTS
+ */
+return new class extends Migration
+{
+    /**
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('kitchen_schedules', function (Blueprint $table) {
+            $table->enum('type', ['kitchen', 'business'])
+                  ->default('kitchen')
+                  ->after('tapa_config_id');
+        });
+
+        Schema::table('tapa_configs', function (Blueprint $table) {
+            $table->unsignedSmallInteger('ordering_cutoff_minutes')
+                  ->default(0)
+                  ->after('extra_tapa_price');
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('kitchen_schedules', function (Blueprint $table) {
+            $table->dropColumn('type');
+        });
+
+        Schema::table('tapa_configs', function (Blueprint $table) {
+            $table->dropColumn('ordering_cutoff_minutes');
+        });
+    }
+};

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -3,7 +3,7 @@
     @php
         $cartaActive   = request()->routeIs('categories.*', 'ingredients.*', 'products.*', 'daily-menus.*');
         $localActive   = request()->routeIs('tables.*', 'zones.*', 'staff.*');
-        $negocioActive = request()->routeIs('tapas.*', 'manager.*', 'split-payment.*');
+        $negocioActive = request()->routeIs('tapas.*', 'negocio.*', 'manager.*', 'split-payment.*');
     @endphp
 
     <!-- Primary Navigation Menu -->
@@ -150,8 +150,8 @@
                             role="menu"
                         >
                             <div class="rounded-md ring-1 ring-black ring-opacity-5 py-1 bg-white dark:bg-gray-700">
-                                <x-dropdown-link role="menuitem" :href="route('tapas.edit')" :active="request()->routeIs('tapas.*')">
-                                    {{ __('Tapas') }}
+                                <x-dropdown-link role="menuitem" :href="route('negocio.config.edit')" :active="request()->routeIs('negocio.*', 'tapas.*')">
+                                    {{ __('Configuración del negocio') }}
                                 </x-dropdown-link>
                                 <x-dropdown-link role="menuitem" :href="route('split-payment.edit')" :active="request()->routeIs('split-payment.*')">
                                     {{ __('Cobro Partido') }}
@@ -285,8 +285,8 @@
                 </x-responsive-nav-link>
 
                 <h3 class="px-3 pt-3 pb-1 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500" role="presentation">{{ __('Negocio') }}</h3>
-                <x-responsive-nav-link :href="route('tapas.edit')" :active="request()->routeIs('tapas.*')">
-                    {{ __('Tapas') }}
+                <x-responsive-nav-link :href="route('negocio.config.edit')" :active="request()->routeIs('negocio.*', 'tapas.*')">
+                    {{ __('Configuración del negocio') }}
                 </x-responsive-nav-link>
                 <x-responsive-nav-link :href="route('split-payment.edit')" :active="request()->routeIs('split-payment.*')">
                     {{ __('Cobro Partido') }}

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -3436,6 +3436,33 @@
             </nav>
         @endif
 
+        {{-- ════════════════════════════════════════════════════════════ --}}
+        {{-- NEGOCIO CERRADO: carta inaccesible + horarios del día      --}}
+        {{-- ════════════════════════════════════════════════════════════ --}}
+        @if(!$businessOpen)
+        <main id="main-content" class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-24">
+            <div class="text-center" role="status" aria-live="polite">
+                <div class="inline-flex items-center justify-center w-20 h-20 rounded-full bg-gray-100 dark:bg-gray-800 mb-6">
+                    <svg aria-hidden="true" class="w-10 h-10 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+                              d="M12 6v6l4 2M12 2a10 10 0 100 20A10 10 0 0012 2z"/>
+                    </svg>
+                </div>
+                <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+                    {{ $table->user->business_name ?: $table->user->name }} {{ __('está cerrado ahora') }}
+                </h2>
+                <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+                    {{ __('Estamos fuera de nuestro horario de atención. Vuelve cuando estemos abiertos.') }}
+                </p>
+                @if($businessNextOpening)
+                <p class="inline-block bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 text-sm font-semibold px-4 py-2 rounded-full">
+                    {{ __('Próxima apertura a las') }} {{ $businessNextOpening }}
+                </p>
+                @endif
+            </div>
+        </main>
+        @else
+
         {{-- ── Contenido principal ──────────────────────────────────── --}}
         <main id="main-content" class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 space-y-10">
 
@@ -3457,6 +3484,22 @@
                             {{ __('La cocina abre a las') }}
                             <span class="font-semibold">{{ $nextOpeningTime }}</span>.
                         @endif
+                    </p>
+                </div>
+            </div>
+            @endif
+
+            {{-- ── Banner período de cierre de pedidos ──────────────── --}}
+            @if($businessOpen && !$orderingAllowed)
+            <div role="alert"
+                 class="rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 p-4 sm:p-5 flex flex-col sm:flex-row items-start sm:items-center gap-3">
+                <span aria-hidden="true" class="text-2xl leading-none">🛑</span>
+                <div class="flex-1">
+                    <p class="text-sm font-semibold text-amber-800 dark:text-amber-300">
+                        {{ __('La cocina ya no acepta pedidos') }}
+                    </p>
+                    <p class="text-xs text-amber-700 dark:text-amber-400 mt-0.5">
+                        {{ __('Estamos en el período de cierre. Puedes solicitar la cuenta desde el botón de abajo.') }}
                     </p>
                 </div>
             </div>
@@ -3582,6 +3625,7 @@
 
                                         {{-- Botón añadir al carrito --}}
                                         <div class="mt-3 flex justify-end">
+                                            @if($orderingAllowed)
                                             <button type="button"
                                                     @click="$store.cart.add(products.find(p => p.id === {{ $product->id }}))"
                                                     class="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full
@@ -3594,6 +3638,19 @@
                                                 </svg>
                                                 Añadir
                                             </button>
+                                            @else
+                                            <span class="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full
+                                                         bg-gray-200 dark:bg-gray-700
+                                                         text-gray-400 dark:text-gray-500 text-sm font-semibold
+                                                         cursor-not-allowed select-none"
+                                                  aria-disabled="true"
+                                                  title="{{ __('Pedidos cerrados') }}">
+                                                <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
+                                                </svg>
+                                                Añadir
+                                            </span>
+                                            @endif
                                         </div>
                                     </div>
                                 </div>
@@ -3616,6 +3673,7 @@
             @endforelse
 
         </main>
+        @endif{{-- /businessOpen --}}
 
         {{-- ── Banner de Tapas disponibles ─────────────────────────── --}}
         @if($tapaConfig && $barItemsCount > 0)

--- a/resources/views/negocio/config.blade.php
+++ b/resources/views/negocio/config.blade.php
@@ -1,0 +1,479 @@
+{{-- @author SebastianBCF --}}
+{{-- @author BenjaminDTS --}}
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Configuración del negocio') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
+
+            @if(session('success'))
+            <div role="alert" class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-6">
+                {{ session('success') }}
+            </div>
+            @endif
+
+            <div class="bg-white dark:bg-gray-800 shadow sm:rounded-lg p-6 sm:p-8">
+
+                @php
+                    $kitchenSchedulesForAlpine = $tapaConfig->kitchenSchedules->map(function ($s) {
+                        return ['opens_at' => substr($s->opens_at, 0, 5), 'closes_at' => substr($s->closes_at, 0, 5)];
+                    })->values();
+
+                    $businessSchedulesForAlpine = $tapaConfig->businessSchedules->map(function ($s) {
+                        return ['opens_at' => substr($s->opens_at, 0, 5), 'closes_at' => substr($s->closes_at, 0, 5)];
+                    })->values();
+                @endphp
+
+                <form
+                    method="POST"
+                    action="{{ route('negocio.config.update') }}"
+                    x-data="{
+                        tapas_enabled:      {{ $tapaConfig->tapas_enabled ? 'true' : 'false' }},
+                        tapas_free:         {{ $tapaConfig->tapas_free ? 'true' : 'false' }},
+                        price_mode:         '{{ old('price_mode', $tapaConfig->price_mode ?? 'fixed') }}',
+                        extra_tapa_enabled: {{ $tapaConfig->extra_tapa_enabled ? 'true' : 'false' }},
+                        kitchen_schedules:  {{ json_encode($kitchenSchedulesForAlpine, JSON_HEX_QUOT) }},
+                        business_schedules: {{ json_encode($businessSchedulesForAlpine, JSON_HEX_QUOT) }},
+                        addKitchenSchedule()     { if (this.kitchen_schedules.length < 4) this.kitchen_schedules.push({ opens_at: '', closes_at: '' }); },
+                        removeKitchenSchedule(i) { this.kitchen_schedules.splice(i, 1); },
+                        addBusinessSchedule()     { if (this.business_schedules.length < 4) this.business_schedules.push({ opens_at: '', closes_at: '' }); },
+                        removeBusinessSchedule(i) { this.business_schedules.splice(i, 1); }
+                    }"
+                >
+                    @csrf
+                    @method('PUT')
+
+                    {{-- ══════════════════════════════════════════════════════ --}}
+                    {{-- SECCIÓN 1 — Horarios del negocio                      --}}
+                    {{-- ══════════════════════════════════════════════════════ --}}
+                    <section aria-labelledby="section-business-title">
+                        <h3 id="section-business-title" class="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                            {{ __('¿Cuándo está abierto tu negocio?') }}
+                        </h3>
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">
+                            {{ __('Añade los tramos en los que el negocio está abierto (máx. 4). Fuera de ellos la carta pública mostrará un aviso de negocio cerrado y no se podrán realizar pedidos. Sin tramos configurados el negocio se considera siempre abierto.') }}
+                        </p>
+
+                        @error('business_schedules')
+                            <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                        @enderror
+                        @error('business_schedules.*.opens_at')
+                            <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                        @enderror
+                        @error('business_schedules.*.closes_at')
+                            <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                        @enderror
+
+                        <div class="space-y-3 mb-4" role="list" aria-label="{{ __('Tramos horarios del negocio') }}">
+                            <template x-for="(slot, i) in business_schedules" :key="i">
+                                <div class="flex items-end gap-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-600"
+                                     role="listitem">
+                                    <div class="flex-1">
+                                        <label :for="'business_opens_at_' + i"
+                                               class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                                            {{ __('Abre') }}
+                                        </label>
+                                        <input type="time"
+                                               :id="'business_opens_at_' + i"
+                                               :name="'business_schedules[' + i + '][opens_at]'"
+                                               x-model="slot.opens_at"
+                                               aria-required="true"
+                                               class="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                    </div>
+                                    <div class="flex-1">
+                                        <label :for="'business_closes_at_' + i"
+                                               class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                                            {{ __('Cierra') }}
+                                        </label>
+                                        <input type="time"
+                                               :id="'business_closes_at_' + i"
+                                               :name="'business_schedules[' + i + '][closes_at]'"
+                                               x-model="slot.closes_at"
+                                               aria-required="true"
+                                               class="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                    </div>
+                                    <button type="button"
+                                            @click="removeBusinessSchedule(i)"
+                                            :aria-label="'Eliminar tramo de negocio ' + (i + 1)"
+                                            class="mb-0.5 flex-shrink-0 p-1.5 rounded-md text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20
+                                                   focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors">
+                                        <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </template>
+                        </div>
+
+                        <button type="button"
+                                @click="addBusinessSchedule()"
+                                :disabled="business_schedules.length >= 4"
+                                class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium
+                                       border border-indigo-300 dark:border-indigo-600 text-indigo-700 dark:text-indigo-300
+                                       hover:bg-indigo-50 dark:hover:bg-indigo-900/20
+                                       focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-colors
+                                       disabled:opacity-40 disabled:cursor-not-allowed">
+                            <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
+                            </svg>
+                            {{ __('Añadir tramo') }}
+                        </button>
+
+                        <p x-show="business_schedules.length === 0"
+                           class="text-xs text-amber-600 dark:text-amber-400 mt-2">
+                            {{ __('Sin tramos: el negocio se considera siempre abierto.') }}
+                        </p>
+                    </section>
+
+                    {{-- ── Cierre de pedidos ────────────────────────────── --}}
+                    <div class="border-t border-gray-200 dark:border-gray-700 mt-6 pt-6">
+                        <label for="ordering_cutoff_minutes" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            {{ __('Minutos antes del cierre sin nuevos pedidos') }}
+                        </label>
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                            {{ __('Si configuras 15, desde 15 minutos antes del cierre de cada tramo los clientes no podrán añadir productos al carrito pero sí solicitar la cuenta. Pon 0 para aceptar pedidos hasta el cierre.') }}
+                        </p>
+                        <input
+                            type="number"
+                            id="ordering_cutoff_minutes"
+                            name="ordering_cutoff_minutes"
+                            value="{{ old('ordering_cutoff_minutes', $tapaConfig->ordering_cutoff_minutes ?? 0) }}"
+                            min="0"
+                            max="120"
+                            aria-required="false"
+                            aria-describedby="error-ordering_cutoff_minutes"
+                            class="mt-1 block w-32 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                        >
+                        @error('ordering_cutoff_minutes')
+                            <p id="error-ordering_cutoff_minutes" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    {{-- ══════════════════════════════════════════════════════ --}}
+                    {{-- SECCIÓN 2 — Horarios de cocina                        --}}
+                    {{-- ══════════════════════════════════════════════════════ --}}
+                    <section aria-labelledby="section-kitchen-title" class="border-t border-gray-200 dark:border-gray-700 mt-6 pt-6">
+                        <h3 id="section-kitchen-title" class="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                            {{ __('¿Cuándo está abierta la cocina?') }}
+                        </h3>
+                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">
+                            {{ __('Añade los tramos en los que la cocina está abierta (máx. 4). Fuera de estos tramos la carta solo mostrará bebidas. Sin tramos configurados la cocina se considera siempre disponible.') }}
+                        </p>
+
+                        @error('kitchen_schedules')
+                            <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                        @enderror
+                        @error('kitchen_schedules.*.opens_at')
+                            <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                        @enderror
+                        @error('kitchen_schedules.*.closes_at')
+                            <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                        @enderror
+
+                        <div class="space-y-3 mb-4" role="list" aria-label="{{ __('Tramos horarios de cocina') }}">
+                            <template x-for="(slot, i) in kitchen_schedules" :key="i">
+                                <div class="flex items-end gap-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-600"
+                                     role="listitem">
+                                    <div class="flex-1">
+                                        <label :for="'kitchen_opens_at_' + i"
+                                               class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                                            {{ __('Abre') }}
+                                        </label>
+                                        <input type="time"
+                                               :id="'kitchen_opens_at_' + i"
+                                               :name="'kitchen_schedules[' + i + '][opens_at]'"
+                                               x-model="slot.opens_at"
+                                               aria-required="true"
+                                               class="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                    </div>
+                                    <div class="flex-1">
+                                        <label :for="'kitchen_closes_at_' + i"
+                                               class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                                            {{ __('Cierra') }}
+                                        </label>
+                                        <input type="time"
+                                               :id="'kitchen_closes_at_' + i"
+                                               :name="'kitchen_schedules[' + i + '][closes_at]'"
+                                               x-model="slot.closes_at"
+                                               aria-required="true"
+                                               class="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                    </div>
+                                    <button type="button"
+                                            @click="removeKitchenSchedule(i)"
+                                            :aria-label="'Eliminar tramo de cocina ' + (i + 1)"
+                                            class="mb-0.5 flex-shrink-0 p-1.5 rounded-md text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20
+                                                   focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors">
+                                        <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </template>
+                        </div>
+
+                        <button type="button"
+                                @click="addKitchenSchedule()"
+                                :disabled="kitchen_schedules.length >= 4"
+                                class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium
+                                       border border-indigo-300 dark:border-indigo-600 text-indigo-700 dark:text-indigo-300
+                                       hover:bg-indigo-50 dark:hover:bg-indigo-900/20
+                                       focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-colors
+                                       disabled:opacity-40 disabled:cursor-not-allowed">
+                            <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
+                            </svg>
+                            {{ __('Añadir tramo') }}
+                        </button>
+
+                        <p x-show="kitchen_schedules.length === 0"
+                           class="text-xs text-amber-600 dark:text-amber-400 mt-2">
+                            {{ __('Sin tramos: la cocina se considera siempre disponible.') }}
+                        </p>
+                    </section>
+
+                    {{-- ══════════════════════════════════════════════════════ --}}
+                    {{-- SECCIÓN 3 — Tapas                                     --}}
+                    {{-- ══════════════════════════════════════════════════════ --}}
+                    <section aria-labelledby="section-tapas-title" class="border-t border-gray-200 dark:border-gray-700 mt-6 pt-6">
+                        <h3 id="section-tapas-title" class="text-base font-semibold text-gray-900 dark:text-gray-100 mb-4">
+                            {{ __('Sistema de tapas') }}
+                        </h3>
+
+                        {{-- Activar tapas --}}
+                        <div class="flex items-center justify-between mb-6">
+                            <div>
+                                <label for="tapas_enabled_btn" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                    {{ __('Activar sistema de tapas') }}
+                                </label>
+                                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                    {{ __('Cuando está activo, los clientes pueden elegir tapas según las bebidas consumidas.') }}
+                                </p>
+                            </div>
+                            <button
+                                id="tapas_enabled_btn"
+                                type="button"
+                                role="switch"
+                                :aria-checked="tapas_enabled.toString()"
+                                @click="tapas_enabled = !tapas_enabled"
+                                :class="tapas_enabled ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+                                class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                            >
+                                <span
+                                    :class="tapas_enabled ? 'translate-x-6' : 'translate-x-1'"
+                                    class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform"
+                                ></span>
+                            </button>
+                            <input type="hidden" name="tapas_enabled" :value="tapas_enabled ? '1' : '0'">
+                        </div>
+
+                        <div x-show="tapas_enabled" x-transition class="space-y-6 border-t border-gray-200 dark:border-gray-700 pt-6">
+
+                            {{-- Gratuitas / de pago --}}
+                            <div class="flex items-center justify-between">
+                                <div>
+                                    <label for="tapas_free_btn" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                        {{ __('Tapas gratuitas') }}
+                                    </label>
+                                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                        {{ __('Desactiva para cobrar un precio fijo por tapa.') }}
+                                    </p>
+                                </div>
+                                <button
+                                    id="tapas_free_btn"
+                                    type="button"
+                                    role="switch"
+                                    :aria-checked="tapas_free.toString()"
+                                    @click="tapas_free = !tapas_free"
+                                    :class="tapas_free ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+                                    class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                                >
+                                    <span
+                                        :class="tapas_free ? 'translate-x-6' : 'translate-x-1'"
+                                        class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform"
+                                    ></span>
+                                </button>
+                                <input type="hidden" name="tapas_free" :value="tapas_free ? '1' : '0'">
+                            </div>
+
+                            {{-- Modalidad de precio (solo si de pago) --}}
+                            <div x-show="!tapas_free" x-transition>
+                                <fieldset>
+                                    <legend class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                                        {{ __('Modalidad de precio') }}
+                                        <span aria-hidden="true" class="text-red-500 ml-0.5">*</span>
+                                    </legend>
+                                    <p id="price-mode-desc" class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                                        {{ __('Elige cómo se calcula el precio que ve el cliente para cada tapa.') }}
+                                    </p>
+                                    <div class="space-y-3" aria-describedby="price-mode-desc">
+                                        <label class="flex items-start gap-3 cursor-pointer">
+                                            <input
+                                                type="radio"
+                                                name="price_mode"
+                                                value="fixed"
+                                                x-model="price_mode"
+                                                class="mt-0.5 h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                            >
+                                            <span>
+                                                <span class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                                    {{ __('Precio fijo para todas las tapas') }}
+                                                </span>
+                                                <span class="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                                                    {{ __('Configuras un único precio que aplica a todas las tapas del menú.') }}
+                                                </span>
+                                            </span>
+                                        </label>
+                                        <label class="flex items-start gap-3 cursor-pointer">
+                                            <input
+                                                type="radio"
+                                                name="price_mode"
+                                                value="per_product"
+                                                x-model="price_mode"
+                                                class="mt-0.5 h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                                            >
+                                            <span>
+                                                <span class="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                                    {{ __('Precio individual por producto') }}
+                                                </span>
+                                                <span class="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                                                    {{ __('Cada tapa usa el precio configurado en su ficha de producto.') }}
+                                                </span>
+                                            </span>
+                                        </label>
+                                    </div>
+                                    @error('price_mode')
+                                        <p id="error-price_mode" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                                    @enderror
+                                </fieldset>
+                            </div>
+
+                            {{-- Precio fijo global --}}
+                            <div x-show="!tapas_free && price_mode === 'fixed'" x-transition>
+                                <label for="tapa_price" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                    {{ __('Precio fijo por tapa (€)') }}
+                                    <span aria-hidden="true" class="text-red-500 ml-0.5">*</span>
+                                </label>
+                                <input
+                                    type="number"
+                                    id="tapa_price"
+                                    name="tapa_price"
+                                    value="{{ old('tapa_price', $tapaConfig->tapa_price) }}"
+                                    min="0"
+                                    max="999.99"
+                                    step="0.01"
+                                    aria-required="true"
+                                    aria-describedby="error-tapa_price"
+                                    class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                                    placeholder="0.00"
+                                >
+                                @error('tapa_price')
+                                    <p id="error-tapa_price" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                            {{-- Aviso precio por producto --}}
+                            <div x-show="!tapas_free && price_mode === 'per_product'" x-transition>
+                                <p class="text-sm text-indigo-700 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/20 rounded-md px-3 py-2">
+                                    {{ __('El precio de cada tapa se configura en la ficha del producto dentro de la categoría "Tapas".') }}
+                                </p>
+                            </div>
+
+                            {{-- Tapa extra --}}
+                            <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
+                                <div class="flex items-center justify-between mb-4">
+                                    <div>
+                                        <label for="extra_tapa_enabled_btn" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                            {{ __('Permitir tapa extra de pago') }}
+                                        </label>
+                                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                            {{ __('El cliente puede pedir una tapa adicional con precio fijo aunque las tapas base sean gratuitas. No consume variante del límite.') }}
+                                        </p>
+                                    </div>
+                                    <button
+                                        id="extra_tapa_enabled_btn"
+                                        type="button"
+                                        role="switch"
+                                        :aria-checked="extra_tapa_enabled.toString()"
+                                        @click="extra_tapa_enabled = !extra_tapa_enabled"
+                                        :class="extra_tapa_enabled ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+                                        class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                                    >
+                                        <span
+                                            :class="extra_tapa_enabled ? 'translate-x-6' : 'translate-x-1'"
+                                            class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform"
+                                        ></span>
+                                    </button>
+                                    <input type="hidden" name="extra_tapa_enabled" :value="extra_tapa_enabled ? '1' : '0'">
+                                </div>
+
+                                <div x-show="extra_tapa_enabled" x-transition>
+                                    <label for="extra_tapa_price" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                        {{ __('Precio de la tapa extra (€)') }}
+                                        <span aria-hidden="true" class="text-red-500 ml-0.5">*</span>
+                                    </label>
+                                    <input
+                                        type="number"
+                                        id="extra_tapa_price"
+                                        name="extra_tapa_price"
+                                        value="{{ old('extra_tapa_price', $tapaConfig->extra_tapa_price) }}"
+                                        min="0"
+                                        max="999.99"
+                                        step="0.01"
+                                        aria-required="true"
+                                        aria-describedby="error-extra_tapa_price"
+                                        class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                                        placeholder="0.00"
+                                    >
+                                    @error('extra_tapa_price')
+                                        <p id="error-extra_tapa_price" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                                    @enderror
+                                </div>
+                            </div>
+
+                            {{-- Máximo de variantes --}}
+                            <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
+                                <label for="max_tapa_variants" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                    {{ __('Máximo de variantes de tapa por mesa') }}
+                                </label>
+                                <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                                    {{ __('Número máximo de tapas distintas que se pueden elegir en los pedidos activos de una mesa (ej. 3 significa que pueden elegir hasta 3 tapas diferentes).') }}
+                                </p>
+                                <input
+                                    type="number"
+                                    id="max_tapa_variants"
+                                    name="max_tapa_variants"
+                                    value="{{ old('max_tapa_variants', $tapaConfig->max_tapa_variants) }}"
+                                    min="1"
+                                    max="20"
+                                    aria-required="true"
+                                    aria-describedby="error-max_tapa_variants"
+                                    class="mt-1 block w-32 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                                >
+                                @error('max_tapa_variants')
+                                    <p id="error-max_tapa_variants" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                                @enderror
+                            </div>
+
+                        </div>
+
+                    </section>
+
+                    <div class="mt-8 flex justify-end">
+                        <button
+                            type="submit"
+                            class="inline-flex items-center px-5 py-2 bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 text-white text-sm font-medium rounded-md transition-colors"
+                        >
+                            {{ __('Guardar configuración') }}
+                        </button>
+                    </div>
+
+                </form>
+            </div>
+
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,9 +53,9 @@ Route::middleware(['auth', 'business.active'])->group(function () {
         Route::get('/negocio/configuracion', [TapasController::class, 'edit'])->name('negocio.config.edit');
         Route::put('/negocio/configuracion', [TapasController::class, 'update'])->name('negocio.config.update');
 
-        // Rutas antiguas redirigidas para no romper marcadores o enlaces externos
+        // Rutas antiguas: GET redirige, PUT sigue llamando al controlador por compat
         Route::get('/tapas/config', fn () => redirect()->route('negocio.config.edit'))->name('tapas.edit');
-        Route::put('/tapas/config', fn () => redirect()->route('negocio.config.edit'))->name('tapas.update');
+        Route::put('/tapas/config', [TapasController::class, 'update'])->name('tapas.update');
 
         Route::get('/split-payment/config', [SplitPaymentConfigController::class, 'edit'])->name('split-payment.edit');
         Route::put('/split-payment/config', [SplitPaymentConfigController::class, 'update'])->name('split-payment.update');

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,8 +50,12 @@ Route::middleware(['auth', 'business.active'])->group(function () {
 
     // Rutas exclusivas del gerente (admin)
     Route::middleware('role:admin')->group(function () {
-        Route::get('/tapas/config', [TapasController::class, 'edit'])->name('tapas.edit');
-        Route::put('/tapas/config', [TapasController::class, 'update'])->name('tapas.update');
+        Route::get('/negocio/configuracion', [TapasController::class, 'edit'])->name('negocio.config.edit');
+        Route::put('/negocio/configuracion', [TapasController::class, 'update'])->name('negocio.config.update');
+
+        // Rutas antiguas redirigidas para no romper marcadores o enlaces externos
+        Route::get('/tapas/config', fn () => redirect()->route('negocio.config.edit'))->name('tapas.edit');
+        Route::put('/tapas/config', fn () => redirect()->route('negocio.config.edit'))->name('tapas.update');
 
         Route::get('/split-payment/config', [SplitPaymentConfigController::class, 'edit'])->name('split-payment.edit');
         Route::put('/split-payment/config', [SplitPaymentConfigController::class, 'update'])->name('split-payment.update');

--- a/tests/Feature/Bloque6/BusinessConfigTest.php
+++ b/tests/Feature/Bloque6/BusinessConfigTest.php
@@ -50,6 +50,7 @@ it('creates default TapaConfig with ordering_cutoff_minutes on first visit', fun
 it('saves a single business schedule slot correctly', function () {
     $this->actingAs($this->user)
          ->put(route('negocio.config.update'), [
+             'tapas_free'         => '1',
              'max_tapa_variants'  => 3,
              'business_schedules' => [
                  ['opens_at' => '09:00', 'closes_at' => '14:00'],
@@ -66,6 +67,7 @@ it('saves a single business schedule slot correctly', function () {
 it('saves multiple business schedule slots correctly', function () {
     $this->actingAs($this->user)
          ->put(route('negocio.config.update'), [
+             'tapas_free'         => '1',
              'max_tapa_variants'  => 3,
              'business_schedules' => [
                  ['opens_at' => '07:00', 'closes_at' => '12:00'],
@@ -174,6 +176,7 @@ it('replaces existing business schedules on update', function () {
 
     $this->actingAs($this->user)
          ->put(route('negocio.config.update'), [
+             'tapas_free'         => '1',
              'max_tapa_variants'  => 3,
              'business_schedules' => [
                  ['opens_at' => '10:00', 'closes_at' => '15:00'],
@@ -188,6 +191,7 @@ it('replaces existing business schedules on update', function () {
 it('business and kitchen schedules are stored independently', function () {
     $this->actingAs($this->user)
          ->put(route('negocio.config.update'), [
+             'tapas_free'         => '1',
              'max_tapa_variants'  => 3,
              'business_schedules' => [
                  ['opens_at' => '09:00', 'closes_at' => '23:00'],
@@ -208,6 +212,7 @@ it('business and kitchen schedules are stored independently', function () {
 it('saves ordering_cutoff_minutes correctly', function () {
     $this->actingAs($this->user)
          ->put(route('negocio.config.update'), [
+             'tapas_free'              => '1',
              'max_tapa_variants'       => 3,
              'ordering_cutoff_minutes' => 15,
          ]);

--- a/tests/Feature/Bloque6/BusinessConfigTest.php
+++ b/tests/Feature/Bloque6/BusinessConfigTest.php
@@ -1,0 +1,332 @@
+<?php
+
+/**
+ * @author BenjaminDTS
+ */
+
+use App\Models\Category;
+use App\Models\Order;
+use App\Models\Product;
+use App\Models\Table;
+use App\Models\TapaConfig;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+
+uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    $plan        = \App\Models\Plan::factory()->create();
+    $this->user  = User::factory()->create(['plan_id' => $plan->id, 'role' => 'admin']);
+    $this->other = User::factory()->create(['plan_id' => $plan->id, 'role' => 'admin']);
+});
+
+// ─── Acceso ───────────────────────────────────────────────────────────────────
+
+it('redirects unauthenticated user away from business config', function () {
+    $this->get(route('negocio.config.edit'))
+         ->assertRedirect(route('login'));
+});
+
+it('gerente can access business configuration page', function () {
+    $this->actingAs($this->user)
+         ->get(route('negocio.config.edit'))
+         ->assertOk()
+         ->assertViewIs('negocio.config');
+});
+
+it('creates default TapaConfig with ordering_cutoff_minutes on first visit', function () {
+    $this->assertDatabaseMissing('tapa_configs', ['user_id' => $this->user->id]);
+
+    $this->actingAs($this->user)->get(route('negocio.config.edit'));
+
+    $this->assertDatabaseHas('tapa_configs', [
+        'user_id'                 => $this->user->id,
+        'ordering_cutoff_minutes' => 0,
+    ]);
+});
+
+// ─── Horarios del negocio ─────────────────────────────────────────────────────
+
+it('saves a single business schedule slot correctly', function () {
+    $this->actingAs($this->user)
+         ->put(route('negocio.config.update'), [
+             'max_tapa_variants'  => 3,
+             'business_schedules' => [
+                 ['opens_at' => '09:00', 'closes_at' => '14:00'],
+             ],
+         ])
+         ->assertRedirect(route('negocio.config.edit'));
+
+    $config = TapaConfig::where('user_id', $this->user->id)->first();
+    expect($config->businessSchedules()->count())->toBe(1);
+    expect($config->businessSchedules()->first()->opens_at)->toStartWith('09:00');
+    expect($config->businessSchedules()->first()->type)->toBe('business');
+});
+
+it('saves multiple business schedule slots correctly', function () {
+    $this->actingAs($this->user)
+         ->put(route('negocio.config.update'), [
+             'max_tapa_variants'  => 3,
+             'business_schedules' => [
+                 ['opens_at' => '07:00', 'closes_at' => '12:00'],
+                 ['opens_at' => '13:00', 'closes_at' => '16:30'],
+                 ['opens_at' => '19:00', 'closes_at' => '23:30'],
+             ],
+         ]);
+
+    $config = TapaConfig::where('user_id', $this->user->id)->first();
+    expect($config->businessSchedules()->count())->toBe(3);
+});
+
+it('business supports multiple open slots in the same day', function () {
+    Carbon::setTestNow('2026-05-21 14:30:00');
+
+    $config = TapaConfig::factory()->create(['user_id' => $this->user->id]);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '07:00:00', 'closes_at' => '12:00:00']);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '13:00:00', 'closes_at' => '16:30:00']);
+
+    expect($config->isBusinessOpen())->toBeTrue();
+
+    Carbon::setTestNow();
+});
+
+it('business is closed when current time is outside all slots', function () {
+    Carbon::setTestNow('2026-05-21 12:30:00');
+
+    $config = TapaConfig::factory()->create(['user_id' => $this->user->id]);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '07:00:00', 'closes_at' => '12:00:00']);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '13:00:00', 'closes_at' => '16:30:00']);
+
+    expect($config->isBusinessOpen())->toBeFalse();
+
+    Carbon::setTestNow();
+});
+
+it('business is open when no schedule is configured', function () {
+    $config = TapaConfig::factory()->create(['user_id' => $this->user->id]);
+    // Sin tramos → siempre abierto
+    expect($config->isBusinessOpen())->toBeTrue();
+});
+
+it('maximum of 4 business slots per type is enforced', function () {
+    $slots = array_fill(0, 5, ['opens_at' => '10:00', 'closes_at' => '11:00']);
+
+    $this->actingAs($this->user)
+         ->put(route('negocio.config.update'), [
+             'max_tapa_variants'  => 3,
+             'business_schedules' => $slots,
+         ])
+         ->assertSessionHasErrors('business_schedules');
+});
+
+it('menu shows closed message when business is closed', function () {
+    Carbon::setTestNow('2026-05-21 12:30:00');
+
+    $config = TapaConfig::factory()->create(['user_id' => $this->user->id]);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '07:00:00', 'closes_at' => '12:00:00']);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '13:00:00', 'closes_at' => '16:30:00']);
+
+    $table = Table::factory()->create(['user_id' => $this->user->id]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+    $response->assertOk();
+    expect($response->viewData('businessOpen'))->toBeFalse();
+
+    Carbon::setTestNow();
+});
+
+it('cannot place order when business is closed via API', function () {
+    Carbon::setTestNow('2026-05-21 12:30:00');
+
+    $config = TapaConfig::factory()->create(['user_id' => $this->user->id]);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '07:00:00', 'closes_at' => '12:00:00']);
+
+    $table   = Table::factory()->create(['user_id' => $this->user->id]);
+    $cat     = Category::factory()->create(['user_id' => $this->user->id, 'destination' => 'bar']);
+    $product = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $cat->id]);
+
+    $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items'      => [['product_id' => $product->id, 'quantity' => 1]],
+    ])->assertStatus(422)
+      ->assertJsonFragment(['success' => false]);
+
+    Carbon::setTestNow();
+});
+
+it('getBusinessNextOpeningTime returns the next opening slot', function () {
+    Carbon::setTestNow('2026-05-21 12:30:00');
+
+    $config = TapaConfig::factory()->create(['user_id' => $this->user->id]);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '07:00:00', 'closes_at' => '12:00:00']);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '13:00:00', 'closes_at' => '16:30:00']);
+    $config->load('businessSchedules');
+
+    expect($config->getBusinessNextOpeningTime())->toBe('13:00');
+
+    Carbon::setTestNow();
+});
+
+it('replaces existing business schedules on update', function () {
+    $config = TapaConfig::factory()->create(['user_id' => $this->user->id]);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '08:00', 'closes_at' => '14:00']);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '18:00', 'closes_at' => '22:00']);
+
+    $this->actingAs($this->user)
+         ->put(route('negocio.config.update'), [
+             'max_tapa_variants'  => 3,
+             'business_schedules' => [
+                 ['opens_at' => '10:00', 'closes_at' => '15:00'],
+             ],
+         ]);
+
+    $config->refresh();
+    expect($config->businessSchedules()->count())->toBe(1);
+    expect($config->businessSchedules()->first()->opens_at)->toStartWith('10:00');
+});
+
+it('business and kitchen schedules are stored independently', function () {
+    $this->actingAs($this->user)
+         ->put(route('negocio.config.update'), [
+             'max_tapa_variants'  => 3,
+             'business_schedules' => [
+                 ['opens_at' => '09:00', 'closes_at' => '23:00'],
+             ],
+             'kitchen_schedules' => [
+                 ['opens_at' => '13:00', 'closes_at' => '16:00'],
+                 ['opens_at' => '20:00', 'closes_at' => '23:00'],
+             ],
+         ]);
+
+    $config = TapaConfig::where('user_id', $this->user->id)->first();
+    expect($config->businessSchedules()->count())->toBe(1);
+    expect($config->kitchenSchedules()->count())->toBe(2);
+});
+
+// ─── Período de cierre de pedidos ─────────────────────────────────────────────
+
+it('saves ordering_cutoff_minutes correctly', function () {
+    $this->actingAs($this->user)
+         ->put(route('negocio.config.update'), [
+             'max_tapa_variants'       => 3,
+             'ordering_cutoff_minutes' => 15,
+         ]);
+
+    $this->assertDatabaseHas('tapa_configs', [
+        'user_id'                 => $this->user->id,
+        'ordering_cutoff_minutes' => 15,
+    ]);
+});
+
+it('isOrderingAllowed returns false when within closing period', function () {
+    Carbon::setTestNow('2026-05-21 23:20:00');
+
+    $config = TapaConfig::factory()->create([
+        'user_id'                 => $this->user->id,
+        'ordering_cutoff_minutes' => 15,
+    ]);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '19:00:00', 'closes_at' => '23:30:00']);
+    $config->load('businessSchedules');
+
+    expect($config->isOrderingAllowed())->toBeFalse();
+
+    Carbon::setTestNow();
+});
+
+it('isOrderingAllowed returns true outside closing period', function () {
+    Carbon::setTestNow('2026-05-21 22:00:00');
+
+    $config = TapaConfig::factory()->create([
+        'user_id'                 => $this->user->id,
+        'ordering_cutoff_minutes' => 15,
+    ]);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '19:00:00', 'closes_at' => '23:30:00']);
+    $config->load('businessSchedules');
+
+    expect($config->isOrderingAllowed())->toBeTrue();
+
+    Carbon::setTestNow();
+});
+
+it('closing period of 0 minutes means ordering allowed until close', function () {
+    Carbon::setTestNow('2026-05-21 23:29:00');
+
+    $config = TapaConfig::factory()->create([
+        'user_id'                 => $this->user->id,
+        'ordering_cutoff_minutes' => 0,
+    ]);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '19:00:00', 'closes_at' => '23:30:00']);
+    $config->load('businessSchedules');
+
+    expect($config->isOrderingAllowed())->toBeTrue();
+
+    Carbon::setTestNow();
+});
+
+it('cannot add to cart during closing period via API', function () {
+    Carbon::setTestNow('2026-05-21 23:20:00');
+
+    $config = TapaConfig::factory()->create([
+        'user_id'                 => $this->user->id,
+        'ordering_cutoff_minutes' => 15,
+    ]);
+    $config->businessSchedules()->create(['type' => 'business', 'opens_at' => '19:00:00', 'closes_at' => '23:30:00']);
+
+    $table   = Table::factory()->create(['user_id' => $this->user->id]);
+    $cat     = Category::factory()->create(['user_id' => $this->user->id, 'destination' => 'bar']);
+    $product = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $cat->id]);
+
+    $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items'      => [['product_id' => $product->id, 'quantity' => 1]],
+    ])->assertStatus(422)
+      ->assertJsonFragment(['success' => false]);
+
+    Carbon::setTestNow();
+});
+
+it('ordering is allowed when business has no schedules configured', function () {
+    $config = TapaConfig::factory()->create([
+        'user_id'                 => $this->user->id,
+        'ordering_cutoff_minutes' => 30,
+    ]);
+    // Sin tramos → siempre abierto → pedidos permitidos
+    expect($config->isOrderingAllowed())->toBeTrue();
+});
+
+// ─── Cocina con múltiples tramos ──────────────────────────────────────────────
+
+it('kitchen is open when current time is within a kitchen slot', function () {
+    Carbon::setTestNow('2026-05-21 21:00:00');
+
+    $config = TapaConfig::factory()->create(['user_id' => $this->user->id, 'tapas_enabled' => true]);
+    $config->kitchenSchedules()->create(['type' => 'kitchen', 'opens_at' => '13:00:00', 'closes_at' => '16:30:00']);
+    $config->kitchenSchedules()->create(['type' => 'kitchen', 'opens_at' => '20:00:00', 'closes_at' => '23:30:00']);
+    $config->load('kitchenSchedules');
+
+    expect($config->isKitchenOpen())->toBeTrue();
+
+    Carbon::setTestNow();
+});
+
+it('kitchen is closed when outside all kitchen slots', function () {
+    Carbon::setTestNow('2026-05-21 17:00:00');
+
+    $config = TapaConfig::factory()->create(['user_id' => $this->user->id, 'tapas_enabled' => true]);
+    $config->kitchenSchedules()->create(['type' => 'kitchen', 'opens_at' => '13:00:00', 'closes_at' => '16:30:00']);
+    $config->kitchenSchedules()->create(['type' => 'kitchen', 'opens_at' => '20:00:00', 'closes_at' => '23:30:00']);
+    $config->load('kitchenSchedules');
+
+    expect($config->isKitchenOpen())->toBeFalse();
+
+    Carbon::setTestNow();
+});
+
+it('menu view receives businessOpen and orderingAllowed variables', function () {
+    $table = Table::factory()->create(['user_id' => $this->user->id]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+    $response->assertOk()
+             ->assertViewHas('businessOpen')
+             ->assertViewHas('orderingAllowed');
+});

--- a/tests/Feature/Bloque6/TapasTest.php
+++ b/tests/Feature/Bloque6/TapasTest.php
@@ -26,22 +26,22 @@ beforeEach(function () {
 // ─── Acceso y autenticación ───────────────────────────────────────────────────
 
 it('redirects unauthenticated user away from tapas config', function () {
-    $this->get(route('tapas.edit'))
+    $this->get(route('negocio.config.edit'))
          ->assertRedirect(route('login'));
 });
 
 it('gerente can access tapas configuration page', function () {
     $this->actingAs($this->user)
-         ->get(route('tapas.edit'))
+         ->get(route('negocio.config.edit'))
          ->assertOk()
-         ->assertViewIs('tapas.edit');
+         ->assertViewIs('negocio.config');
 });
 
 it('creates a default TapaConfig on first visit', function () {
     $this->assertDatabaseMissing('tapa_configs', ['user_id' => $this->user->id]);
 
     $this->actingAs($this->user)
-         ->get(route('tapas.edit'));
+         ->get(route('negocio.config.edit'));
 
     $this->assertDatabaseHas('tapa_configs', [
         'user_id'        => $this->user->id,
@@ -55,12 +55,12 @@ it('creates a default TapaConfig on first visit', function () {
 
 it('gerente can enable tapas', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
          ])
-         ->assertRedirect(route('tapas.edit'));
+         ->assertRedirect(route('negocio.config.edit'));
 
     $this->assertDatabaseHas('tapa_configs', [
         'user_id'       => $this->user->id,
@@ -75,12 +75,12 @@ it('gerente can disable tapas', function () {
     ]);
 
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '0',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
          ])
-         ->assertRedirect(route('tapas.edit'));
+         ->assertRedirect(route('negocio.config.edit'));
 
     $this->assertDatabaseHas('tapa_configs', [
         'user_id'       => $this->user->id,
@@ -92,7 +92,7 @@ it('gerente can disable tapas', function () {
 
 it('gerente can set tapas as free', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 2,
@@ -106,7 +106,7 @@ it('gerente can set tapas as free', function () {
 
 it('gerente can set tapas with price', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '0',
              'max_tapa_variants' => 2,
@@ -128,7 +128,7 @@ it('tapa_price is cleared when tapas_free is switched to true', function () {
     ]);
 
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
@@ -142,7 +142,7 @@ it('tapa_price is cleared when tapas_free is switched to true', function () {
 
 it('fails update when tapas are paid and tapa_price is missing', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '0',
              'max_tapa_variants' => 3,
@@ -152,7 +152,7 @@ it('fails update when tapas are paid and tapa_price is missing', function () {
 
 it('fails update when tapas are paid and tapa_price is invalid', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '0',
              'max_tapa_variants' => 3,
@@ -165,7 +165,7 @@ it('fails update when tapas are paid and tapa_price is invalid', function () {
 
 it('max tapa variants limit is respected in update', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 5,
@@ -179,7 +179,7 @@ it('max tapa variants limit is respected in update', function () {
 
 it('fails update when max_tapa_variants exceeds 20', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 99,
@@ -189,7 +189,7 @@ it('fails update when max_tapa_variants exceeds 20', function () {
 
 it('fails update when max_tapa_variants is below 1', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 0,
@@ -201,14 +201,14 @@ it('fails update when max_tapa_variants is below 1', function () {
 
 it('each restaurant has its own independent tapa config', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 4,
          ]);
 
     $this->actingAs($this->other)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '0',
              'tapas_free'        => '0',
              'max_tapa_variants' => 2,
@@ -304,7 +304,7 @@ it('waiter role cannot access tapas config', function () {
     $waiter = User::factory()->create(['role' => 'waiter']);
 
     $this->actingAs($waiter)
-         ->get(route('tapas.edit'))
+         ->get(route('negocio.config.edit'))
          ->assertForbidden();
 });
 
@@ -312,13 +312,13 @@ it('kitchen role cannot access tapas config', function () {
     $kitchen = User::factory()->create(['role' => 'kitchen']);
 
     $this->actingAs($kitchen)
-         ->get(route('tapas.edit'))
+         ->get(route('negocio.config.edit'))
          ->assertForbidden();
 });
 
 it('flash success message shown after saving tapa config', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
@@ -332,7 +332,7 @@ it('creates Tapas category when tapas are enabled for the first time', function 
     $this->assertDatabaseMissing('categories', ['user_id' => $this->user->id, 'name' => 'Tapas']);
 
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
@@ -346,7 +346,7 @@ it('creates Tapas category when tapas are enabled for the first time', function 
 
 it('creates Tapas category with destination kitchen', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
@@ -367,7 +367,7 @@ it('does not create duplicate Tapas category if already exists', function () {
     ]);
 
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
@@ -389,7 +389,7 @@ it('does not delete Tapas category when tapas are disabled', function () {
     ]);
 
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '0',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
@@ -405,7 +405,7 @@ it('does not delete Tapas category when tapas are disabled', function () {
 
 it('fails to save extra tapa enabled without extra tapa price', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'      => '1',
              'tapas_free'         => '1',
              'max_tapa_variants'  => 3,
@@ -417,19 +417,19 @@ it('fails to save extra tapa enabled without extra tapa price', function () {
 
 it('allows saving extra tapa disabled without extra tapa price', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'      => '1',
              'tapas_free'         => '1',
              'max_tapa_variants'  => 3,
              'extra_tapa_enabled' => '0',
          ])
          ->assertSessionMissing('errors')
-         ->assertRedirect(route('tapas.edit'));
+         ->assertRedirect(route('negocio.config.edit'));
 });
 
 it('saves extra tapa config correctly', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'      => '1',
              'tapas_free'         => '1',
              'max_tapa_variants'  => 3,
@@ -452,7 +452,7 @@ it('clears extra tapa price when extra tapa is disabled', function () {
     ]);
 
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'      => '1',
              'tapas_free'         => '1',
              'max_tapa_variants'  => 3,
@@ -469,15 +469,15 @@ it('clears extra tapa price when extra tapa is disabled', function () {
 
 it('saves a single kitchen schedule slot correctly', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
-             'schedules'         => [
+             'kitchen_schedules'  => [
                  ['opens_at' => '10:00', 'closes_at' => '16:00'],
              ],
          ])
-         ->assertRedirect(route('tapas.edit'));
+         ->assertRedirect(route('negocio.config.edit'));
 
     $config = TapaConfig::where('user_id', $this->user->id)->first();
     expect($config->schedules()->count())->toBe(1);
@@ -486,11 +486,11 @@ it('saves a single kitchen schedule slot correctly', function () {
 
 it('saves multiple kitchen schedule slots correctly', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
-             'schedules'         => [
+             'kitchen_schedules'  => [
                  ['opens_at' => '13:00', 'closes_at' => '16:30'],
                  ['opens_at' => '20:00', 'closes_at' => '23:30'],
              ],
@@ -506,11 +506,11 @@ it('replaces existing schedules on update', function () {
     $config->schedules()->create(['opens_at' => '19:00', 'closes_at' => '23:00']);
 
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
-             'schedules'         => [
+             'kitchen_schedules'  => [
                  ['opens_at' => '12:00', 'closes_at' => '15:00'],
              ],
          ]);
@@ -522,12 +522,12 @@ it('replaces existing schedules on update', function () {
 
 it('allows no schedules meaning kitchen always open', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
          ])
-         ->assertRedirect(route('tapas.edit'));
+         ->assertRedirect(route('negocio.config.edit'));
 
     $config = TapaConfig::where('user_id', $this->user->id)->first();
     expect($config->schedules()->count())->toBe(0);
@@ -535,41 +535,41 @@ it('allows no schedules meaning kitchen always open', function () {
 
 it('fails when a schedule slot is missing closes_at', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
-             'schedules'         => [
+             'kitchen_schedules'  => [
                  ['opens_at' => '10:00'],
              ],
          ])
-         ->assertSessionHasErrors('schedules.0.closes_at');
+         ->assertSessionHasErrors('kitchen_schedules.0.closes_at');
 });
 
 it('fails when a schedule slot has invalid time format', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
-             'schedules'         => [
+             'kitchen_schedules'  => [
                  ['opens_at' => 'not-a-time', 'closes_at' => '23:00'],
              ],
          ])
-         ->assertSessionHasErrors('schedules.0.opens_at');
+         ->assertSessionHasErrors('kitchen_schedules.0.opens_at');
 });
 
-it('fails when schedules array exceeds 10 slots', function () {
-    $slots = array_fill(0, 11, ['opens_at' => '10:00', 'closes_at' => '11:00']);
+it('fails when kitchen_schedules array exceeds 4 slots', function () {
+    $slots = array_fill(0, 5, ['opens_at' => '10:00', 'closes_at' => '11:00']);
 
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
-             'schedules'         => $slots,
+             'kitchen_schedules'  => $slots,
          ])
-         ->assertSessionHasErrors('schedules');
+         ->assertSessionHasErrors('kitchen_schedules');
 });
 
 it('menu hides kitchen categories when kitchen is closed', function () {
@@ -796,7 +796,7 @@ it('tapa products only include active products from Tapas category', function ()
 
 it('saves price_mode fixed correctly', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '0',
              'price_mode'        => 'fixed',
@@ -810,13 +810,13 @@ it('saves price_mode fixed correctly', function () {
 
 it('saves price_mode per_product correctly', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '0',
              'price_mode'        => 'per_product',
              'max_tapa_variants' => 3,
          ])
-         ->assertRedirect(route('tapas.edit'));
+         ->assertRedirect(route('negocio.config.edit'));
 
     $config = TapaConfig::where('user_id', $this->user->id)->first();
     expect($config->price_mode)->toBe('per_product')
@@ -825,7 +825,7 @@ it('saves price_mode per_product correctly', function () {
 
 it('fails to save paid tapas with fixed price mode and no global price', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '0',
              'price_mode'        => 'fixed',
@@ -837,25 +837,25 @@ it('fails to save paid tapas with fixed price mode and no global price', functio
 
 it('allows saving paid tapas with per_product mode and no global price', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '0',
              'price_mode'        => 'per_product',
              'max_tapa_variants' => 3,
          ])
          ->assertSessionMissing('errors')
-         ->assertRedirect(route('tapas.edit'));
+         ->assertRedirect(route('negocio.config.edit'));
 });
 
 it('allows saving free tapas without any price regardless of mode', function () {
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '1',
              'max_tapa_variants' => 3,
          ])
          ->assertSessionMissing('errors')
-         ->assertRedirect(route('tapas.edit'));
+         ->assertRedirect(route('negocio.config.edit'));
 
     $config = TapaConfig::where('user_id', $this->user->id)->first();
     expect($config->tapa_price)->toBeNull();
@@ -870,7 +870,7 @@ it('clears tapa_price when mode changes to per_product', function () {
     ]);
 
     $this->actingAs($this->user)
-         ->put(route('tapas.update'), [
+         ->put(route('negocio.config.update'), [
              'tapas_enabled'     => '1',
              'tapas_free'        => '0',
              'price_mode'        => 'per_product',

--- a/tests/Unit/TapasCalculatorTest.php
+++ b/tests/Unit/TapasCalculatorTest.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Carbon;
 
 it('isKitchenOpen returns true with no schedules configured', function () {
     $config = new TapaConfig();
-    $config->setRelation('schedules', collect());
+    $config->setRelation('kitchenSchedules', collect());
 
     expect($config->isKitchenOpen())->toBeTrue();
 });
@@ -24,7 +24,7 @@ it('isKitchenOpen returns true when current time is within schedule', function (
     Carbon::setTestNow('2026-05-03 12:00:00');
 
     $config = new TapaConfig();
-    $config->setRelation('schedules', collect([
+    $config->setRelation('kitchenSchedules', collect([
         new KitchenSchedule(['opens_at' => '10:00:00', 'closes_at' => '23:00:00']),
     ]));
 
@@ -37,7 +37,7 @@ it('isKitchenOpen returns false when current time is outside schedule', function
     Carbon::setTestNow('2026-05-03 09:00:00');
 
     $config = new TapaConfig();
-    $config->setRelation('schedules', collect([
+    $config->setRelation('kitchenSchedules', collect([
         new KitchenSchedule(['opens_at' => '10:00:00', 'closes_at' => '23:00:00']),
     ]));
 
@@ -50,7 +50,7 @@ it('isKitchenOpen supports ranges crossing midnight', function () {
     Carbon::setTestNow('2026-05-03 01:00:00');
 
     $config = new TapaConfig();
-    $config->setRelation('schedules', collect([
+    $config->setRelation('kitchenSchedules', collect([
         new KitchenSchedule(['opens_at' => '22:00:00', 'closes_at' => '02:00:00']),
     ]));
 
@@ -63,7 +63,7 @@ it('isKitchenOpen returns false at midday when range crosses midnight', function
     Carbon::setTestNow('2026-05-03 12:00:00');
 
     $config = new TapaConfig();
-    $config->setRelation('schedules', collect([
+    $config->setRelation('kitchenSchedules', collect([
         new KitchenSchedule(['opens_at' => '22:00:00', 'closes_at' => '02:00:00']),
     ]));
 
@@ -76,7 +76,7 @@ it('isKitchenOpen returns true when time matches any of multiple schedules', fun
     Carbon::setTestNow('2026-05-03 21:00:00');
 
     $config = new TapaConfig();
-    $config->setRelation('schedules', collect([
+    $config->setRelation('kitchenSchedules', collect([
         new KitchenSchedule(['opens_at' => '13:00:00', 'closes_at' => '16:30:00']),
         new KitchenSchedule(['opens_at' => '20:00:00', 'closes_at' => '23:30:00']),
     ]));
@@ -90,7 +90,7 @@ it('isKitchenOpen returns false when time falls in none of multiple schedules', 
     Carbon::setTestNow('2026-05-03 18:00:00');
 
     $config = new TapaConfig();
-    $config->setRelation('schedules', collect([
+    $config->setRelation('kitchenSchedules', collect([
         new KitchenSchedule(['opens_at' => '13:00:00', 'closes_at' => '16:30:00']),
         new KitchenSchedule(['opens_at' => '20:00:00', 'closes_at' => '23:30:00']),
     ]));
@@ -106,7 +106,7 @@ it('shouldSuggestTapa returns false when tapas disabled even if kitchen is open'
     Carbon::setTestNow('2026-05-03 12:00:00');
 
     $config = new TapaConfig(['tapas_enabled' => false, 'max_tapa_variants' => 3]);
-    $config->setRelation('schedules', collect([
+    $config->setRelation('kitchenSchedules', collect([
         new KitchenSchedule(['opens_at' => '10:00:00', 'closes_at' => '23:00:00']),
     ]));
 
@@ -119,7 +119,7 @@ it('shouldSuggestTapa returns false when kitchen closed even if tapas enabled', 
     Carbon::setTestNow('2026-05-03 09:00:00');
 
     $config = new TapaConfig(['tapas_enabled' => true, 'max_tapa_variants' => 3]);
-    $config->setRelation('schedules', collect([
+    $config->setRelation('kitchenSchedules', collect([
         new KitchenSchedule(['opens_at' => '10:00:00', 'closes_at' => '23:00:00']),
     ]));
 
@@ -130,21 +130,21 @@ it('shouldSuggestTapa returns false when kitchen closed even if tapas enabled', 
 
 it('shouldSuggestTapa returns false when barItemsCount is zero', function () {
     $config = new TapaConfig(['tapas_enabled' => true, 'max_tapa_variants' => 3]);
-    $config->setRelation('schedules', collect());
+    $config->setRelation('kitchenSchedules', collect());
 
     expect($config->shouldSuggestTapa(0, 0))->toBeFalse();
 });
 
 it('shouldSuggestTapa returns false when max variants already reached', function () {
     $config = new TapaConfig(['tapas_enabled' => true, 'max_tapa_variants' => 2]);
-    $config->setRelation('schedules', collect());
+    $config->setRelation('kitchenSchedules', collect());
 
     expect($config->shouldSuggestTapa(3, 2))->toBeFalse();
 });
 
 it('shouldSuggestTapa returns true when all conditions are met', function () {
     $config = new TapaConfig(['tapas_enabled' => true, 'max_tapa_variants' => 3]);
-    $config->setRelation('schedules', collect());
+    $config->setRelation('kitchenSchedules', collect());
 
     expect($config->shouldSuggestTapa(2, 1))->toBeTrue();
 });
@@ -219,4 +219,102 @@ it('getPriceForProduct returns 0 when fixed mode and tapa_price is null', functi
     $product->price = 4.00;
 
     expect($config->getPriceForProduct($product))->toBe(0.0);
+});
+
+// ─── isBusinessOpen ───────────────────────────────────────────────────────────
+
+it('isBusinessOpen returns true with no schedule configured', function () {
+    $config = new TapaConfig(['ordering_cutoff_minutes' => 0]);
+    $config->setRelation('businessSchedules', collect());
+
+    expect($config->isBusinessOpen())->toBeTrue();
+});
+
+it('isBusinessOpen returns true inside any active slot', function () {
+    Carbon::setTestNow('2026-05-21 14:00:00');
+
+    $config = new TapaConfig(['ordering_cutoff_minutes' => 0]);
+    $config->setRelation('businessSchedules', collect([
+        new KitchenSchedule(['type' => 'business', 'opens_at' => '13:00:00', 'closes_at' => '16:30:00']),
+    ]));
+
+    expect($config->isBusinessOpen())->toBeTrue();
+
+    Carbon::setTestNow();
+});
+
+it('isBusinessOpen returns false outside all slots', function () {
+    Carbon::setTestNow('2026-05-21 12:30:00');
+
+    $config = new TapaConfig(['ordering_cutoff_minutes' => 0]);
+    $config->setRelation('businessSchedules', collect([
+        new KitchenSchedule(['type' => 'business', 'opens_at' => '07:00:00', 'closes_at' => '12:00:00']),
+        new KitchenSchedule(['type' => 'business', 'opens_at' => '13:00:00', 'closes_at' => '16:30:00']),
+    ]));
+
+    expect($config->isBusinessOpen())->toBeFalse();
+
+    Carbon::setTestNow();
+});
+
+// ─── isOrderingAllowed ────────────────────────────────────────────────────────
+
+it('isOrderingAllowed returns false when within closing minutes', function () {
+    Carbon::setTestNow('2026-05-21 23:20:00');
+
+    $config = new TapaConfig(['ordering_cutoff_minutes' => 15]);
+    $config->setRelation('businessSchedules', collect([
+        new KitchenSchedule(['type' => 'business', 'opens_at' => '19:00:00', 'closes_at' => '23:30:00']),
+    ]));
+
+    expect($config->isOrderingAllowed())->toBeFalse();
+
+    Carbon::setTestNow();
+});
+
+it('isOrderingAllowed returns true when not in closing period', function () {
+    Carbon::setTestNow('2026-05-21 22:00:00');
+
+    $config = new TapaConfig(['ordering_cutoff_minutes' => 15]);
+    $config->setRelation('businessSchedules', collect([
+        new KitchenSchedule(['type' => 'business', 'opens_at' => '19:00:00', 'closes_at' => '23:30:00']),
+    ]));
+
+    expect($config->isOrderingAllowed())->toBeTrue();
+
+    Carbon::setTestNow();
+});
+
+it('isOrderingAllowed returns true when cutoff is 0', function () {
+    Carbon::setTestNow('2026-05-21 23:29:00');
+
+    $config = new TapaConfig(['ordering_cutoff_minutes' => 0]);
+    $config->setRelation('businessSchedules', collect([
+        new KitchenSchedule(['type' => 'business', 'opens_at' => '19:00:00', 'closes_at' => '23:30:00']),
+    ]));
+
+    expect($config->isOrderingAllowed())->toBeTrue();
+
+    Carbon::setTestNow();
+});
+
+it('minutesUntilBusinessClose returns null when no business schedules', function () {
+    $config = new TapaConfig(['ordering_cutoff_minutes' => 0]);
+    $config->setRelation('businessSchedules', collect());
+
+    expect($config->minutesUntilBusinessClose())->toBeNull();
+});
+
+it('minutesUntilBusinessClose returns positive integer when inside slot', function () {
+    Carbon::setTestNow('2026-05-21 22:00:00');
+
+    $config = new TapaConfig(['ordering_cutoff_minutes' => 15]);
+    $config->setRelation('businessSchedules', collect([
+        new KitchenSchedule(['type' => 'business', 'opens_at' => '19:00:00', 'closes_at' => '23:30:00']),
+    ]));
+
+    $minutes = $config->minutesUntilBusinessClose();
+    expect($minutes)->toBeInt()->toBeGreaterThan(0);
+
+    Carbon::setTestNow();
 });


### PR DESCRIPTION
## Resumen

- Renombra la sección «Configuración de tapas» a **Configuración del negocio** (ruta `negocio.config.edit`)
- Añade soporte de **horarios de apertura del negocio** con hasta 4 tramos por día (columna `type` en `kitchen_schedules`)
- Añade **período de cierre de pedidos** (`ordering_cutoff_minutes` en `tapa_configs`): X minutos antes de cerrar no se aceptan nuevos pedidos (la solicitud de cuenta sigue funcionando)
- La carta digital muestra mensaje de «negocio cerrado» y banner de «pedidos bloqueados» según estado
- El API de pedidos rechaza con 422 si el negocio está cerrado o en período de cierre
- Backward compat: `tapas.edit` redirige a `negocio.config.edit`; `tapas.update` sigue funcionando

## Archivos principales

- `database/migrations/2026_05_21_000001_add_business_schedule_to_kitchen_schedules_and_tapa_configs.php`
- `app/Models/TapaConfig.php` — `isBusinessOpen()`, `isOrderingAllowed()`, `minutesUntilBusinessClose()`, `getBusinessNextOpeningTime()`
- `app/Http/Controllers/TapasController.php` — gestión de ambos tipos de tramos
- `resources/views/negocio/config.blade.php` — vista unificada con Alpine.js
- `resources/views/menu/show.blade.php` — banner cerrado / pedidos bloqueados

## Plan de tests

- [x] `php artisan test tests/Feature/Bloque6/` → 23 passed (BusinessConfigTest) + suite TapasTest
- [x] `php artisan test tests/Unit/TapasCalculatorTest.php` → 21 passed
- [x] `php artisan test` → 884 passed (10 fallos pre-existentes por extensión GD ausente, sin relación con esta rama)