### PR TITLE
[feat] bloque16 — cobro partido con tarjeta

### DIFF
--- a/app/Http/Controllers/Api/SplitPaymentController.php
+++ b/app/Http/Controllers/Api/SplitPaymentController.php
@@ -174,6 +174,16 @@ class SplitPaymentController extends Controller
             return response()->json(['success' => false, 'message' => 'El número de parte excede el total de personas.'], 422);
         }
 
+        $alreadyClaimed = OrderItemPayment::where('order_id', $order->id)
+            ->where('mode', 'equitative')
+            ->where('part_number', $partNumber)
+            ->whereIn('status', ['pending', 'paid'])
+            ->exists();
+
+        if ($alreadyClaimed) {
+            return response()->json(['success' => false, 'message' => 'Esta parte ya ha sido reclamada.'], 409);
+        }
+
         $part = round((float) $order->total / $people, 2);
 
         $result = $this->stripe->createSplitPaymentIntent(

--- a/app/Http/Controllers/SplitPaymentConfigController.php
+++ b/app/Http/Controllers/SplitPaymentConfigController.php
@@ -51,7 +51,7 @@ class SplitPaymentConfigController extends Controller
         Auth::user()->update([
             'split_payment_enabled'   => $enabled,
             'split_payment_max_parts' => $enabled
-                ? ($request->input('split_payment_max_parts') ?: null)
+                ? ($validated['split_payment_max_parts'] ?? null)
                 : null,
         ]);
 

--- a/app/Http/Controllers/SplitPaymentConfigController.php
+++ b/app/Http/Controllers/SplitPaymentConfigController.php
@@ -14,6 +14,7 @@ use Illuminate\View\View;
  * y configurar el número máximo de partes en que se puede dividir la cuenta por mesa.
  *
  * @author BenjaminDTS
+ * @author SebastianBCF
  */
 class SplitPaymentConfigController extends Controller
 {

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use Illuminate\Support\Facades\DB;
 
 /**
  * Class Order

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -19,7 +19,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string $destination   'kitchen' o 'bar', copiado de la categoría del producto
  *
  * @author BenjaminDTS
- * @author Ayrtonalania
+ * @author AyrtonAlania
  */
 class OrderItem extends Model
 {


### PR DESCRIPTION
## Qué se implementa

- **16.1**: Migración — columnas `split_payment_enabled` (boolean, false por defecto) y `split_payment_max_parts` (integer, nullable) en `users`
- **16.2**: Panel del gerente — activar/desactivar cobro partido; configurar número máximo de partes por mesa (`SplitPaymentConfigController`)
- **16.3**: Carta pública — Modo A (por ítems: el comensal selecciona qué ítems paga, los reclamados quedan bloqueados) y Modo B (equitativo: divide el total entre N personas con Stripe independiente)
- **16.4**: `SplitPaymentController` + tabla `order_item_payments` + múltiples `PaymentIntent` independientes (uno por comensal en ambos modos), tracking de pagos vs. pendientes en `orders`
- **16.5**: Tests completos del Bloque 16 (62 Feature + 6 Unit)

## Reglas de negocio clave

- Cobro partido solo disponible si el gerente activa `split_payment_enabled`
- **Modo A**: cada ítem solo puede ser reclamado por un comensal (DB lock + 409 si ya reclamado)
- **Modo B**: partes mínimo 2, máximo el configurado por el gerente; guard de deduplicación por `part_number` (409 si ya reclamado)
- La orden pasa a `paid` automáticamente cuando todos los pagos están confirmados (`isFullyPaidViaSplit()`)
- Stripe siempre mockeado en tests — nunca llamadas reales

## Fixes incluidos (revisión pre-merge)

- `fix`: eliminar import `DB` no usado en `Order` model
- `fix`: añadir guard 409 contra claims duplicados en `payEquitative` (misma `part_number` no puede reclamarse dos veces)
- `fix`: usar `$validated` en lugar de `$request->input()` en `SplitPaymentConfigController::update()`
- `fix`: capitalización `@author AyrtonAlania` en `OrderItem` model
- `fix`: añadir `@author SebastianBCF` en `SplitPaymentConfigController`

## Checklist CLAUDE.md

- [x] `php artisan test` pasa al 100% (914 tests, 0 fallos)
- [x] Un commit por archivo modificado
- [x] Stripe mockeado en todos los tests del Bloque 16
- [x] `@author` en cabeceras de clase (AyrtonAlania, SebastianBCF, BenjaminDTS según corresponde)
- [x] CLAUDE.md actualizado (Bloque 16 completado, progreso 73% -> 80%)
- [x] README actualizado (Bloque 16 marcado como Completado, 93% progreso global)