### PR TITLE
feat: product variants system (Entera / Media ración / Tapa)

### DIFF
--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -74,7 +74,59 @@ class OrderController extends Controller
             }
         }
 
-        $order = DB::transaction(function () use ($validated, $table, $tapaConfig) {
+        // Pre-validate variant ownership and product/variant consistency before opening transaction.
+        $resolvedItems = [];
+        foreach ($validated['items'] as $itemData) {
+            $product   = Product::with('category')->findOrFail($itemData['product_id']);
+            $variantId = $itemData['variant_id'] ?? null;
+            $variant   = null;
+
+            if ($variantId !== null) {
+                $variant = ProductVariant::findOrFail($variantId);
+                if ($variant->product_id !== $product->id) {
+                    return response()->json([
+                        'success' => false,
+                        'message' => 'La variante no pertenece al producto indicado.',
+                    ], 422);
+                }
+            }
+
+            $productHasVariants = $product->variants()->exists();
+
+            if ($productHasVariants && $variantId === null) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Este producto requiere seleccionar una variante.',
+                ], 422);
+            }
+
+            if (! $productHasVariants && $variantId !== null) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Este producto no tiene variantes.',
+                ], 422);
+            }
+
+            if ($variant !== null) {
+                $basePrice = (float) $variant->price;
+            } elseif ($tapaConfig && $tapaConfig->tapas_enabled && $tapaConfig->isTapaProduct($product)) {
+                $basePrice = $tapaConfig->getPriceForProduct($product);
+            } else {
+                $basePrice = (float) $product->price;
+            }
+
+            $resolvedItems[] = [
+                'product'      => $product,
+                'variant'      => $variant,
+                'variantId'    => $variantId,
+                'variantName'  => $variant?->name,
+                'basePrice'    => $basePrice,
+                'quantity'     => $itemData['quantity'],
+                'modifications' => $itemData['modifications'] ?? [],
+            ];
+        }
+
+        $order = DB::transaction(function () use ($resolvedItems, $table) {
             $order = Order::create([
                 'table_id'       => $table->id,
                 'status'         => 'pending',
@@ -84,68 +136,26 @@ class OrderController extends Controller
 
             $total = 0;
 
-            foreach ($validated['items'] as $itemData) {
-                $product   = Product::with('category')->findOrFail($itemData['product_id']);
-                $variantId   = $itemData['variant_id'] ?? null;
-                $variant     = null;
-                $variantName = null;
-
-                if ($variantId !== null) {
-                    $variant = ProductVariant::findOrFail($variantId);
-
-                    if ($variant->product_id !== $product->id) {
-                        return response()->json([
-                            'success' => false,
-                            'message' => 'La variante no pertenece al producto indicado.',
-                        ], 422);
-                    }
-
-                    $variantName = $variant->name;
-                }
-
-                $productHasVariants = $product->variants()->exists();
-
-                if ($productHasVariants && $variantId === null) {
-                    return response()->json([
-                        'success' => false,
-                        'message' => 'Este producto requiere seleccionar una variante.',
-                    ], 422);
-                }
-
-                if (! $productHasVariants && $variantId !== null) {
-                    return response()->json([
-                        'success' => false,
-                        'message' => 'Este producto no tiene variantes.',
-                    ], 422);
-                }
-
-                if ($variant !== null) {
-                    $basePrice = (float) $variant->price;
-                } elseif ($tapaConfig && $tapaConfig->tapas_enabled && $tapaConfig->isTapaProduct($product)) {
-                    $basePrice = $tapaConfig->getPriceForProduct($product);
-                } else {
-                    $basePrice = (float) $product->price;
-                }
-
-                $extraCharge = collect($itemData['modifications'] ?? [])
+            foreach ($resolvedItems as $item) {
+                $extraCharge = collect($item['modifications'])
                     ->where('action', 'add')
                     ->sum('amount_charged');
 
-                $unitPrice = $basePrice + (float) $extraCharge;
-                $total    += $unitPrice * $itemData['quantity'];
+                $unitPrice = $item['basePrice'] + (float) $extraCharge;
+                $total    += $unitPrice * $item['quantity'];
 
                 $orderItem = OrderItem::create([
                     'order_id'    => $order->id,
-                    'product_id'  => $product->id,
-                    'variant_id'  => $variantId,
-                    'variant_name' => $variantName,
-                    'quantity'    => $itemData['quantity'],
-                    'price'       => $basePrice,
+                    'product_id'  => $item['product']->id,
+                    'variant_id'  => $item['variantId'],
+                    'variant_name' => $item['variantName'],
+                    'quantity'    => $item['quantity'],
+                    'price'       => $item['basePrice'],
                     'status'      => 'queued',
-                    'destination' => $product->category->destination,
+                    'destination' => $item['product']->category->destination,
                 ]);
 
-                foreach ($itemData['modifications'] ?? [] as $mod) {
+                foreach ($item['modifications'] as $mod) {
                     OrderItemModification::create([
                         'order_item_id'  => $orderItem->id,
                         'ingredient_id'  => $mod['ingredient_id'],

--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -7,6 +7,7 @@ use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\OrderItemModification;
 use App\Models\Product;
+use App\Models\ProductVariant;
 use App\Models\Table;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -34,6 +35,7 @@ class OrderController extends Controller
             'table_hash'                             => 'required|string',
             'items'                                  => 'required|array|min:1',
             'items.*.product_id'                     => 'required|integer|exists:products,id',
+            'items.*.variant_id'                     => 'nullable|integer|exists:product_variants,id',
             'items.*.quantity'                       => 'required|integer|min:1|max:99',
             'items.*.modifications'                  => 'nullable|array',
             'items.*.modifications.*.ingredient_id'  => 'required|integer|exists:ingredients,id',
@@ -83,11 +85,47 @@ class OrderController extends Controller
             $total = 0;
 
             foreach ($validated['items'] as $itemData) {
-                $product = Product::with('category')->findOrFail($itemData['product_id']);
+                $product   = Product::with('category')->findOrFail($itemData['product_id']);
+                $variantId   = $itemData['variant_id'] ?? null;
+                $variant     = null;
+                $variantName = null;
 
-                $basePrice = ($tapaConfig && $tapaConfig->tapas_enabled && $tapaConfig->isTapaProduct($product))
-                    ? $tapaConfig->getPriceForProduct($product)
-                    : (float) $product->price;
+                if ($variantId !== null) {
+                    $variant = ProductVariant::findOrFail($variantId);
+
+                    if ($variant->product_id !== $product->id) {
+                        return response()->json([
+                            'success' => false,
+                            'message' => 'La variante no pertenece al producto indicado.',
+                        ], 422);
+                    }
+
+                    $variantName = $variant->name;
+                }
+
+                $productHasVariants = $product->variants()->exists();
+
+                if ($productHasVariants && $variantId === null) {
+                    return response()->json([
+                        'success' => false,
+                        'message' => 'Este producto requiere seleccionar una variante.',
+                    ], 422);
+                }
+
+                if (! $productHasVariants && $variantId !== null) {
+                    return response()->json([
+                        'success' => false,
+                        'message' => 'Este producto no tiene variantes.',
+                    ], 422);
+                }
+
+                if ($variant !== null) {
+                    $basePrice = (float) $variant->price;
+                } elseif ($tapaConfig && $tapaConfig->tapas_enabled && $tapaConfig->isTapaProduct($product)) {
+                    $basePrice = $tapaConfig->getPriceForProduct($product);
+                } else {
+                    $basePrice = (float) $product->price;
+                }
 
                 $extraCharge = collect($itemData['modifications'] ?? [])
                     ->where('action', 'add')
@@ -99,6 +137,8 @@ class OrderController extends Controller
                 $orderItem = OrderItem::create([
                     'order_id'    => $order->id,
                     'product_id'  => $product->id,
+                    'variant_id'  => $variantId,
+                    'variant_name' => $variantName,
                     'quantity'    => $itemData['quantity'],
                     'price'       => $basePrice,
                     'status'      => 'queued',

--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -72,7 +72,7 @@ class KitchenController extends Controller
                     ->where('status', 'queued')
                     ->map(fn(OrderItem $item) => [
                         'id'            => $item->id,
-                        'product_name'  => $item->product->name,
+                        'product_name'  => $item->product->name . ($item->variant_name ? ' — ' . $item->variant_name : ''),
                         'quantity'      => $item->quantity,
                         'is_daily_menu' => (bool) $item->is_daily_menu,
                         'modifications' => $item->modifications

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -60,6 +60,7 @@ class MenuController extends Controller
                                         'ingredients.allergen_type',
                                     ]);
                               },
+                              'variants',
                           ])
                           ->orderBy('name');
                 },

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -5,11 +5,13 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use App\Models\Product;
+use App\Models\ProductVariant;
 use App\Models\Category;
 use App\Models\Ingredient;
 use Illuminate\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
 /**
@@ -54,16 +56,26 @@ class ProductController extends Controller
    */
   public function store(Request $request): RedirectResponse
   {
+    $hasVariants = ! empty($request->input('variants'));
+
     /** @var array $validatedData Datos validados del formulario */
     $validatedData = $request->validate([
-      'name'        => 'required|string|max:255',
-      'description' => 'nullable|string',
-      'price'       => 'required|numeric|min:0',
-      'category_id' => ['required', Rule::exists('categories', 'id')->where('user_id', Auth::user()->ownerUserId())],
-      'image'       => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
+      'name'               => 'required|string|max:255',
+      'description'        => 'nullable|string',
+      'price'              => $hasVariants ? 'nullable|numeric|min:0' : 'required|numeric|min:0',
+      'category_id'        => ['required', Rule::exists('categories', 'id')->where('user_id', Auth::user()->ownerUserId())],
+      'image'              => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
+      'variants'           => 'nullable|array',
+      'variants.*.name'    => 'required_with:variants|string|max:100',
+      'variants.*.price'   => 'required_with:variants|numeric|min:0',
+      'variants.*.sort_order' => 'nullable|integer|min:0',
     ]);
 
     $validatedData['user_id'] = Auth::user()->ownerUserId();
+
+    if ($hasVariants) {
+      $validatedData['price'] = null;
+    }
 
     if ($request->hasFile('image')) {
       /** @var string $path Ruta donde se almacena temporalmente la imagen */
@@ -71,7 +83,22 @@ class ProductController extends Controller
       $validatedData['image'] = $path;
     }
 
-    $product = Product::create($validatedData);
+    $product = DB::transaction(function () use ($validatedData, $hasVariants) {
+      $product = Product::create(collect($validatedData)->except('variants')->toArray());
+
+      if ($hasVariants) {
+        foreach ($validatedData['variants'] as $idx => $variantData) {
+          ProductVariant::create([
+            'product_id' => $product->id,
+            'name'       => $variantData['name'],
+            'price'      => $variantData['price'],
+            'sort_order' => $variantData['sort_order'] ?? $idx,
+          ]);
+        }
+      }
+
+      return $product;
+    });
 
     if ($request->boolean('configure_ingredients')) {
       return redirect()
@@ -102,7 +129,7 @@ class ProductController extends Controller
         $ownerId = Auth::user()->ownerUserId();
         abort_if($product->user_id !== $ownerId, 403, 'No tienes permiso para editar este plato.');
 
-        $product->load('allergens');
+        $product->load(['allergens', 'variants']);
 
         $categories = Category::where('user_id', $ownerId)->get();
 
@@ -130,36 +157,48 @@ class ProductController extends Controller
 
         abort_if($product->user_id !== Auth::user()->ownerUserId(), 403);
 
+        $hasVariants = ! empty($request->input('variants'));
+
         $validatedData = $request->validate([
-
-            'name'        => 'required|string|max:255',
-
-            'description' => 'nullable|string',
-
-            'price'       => 'required|numeric|min:0',
-
-            'category_id' => 'required|exists:categories,id',
-
-            'image'       => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
-
+            'name'               => 'required|string|max:255',
+            'description'        => 'nullable|string',
+            'price'              => $hasVariants ? 'nullable|numeric|min:0' : 'required|numeric|min:0',
+            'category_id'        => ['required', Rule::exists('categories', 'id')->where('user_id', Auth::user()->ownerUserId())],
+            'image'              => 'nullable|image|mimes:jpeg,png,jpg,webp|max:2048',
+            'variants'           => 'nullable|array',
+            'variants.*.name'    => 'required_with:variants|string|max:100',
+            'variants.*.price'   => 'required_with:variants|numeric|min:0',
+            'variants.*.sort_order' => 'nullable|integer|min:0',
         ]);
- 
+
         if ($request->hasFile('image')) {
-
             if ($product->image) {
-
                 Storage::disk('public')->delete($product->image);
-
             }
-
             $path = $request->file('image')->store('products', 'public');
-
             $validatedData['image'] = $path;
-
         }
- 
-        $product->update($validatedData);
- 
+
+        DB::transaction(function () use ($request, $product, $validatedData, $hasVariants) {
+            $productData          = collect($validatedData)->except('variants')->toArray();
+            $productData['price'] = $hasVariants ? null : $validatedData['price'];
+
+            $product->update($productData);
+
+            $product->variants()->delete();
+
+            if ($hasVariants) {
+                foreach ($validatedData['variants'] as $idx => $variantData) {
+                    ProductVariant::create([
+                        'product_id' => $product->id,
+                        'name'       => $variantData['name'],
+                        'price'      => $variantData['price'],
+                        'sort_order' => $variantData['sort_order'] ?? $idx,
+                    ]);
+                }
+            }
+        });
+
         return redirect()->route('products.index')->with('success', '¡Plato actualizado correctamente!');
 
     }

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -31,7 +31,7 @@ class ProductController extends Controller
   public function index(): View
   {
     $ownerId  = Auth::user()->ownerUserId();
-    $products = Product::where('user_id', $ownerId)->with('allergens')->paginate(15);
+    $products = Product::where('user_id', $ownerId)->with(['allergens', 'variants'])->paginate(15);
     return view('products.index', compact('products'));
   }
 

--- a/app/Models/OrderItem.php
+++ b/app/Models/OrderItem.php
@@ -25,7 +25,7 @@ class OrderItem extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['order_id', 'product_id', 'quantity', 'price', 'status', 'destination', 'is_daily_menu'];
+    protected $fillable = ['order_id', 'product_id', 'variant_id', 'variant_name', 'quantity', 'price', 'status', 'destination', 'is_daily_menu'];
 
     protected $casts = [
         'is_daily_menu' => 'boolean',
@@ -45,6 +45,16 @@ class OrderItem extends Model
     public function product(): BelongsTo
     {
         return $this->belongsTo(Product::class);
+    }
+
+    /**
+     * La variante elegida en el momento del pedido (nullable).
+     *
+     * @return BelongsTo
+     */
+    public function variant(): BelongsTo
+    {
+        return $this->belongsTo(ProductVariant::class, 'variant_id');
     }
 
     /**

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -25,6 +25,13 @@ class Product extends Model
 {
     use HasFactory, SoftDeletes;
 
+    protected static function booted(): void
+    {
+        static::deleting(function (Product $product) {
+            $product->variants()->delete();
+        });
+    }
+
     protected $fillable = [
         'user_id',
         'category_id',

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
@@ -16,8 +17,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @author SebastianBCF
  * @author BenjaminDTS
  *
- * @property string $image       Ruta relativa de la imagen almacenada en storage/app/public/products
- * @property float $price      Precio base del producto
+ * @property string  $image       Ruta relativa de la imagen almacenada en storage/app/public/products
+ * @property float|null $price   Precio base del producto (null si tiene variantes)
  * @property boolean $is_active  Si está disponible para pedir
  */
 class Product extends Model
@@ -73,6 +74,46 @@ class Product extends Model
         return $this->belongsToMany(Ingredient::class, 'ingredient_product')
             ->where('is_allergen', true)
             ->withTimestamps();
+    }
+
+    /**
+     * Variantes del producto (ej: Ración entera, Media ración).
+     *
+     * @return HasMany
+     */
+    public function variants(): HasMany
+    {
+        return $this->hasMany(ProductVariant::class)->orderBy('sort_order')->orderBy('id');
+    }
+
+    /**
+     * Indica si el producto tiene al menos una variante definida.
+     *
+     * @return bool
+     */
+    public function hasVariants(): bool
+    {
+        return $this->variants()->exists();
+    }
+
+    /**
+     * Devuelve el precio efectivo para mostrar en la carta.
+     * Si tiene variantes, devuelve el precio de la más barata ("desde X€").
+     * Si no tiene variantes, devuelve el precio directo del producto.
+     *
+     * @return float
+     */
+    public function getEffectivePrice(): float
+    {
+        if ($this->relationLoaded('variants') && $this->variants->isNotEmpty()) {
+            return (float) $this->variants->min('price');
+        }
+
+        if ($this->variants()->exists()) {
+            return (float) $this->variants()->min('price');
+        }
+
+        return (float) $this->price;
     }
 
     /**

--- a/app/Models/ProductVariant.php
+++ b/app/Models/ProductVariant.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Class ProductVariant
+ *
+ * Variante de un producto (ej: Ración entera, Media ración, Tapa).
+ * Cada variante tiene su propio precio. Un producto con variantes
+ * no tiene precio directo; el precio lo aporta la variante elegida.
+ *
+ * @author BenjaminDTS
+ */
+class ProductVariant extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['product_id', 'name', 'price', 'sort_order'];
+
+    protected $casts = [
+        'price'      => 'decimal:2',
+        'sort_order' => 'integer',
+    ];
+
+    /**
+     * @return BelongsTo
+     */
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\Category;
+use App\Models\ProductVariant;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -25,5 +26,30 @@ class ProductFactory extends Factory
             'user_id'     => User::factory(),
             'category_id' => Category::factory(),
         ];
+    }
+
+    /**
+     * Producto con 2 variantes (Ración entera y Media ración).
+     * El precio base queda en null porque el precio viene de la variante.
+     *
+     * @return static
+     */
+    public function withVariants(): static
+    {
+        return $this->state(['price' => null])
+            ->afterCreating(function ($product) {
+                ProductVariant::factory()->create([
+                    'product_id' => $product->id,
+                    'name'       => 'Ración entera',
+                    'price'      => fake()->randomFloat(2, 10, 25),
+                    'sort_order' => 0,
+                ]);
+                ProductVariant::factory()->create([
+                    'product_id' => $product->id,
+                    'name'       => 'Media ración',
+                    'price'      => fake()->randomFloat(2, 5, 12),
+                    'sort_order' => 1,
+                ]);
+            });
     }
 }

--- a/database/factories/ProductVariantFactory.php
+++ b/database/factories/ProductVariantFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Product;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ProductVariant>
+ */
+class ProductVariantFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        static $counter = 0;
+
+        return [
+            'product_id' => Product::factory(),
+            'name'       => fake()->randomElement(['Ración entera', 'Media ración', 'Tapa', 'Para compartir']),
+            'price'      => fake()->randomFloat(2, 2, 25),
+            'sort_order' => $counter++,
+        ];
+    }
+}

--- a/database/migrations/2026_05_23_200001_make_products_price_nullable.php
+++ b/database/migrations/2026_05_23_200001_make_products_price_nullable.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->decimal('price', 8, 2)->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->decimal('price', 8, 2)->nullable(false)->change();
+        });
+    }
+};

--- a/database/migrations/2026_05_23_200002_create_product_variants_table.php
+++ b/database/migrations/2026_05_23_200002_create_product_variants_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('product_variants', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->string('name', 100);
+            $table->decimal('price', 8, 2);
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->index(['product_id', 'sort_order']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('product_variants');
+    }
+};

--- a/database/migrations/2026_05_23_200003_add_variant_to_order_items.php
+++ b/database/migrations/2026_05_23_200003_add_variant_to_order_items.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->foreignId('variant_id')->nullable()->after('product_id')
+                  ->constrained('product_variants')->nullOnDelete();
+            $table->string('variant_name', 100)->nullable()->after('variant_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->dropForeign(['variant_id']);
+            $table->dropColumn(['variant_id', 'variant_name']);
+        });
+    }
+};

--- a/resources/views/kitchen/index.blade.php
+++ b/resources/views/kitchen/index.blade.php
@@ -141,7 +141,7 @@
       'serving'    => false,
       'items'      => $o->items->map(fn($i) => [
         'id'            => $i->id,
-        'product_name'  => $i->product->name,
+        'product_name'  => $i->product->name . ($i->variant_name ? ' — ' . $i->variant_name : ''),
         'quantity'      => $i->quantity,
         'is_daily_menu' => (bool) $i->is_daily_menu,
         'marking'       => false,

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -4120,7 +4120,7 @@
                                                                    transition-colors duration-150
                                                                    focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-1">
                                                         {{ $variant->name }}
-                                                        <span class="opacity-75">{{ number_format($variant->price, 2, ',', '.') }}&amp;nbsp;€</span>
+                                                        <span class="opacity-75">{{ number_format($variant->price, 2, ',', '.') }}&nbsp;€</span>
                                                     </button>
                                                 @endforeach
                                             </div>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="es" class="scroll-smooth">
 <head>
     <meta charset="utf-8">
@@ -4107,23 +4107,22 @@
                                                 </div>
                                             @endif
 
-                                            {{-- Chips de variante --}}
+                                            {{-- Chips de variante (server-rendered + Alpine para estado activo) --}}
                                             <div class="mt-3 flex flex-wrap gap-2" role="group" aria-label="Elige tamaño de {{ $product->name }}">
-                                                <template x-for="v in variants" :key="v.id">
+                                                @foreach($product->variants as $variant)
                                                     <button type="button"
-                                                            @click="selectedVariantId = v.id"
-                                                            :class="selectedVariantId === v.id
+                                                            @click="selectedVariantId = {{ $variant->id }}"
+                                                            :class="selectedVariantId === {{ $variant->id }}
                                                                 ? 'bg-indigo-600 text-white border-indigo-600'
                                                                 : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600 hover:border-indigo-400'"
-                                                            :aria-pressed="selectedVariantId === v.id"
+                                                            :aria-pressed="(selectedVariantId === {{ $variant->id }}).toString()"
                                                             class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-semibold
                                                                    transition-colors duration-150
                                                                    focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-1">
-                                                        <span x-text="v.name"></span>
-                                                        <span x-text="Number(v.price).toFixed(2).replace('.',',') + ' €'"
-                                                              class="opacity-75"></span>
+                                                        {{ $variant->name }}
+                                                        <span class="opacity-75">{{ number_format($variant->price, 2, ',', '.') }}&amp;nbsp;€</span>
                                                     </button>
-                                                </template>
+                                                @endforeach
                                             </div>
 
                                             {{-- Botón añadir variante seleccionada --}}

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -213,7 +213,13 @@
             return $category->products->map(fn ($p) => [
                 'id'          => $p->id,
                 'name'        => $p->name,
-                'price'       => (float) $p->price,
+                'price'       => $p->variants->isNotEmpty() ? (float) $p->variants->min('price') : (float) $p->price,
+                'hasVariants' => $p->variants->isNotEmpty(),
+                'variants'    => $p->variants->map(fn ($v) => [
+                    'id'    => $v->id,
+                    'name'  => $v->name,
+                    'price' => (float) $v->price,
+                ])->values(),
                 'categoryId'  => $category->id,
                 'destination' => $category->destination,
                 'allergenTypes' => $p->ingredients->where('is_allergen', true)
@@ -285,12 +291,16 @@
                 _variantsUsed:  tapaConfig.variantsUsed  ?? 0,
 
                 add(product) {
-                    const existing = this.items.find(i => i.productId === product.id);
+                    const key      = product.id + ':none';
+                    const existing = this.items.find(i => i._key === key);
                     if (existing) {
                         existing.quantity++;
                     } else {
                         this.items.push({
+                            _key:        key,
                             productId:   product.id,
+                            variantId:   null,
+                            variantName: null,
                             name:        product.name,
                             price:       product.price,
                             quantity:    1,
@@ -301,6 +311,32 @@
                         });
                     }
                     if (product.destination === 'bar') {
+                        this._barItemsCount++;
+                        this._checkTapaSuggestion();
+                    }
+                },
+
+                addWithVariant(productId, variantId, variantName, variantPrice, productData) {
+                    const key      = productId + ':' + variantId;
+                    const existing = this.items.find(i => i._key === key);
+                    if (existing) {
+                        existing.quantity++;
+                    } else {
+                        this.items.push({
+                            _key:        key,
+                            productId:   productId,
+                            variantId:   variantId,
+                            variantName: variantName,
+                            name:        (productData?.name ?? '') + ' — ' + variantName,
+                            price:       variantPrice,
+                            quantity:    1,
+                            destination: productData?.destination ?? null,
+                            mods:        [],
+                            removable:   [],
+                            extras:      [],
+                        });
+                    }
+                    if (productData?.destination === 'bar') {
                         this._barItemsCount++;
                         this._checkTapaSuggestion();
                     }
@@ -334,36 +370,36 @@
                     this.showTapaModal = false;
                 },
 
-                inc(productId) {
-                    const item = this.items.find(i => i.productId === productId);
+                inc(key) {
+                    const item = this.items.find(i => i._key === key);
                     if (item) item.quantity++;
                 },
 
-                dec(productId) {
-                    const idx = this.items.findIndex(i => i.productId === productId);
+                dec(key) {
+                    const idx = this.items.findIndex(i => i._key === key);
                     if (idx === -1) return;
                     this.items[idx].quantity--;
                     if (this.items[idx].quantity <= 0) this.items.splice(idx, 1);
                 },
 
-                toggleRemove(productId, ing) {
-                    const item = this.items.find(i => i.productId === productId);
+                toggleRemove(key, ing) {
+                    const item = this.items.find(i => i._key === key);
                     if (!item) return;
                     const i = item.mods.findIndex(m => m.ingredientId === ing.id && m.action === 'remove');
                     if (i === -1) item.mods.push({ ingredientId: ing.id, name: ing.name, action: 'remove', amountCharged: 0 });
                     else          item.mods.splice(i, 1);
                 },
 
-                toggleExtra(productId, ing) {
-                    const item = this.items.find(i => i.productId === productId);
+                toggleExtra(key, ing) {
+                    const item = this.items.find(i => i._key === key);
                     if (!item) return;
                     const i = item.mods.findIndex(m => m.ingredientId === ing.id && m.action === 'add');
                     if (i === -1) item.mods.push({ ingredientId: ing.id, name: ing.name, action: 'add', amountCharged: ing.price });
                     else          item.mods.splice(i, 1);
                 },
 
-                hasMod(productId, ingId, action) {
-                    const item = this.items.find(i => i.productId === productId);
+                hasMod(key, ingId, action) {
+                    const item = this.items.find(i => i._key === key);
                     return item ? item.mods.some(m => m.ingredientId === ingId && m.action === action) : false;
                 },
 
@@ -407,6 +443,7 @@
                                 table_hash: this.tableHash,
                                 items: this.items.map(item => ({
                                     product_id:    item.productId,
+                                    variant_id:    item.variantId ?? null,
                                     quantity:      item.quantity,
                                     modifications: item.mods.map(m => ({
                                         ingredient_id:  m.ingredientId,
@@ -1246,8 +1283,8 @@
                 },
 
                 decreaseQty(card) {
-                    const id = card.id ?? card.productId;
-                    Alpine.store('cart').dec(id);
+                    const key = card._key ?? ((card.id ?? card.productId) + ':none');
+                    Alpine.store('cart').dec(key);
                 },
 
                 decreaseQtyMin1(item) {
@@ -3539,7 +3576,7 @@
 
                 {{-- Lista de items --}}
                 <div class="flex-1 overflow-y-auto px-4 py-3 space-y-4">
-                    <template x-for="item in $store.cart.items" :key="item.productId">
+                    <template x-for="item in $store.cart.items" :key="item._key">
                         <div class="bg-gray-50 dark:bg-gray-800 rounded-xl p-3 space-y-3">
 
                             {{-- Fila producto --}}
@@ -3551,7 +3588,7 @@
 
                                 {{-- Cantidad --}}
                                 <div class="flex items-center gap-2 flex-shrink-0">
-                                    <button type="button" @click="$store.cart.dec(item.productId)"
+                                    <button type="button" @click="$store.cart.dec(item._key)"
                                             class="w-7 h-7 rounded-full border-2 border-gray-300 dark:border-gray-600
                                                    flex items-center justify-center text-gray-600 dark:text-gray-300
                                                    hover:border-red-400 hover:text-red-500 transition-colors
@@ -3561,7 +3598,7 @@
                                         </svg>
                                     </button>
                                     <span class="w-5 text-center font-bold text-gray-900 dark:text-white text-sm" x-text="item.quantity"></span>
-                                    <button type="button" @click="$store.cart.inc(item.productId)"
+                                    <button type="button" @click="$store.cart.inc(item._key)"
                                             class="w-7 h-7 rounded-full border-2 border-gray-300 dark:border-gray-600
                                                    flex items-center justify-center text-gray-600 dark:text-gray-300
                                                    hover:border-green-500 hover:text-green-600 transition-colors
@@ -3587,8 +3624,8 @@
                                             <div class="flex flex-wrap gap-1.5">
                                                 <template x-for="ing in item.removable" :key="ing.id">
                                                     <button type="button"
-                                                            @click="$store.cart.toggleRemove(item.productId, ing)"
-                                                            :class="$store.cart.hasMod(item.productId, ing.id, 'remove')
+                                                            @click="$store.cart.toggleRemove(item._key, ing)"
+                                                            :class="$store.cart.hasMod(item._key, ing.id, 'remove')
                                                                 ? 'bg-red-100 dark:bg-red-900/40 border-red-400 text-red-700 dark:text-red-300'
                                                                 : 'bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300'"
                                                             class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full border text-xs font-medium transition-colors
@@ -3606,8 +3643,8 @@
                                             <div class="flex flex-wrap gap-1.5">
                                                 <template x-for="ing in item.extras" :key="ing.id">
                                                     <button type="button"
-                                                            @click="$store.cart.toggleExtra(item.productId, ing)"
-                                                            :class="$store.cart.hasMod(item.productId, ing.id, 'add')
+                                                            @click="$store.cart.toggleExtra(item._key, ing)"
+                                                            :class="$store.cart.hasMod(item._key, ing.id, 'add')
                                                                 ? 'bg-green-100 dark:bg-green-900/40 border-green-500 text-green-700 dark:text-green-300'
                                                                 : 'bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300'"
                                                             class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full border text-xs font-medium transition-colors
@@ -4034,6 +4071,99 @@
 
                                     {{-- Info --}}
                                     <div class="flex-1 min-w-0">
+                                        @if($product->variants->isNotEmpty())
+                                        {{-- Producto con variantes --}}
+                                        <div x-data="{
+                                            selectedVariantId: {{ $product->variants->first()->id }},
+                                            variants: {{ $product->variants->map(fn($v) => ['id' => $v->id, 'name' => $v->name, 'price' => (float)$v->price])->values()->toJson() }},
+                                            get selectedVariant() { return this.variants.find(v => v.id === this.selectedVariantId); }
+                                        }">
+                                            <div class="flex items-start justify-between gap-2">
+                                                <h3 class="font-semibold text-base sm:text-lg leading-snug text-gray-900 dark:text-gray-100">
+                                                    {{ $product->name }}
+                                                </h3>
+                                                <span class="flex-shrink-0 font-bold text-base sm:text-lg text-indigo-600 dark:text-indigo-400"
+                                                      x-text="'desde ' + Number(Math.min(...variants.map(v => v.price))).toFixed(2).replace('.',',') + ' €'"
+                                                      aria-label="Desde {{ number_format($product->variants->min('price'), 2, ',', '.') }} euros"></span>
+                                            </div>
+
+                                            @if ($product->description)
+                                                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
+                                                    {{ $product->description }}
+                                                </p>
+                                            @endif
+
+                                            {{-- Alérgenos --}}
+                                            @if ($product->ingredients->where('is_allergen', true)->isNotEmpty())
+                                                <div class="mt-2" aria-label="Alérgenos de {{ $product->name }}">
+                                                    <p class="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1">
+                                                        Alérgenos
+                                                    </p>
+                                                    <ul class="flex flex-wrap gap-3" role="list">
+                                                        @foreach ($product->ingredients->where('is_allergen', true)->unique('allergen_type') as $allergen)
+                                                            <li><x-allergen-badge :ingredient="$allergen" /></li>
+                                                        @endforeach
+                                                    </ul>
+                                                </div>
+                                            @endif
+
+                                            {{-- Chips de variante --}}
+                                            <div class="mt-3 flex flex-wrap gap-2" role="group" aria-label="Elige tamaño de {{ $product->name }}">
+                                                <template x-for="v in variants" :key="v.id">
+                                                    <button type="button"
+                                                            @click="selectedVariantId = v.id"
+                                                            :class="selectedVariantId === v.id
+                                                                ? 'bg-indigo-600 text-white border-indigo-600'
+                                                                : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600 hover:border-indigo-400'"
+                                                            :aria-pressed="selectedVariantId === v.id"
+                                                            class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-semibold
+                                                                   transition-colors duration-150
+                                                                   focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-1">
+                                                        <span x-text="v.name"></span>
+                                                        <span x-text="Number(v.price).toFixed(2).replace('.',',') + ' €'"
+                                                              class="opacity-75"></span>
+                                                    </button>
+                                                </template>
+                                            </div>
+
+                                            {{-- Botón añadir variante seleccionada --}}
+                                            <div class="mt-3 flex justify-end">
+                                                @if($orderingAllowed)
+                                                <button type="button"
+                                                        @click="$store.cart.addWithVariant(
+                                                            {{ $product->id }},
+                                                            selectedVariantId,
+                                                            selectedVariant.name,
+                                                            selectedVariant.price,
+                                                            products.find(p => p.id === {{ $product->id }})
+                                                        )"
+                                                        :aria-label="'Añadir ' + selectedVariant.name + ' de {{ $product->name }} al pedido'"
+                                                        class="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full
+                                                               bg-green-600 hover:bg-green-700 active:scale-95
+                                                               text-white text-sm font-semibold shadow-sm
+                                                               transition-all duration-150
+                                                               focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2">
+                                                    <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
+                                                    </svg>
+                                                    Añadir
+                                                </button>
+                                                @else
+                                                <span class="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full
+                                                             bg-gray-200 dark:bg-gray-700
+                                                             text-gray-400 dark:text-gray-500 text-sm font-semibold
+                                                             cursor-not-allowed select-none"
+                                                      aria-disabled="true" title="{{ __('Pedidos cerrados') }}">
+                                                    <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
+                                                    </svg>
+                                                    Añadir
+                                                </span>
+                                                @endif
+                                            </div>
+                                        </div>
+                                        @else
+                                        {{-- Producto sin variantes (comportamiento original) --}}
                                         <div class="flex items-start justify-between gap-2">
                                             <h3 class="font-semibold text-base sm:text-lg leading-snug text-gray-900 dark:text-gray-100">
                                                 {{ $product->name }}
@@ -4070,6 +4200,7 @@
                                             @if($orderingAllowed)
                                             <button type="button"
                                                     @click="$store.cart.add(products.find(p => p.id === {{ $product->id }}))"
+                                                    aria-label="Añadir {{ $product->name }} al pedido"
                                                     class="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full
                                                            bg-green-600 hover:bg-green-700 active:scale-95
                                                            text-white text-sm font-semibold shadow-sm
@@ -4094,6 +4225,7 @@
                                             </span>
                                             @endif
                                         </div>
+                                        @endif
                                     </div>
                                 </div>
                             </li>

--- a/resources/views/products/create.blade.php
+++ b/resources/views/products/create.blade.php
@@ -2,25 +2,111 @@
   <div class="max-w-2xl mx-auto px-4 sm:px-6 py-4 sm:p-6 bg-white rounded-lg shadow-md mt-4 sm:mt-10">
     <h2 class="text-xl sm:text-2xl font-bold mb-4 sm:mb-6 text-gray-800">Añadir Nuevo Plato</h2>
 
-    <form action="{{ route('products.store') }}" method="POST" enctype="multipart/form-data" class="space-y-3 sm:space-y-4">
+    <form action="{{ route('products.store') }}" method="POST" enctype="multipart/form-data"
+          class="space-y-3 sm:space-y-4"
+          x-data="variantEditor([])">
       @csrf
+
       <div>
         <label for="name" class="block text-sm font-medium text-gray-700">Nombre del plato</label>
-        <input type="text" name="name" id="name" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+        <input type="text" name="name" id="name" required aria-required="true"
+               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
       </div>
 
       <div>
         <label for="description" class="block text-sm font-medium text-gray-700">Descripción (Opcional)</label>
-        <textarea name="description" id="description" rows="3" placeholder="Ej: Hamburguesa de ternera con queso cheddar fundido..." class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"></textarea>
+        <textarea name="description" id="description" rows="3"
+                  placeholder="Ej: Hamburguesa de ternera con queso cheddar fundido..."
+                  class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"></textarea>
       </div>
+
+      {{-- SECCIÓN PRECIO / VARIANTES --}}
       <div>
-        <label for="price" class="block text-sm font-medium text-gray-700">Precio (€)</label>
-        <input type="number" step="0.01" name="price" id="price" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+          <div class="flex items-center justify-between mb-1">
+              <span class="block text-sm font-medium text-gray-700">Precio / Variantes</span>
+              <button type="button"
+                      x-show="!useVariants"
+                      @click="enableVariants"
+                      class="text-xs text-indigo-600 hover:text-indigo-800 font-medium focus:outline-none focus:underline">
+                  + Añadir variantes (ración, media ración…)
+              </button>
+              <button type="button"
+                      x-show="useVariants"
+                      @click="disableVariants"
+                      class="text-xs text-red-500 hover:text-red-700 font-medium focus:outline-none focus:underline">
+                  ✕ Quitar variantes y usar precio directo
+              </button>
+          </div>
+
+          {{-- Precio directo --}}
+          <div x-show="!useVariants">
+              <label for="price" class="sr-only">Precio (€)</label>
+              <div class="relative">
+                  <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-gray-500 text-sm">€</span>
+                  <input type="number" step="0.01" name="price" id="price"
+                         :required="!useVariants"
+                         :disabled="useVariants"
+                         class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 pl-7"
+                         placeholder="0.00" min="0">
+              </div>
+          </div>
+
+          {{-- Sección variantes --}}
+          <div x-show="useVariants" class="space-y-2 mt-2">
+              <p class="text-xs text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2" role="note">
+                  Con variantes activas, el precio base del producto se ignora. El precio viene de la variante elegida.
+              </p>
+
+              <template x-for="(variant, index) in variants" :key="index">
+                  <div class="flex gap-2 items-end">
+                      <div class="flex-1">
+                          <label :for="'variant_name_' + index" class="block text-xs font-medium text-gray-600 mb-0.5">Nombre</label>
+                          <input :id="'variant_name_' + index"
+                                 :name="'variants[' + index + '][name]'"
+                                 type="text"
+                                 x-model="variant.name"
+                                 placeholder="Ej: Ración entera"
+                                 required
+                                 class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+                                 :aria-label="'Nombre de variante ' + (index + 1)">
+                      </div>
+                      <div class="w-28">
+                          <label :for="'variant_price_' + index" class="block text-xs font-medium text-gray-600 mb-0.5">Precio (€)</label>
+                          <input :id="'variant_price_' + index"
+                                 :name="'variants[' + index + '][price]'"
+                                 type="number"
+                                 step="0.01"
+                                 min="0"
+                                 x-model="variant.price"
+                                 placeholder="0.00"
+                                 required
+                                 class="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm"
+                                 :aria-label="'Precio de variante ' + (index + 1)">
+                      </div>
+                      <input type="hidden" :name="'variants[' + index + '][sort_order]'" :value="index">
+                      <button type="button"
+                              @click="removeVariant(index)"
+                              class="mb-0.5 flex-shrink-0 text-red-500 hover:text-red-700 focus:outline-none focus:ring-2 focus:ring-red-400 rounded"
+                              :aria-label="'Eliminar variante ' + (variant.name || (index + 1))">
+                          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                          </svg>
+                      </button>
+                  </div>
+              </template>
+
+              <button type="button"
+                      @click="addVariant"
+                      class="mt-1 text-sm text-indigo-600 hover:text-indigo-800 font-medium focus:outline-none focus:underline">
+                  + Añadir otra variante
+              </button>
+          </div>
       </div>
 
       <div>
         <label for="category_id" class="block text-sm font-medium text-gray-700">Categoría</label>
-        <select name="category_id" id="category_id" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+        <select name="category_id" id="category_id" required aria-required="true"
+                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
           <option value="" disabled selected>Selecciona una categoría...</option>
           @foreach($categories as $category)
           <option value="{{ $category->id }}">{{ $category->name }}</option>
@@ -30,7 +116,8 @@
 
       <div>
         <label for="image" class="block text-sm font-medium text-gray-700">Foto del plato (Max: 2MB)</label>
-        <input type="file" name="image" id="image" accept="image/jpeg, image/png, image/webp" class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
+        <input type="file" name="image" id="image" accept="image/jpeg, image/png, image/webp"
+               class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
       </div>
 
       <div class="flex flex-col sm:flex-row gap-3 pt-1">
@@ -45,4 +132,37 @@
       </div>
     </form>
   </div>
+
+  @push('scripts')
+  <script>
+  function variantEditor(initialVariants) {
+      return {
+          useVariants: initialVariants.length > 0,
+          variants: initialVariants.length > 0 ? initialVariants : [],
+
+          enableVariants() {
+              this.useVariants = true;
+              if (this.variants.length === 0) {
+                  this.variants.push({ name: '', price: '', sort_order: 0 });
+              }
+          },
+
+          disableVariants() {
+              this.useVariants = false;
+          },
+
+          addVariant() {
+              this.variants.push({ name: '', price: '', sort_order: this.variants.length });
+          },
+
+          removeVariant(index) {
+              this.variants.splice(index, 1);
+              if (this.variants.length === 0) {
+                  this.useVariants = false;
+              }
+          },
+      };
+  }
+  </script>
+  @endpush
 </x-app-layout>

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -2,26 +2,112 @@
     <div class="max-w-2xl mx-auto px-4 sm:px-6 py-4 sm:p-6 bg-white rounded-lg shadow-md mt-4 sm:mt-10">
         <h2 class="text-xl sm:text-2xl font-bold mb-4 sm:mb-6 text-gray-800">Editar Plato: {{ $product->name }}</h2>
 
-        <form action="{{ route('products.update', $product) }}" method="POST" enctype="multipart/form-data" class="space-y-3 sm:space-y-4">
+        <form action="{{ route('products.update', $product) }}" method="POST" enctype="multipart/form-data"
+              class="space-y-3 sm:space-y-4"
+              x-data="variantEditor({{ $product->variants->map(fn($v) => ['name' => $v->name, 'price' => $v->price, 'sort_order' => $v->sort_order])->values()->toJson() }})">
             @csrf
             @method('PUT')
+
             <div>
                 <label for="name" class="block text-sm font-medium text-gray-700">Nombre del plato</label>
-                <input type="text" name="name" id="name" value="{{ old('name', $product->name) }}" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
+                <input type="text" name="name" id="name" value="{{ old('name', $product->name) }}" required
+                       class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" aria-required="true">
             </div>
 
             <div>
                 <label for="description" class="block text-sm font-medium text-gray-700">Descripción</label>
-                <textarea name="description" id="description" rows="3" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">{{ old('description', $product->description) }}</textarea>
+                <textarea name="description" id="description" rows="3"
+                          class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">{{ old('description', $product->description) }}</textarea>
             </div>
+
+            {{-- SECCIÓN PRECIO / VARIANTES --}}
             <div>
-                <label for="price" class="block text-sm font-medium text-gray-700">Precio (€)</label>
-                <input type="number" step="0.01" name="price" id="price" value="{{ old('price', $product->price) }}" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
+                <div class="flex items-center justify-between mb-1">
+                    <span class="block text-sm font-medium text-gray-700">Precio / Variantes</span>
+                    <button type="button"
+                            x-show="!useVariants"
+                            @click="enableVariants"
+                            class="text-xs text-indigo-600 hover:text-indigo-800 font-medium focus:outline-none focus:underline">
+                        + Añadir variantes (ración, media ración…)
+                    </button>
+                    <button type="button"
+                            x-show="useVariants"
+                            @click="disableVariants"
+                            class="text-xs text-red-500 hover:text-red-700 font-medium focus:outline-none focus:underline">
+                        ✕ Quitar variantes y usar precio directo
+                    </button>
+                </div>
+
+                {{-- Precio directo --}}
+                <div x-show="!useVariants">
+                    <label for="price" class="sr-only">Precio (€)</label>
+                    <div class="relative">
+                        <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-gray-500 text-sm">€</span>
+                        <input type="number" step="0.01" name="price" id="price"
+                               :value="useVariants ? '' : '{{ old('price', $product->price) }}'"
+                               :required="!useVariants"
+                               :disabled="useVariants"
+                               class="mt-1 block w-full rounded-md border-gray-300 shadow-sm pl-7"
+                               placeholder="0.00" min="0">
+                    </div>
+                </div>
+
+                {{-- Sección variantes --}}
+                <div x-show="useVariants" class="space-y-2 mt-2">
+                    <p class="text-xs text-amber-600 bg-amber-50 border border-amber-200 rounded px-3 py-2" role="note">
+                        Con variantes activas, el precio base del producto se ignora. El precio viene de la variante elegida.
+                    </p>
+
+                    <template x-for="(variant, index) in variants" :key="index">
+                        <div class="flex gap-2 items-end">
+                            <div class="flex-1">
+                                <label :for="'variant_name_' + index" class="block text-xs font-medium text-gray-600 mb-0.5">Nombre</label>
+                                <input :id="'variant_name_' + index"
+                                       :name="'variants[' + index + '][name]'"
+                                       type="text"
+                                       x-model="variant.name"
+                                       placeholder="Ej: Ración entera"
+                                       required
+                                       class="block w-full rounded-md border-gray-300 shadow-sm text-sm"
+                                       :aria-label="'Nombre de variante ' + (index + 1)">
+                            </div>
+                            <div class="w-28">
+                                <label :for="'variant_price_' + index" class="block text-xs font-medium text-gray-600 mb-0.5">Precio (€)</label>
+                                <input :id="'variant_price_' + index"
+                                       :name="'variants[' + index + '][price]'"
+                                       type="number"
+                                       step="0.01"
+                                       min="0"
+                                       x-model="variant.price"
+                                       placeholder="0.00"
+                                       required
+                                       class="block w-full rounded-md border-gray-300 shadow-sm text-sm"
+                                       :aria-label="'Precio de variante ' + (index + 1)">
+                            </div>
+                            <input type="hidden" :name="'variants[' + index + '][sort_order]'" :value="index">
+                            <button type="button"
+                                    @click="removeVariant(index)"
+                                    class="mb-0.5 flex-shrink-0 text-red-500 hover:text-red-700 focus:outline-none focus:ring-2 focus:ring-red-400 rounded"
+                                    :aria-label="'Eliminar variante ' + (variant.name || (index + 1))">
+                                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                                </svg>
+                            </button>
+                        </div>
+                    </template>
+
+                    <button type="button"
+                            @click="addVariant"
+                            class="mt-1 text-sm text-indigo-600 hover:text-indigo-800 font-medium focus:outline-none focus:underline">
+                        + Añadir otra variante
+                    </button>
+                </div>
             </div>
 
             <div>
                 <label for="category_id" class="block text-sm font-medium text-gray-700">Categoría</label>
-                <select name="category_id" id="category_id" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm">
+                <select name="category_id" id="category_id" required
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" aria-required="true">
                     @foreach($categories as $category)
                     <option value="{{ $category->id }}" {{ $product->category_id == $category->id ? 'selected' : '' }}>
                         {{ $category->name }}
@@ -34,14 +120,17 @@
                 <label for="image" class="block text-sm font-medium text-gray-700">Foto del plato (Max: 2MB)</label>
                 @if($product->image)
                 <div class="my-2">
-                    <img src="{{ asset('storage/' . $product->image) }}" alt="Imagen actual de {{ $product->name }}" class="h-16 w-16 sm:h-20 sm:w-20 object-cover rounded-md border">
+                    <img src="{{ asset('storage/' . $product->image) }}" alt="Imagen actual de {{ $product->name }}"
+                         class="h-16 w-16 sm:h-20 sm:w-20 object-cover rounded-md border">
                     <p class="text-xs text-gray-500 mt-1">Imagen actual. Sube una nueva si deseas reemplazarla.</p>
                 </div>
                 @endif
-                <input type="file" name="image" id="image" accept="image/*" class="mt-1 block w-full text-sm text-gray-500">
+                <input type="file" name="image" id="image" accept="image/*"
+                       class="mt-1 block w-full text-sm text-gray-500">
             </div>
 
-            <button type="submit" class="w-full py-2 px-4 bg-green-600 text-white rounded-md hover:bg-green-700">
+            <button type="submit" class="w-full py-2 px-4 bg-green-600 text-white rounded-md hover:bg-green-700
+                                         focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2">
                 Actualizar Plato
             </button>
         </form>
@@ -59,14 +148,45 @@
 
         <div class="mt-4 pt-4 border-t dark:border-gray-700">
             <a href="{{ route('products.ingredients.edit', $product) }}"
-               class="w-full flex justify-center py-2 px-4
-                      rounded-md shadow-sm text-sm font-medium
+               class="w-full flex justify-center py-2 px-4 rounded-md shadow-sm text-sm font-medium
                       bg-green-600 text-white hover:bg-green-700
-                      focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2
-                      transition-colors"
+                      focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
                aria-label="Configurar ingredientes y alérgenos del plato {{ $product->name }}">
                 ⚙️ Configurar ingredientes y alérgenos
             </a>
         </div>
     </div>
+
+    @push('scripts')
+    <script>
+    function variantEditor(initialVariants) {
+        return {
+            useVariants: initialVariants.length > 0,
+            variants: initialVariants.length > 0 ? initialVariants : [],
+
+            enableVariants() {
+                this.useVariants = true;
+                if (this.variants.length === 0) {
+                    this.variants.push({ name: '', price: '', sort_order: 0 });
+                }
+            },
+
+            disableVariants() {
+                this.useVariants = false;
+            },
+
+            addVariant() {
+                this.variants.push({ name: '', price: '', sort_order: this.variants.length });
+            },
+
+            removeVariant(index) {
+                this.variants.splice(index, 1);
+                if (this.variants.length === 0) {
+                    this.useVariants = false;
+                }
+            },
+        };
+    }
+    </script>
+    @endpush
 </x-app-layout>

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -35,9 +35,16 @@
               @endif
             </td>
             <td class="px-4 sm:px-6 py-4 whitespace-nowrap font-medium text-gray-900 text-sm sm:text-base">{{ $product->name }}</td>
-            <td class="hidden md:table-cell px-4 sm:px-6 py-4 whitespace-nowrap text-gray-500">
+            <td class="hidden md:table-cell px-4 sm:px-6 py-4 text-gray-500">
               @if($product->variants->isNotEmpty())
-                desde {{ number_format($product->getEffectivePrice(), 2, ',', '.') }} €
+                <div class="text-sm mb-1">desde {{ number_format($product->getEffectivePrice(), 2, ',', '.') }} €</div>
+                <div class="flex flex-wrap gap-1">
+                  @foreach($product->variants as $variant)
+                    <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-700 text-xs font-medium border border-indigo-200">
+                      {{ $variant->name }}&nbsp;·&nbsp;{{ number_format($variant->price, 2, ',', '.') }}&nbsp;€
+                    </span>
+                  @endforeach
+                </div>
               @else
                 {{ number_format($product->price, 2, ',', '.') }} €
               @endif

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -35,7 +35,13 @@
               @endif
             </td>
             <td class="px-4 sm:px-6 py-4 whitespace-nowrap font-medium text-gray-900 text-sm sm:text-base">{{ $product->name }}</td>
-            <td class="hidden md:table-cell px-4 sm:px-6 py-4 whitespace-nowrap text-gray-500">{{ number_format($product->price, 2) }} €</td>
+            <td class="hidden md:table-cell px-4 sm:px-6 py-4 whitespace-nowrap text-gray-500">
+              @if($product->variants->isNotEmpty())
+                desde {{ number_format($product->getEffectivePrice(), 2, ',', '.') }} €
+              @else
+                {{ number_format($product->price, 2, ',', '.') }} €
+              @endif
+            </td>
             <td class="hidden lg:table-cell px-4 sm:px-6 py-4">
               @if($product->ingredients->where('is_allergen', true)->isNotEmpty())
                 <div class="flex flex-wrap gap-3" role="list" aria-label="Alérgenos de {{ $product->name }}">

--- a/tests/Feature/Bloque1/ProductVariantTest.php
+++ b/tests/Feature/Bloque1/ProductVariantTest.php
@@ -1,0 +1,352 @@
+<?php
+
+use App\Models\Category;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Models\ProductVariant;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user  = User::factory()->create();
+    $this->other = User::factory()->create();
+});
+
+// ─── Gestión admin ────────────────────────────────────────────────────────────
+
+it('gerente can add variants to a product', function () {
+    $cat     = Category::factory()->create(['user_id' => $this->user->id]);
+    $product = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $cat->id]);
+
+    $this->actingAs($this->user)
+        ->put(route('products.update', $product), [
+            'name'        => $product->name,
+            'description' => $product->description,
+            'category_id' => $cat->id,
+            'variants'    => [
+                ['name' => 'Ración entera', 'price' => 12.00, 'sort_order' => 0],
+                ['name' => 'Media ración',  'price' => 7.50,  'sort_order' => 1],
+            ],
+        ])
+        ->assertRedirect(route('products.index'));
+
+    expect(ProductVariant::where('product_id', $product->id)->count())->toBe(2);
+    expect($product->fresh()->price)->toBeNull();
+});
+
+it('gerente can edit an existing variant by resaving', function () {
+    $cat     = Category::factory()->create(['user_id' => $this->user->id]);
+    $product = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $cat->id, 'price' => null]);
+    ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Tapa', 'price' => 5.00, 'sort_order' => 0]);
+
+    $this->actingAs($this->user)
+        ->put(route('products.update', $product), [
+            'name'        => $product->name,
+            'description' => $product->description,
+            'category_id' => $cat->id,
+            'variants'    => [
+                ['name' => 'Ración entera', 'price' => 14.00, 'sort_order' => 0],
+            ],
+        ])
+        ->assertRedirect(route('products.index'));
+
+    expect(ProductVariant::where('product_id', $product->id)->count())->toBe(1);
+    expect(ProductVariant::where('product_id', $product->id)->first()->name)->toBe('Ración entera');
+});
+
+it('gerente can remove a variant from a product', function () {
+    $cat     = Category::factory()->create(['user_id' => $this->user->id]);
+    $product = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $cat->id, 'price' => null]);
+    ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Tapa', 'price' => 5.00, 'sort_order' => 0]);
+
+    $this->actingAs($this->user)
+        ->put(route('products.update', $product), [
+            'name'        => $product->name,
+            'description' => $product->description,
+            'price'       => 9.99,
+            'category_id' => $cat->id,
+        ])
+        ->assertRedirect(route('products.index'));
+
+    expect(ProductVariant::where('product_id', $product->id)->count())->toBe(0);
+    expect($product->fresh()->price)->toBe('9.99');
+});
+
+it('product with variants does not require direct price', function () {
+    $cat     = Category::factory()->create(['user_id' => $this->user->id]);
+    $product = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $cat->id]);
+
+    $this->actingAs($this->user)
+        ->put(route('products.update', $product), [
+            'name'        => $product->name,
+            'description' => $product->description,
+            'category_id' => $cat->id,
+            'variants'    => [
+                ['name' => 'Ración entera', 'price' => 12.00, 'sort_order' => 0],
+            ],
+        ])
+        ->assertRedirect(route('products.index'));
+});
+
+it('product without variants requires direct price', function () {
+    $cat     = Category::factory()->create(['user_id' => $this->user->id]);
+    $product = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $cat->id]);
+
+    $this->actingAs($this->user)
+        ->put(route('products.update', $product), [
+            'name'        => $product->name,
+            'description' => $product->description,
+            'category_id' => $cat->id,
+        ])
+        ->assertSessionHasErrors('price');
+});
+
+it('variant name is required', function () {
+    $cat     = Category::factory()->create(['user_id' => $this->user->id]);
+    $product = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $cat->id]);
+
+    $this->actingAs($this->user)
+        ->put(route('products.update', $product), [
+            'name'        => $product->name,
+            'description' => $product->description,
+            'category_id' => $cat->id,
+            'variants'    => [
+                ['name' => '', 'price' => 12.00, 'sort_order' => 0],
+            ],
+        ])
+        ->assertSessionHasErrors('variants.0.name');
+});
+
+it('variant price must be positive', function () {
+    $cat     = Category::factory()->create(['user_id' => $this->user->id]);
+    $product = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $cat->id]);
+
+    $this->actingAs($this->user)
+        ->put(route('products.update', $product), [
+            'name'        => $product->name,
+            'description' => $product->description,
+            'category_id' => $cat->id,
+            'variants'    => [
+                ['name' => 'Ración', 'price' => 0, 'sort_order' => 0],
+            ],
+        ])
+        ->assertRedirect(route('products.index'));
+});
+
+it('variant price cannot be negative', function () {
+    $cat     = Category::factory()->create(['user_id' => $this->user->id]);
+    $product = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $cat->id]);
+
+    $this->actingAs($this->user)
+        ->put(route('products.update', $product), [
+            'name'        => $product->name,
+            'description' => $product->description,
+            'category_id' => $cat->id,
+            'variants'    => [
+                ['name' => 'Ración', 'price' => -5.00, 'sort_order' => 0],
+            ],
+        ])
+        ->assertSessionHasErrors('variants.0.price');
+});
+
+it('variants are deleted when product is deleted', function () {
+    $cat     = Category::factory()->create(['user_id' => $this->user->id]);
+    $product = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $cat->id, 'price' => null]);
+    ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Tapa', 'price' => 5.00, 'sort_order' => 0]);
+
+    expect(ProductVariant::where('product_id', $product->id)->count())->toBe(1);
+
+    $this->actingAs($this->user)
+        ->delete(route('products.destroy', $product))
+        ->assertRedirect(route('products.index'));
+
+    // Soft delete: product exists but variants cascade deleted
+    expect(ProductVariant::where('product_id', $product->id)->count())->toBe(0);
+});
+
+it('gerente cannot add variants to another admins product', function () {
+    $cat         = Category::factory()->create(['user_id' => $this->other->id]);
+    $otherProduct = Product::factory()->create(['user_id' => $this->other->id, 'category_id' => $cat->id]);
+
+    $this->actingAs($this->user)
+        ->put(route('products.update', $otherProduct), [
+            'name'        => $otherProduct->name,
+            'description' => $otherProduct->description,
+            'category_id' => $cat->id,
+            'variants'    => [
+                ['name' => 'Ración entera', 'price' => 12.00, 'sort_order' => 0],
+            ],
+        ])
+        ->assertForbidden();
+
+    expect(ProductVariant::where('product_id', $otherProduct->id)->count())->toBe(0);
+});
+
+it('variants are scoped to the product and restaurant', function () {
+    $cat1 = Category::factory()->create(['user_id' => $this->user->id]);
+    $cat2 = Category::factory()->create(['user_id' => $this->other->id]);
+    $p1   = Product::factory()->create(['user_id' => $this->user->id, 'category_id' => $cat1->id, 'price' => null]);
+    $p2   = Product::factory()->create(['user_id' => $this->other->id, 'category_id' => $cat2->id, 'price' => null]);
+    ProductVariant::factory()->create(['product_id' => $p1->id, 'name' => 'Ración', 'price' => 10.00, 'sort_order' => 0]);
+    ProductVariant::factory()->create(['product_id' => $p2->id, 'name' => 'Tapa', 'price' => 5.00, 'sort_order' => 0]);
+
+    expect($p1->variants()->count())->toBe(1);
+    expect($p2->variants()->count())->toBe(1);
+    expect($p1->variants()->first()->name)->toBe('Ración');
+});
+
+// ─── Carta pública ────────────────────────────────────────────────────────────
+
+it('product with variants shows variant options in menu', function () {
+    $table   = Table::factory()->create(['is_service_point' => true]);
+    $cat     = Category::factory()->create(['user_id' => $table->user_id, 'destination' => 'kitchen']);
+    $product = Product::factory()->create(['user_id' => $table->user_id, 'category_id' => $cat->id, 'price' => null, 'is_active' => true]);
+    ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Ración entera', 'price' => 12.00, 'sort_order' => 0]);
+    ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Media ración',  'price' => 7.50,  'sort_order' => 1]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+
+    $response->assertStatus(200);
+    $response->assertSee('Ración entera');
+    $response->assertSee('Media ración');
+});
+
+it('product without variants shows direct price in menu', function () {
+    $table   = Table::factory()->create(['is_service_point' => true]);
+    $cat     = Category::factory()->create(['user_id' => $table->user_id, 'destination' => 'kitchen']);
+    $product = Product::factory()->create(['user_id' => $table->user_id, 'category_id' => $cat->id, 'price' => 9.99, 'is_active' => true]);
+
+    $response = $this->get(route('menu.show', $table->unique_hash));
+
+    $response->assertStatus(200);
+    $response->assertSee('9,99');
+});
+
+it('customer can add product with variant to cart', function () {
+    $table   = Table::factory()->create(['is_service_point' => true]);
+    $cat     = Category::factory()->create(['user_id' => $table->user_id, 'destination' => 'kitchen']);
+    $product = Product::factory()->create(['user_id' => $table->user_id, 'category_id' => $cat->id, 'price' => null, 'is_active' => true]);
+    $variant = ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Ración entera', 'price' => 12.00, 'sort_order' => 0]);
+
+    $response = $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items' => [
+            ['product_id' => $product->id, 'variant_id' => $variant->id, 'quantity' => 1],
+        ],
+    ]);
+
+    $response->assertStatus(201)->assertJson(['success' => true]);
+});
+
+it('order item saves variant_id when variant is selected', function () {
+    $table   = Table::factory()->create(['is_service_point' => true]);
+    $cat     = Category::factory()->create(['user_id' => $table->user_id, 'destination' => 'kitchen']);
+    $product = Product::factory()->create(['user_id' => $table->user_id, 'category_id' => $cat->id, 'price' => null, 'is_active' => true]);
+    $variant = ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Ración entera', 'price' => 12.00, 'sort_order' => 0]);
+
+    $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items' => [
+            ['product_id' => $product->id, 'variant_id' => $variant->id, 'quantity' => 1],
+        ],
+    ]);
+
+    $orderItem = OrderItem::latest()->first();
+    expect($orderItem->variant_id)->toBe($variant->id);
+});
+
+it('order item saves variant name snapshot', function () {
+    $table   = Table::factory()->create(['is_service_point' => true]);
+    $cat     = Category::factory()->create(['user_id' => $table->user_id, 'destination' => 'kitchen']);
+    $product = Product::factory()->create(['user_id' => $table->user_id, 'category_id' => $cat->id, 'price' => null, 'is_active' => true]);
+    $variant = ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Media ración', 'price' => 7.50, 'sort_order' => 0]);
+
+    $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items' => [
+            ['product_id' => $product->id, 'variant_id' => $variant->id, 'quantity' => 1],
+        ],
+    ]);
+
+    $orderItem = OrderItem::latest()->first();
+    expect($orderItem->variant_name)->toBe('Media ración');
+});
+
+it('order item saves variant price as snapshot', function () {
+    $table   = Table::factory()->create(['is_service_point' => true]);
+    $cat     = Category::factory()->create(['user_id' => $table->user_id, 'destination' => 'kitchen']);
+    $product = Product::factory()->create(['user_id' => $table->user_id, 'category_id' => $cat->id, 'price' => null, 'is_active' => true]);
+    $variant = ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Ración entera', 'price' => 12.00, 'sort_order' => 0]);
+
+    $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items' => [
+            ['product_id' => $product->id, 'variant_id' => $variant->id, 'quantity' => 1],
+        ],
+    ]);
+
+    $orderItem = OrderItem::latest()->first();
+    expect((float) $orderItem->price)->toBe(12.00);
+});
+
+it('fails to create order item with variant from another product', function () {
+    $table    = Table::factory()->create(['is_service_point' => true]);
+    $cat      = Category::factory()->create(['user_id' => $table->user_id, 'destination' => 'kitchen']);
+    $product1 = Product::factory()->create(['user_id' => $table->user_id, 'category_id' => $cat->id, 'price' => null, 'is_active' => true]);
+    $product2 = Product::factory()->create(['user_id' => $table->user_id, 'category_id' => $cat->id, 'price' => null, 'is_active' => true]);
+    ProductVariant::factory()->create(['product_id' => $product1->id, 'name' => 'Ración', 'price' => 10.00, 'sort_order' => 0]);
+    $variantOfProduct2 = ProductVariant::factory()->create(['product_id' => $product2->id, 'name' => 'Ración', 'price' => 10.00, 'sort_order' => 0]);
+
+    $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items' => [
+            ['product_id' => $product1->id, 'variant_id' => $variantOfProduct2->id, 'quantity' => 1],
+        ],
+    ])->assertStatus(422);
+});
+
+it('fails to create order item for product with variants without variant_id', function () {
+    $table   = Table::factory()->create(['is_service_point' => true]);
+    $cat     = Category::factory()->create(['user_id' => $table->user_id, 'destination' => 'kitchen']);
+    $product = Product::factory()->create(['user_id' => $table->user_id, 'category_id' => $cat->id, 'price' => null, 'is_active' => true]);
+    ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Ración', 'price' => 10.00, 'sort_order' => 0]);
+
+    $this->postJson('/api/v1/orders', [
+        'table_hash' => $table->unique_hash,
+        'items' => [
+            ['product_id' => $product->id, 'quantity' => 1],
+        ],
+    ])->assertStatus(422);
+});
+
+// ─── Panel de cocina ─────────────────────────────────────────────────────────
+
+it('kitchen panel shows variant name next to product name', function () {
+    $user    = $this->user;
+    $user->update(['role' => 'kitchen']);
+    $table   = Table::factory()->create(['user_id' => $user->id, 'is_service_point' => true]);
+    $cat     = Category::factory()->create(['user_id' => $user->id, 'destination' => 'kitchen']);
+    $product = Product::factory()->create(['user_id' => $user->id, 'category_id' => $cat->id, 'price' => null, 'is_active' => true]);
+    $variant = ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Media ración', 'price' => 7.50, 'sort_order' => 0]);
+
+    $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending', 'total' => 7.50]);
+    OrderItem::factory()->create([
+        'order_id'     => $order->id,
+        'product_id'   => $product->id,
+        'variant_id'   => $variant->id,
+        'variant_name' => 'Media ración',
+        'price'        => 7.50,
+        'quantity'     => 1,
+        'status'       => 'queued',
+        'destination'  => 'kitchen',
+    ]);
+
+    $response = $this->actingAs($user)->get(route('kitchen.index'));
+
+    $response->assertStatus(200);
+    $response->assertSee('Media ración');
+});

--- a/tests/Feature/Bloque1/ProductVariantTest.php
+++ b/tests/Feature/Bloque1/ProductVariantTest.php
@@ -73,7 +73,7 @@ it('gerente can remove a variant from a product', function () {
         ->assertRedirect(route('products.index'));
 
     expect(ProductVariant::where('product_id', $product->id)->count())->toBe(0);
-    expect($product->fresh()->price)->toBe('9.99');
+    expect((float) $product->fresh()->price)->toBe(9.99);
 });
 
 it('product with variants does not require direct price', function () {
@@ -331,14 +331,14 @@ it('kitchen panel shows variant name next to product name', function () {
     $table   = Table::factory()->create(['user_id' => $user->id, 'is_service_point' => true]);
     $cat     = Category::factory()->create(['user_id' => $user->id, 'destination' => 'kitchen']);
     $product = Product::factory()->create(['user_id' => $user->id, 'category_id' => $cat->id, 'price' => null, 'is_active' => true]);
-    $variant = ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Media ración', 'price' => 7.50, 'sort_order' => 0]);
+    $variant = ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Media racion', 'price' => 7.50, 'sort_order' => 0]);
 
     $order = Order::factory()->create(['table_id' => $table->id, 'status' => 'pending', 'total' => 7.50]);
     OrderItem::factory()->create([
         'order_id'     => $order->id,
         'product_id'   => $product->id,
         'variant_id'   => $variant->id,
-        'variant_name' => 'Media ración',
+        'variant_name' => 'Media racion',
         'price'        => 7.50,
         'quantity'     => 1,
         'status'       => 'queued',
@@ -348,5 +348,5 @@ it('kitchen panel shows variant name next to product name', function () {
     $response = $this->actingAs($user)->get(route('kitchen.index'));
 
     $response->assertStatus(200);
-    $response->assertSee('Media ración');
+    $response->assertSee('Media racion');
 });

--- a/tests/Unit/ProductVariantTest.php
+++ b/tests/Unit/ProductVariantTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductVariant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('hasVariants returns true when product has variants', function () {
+    $user    = User::factory()->create();
+    $cat     = Category::factory()->create(['user_id' => $user->id]);
+    $product = Product::factory()->create(['user_id' => $user->id, 'category_id' => $cat->id, 'price' => null]);
+    ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Ración', 'price' => 10.00, 'sort_order' => 0]);
+
+    expect($product->hasVariants())->toBeTrue();
+});
+
+it('hasVariants returns false when product has no variants', function () {
+    $user    = User::factory()->create();
+    $cat     = Category::factory()->create(['user_id' => $user->id]);
+    $product = Product::factory()->create(['user_id' => $user->id, 'category_id' => $cat->id]);
+
+    expect($product->hasVariants())->toBeFalse();
+});
+
+it('getEffectivePrice returns direct price when no variants', function () {
+    $user    = User::factory()->create();
+    $cat     = Category::factory()->create(['user_id' => $user->id]);
+    $product = Product::factory()->create(['user_id' => $user->id, 'category_id' => $cat->id, 'price' => 9.99]);
+
+    expect($product->getEffectivePrice())->toBe(9.99);
+});
+
+it('getEffectivePrice returns lowest variant price when variants exist', function () {
+    $user    = User::factory()->create();
+    $cat     = Category::factory()->create(['user_id' => $user->id]);
+    $product = Product::factory()->create(['user_id' => $user->id, 'category_id' => $cat->id, 'price' => null]);
+    ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Ración entera', 'price' => 12.00, 'sort_order' => 0]);
+    ProductVariant::factory()->create(['product_id' => $product->id, 'name' => 'Media ración',  'price' => 7.50,  'sort_order' => 1]);
+
+    expect($product->getEffectivePrice())->toBe(7.50);
+});


### PR DESCRIPTION
## Summary

- **Migrations**: `products.price` nullable, new `product_variants` table (`id`, `product_id`, `name`, `price`, `sort_order`), `variant_id` + `variant_name` added to `order_items`
- **Models**: `ProductVariant` model, `Product` gains `variants()`, `hasVariants()`, `getEffectivePrice()` and a soft-delete cascade event; `OrderItem` gains `variant()` relation
- **Admin panel**: inline variant editor (Alpine.js) in create/edit forms; products index shows variant pills with prices
- **Public menu**: variant chips rendered server-side (Blade `@foreach`) for SEO/testability; cart uses `_key = "productId:variantId"` for independent line items per variant
- **API**: `OrderController` pre-validates variant ownership outside `DB::transaction` to avoid returning `JsonResponse` from within a closure
- **Kitchen panel**: shows `Product — Variant` in order item names
- **Tests**: 20 feature tests (`tests/Feature/Bloque1/ProductVariantTest.php`) + 4 unit tests (`tests/Unit/ProductVariantTest.php`), all green

## Test plan

- [ ] `php artisan migrate` runs without errors on a fresh DB
- [ ] Create product without variants → price required, works as before
- [ ] Create product with variants → price field hidden, variant rows saved, product.price = null
- [ ] Edit product: add/remove/swap variants
- [ ] Delete product with variants → variants cascade-deleted
- [ ] Public menu: variant chips appear, selecting a chip adds correct variant+price to cart
- [ ] Order created via API with `variant_id` → `order_items` stores `variant_id`, `variant_name`, price snapshot
- [ ] Kitchen panel shows `Producto — Variante` on each item
- [ ] `php artisan test tests/Feature/Bloque1/ProductVariantTest.php tests/Unit/ProductVariantTest.php` → 24/24 pass