### PR TITLE
feat(negocio): integrate split payment config into business settings

### DIFF
--- a/app/Http/Controllers/TapasController.php
+++ b/app/Http/Controllers/TapasController.php
@@ -82,6 +82,8 @@ class TapasController extends Controller
             'business_schedules'                  => ['nullable', 'array', 'max:4'],
             'business_schedules.*.opens_at'       => ['required', 'date_format:H:i'],
             'business_schedules.*.closes_at'      => ['required', 'date_format:H:i'],
+            'split_payment_enabled'               => ['sometimes', 'boolean'],
+            'split_payment_max_parts'             => ['nullable', 'integer', 'min:2', 'max:20'],
         ]);
 
         $userId       = Auth::id();
@@ -133,6 +135,15 @@ class TapasController extends Controller
                 'closes_at' => $slot['closes_at'],
             ]);
         }
+
+        // Guardar cobro partido en el usuario
+        $splitEnabled = $request->boolean('split_payment_enabled');
+        Auth::user()->update([
+            'split_payment_enabled'   => $splitEnabled,
+            'split_payment_max_parts' => $splitEnabled
+                ? ($request->input('split_payment_max_parts') ?: null)
+                : null,
+        ]);
 
         return redirect()->route('negocio.config.edit')
                          ->with('success', 'Configuración del negocio guardada correctamente.');

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -3,7 +3,7 @@
     @php
         $cartaActive   = request()->routeIs('categories.*', 'ingredients.*', 'products.*', 'daily-menus.*');
         $localActive   = request()->routeIs('tables.*', 'zones.*', 'staff.*');
-        $negocioActive = request()->routeIs('tapas.*', 'negocio.*', 'manager.*', 'split-payment.*');
+        $negocioActive = request()->routeIs('tapas.*', 'negocio.*', 'manager.*');
     @endphp
 
     <!-- Primary Navigation Menu -->
@@ -153,9 +153,6 @@
                                 <x-dropdown-link role="menuitem" :href="route('negocio.config.edit')" :active="request()->routeIs('negocio.*', 'tapas.*')">
                                     {{ __('Configuración del negocio') }}
                                 </x-dropdown-link>
-                                <x-dropdown-link role="menuitem" :href="route('split-payment.edit')" :active="request()->routeIs('split-payment.*')">
-                                    {{ __('Cobro Partido') }}
-                                </x-dropdown-link>
                                 <x-dropdown-link role="menuitem" :href="route('manager.income')" :active="request()->routeIs('manager.*')">
                                     {{ __('Ingresos') }}
                                 </x-dropdown-link>
@@ -287,9 +284,6 @@
                 <h3 class="px-3 pt-3 pb-1 text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500" role="presentation">{{ __('Negocio') }}</h3>
                 <x-responsive-nav-link :href="route('negocio.config.edit')" :active="request()->routeIs('negocio.*', 'tapas.*')">
                     {{ __('Configuración del negocio') }}
-                </x-responsive-nav-link>
-                <x-responsive-nav-link :href="route('split-payment.edit')" :active="request()->routeIs('split-payment.*')">
-                    {{ __('Cobro Partido') }}
                 </x-responsive-nav-link>
                 <x-responsive-nav-link :href="route('manager.income')" :active="request()->routeIs('manager.*')">
                     {{ __('Ingresos') }}

--- a/resources/views/negocio/config.blade.php
+++ b/resources/views/negocio/config.blade.php
@@ -38,6 +38,7 @@
                         extra_tapa_enabled: {{ $tapaConfig->extra_tapa_enabled ? 'true' : 'false' }},
                         kitchen_schedules:  {{ json_encode($kitchenSchedulesForAlpine, JSON_HEX_QUOT) }},
                         business_schedules: {{ json_encode($businessSchedulesForAlpine, JSON_HEX_QUOT) }},
+                        split_enabled:      {{ auth()->user()->split_payment_enabled ? 'true' : 'false' }},
                         addKitchenSchedule()     { if (this.kitchen_schedules.length < 4) this.kitchen_schedules.push({ opens_at: '', closes_at: '' }); },
                         removeKitchenSchedule(i) { this.kitchen_schedules.splice(i, 1); },
                         addBusinessSchedule()     { if (this.business_schedules.length < 4) this.business_schedules.push({ opens_at: '', closes_at: '' }); },
@@ -460,6 +461,65 @@
 
                         </div>
 
+                    </section>
+
+                    {{-- ════════════════════════════════════════════ --}}
+                    {{-- SECCIÓN: Cobro partido                     --}}
+                    {{-- ════════════════════════════════════════════ --}}
+                    <section aria-labelledby="split-payment-heading" class="pt-8 border-t border-gray-200 dark:border-gray-700">
+                        <h3 id="split-payment-heading" class="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                            {{ __('Cobro partido') }}
+                        </h3>
+                        <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">
+                            {{ __('Permite a los clientes dividir la cuenta entre varios comensales desde la carta digital.') }}
+                        </p>
+
+                        {{-- Toggle --}}
+                        <div class="flex items-center justify-between mb-4">
+                            <label for="split_enabled_btn" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                {{ __('Activar cobro partido') }}
+                            </label>
+                            <button
+                                id="split_enabled_btn"
+                                type="button"
+                                role="switch"
+                                :aria-checked="split_enabled.toString()"
+                                @click="split_enabled = !split_enabled"
+                                :class="split_enabled ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+                                class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+                            >
+                                <span
+                                    :class="split_enabled ? 'translate-x-6' : 'translate-x-1'"
+                                    class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform"
+                                ></span>
+                            </button>
+                            <input type="hidden" name="split_payment_enabled" :value="split_enabled ? '1' : '0'">
+                        </div>
+
+                        {{-- Máximo de partes (visible solo si activo) --}}
+                        <div x-show="split_enabled" x-transition>
+                            <label for="split_payment_max_parts" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                {{ __('Máximo de partes por mesa') }}
+                            </label>
+                            <p id="max-parts-desc" class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                                {{ __('Deja vacío para no limitar el número de partes en que se puede dividir la cuenta.') }}
+                            </p>
+                            <input
+                                type="number"
+                                id="split_payment_max_parts"
+                                name="split_payment_max_parts"
+                                value="{{ old('split_payment_max_parts', auth()->user()->split_payment_max_parts > 0 ? auth()->user()->split_payment_max_parts : '') }}"
+                                min="2"
+                                max="20"
+                                :disabled="!split_enabled"
+                                aria-describedby="max-parts-desc error-split_payment_max_parts"
+                                class="mt-1 block w-32 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                                placeholder="{{ __('Sin límite') }}"
+                            >
+                            @error('split_payment_max_parts')
+                                <p id="error-split_payment_max_parts" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                            @enderror
+                        </div>
                     </section>
 
                     <div class="mt-8 flex justify-end">

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\StaffController;
 use App\Http\Controllers\BarPanelController;
 use App\Http\Controllers\ManagerRevenueController;
 use App\Http\Controllers\PaymentController;
-use App\Http\Controllers\SplitPaymentConfigController;
 use App\Http\Controllers\TapasController;
 use App\Http\Controllers\CategoryController;
 use App\Http\Controllers\KitchenController;
@@ -57,8 +56,6 @@ Route::middleware(['auth', 'business.active'])->group(function () {
         Route::get('/tapas/config', fn () => redirect()->route('negocio.config.edit'))->name('tapas.edit');
         Route::put('/tapas/config', [TapasController::class, 'update'])->name('tapas.update');
 
-        Route::get('/split-payment/config', [SplitPaymentConfigController::class, 'edit'])->name('split-payment.edit');
-        Route::put('/split-payment/config', [SplitPaymentConfigController::class, 'update'])->name('split-payment.update');
 
         Route::get('/manager/income', [ManagerRevenueController::class, 'index'])->name('manager.income');
 

--- a/tests/Feature/Bloque16/SplitPaymentConfigTest.php
+++ b/tests/Feature/Bloque16/SplitPaymentConfigTest.php
@@ -33,30 +33,32 @@ beforeEach(function () {
 });
 
 it('redirects unauthenticated user from split payment config', function () {
-    $this->get(route('split-payment.edit'))->assertRedirect(route('login'));
-    $this->put(route('split-payment.update'))->assertRedirect(route('login'));
+    $this->get(route('negocio.config.edit'))->assertRedirect(route('login'));
+    $this->put(route('negocio.config.update'))->assertRedirect(route('login'));
 });
 
 it('waiter cannot access split payment config', function () {
     $this->actingAs($this->waiter)
-         ->get(route('split-payment.edit'))
+         ->get(route('negocio.config.edit'))
          ->assertForbidden();
 });
 
 it('admin can view split payment config', function () {
     $this->actingAs($this->admin)
-         ->get(route('split-payment.edit'))
+         ->get(route('negocio.config.edit'))
          ->assertOk()
-         ->assertViewIs('split-payment.edit')
-         ->assertViewHas('user', $this->admin);
+         ->assertViewIs('negocio.config')
+         ->assertViewHas('tapaConfig');
 });
 
 it('admin can enable split payment', function () {
     $this->actingAs($this->admin)
-         ->put(route('split-payment.update'), [
-             'split_payment_enabled' => '1',
+         ->put(route('negocio.config.update'), [
+             'split_payment_enabled'   => '1',
+             'max_tapa_variants'       => '3',
+             'tapas_free'              => '1',
          ])
-         ->assertRedirect(route('split-payment.edit'));
+         ->assertRedirect(route('negocio.config.edit'));
 
     expect($this->admin->fresh()->split_payment_enabled)->toBeTrue();
 });
@@ -65,10 +67,12 @@ it('admin can disable split payment', function () {
     $this->admin->update(['split_payment_enabled' => true, 'split_payment_max_parts' => 4]);
 
     $this->actingAs($this->admin)
-         ->put(route('split-payment.update'), [
+         ->put(route('negocio.config.update'), [
              'split_payment_enabled' => '0',
+             'max_tapa_variants'     => '3',
+             'tapas_free'            => '1',
          ])
-         ->assertRedirect(route('split-payment.edit'));
+         ->assertRedirect(route('negocio.config.edit'));
 
     $fresh = $this->admin->fresh();
     expect($fresh->split_payment_enabled)->toBeFalse()
@@ -77,38 +81,46 @@ it('admin can disable split payment', function () {
 
 it('admin can set max parts limit', function () {
     $this->actingAs($this->admin)
-         ->put(route('split-payment.update'), [
+         ->put(route('negocio.config.update'), [
              'split_payment_enabled'   => '1',
              'split_payment_max_parts' => '5',
+             'max_tapa_variants'       => '3',
+             'tapas_free'              => '1',
          ])
-         ->assertRedirect(route('split-payment.edit'));
+         ->assertRedirect(route('negocio.config.edit'));
 
     expect($this->admin->fresh()->split_payment_max_parts)->toBe(5);
 });
 
 it('max parts must be at least 2', function () {
     $this->actingAs($this->admin)
-         ->put(route('split-payment.update'), [
+         ->put(route('negocio.config.update'), [
              'split_payment_enabled'   => '1',
              'split_payment_max_parts' => '1',
+             'max_tapa_variants'       => '3',
+             'tapas_free'              => '1',
          ])
          ->assertSessionHasErrors('split_payment_max_parts');
 });
 
 it('max parts cannot exceed 20', function () {
     $this->actingAs($this->admin)
-         ->put(route('split-payment.update'), [
+         ->put(route('negocio.config.update'), [
              'split_payment_enabled'   => '1',
              'split_payment_max_parts' => '21',
+             'max_tapa_variants'       => '3',
+             'tapas_free'              => '1',
          ])
          ->assertSessionHasErrors('split_payment_max_parts');
 });
 
 it('max parts must be an integer', function () {
     $this->actingAs($this->admin)
-         ->put(route('split-payment.update'), [
+         ->put(route('negocio.config.update'), [
              'split_payment_enabled'   => '1',
              'split_payment_max_parts' => 'abc',
+             'max_tapa_variants'       => '3',
+             'tapas_free'              => '1',
          ])
          ->assertSessionHasErrors('split_payment_max_parts');
 });
@@ -117,30 +129,36 @@ it('max parts is cleared when split payment is disabled', function () {
     $this->admin->update(['split_payment_enabled' => true, 'split_payment_max_parts' => 6]);
 
     $this->actingAs($this->admin)
-         ->put(route('split-payment.update'), [
+         ->put(route('negocio.config.update'), [
              'split_payment_enabled'   => '0',
              'split_payment_max_parts' => '6',
+             'max_tapa_variants'       => '3',
+             'tapas_free'              => '1',
          ])
-         ->assertRedirect(route('split-payment.edit'));
+         ->assertRedirect(route('negocio.config.edit'));
 
     expect($this->admin->fresh()->split_payment_max_parts)->toBeNull();
 });
 
 it('max parts can be left empty for no limit', function () {
     $this->actingAs($this->admin)
-         ->put(route('split-payment.update'), [
+         ->put(route('negocio.config.update'), [
              'split_payment_enabled'   => '1',
              'split_payment_max_parts' => '',
+             'max_tapa_variants'       => '3',
+             'tapas_free'              => '1',
          ])
-         ->assertRedirect(route('split-payment.edit'));
+         ->assertRedirect(route('negocio.config.edit'));
 
     expect($this->admin->fresh()->split_payment_max_parts)->toBeNull();
 });
 
 it('shows success flash after saving config', function () {
     $this->actingAs($this->admin)
-         ->put(route('split-payment.update'), [
+         ->put(route('negocio.config.update'), [
              'split_payment_enabled' => '1',
+             'max_tapa_variants'     => '3',
+             'tapas_free'            => '1',
          ])
          ->assertSessionHas('success');
 });
@@ -149,9 +167,11 @@ it('split payment config is scoped to the restaurant', function () {
     $this->admin->update(['split_payment_enabled' => true, 'split_payment_max_parts' => 3]);
 
     $this->actingAs($this->other)
-         ->put(route('split-payment.update'), [
+         ->put(route('negocio.config.update'), [
              'split_payment_enabled'   => '0',
              'split_payment_max_parts' => null,
+             'max_tapa_variants'       => '3',
+             'tapas_free'              => '1',
          ]);
 
     expect($this->admin->fresh()->split_payment_enabled)->toBeTrue()
@@ -162,7 +182,11 @@ it('other admin cannot change another admins split payment config', function () 
     $this->admin->update(['split_payment_enabled' => true]);
 
     $this->actingAs($this->other)
-         ->put(route('split-payment.update'), ['split_payment_enabled' => '0']);
+         ->put(route('negocio.config.update'), [
+             'split_payment_enabled' => '0',
+             'max_tapa_variants'     => '3',
+             'tapas_free'            => '1',
+         ]);
 
     expect($this->admin->fresh()->split_payment_enabled)->toBeTrue();
 });


### PR DESCRIPTION
## Summary
- Elimina la ruta y controlador `SplitPaymentConfigController` independientes
- Elimina el enlace de nav "Cobro Partido" separado
- `TapasController::update` ahora guarda `split_payment_enabled` y `split_payment_max_parts` en el usuario
- `negocio/config.blade.php` incluye nueva sección con toggle activar/desactivar cobro partido y campo de máximo de partes

## Test plan
- [ ] El formulario de configuración del negocio guarda correctamente el cobro partido
- [ ] El toggle y el campo de máximo de partes funcionan en la vista
- [ ] La ruta `/split-payment/config` ya no existe (404)
- [ ] El enlace "Cobro Partido" desaparece del nav