### PR TITLE
feat: split payment accounting via order_payments table

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -44,21 +44,49 @@ class DashboardController extends Controller
             ->where('orders.payment_status', 'paid')
             ->whereBetween('orders.updated_at', [$start, $end]);
 
-        $summary = (clone $base)
+        $nonSplitRaw = (clone $base)
+            ->whereIn('orders.payment_method', ['cash', 'card'])
             ->selectRaw("
                 COALESCE(SUM(CASE WHEN orders.payment_method = 'cash' THEN orders.total ELSE 0 END), 0) as cash_revenue,
                 COALESCE(SUM(CASE WHEN orders.payment_method = 'card' THEN orders.total ELSE 0 END), 0) as card_revenue,
                 COALESCE(SUM(CASE WHEN orders.payment_method = 'cash' THEN orders.tip  ELSE 0 END), 0)  as cash_tip_revenue,
                 COALESCE(SUM(CASE WHEN orders.payment_method = 'card' THEN orders.tip  ELSE 0 END), 0)  as card_tip_revenue,
                 SUM(CASE WHEN orders.payment_method = 'cash' THEN 1 ELSE 0 END)                         as cash_count,
-                SUM(CASE WHEN orders.payment_method = 'card' THEN 1 ELSE 0 END)                         as card_count,
-                COUNT(*)                                                                                 as total_count
+                SUM(CASE WHEN orders.payment_method = 'card' THEN 1 ELSE 0 END)                         as card_count
             ")
-            ->first() ?? (object) [
-                'cash_revenue'     => 0, 'card_revenue'     => 0,
-                'cash_tip_revenue' => 0, 'card_tip_revenue' => 0,
-                'cash_count'       => 0, 'card_count'       => 0, 'total_count' => 0,
-            ];
+            ->first();
+
+        $splitRaw = DB::table('order_payments')
+            ->join('orders', 'order_payments.order_id', '=', 'orders.id')
+            ->join('tables', 'orders.table_id', '=', 'tables.id')
+            ->where('tables.user_id', $ownerUserId)
+            ->where('orders.payment_status', 'paid')
+            ->whereBetween('orders.updated_at', [$start, $end])
+            ->selectRaw("
+                COALESCE(SUM(CASE WHEN order_payments.method = 'cash' THEN order_payments.amount ELSE 0 END), 0) as split_cash_revenue,
+                COALESCE(SUM(CASE WHEN order_payments.method = 'card' THEN order_payments.amount ELSE 0 END), 0) as split_card_revenue,
+                COALESCE(SUM(CASE WHEN order_payments.method = 'cash' THEN order_payments.tip    ELSE 0 END), 0) as split_cash_tip_revenue,
+                COALESCE(SUM(CASE WHEN order_payments.method = 'card' THEN order_payments.tip    ELSE 0 END), 0) as split_card_tip_revenue,
+                COUNT(DISTINCT order_payments.order_id)                                                          as split_count
+            ")
+            ->first();
+
+        $summary = (object) [
+            'cash_revenue'           => (float) ($nonSplitRaw->cash_revenue ?? 0),
+            'card_revenue'           => (float) ($nonSplitRaw->card_revenue ?? 0),
+            'cash_tip_revenue'       => (float) ($nonSplitRaw->cash_tip_revenue ?? 0),
+            'card_tip_revenue'       => (float) ($nonSplitRaw->card_tip_revenue ?? 0),
+            'cash_count'             => (int)   ($nonSplitRaw->cash_count ?? 0),
+            'card_count'             => (int)   ($nonSplitRaw->card_count ?? 0),
+            'split_cash_revenue'     => (float) ($splitRaw->split_cash_revenue ?? 0),
+            'split_card_revenue'     => (float) ($splitRaw->split_card_revenue ?? 0),
+            'split_cash_tip_revenue' => (float) ($splitRaw->split_cash_tip_revenue ?? 0),
+            'split_card_tip_revenue' => (float) ($splitRaw->split_card_tip_revenue ?? 0),
+            'split_count'            => (int)   ($splitRaw->split_count ?? 0),
+            'total_count'            => (int) ($nonSplitRaw->cash_count ?? 0)
+                                      + (int) ($nonSplitRaw->card_count ?? 0)
+                                      + (int) ($splitRaw->split_count ?? 0),
+        ];
 
         $topTable = (clone $base)
             ->select('tables.name as table_name')
@@ -91,8 +119,10 @@ class DashboardController extends Controller
             ->limit(3)
             ->get();
 
-        $grand     = (float) $summary->cash_revenue + (float) $summary->card_revenue
-                   + (float) $summary->cash_tip_revenue + (float) $summary->card_tip_revenue;
+        $grand     = $summary->cash_revenue + $summary->card_revenue
+                   + $summary->cash_tip_revenue + $summary->card_tip_revenue
+                   + $summary->split_cash_revenue + $summary->split_card_revenue
+                   + $summary->split_cash_tip_revenue + $summary->split_card_tip_revenue;
         $avgTicket = $summary->total_count > 0
             ? round($grand / $summary->total_count, 2)
             : 0.0;

--- a/app/Http/Controllers/ManagerRevenueController.php
+++ b/app/Http/Controllers/ManagerRevenueController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Order;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 
 /**
@@ -29,24 +30,57 @@ class ManagerRevenueController extends Controller
             default => [now()->startOfMonth(), now()->endOfMonth()],
         };
 
-        // JOIN en lugar de whereHas para evitar N+1 y garantizar multitenancy en una sola query
+        $ownerUserId = Auth::user()->ownerUserId();
+
         $base = Order::query()
             ->join('tables', 'orders.table_id', '=', 'tables.id')
-            ->where('tables.user_id', Auth::user()->ownerUserId())
+            ->where('tables.user_id', $ownerUserId)
             ->where('orders.payment_status', 'paid')
             ->whereBetween('orders.updated_at', [$start, $end]);
 
-        $summary = (clone $base)
+        $nonSplitRaw = (clone $base)
+            ->whereIn('orders.payment_method', ['cash', 'card'])
             ->selectRaw("
                 COALESCE(SUM(CASE WHEN orders.payment_method = 'cash' THEN orders.total ELSE 0 END), 0) as cash_revenue,
                 COALESCE(SUM(CASE WHEN orders.payment_method = 'card' THEN orders.total ELSE 0 END), 0) as card_revenue,
                 COALESCE(SUM(CASE WHEN orders.payment_method = 'cash' THEN orders.tip  ELSE 0 END), 0)  as cash_tip_revenue,
                 COALESCE(SUM(CASE WHEN orders.payment_method = 'card' THEN orders.tip  ELSE 0 END), 0)  as card_tip_revenue,
                 SUM(CASE WHEN orders.payment_method = 'cash' THEN 1 ELSE 0 END)                         as cash_count,
-                SUM(CASE WHEN orders.payment_method = 'card' THEN 1 ELSE 0 END)                         as card_count,
-                COUNT(*)                                                                                 as total_count
+                SUM(CASE WHEN orders.payment_method = 'card' THEN 1 ELSE 0 END)                         as card_count
             ")
             ->first();
+
+        $splitRaw = DB::table('order_payments')
+            ->join('orders', 'order_payments.order_id', '=', 'orders.id')
+            ->join('tables', 'orders.table_id', '=', 'tables.id')
+            ->where('tables.user_id', $ownerUserId)
+            ->where('orders.payment_status', 'paid')
+            ->whereBetween('orders.updated_at', [$start, $end])
+            ->selectRaw("
+                COALESCE(SUM(CASE WHEN order_payments.method = 'cash' THEN order_payments.amount ELSE 0 END), 0) as split_cash_revenue,
+                COALESCE(SUM(CASE WHEN order_payments.method = 'card' THEN order_payments.amount ELSE 0 END), 0) as split_card_revenue,
+                COALESCE(SUM(CASE WHEN order_payments.method = 'cash' THEN order_payments.tip    ELSE 0 END), 0) as split_cash_tip_revenue,
+                COALESCE(SUM(CASE WHEN order_payments.method = 'card' THEN order_payments.tip    ELSE 0 END), 0) as split_card_tip_revenue,
+                COUNT(DISTINCT order_payments.order_id)                                                          as split_count
+            ")
+            ->first();
+
+        $summary = (object) [
+            'cash_revenue'           => (float) ($nonSplitRaw->cash_revenue ?? 0),
+            'card_revenue'           => (float) ($nonSplitRaw->card_revenue ?? 0),
+            'cash_tip_revenue'       => (float) ($nonSplitRaw->cash_tip_revenue ?? 0),
+            'card_tip_revenue'       => (float) ($nonSplitRaw->card_tip_revenue ?? 0),
+            'cash_count'             => (int)   ($nonSplitRaw->cash_count ?? 0),
+            'card_count'             => (int)   ($nonSplitRaw->card_count ?? 0),
+            'split_cash_revenue'     => (float) ($splitRaw->split_cash_revenue ?? 0),
+            'split_card_revenue'     => (float) ($splitRaw->split_card_revenue ?? 0),
+            'split_cash_tip_revenue' => (float) ($splitRaw->split_cash_tip_revenue ?? 0),
+            'split_card_tip_revenue' => (float) ($splitRaw->split_card_tip_revenue ?? 0),
+            'split_count'            => (int)   ($splitRaw->split_count ?? 0),
+            'total_count'            => (int) ($nonSplitRaw->cash_count ?? 0)
+                                      + (int) ($nonSplitRaw->card_count ?? 0)
+                                      + (int) ($splitRaw->split_count ?? 0),
+        ];
 
         $orders = (clone $base)
             ->select(

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -3,8 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Models\Order;
+use App\Models\OrderPayment;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Gestiona los flujos de pago desde el panel del camarero.
@@ -16,8 +18,10 @@ class PaymentController extends Controller
 {
     /**
      * El camarero confirma el pago en efectivo de un pedido.
-     * Cierra el pedido y registra el método de pago como cash.
-     * La propina en efectivo no se registra digitalmente.
+     * Si hay partes ya pagadas con tarjeta (cobro partido), registra todos los
+     * pagos en order_payments y cierra el pedido como 'split'.
+     * En caso contrario, cierra como pago puro en efectivo.
+     * La propina en efectivo nunca se registra digitalmente.
      *
      * @param  Order  $order
      * @return JsonResponse
@@ -27,12 +31,56 @@ class PaymentController extends Controller
         abort_if($order->table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
         abort_if($order->status === 'closed', 422, 'Este pedido ya está cerrado.');
 
-        $order->update([
-            'payment_method' => 'cash',
-            'payment_status' => 'paid',
-            'status'         => 'closed',
-            'bill_requested' => false,
-        ]);
+        $paidCardParts = $order->splitPayments()->where('status', 'paid')->get();
+
+        if ($paidCardParts->isNotEmpty()) {
+            // Leer propina en efectivo del bill-request antes de sobreescribir orders.tip
+            $cashTip = max(0, round((float) $order->tip, 2));
+
+            DB::transaction(function () use ($order, $paidCardParts, $cashTip) {
+                $cardPayments = $paidCardParts
+                    ->groupBy('stripe_payment_intent_id')
+                    ->map(fn ($parts) => [
+                        'amount' => round((float) $parts->sum('amount'), 2),
+                        'tip'    => round((float) $parts->sum('tip'), 2),
+                    ]);
+
+                foreach ($cardPayments as $payment) {
+                    OrderPayment::create([
+                        'order_id' => $order->id,
+                        'method'   => 'card',
+                        'amount'   => $payment['amount'],
+                        'tip'      => $payment['tip'],
+                    ]);
+                }
+
+                $paidCardAmount = round((float) $paidCardParts->sum('amount'), 2);
+                $remaining      = max(0, round((float) $order->total - $paidCardAmount, 2));
+                $cardTips       = round((float) $paidCardParts->sum('tip'), 2);
+
+                OrderPayment::create([
+                    'order_id' => $order->id,
+                    'method'   => 'cash',
+                    'amount'   => $remaining,
+                    'tip'      => $cashTip,
+                ]);
+
+                $order->update([
+                    'payment_method' => 'split',
+                    'payment_status' => 'paid',
+                    'status'         => 'closed',
+                    'bill_requested' => false,
+                    'tip'            => $cardTips + $cashTip,
+                ]);
+            });
+        } else {
+            $order->update([
+                'payment_method' => 'cash',
+                'payment_status' => 'paid',
+                'status'         => 'closed',
+                'bill_requested' => false,
+            ]);
+        }
 
         return response()->json(['success' => true]);
     }

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -101,6 +101,16 @@ class Order extends Model
     }
 
     /**
+     * Registros contables de cobro partido (solo para payment_method='split').
+     *
+     * @return HasMany
+     */
+    public function orderPayments(): HasMany
+    {
+        return $this->hasMany(OrderPayment::class);
+    }
+
+    /**
      * Suma de los pagos parciales con status 'paid'.
      *
      * @return float

--- a/app/Models/OrderPayment.php
+++ b/app/Models/OrderPayment.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Registro contable de un pago (o parte de un pago) sobre un pedido.
+ * Se crea únicamente en pedidos de cobro partido (payment_method='split').
+ * Para pagos simples (cash/card), el registro vive en orders.total.
+ *
+ * @property int    $order_id
+ * @property string $method   'cash' | 'card'
+ * @property float  $amount
+ * @property float  $tip
+ *
+ * @author BenjaminDTS
+ */
+class OrderPayment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'order_id',
+        'method',
+        'amount',
+        'tip',
+    ];
+
+    protected $casts = [
+        'amount' => 'float',
+        'tip'    => 'float',
+    ];
+
+    /**
+     * @return BelongsTo
+     */
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+}

--- a/database/factories/OrderPaymentFactory.php
+++ b/database/factories/OrderPaymentFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Order;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\OrderPayment>
+ */
+class OrderPaymentFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'order_id' => Order::factory(),
+            'method'   => fake()->randomElement(['cash', 'card']),
+            'amount'   => fake()->randomFloat(2, 5, 100),
+            'tip'      => 0,
+        ];
+    }
+}

--- a/database/migrations/0007_create_orders_table.php
+++ b/database/migrations/0007_create_orders_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->enum('status', ['pending', 'cooking', 'ready', 'served', 'closed'])->default('pending');
             $table->decimal('total', 10, 2)->default(0);
             $table->decimal('tip', 10, 2)->default(0);
-            $table->enum('payment_method', ['cash', 'card'])->nullable();
+            $table->enum('payment_method', ['cash', 'card', 'split'])->nullable();
             $table->enum('payment_status', ['pending', 'paid'])->default('pending');
             $table->text('note')->nullable();
             $table->timestamps();

--- a/database/migrations/2026_05_23_130000_create_order_payments_table.php
+++ b/database/migrations/2026_05_23_130000_create_order_payments_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('order_payments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('order_id')->constrained()->cascadeOnDelete();
+            $table->enum('method', ['cash', 'card']);
+            $table->decimal('amount', 10, 2);
+            $table->decimal('tip', 10, 2)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('order_payments');
+    }
+};

--- a/database/migrations/2026_05_23_130001_add_split_to_orders_payment_method.php
+++ b/database/migrations/2026_05_23_130001_add_split_to_orders_payment_method.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE orders MODIFY COLUMN payment_method ENUM('cash', 'card', 'split') NULL");
+        }
+    }
+
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'mysql') {
+            DB::statement("ALTER TABLE orders MODIFY COLUMN payment_method ENUM('cash', 'card') NULL");
+        }
+    }
+};

--- a/resources/views/dashboard/index.blade.php
+++ b/resources/views/dashboard/index.blade.php
@@ -87,7 +87,7 @@
                     </a>
                 </div>
 
-                <div class="grid grid-cols-2 lg:grid-cols-3 gap-4">
+                <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
 
                     {{-- Efectivo --}}
                     <div role="region" aria-label="Total ingresos en efectivo"
@@ -121,6 +121,29 @@
                             {{ $summary->card_count }}
                             pedido{{ $summary->card_count != 1 ? 's' : '' }}
                         </p>
+                    </div>
+
+                    {{-- Cobro partido --}}
+                    <div role="region" aria-label="Total ingresos por cobro partido"
+                         class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">🔀</span>
+                            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Cobro partido</span>
+                        </div>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white tabular-nums">
+                            {{ number_format($summary->split_cash_revenue + $summary->split_card_revenue, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                            {{ $summary->split_count }}
+                            pedido{{ $summary->split_count != 1 ? 's' : '' }}
+                        </p>
+                        @if($summary->split_count > 0)
+                            <p class="mt-2 text-xs text-gray-400 dark:text-gray-500">
+                                💵 {{ number_format($summary->split_cash_revenue, 2, ',', '.') }}&nbsp;€
+                                · 💳 {{ number_format($summary->split_card_revenue, 2, ',', '.') }}&nbsp;€
+                            </p>
+                        @endif
                     </div>
 
                     {{-- Total global --}}
@@ -157,7 +180,7 @@
                             </span>
                         </div>
                         <p class="text-2xl font-bold text-green-700 dark:text-green-400 tabular-nums">
-                            {{ number_format($summary->cash_tip_revenue, 2, ',', '.') }}&nbsp;€
+                            {{ number_format($summary->cash_tip_revenue + $summary->split_cash_tip_revenue, 2, ',', '.') }}&nbsp;€
                         </p>
                         <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Propinas recibidas en mano</p>
                     </div>
@@ -175,7 +198,7 @@
                             </span>
                         </div>
                         <p class="text-2xl font-bold text-indigo-600 dark:text-indigo-400 tabular-nums">
-                            {{ number_format($summary->card_tip_revenue, 2, ',', '.') }}&nbsp;€
+                            {{ number_format($summary->card_tip_revenue + $summary->split_card_tip_revenue, 2, ',', '.') }}&nbsp;€
                         </p>
                         <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Propinas cobradas con Stripe</p>
                     </div>

--- a/resources/views/manager/income.blade.php
+++ b/resources/views/manager/income.blade.php
@@ -29,9 +29,14 @@
             {{-- Tarjetas de resumen --}}
             <section aria-labelledby="summary-heading">
                 <h2 id="summary-heading" class="sr-only">Resumen de ingresos</h2>
-                @php $grand = $summary->cash_revenue + $summary->card_revenue + $summary->cash_tip_revenue + $summary->card_tip_revenue; @endphp
+                @php
+                    $grand = $summary->cash_revenue + $summary->card_revenue
+                           + $summary->cash_tip_revenue + $summary->card_tip_revenue
+                           + $summary->split_cash_revenue + $summary->split_card_revenue
+                           + $summary->split_cash_tip_revenue + $summary->split_card_tip_revenue;
+                @endphp
 
-                <div class="grid grid-cols-2 lg:grid-cols-3 gap-4">
+                <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
 
                     {{-- Efectivo --}}
                     <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
@@ -63,6 +68,28 @@
                             {{ $summary->card_count }}
                             pedido{{ $summary->card_count != 1 ? 's' : '' }}
                         </p>
+                    </div>
+
+                    {{-- Cobro partido --}}
+                    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                                border border-gray-200 dark:border-gray-700 p-5">
+                        <div class="flex items-center gap-2 mb-3">
+                            <span class="text-xl" aria-hidden="true">🔀</span>
+                            <span class="text-sm font-medium text-gray-500 dark:text-gray-400">Cobro partido</span>
+                        </div>
+                        <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                            {{ number_format($summary->split_cash_revenue + $summary->split_card_revenue, 2, ',', '.') }}&nbsp;€
+                        </p>
+                        <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                            {{ $summary->split_count }}
+                            pedido{{ $summary->split_count != 1 ? 's' : '' }}
+                        </p>
+                        @if($summary->split_count > 0)
+                            <p class="mt-2 text-xs text-gray-400 dark:text-gray-500">
+                                💵 {{ number_format($summary->split_cash_revenue, 2, ',', '.') }}&nbsp;€
+                                · 💳 {{ number_format($summary->split_card_revenue, 2, ',', '.') }}&nbsp;€
+                            </p>
+                        @endif
                     </div>
 
                     {{-- Total cobrado --}}
@@ -97,7 +124,7 @@
                             </span>
                         </div>
                         <p class="text-2xl font-bold text-green-700 dark:text-green-400">
-                            {{ number_format($summary->cash_tip_revenue, 2, ',', '.') }}&nbsp;€
+                            {{ number_format($summary->cash_tip_revenue + $summary->split_cash_tip_revenue, 2, ',', '.') }}&nbsp;€
                         </p>
                         <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Propinas recibidas en mano</p>
                     </div>
@@ -114,7 +141,7 @@
                             </span>
                         </div>
                         <p class="text-2xl font-bold text-indigo-600 dark:text-indigo-400">
-                            {{ number_format($summary->card_tip_revenue, 2, ',', '.') }}&nbsp;€
+                            {{ number_format($summary->card_tip_revenue + $summary->split_card_tip_revenue, 2, ',', '.') }}&nbsp;€
                         </p>
                         <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">Propinas cobradas con Stripe</p>
                     </div>
@@ -198,6 +225,13 @@
                                                                  text-indigo-700 dark:text-indigo-300">
                                                         <span aria-hidden="true">💳</span> Tarjeta
                                                     </span>
+                                                @elseif($order->payment_method === 'split')
+                                                    <span class="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full
+                                                                 text-xs font-medium
+                                                                 bg-purple-100 dark:bg-purple-900/40
+                                                                 text-purple-700 dark:text-purple-300">
+                                                        <span aria-hidden="true">🔀</span> Partido
+                                                    </span>
                                                 @else
                                                     <span class="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full
                                                                  text-xs font-medium
@@ -219,6 +253,7 @@
                                                             +{{ number_format($order->tip, 2, ',', '.') }}&nbsp;€
                                                         </span>
                                                     @else
+                                                        {{-- card y split: la propina registrada es siempre de tarjeta --}}
                                                         <span class="text-indigo-600 dark:text-indigo-400">
                                                             +{{ number_format($order->tip, 2, ',', '.') }}&nbsp;€
                                                         </span>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -418,11 +418,14 @@
                         });
                         const data = await res.json();
                         if (res.ok && data.success) {
-                            const bill       = Alpine.store('bill');
-                            bill.active      = true;
-                            bill.requested   = false;
-                            bill.method      = null;
-                            bill.paymentDone = false;
+                            const bill             = Alpine.store('bill');
+                            bill.active            = true;
+                            bill.requested         = false;
+                            bill.method            = null;
+                            bill.paymentDone       = false;
+                            bill.orderTotal        = parseFloat(data.total) || 0;
+                            bill.grandTotal        = parseFloat(data.total) || 0;
+                            bill.originalOrderTotal = parseFloat(data.total) || 0;
                             this.sent  = true;
                             this.items = [];
                             this.open  = false;
@@ -572,6 +575,7 @@
                 splitStripeReady:  false,
                 splitStripeError:  null,
                 splitStripeTotal:  0,
+                splitStripeTip:    0,
                 _splitStripe:      null,
                 _splitElements:    null,
 
@@ -968,6 +972,7 @@
                             return;
                         }
                         this.splitStripeTotal = data.amount ?? amount;
+                        this.splitStripeTip   = tip;
                         requestAnimationFrame(() => requestAnimationFrame(() => this._mountSplitStripe(data.client_secret)));
                     } catch {
                         this.splitStripeError = 'Error de conexión al iniciar el pago.';
@@ -1031,12 +1036,13 @@
                             const data = await res.json();
                             if (res.ok && data.success) {
                                 this.splitPayingCard = false;
-                                this.paymentDone     = true;
-                                this.orderTotal      = Math.max(0, this.orderTotal - this.splitStripeTotal);
+                                const basePaid       = this.splitStripeTotal - (this.splitStripeTip || 0);
+                                this.orderTotal      = Math.max(0, this.orderTotal - basePaid);
                                 this.grandTotal      = this.orderTotal;
                                 if (data.fully_paid) {
-                                    this.requested = true;
-                                    this.active    = false;
+                                    this.paymentDone = true;
+                                    this.requested   = true;
+                                    this.active      = false;
                                 }
                             } else {
                                 this.splitStripeError = data.message ?? 'Error al confirmar el pago.';

--- a/tests/Feature/Bloque9/DashboardTest.php
+++ b/tests/Feature/Bloque9/DashboardTest.php
@@ -5,6 +5,7 @@
  */
 
 use App\Models\Order;
+use App\Models\OrderPayment;
 use App\Models\Table;
 use App\Models\User;
 use Illuminate\Support\Carbon;
@@ -763,4 +764,148 @@ it('average ticket updates correctly when period filter changes', function () {
                             ->viewData('avgTicket');
 
     expect((float) $avgTicketCustom)->toBe(60.0);
+});
+
+// ─── Cobro partido ─────────────────────────────────────────────────────────────
+
+it('split payment orders appear in split_count not cash or card count', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    $order = Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'split',
+        'payment_status' => 'paid',
+        'total'          => 40.00,
+        'tip'            => 2.00,
+        'updated_at'     => now(),
+    ]);
+
+    OrderPayment::factory()->create(['order_id' => $order->id, 'method' => 'card', 'amount' => 30.00, 'tip' => 2.00]);
+    OrderPayment::factory()->create(['order_id' => $order->id, 'method' => 'cash', 'amount' => 10.00, 'tip' => 0]);
+
+    $summary = $this->actingAs($this->admin)
+                    ->get(route('dashboard', ['period' => 'month']))
+                    ->assertOk()
+                    ->viewData('summary');
+
+    expect((int) $summary->cash_count)->toBe(0);
+    expect((int) $summary->card_count)->toBe(0);
+    expect((int) $summary->split_count)->toBe(1);
+    expect((int) $summary->total_count)->toBe(1);
+});
+
+it('split payment revenue and tips are broken down by method in summary', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    $order = Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'split',
+        'payment_status' => 'paid',
+        'total'          => 50.00,
+        'tip'            => 5.00,
+        'updated_at'     => now(),
+    ]);
+
+    OrderPayment::factory()->create(['order_id' => $order->id, 'method' => 'card', 'amount' => 35.00, 'tip' => 3.00]);
+    OrderPayment::factory()->create(['order_id' => $order->id, 'method' => 'cash', 'amount' => 15.00, 'tip' => 2.00]);
+
+    $summary = $this->actingAs($this->admin)
+                    ->get(route('dashboard', ['period' => 'month']))
+                    ->assertOk()
+                    ->viewData('summary');
+
+    expect((float) $summary->split_card_revenue)->toBe(35.0);
+    expect((float) $summary->split_cash_revenue)->toBe(15.0);
+    expect((float) $summary->split_card_tip_revenue)->toBe(3.0);
+    expect((float) $summary->split_cash_tip_revenue)->toBe(2.0);
+});
+
+it('split revenue is included in grand total', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 20.00,
+        'tip'            => 0,
+        'updated_at'     => now(),
+    ]);
+
+    $splitOrder = Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'split',
+        'payment_status' => 'paid',
+        'total'          => 40.00,
+        'tip'            => 2.00,
+        'updated_at'     => now(),
+    ]);
+
+    OrderPayment::factory()->create(['order_id' => $splitOrder->id, 'method' => 'card', 'amount' => 30.00, 'tip' => 2.00]);
+    OrderPayment::factory()->create(['order_id' => $splitOrder->id, 'method' => 'cash', 'amount' => 10.00, 'tip' => 1.00]);
+
+    $grand = $this->actingAs($this->admin)
+                  ->get(route('dashboard', ['period' => 'month']))
+                  ->assertOk()
+                  ->viewData('grand');
+
+    // cash(20) + split_card(30) + split_cash(10) + split_card_tip(2) + split_cash_tip(1) = 63
+    expect((float) $grand)->toBe(63.0);
+});
+
+it('split revenue from other restaurants is not counted', function () {
+    $otherTable = Table::factory()->create(['user_id' => $this->other->id]);
+
+    $otherOrder = Order::factory()->create([
+        'table_id'       => $otherTable->id,
+        'payment_method' => 'split',
+        'payment_status' => 'paid',
+        'total'          => 100.00,
+        'updated_at'     => now(),
+    ]);
+
+    OrderPayment::factory()->create(['order_id' => $otherOrder->id, 'method' => 'card', 'amount' => 70.00]);
+    OrderPayment::factory()->create(['order_id' => $otherOrder->id, 'method' => 'cash', 'amount' => 30.00]);
+
+    $summary = $this->actingAs($this->admin)
+                    ->get(route('dashboard', ['period' => 'month']))
+                    ->assertOk()
+                    ->viewData('summary');
+
+    expect((float) $summary->split_cash_revenue)->toBe(0.0);
+    expect((float) $summary->split_card_revenue)->toBe(0.0);
+    expect((int) $summary->split_count)->toBe(0);
+});
+
+it('average ticket includes split orders', function () {
+    $table = Table::factory()->create(['user_id' => $this->admin->id]);
+
+    Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'cash',
+        'payment_status' => 'paid',
+        'total'          => 30.00,
+        'tip'            => 0,
+        'updated_at'     => now(),
+    ]);
+
+    $splitOrder = Order::factory()->create([
+        'table_id'       => $table->id,
+        'payment_method' => 'split',
+        'payment_status' => 'paid',
+        'total'          => 50.00,
+        'tip'            => 0,
+        'updated_at'     => now(),
+    ]);
+
+    OrderPayment::factory()->create(['order_id' => $splitOrder->id, 'method' => 'card', 'amount' => 30.00, 'tip' => 0]);
+    OrderPayment::factory()->create(['order_id' => $splitOrder->id, 'method' => 'cash', 'amount' => 20.00, 'tip' => 0]);
+
+    $avgTicket = $this->actingAs($this->admin)
+                      ->get(route('dashboard', ['period' => 'month']))
+                      ->assertOk()
+                      ->viewData('avgTicket');
+
+    // (cash 30 + split_card 30 + split_cash 20) / 2 orders = 40
+    expect((float) $avgTicket)->toBe(40.0);
 });


### PR DESCRIPTION
## Summary

- Nueva tabla `order_payments` como fuente de verdad para cobros partidos: registra método (cash/card), importe y propina por cada parte
- `PaymentController` escribe las filas de `order_payments` al confirmar el pago en efectivo de un cobro partido, capturando correctamente la propina en efectivo antes de sobreescribir `orders.tip`
- `DashboardController` y `ManagerRevenueController` fusionan dos consultas (`orders` para cash/card puro, `order_payments` para split) en un único objeto `$summary` con desglose completo
- Vistas dashboard e ingresos: nueva tarjeta 🔀 Cobro partido con desglose efectivo/tarjeta; propinas de split sumadas a las tarjetas correspondientes
- **Bug fix** carta pública: `paymentDone = true` ya no se activa hasta que el pedido esté completamente pagado (`data.fully_paid`)
- **Bug fix** cobro partido equitativo: `originalOrderTotal` y `orderTotal` se actualizan al enviar el pedido, evitando que aparezca `Tu parte: 0,00 €` cuando la página cargó antes de que existiera el pedido
- **Bug fix** cobro partido con propina: `submitSplitPayment` ahora solo resta el importe base (sin propina) de `orderTotal`, evitando que el total restante se muestre incorrecto

## Test plan

- [x] `php artisan test tests/Feature/Bloque9/DashboardTest.php` — 43/43 passing
- [x] 5 nuevos tests de cobro partido: `split_count`, desglose de ingresos/propinas, total general, aislamiento multi-tenant, ticket medio
- [x] Migraciones ejecutadas en MySQL sin errores
- [x] Guard `DB::getDriverName() === 'mysql'` en la migración de MODIFY COLUMN para compatibilidad con SQLite en tests
- [x] Enum base `0007_create_orders_table.php` actualizado con `split` para que SQLite no rechace la inserción en tests