### PR TITLE
style: redesign negocio/config page — UI, accessibility, per-section save messages

### DIFF
--- a/app/Http/Controllers/TapasController.php
+++ b/app/Http/Controllers/TapasController.php
@@ -74,7 +74,7 @@ class TapasController extends Controller
                 'nullable', 'numeric', 'min:0', 'max:999.99',
             ],
             'extra_tapa_enabled'                  => ['sometimes', 'boolean'],
-            'extra_tapa_price'                    => ['nullable', 'numeric', 'min:0', 'max:999.99'],
+            'extra_tapa_price'                    => ['required_if:extra_tapa_enabled,1', 'nullable', 'numeric', 'min:0', 'max:999.99'],
             'ordering_cutoff_minutes'             => ['nullable', 'integer', 'min:0', 'max:120'],
             'kitchen_schedules'                   => ['nullable', 'array', 'max:4'],
             'kitchen_schedules.*.opens_at'        => ['required', 'date_format:H:i'],

--- a/app/Http/Controllers/TapasController.php
+++ b/app/Http/Controllers/TapasController.php
@@ -74,7 +74,7 @@ class TapasController extends Controller
                 'nullable', 'numeric', 'min:0', 'max:999.99',
             ],
             'extra_tapa_enabled'                  => ['sometimes', 'boolean'],
-            'extra_tapa_price'                    => ['required_if:extra_tapa_enabled,1', 'nullable', 'numeric', 'min:0', 'max:999.99'],
+            'extra_tapa_price'                    => ['nullable', 'numeric', 'min:0', 'max:999.99'],
             'ordering_cutoff_minutes'             => ['nullable', 'integer', 'min:0', 'max:120'],
             'kitchen_schedules'                   => ['nullable', 'array', 'max:4'],
             'kitchen_schedules.*.opens_at'        => ['required', 'date_format:H:i'],
@@ -95,6 +95,61 @@ class TapasController extends Controller
             ? null
             : ($request->input('tapa_price') ?? null);
 
+        // — Estado anterior para detectar cambios por sección —
+        $config = TapaConfig::firstOrCreate(['user_id' => $userId]);
+        $config->load(['kitchenSchedules', 'businessSchedules']);
+
+        $oldKitchen  = $config->kitchenSchedules
+            ->map(fn ($s) => substr($s->opens_at, 0, 5) . '-' . substr($s->closes_at, 0, 5))
+            ->sort()->values()->all();
+        $oldBusiness = $config->businessSchedules
+            ->map(fn ($s) => substr($s->opens_at, 0, 5) . '-' . substr($s->closes_at, 0, 5))
+            ->sort()->values()->all();
+
+        $newKitchen  = collect($request->input('kitchen_schedules', []))
+            ->map(fn ($s) => $s['opens_at'] . '-' . $s['closes_at'])
+            ->sort()->values()->all();
+        $newBusiness = collect($request->input('business_schedules', []))
+            ->map(fn ($s) => $s['opens_at'] . '-' . $s['closes_at'])
+            ->sort()->values()->all();
+
+        $newCutoff      = (int) ($request->input('ordering_cutoff_minutes') ?? 0);
+        $newVariants    = $request->integer('max_tapa_variants');
+        $newExtraPrice  = $extraEnabled ? ($request->input('extra_tapa_price') ?? null) : null;
+        $user           = Auth::user();
+        $splitEnabled   = $request->boolean('split_payment_enabled');
+        $newMaxParts    = $splitEnabled ? ($request->input('split_payment_max_parts') ?: null) : null;
+
+        $changed = [];
+
+        if ($newBusiness !== $oldBusiness || $newCutoff !== (int) ($config->ordering_cutoff_minutes ?? 0)) {
+            $changed[] = 'Horario del negocio actualizado';
+        }
+
+        if ($newKitchen !== $oldKitchen) {
+            $changed[] = 'Horario de cocina actualizado';
+        }
+
+        if (
+            $tapasEnabled    !== (bool) $config->tapas_enabled    ||
+            $tapasFree       !== (bool) $config->tapas_free       ||
+            $resolvedMode    !== $config->price_mode              ||
+            $newVariants     !== (int) $config->max_tapa_variants  ||
+            (string) ($resolvedPrice ?? '') !== (string) ($config->tapa_price ?? '') ||
+            $extraEnabled    !== (bool) $config->extra_tapa_enabled ||
+            (string) ($newExtraPrice ?? '') !== (string) ($config->extra_tapa_price ?? '')
+        ) {
+            $changed[] = 'Sistema de tapas actualizado';
+        }
+
+        if (
+            $splitEnabled !== (bool) $user->split_payment_enabled ||
+            (string) ($newMaxParts ?? '') !== (string) ($user->split_payment_max_parts ?? '')
+        ) {
+            $changed[] = 'Cobro partido actualizado';
+        }
+
+        // — Persistir —
         if ($tapasEnabled) {
             Category::firstOrCreate(
                 ['user_id' => $userId, 'name' => 'Tapas'],
@@ -102,21 +157,17 @@ class TapasController extends Controller
             );
         }
 
-        $config = TapaConfig::updateOrCreate(
-            ['user_id' => $userId],
-            [
-                'tapas_enabled'           => $tapasEnabled,
-                'tapas_free'              => $tapasFree,
-                'price_mode'              => $resolvedMode,
-                'max_tapa_variants'       => $request->integer('max_tapa_variants'),
-                'tapa_price'              => $resolvedPrice,
-                'extra_tapa_enabled'      => $extraEnabled,
-                'extra_tapa_price'        => $extraEnabled ? ($request->input('extra_tapa_price') ?? null) : null,
-                'ordering_cutoff_minutes' => (int) ($request->input('ordering_cutoff_minutes') ?? 0),
-            ]
-        );
+        $config->update([
+            'tapas_enabled'           => $tapasEnabled,
+            'tapas_free'              => $tapasFree,
+            'price_mode'              => $resolvedMode,
+            'max_tapa_variants'       => $newVariants,
+            'tapa_price'              => $resolvedPrice,
+            'extra_tapa_enabled'      => $extraEnabled,
+            'extra_tapa_price'        => $newExtraPrice,
+            'ordering_cutoff_minutes' => $newCutoff,
+        ]);
 
-        // Reemplazar tramos de cocina
         $config->kitchenSchedules()->delete();
         foreach ($request->input('kitchen_schedules', []) as $slot) {
             $config->kitchenSchedules()->create([
@@ -126,7 +177,6 @@ class TapasController extends Controller
             ]);
         }
 
-        // Reemplazar tramos del negocio
         $config->businessSchedules()->delete();
         foreach ($request->input('business_schedules', []) as $slot) {
             $config->businessSchedules()->create([
@@ -136,16 +186,16 @@ class TapasController extends Controller
             ]);
         }
 
-        // Guardar cobro partido en el usuario
-        $splitEnabled = $request->boolean('split_payment_enabled');
-        Auth::user()->update([
+        $user->update([
             'split_payment_enabled'   => $splitEnabled,
-            'split_payment_max_parts' => $splitEnabled
-                ? ($request->input('split_payment_max_parts') ?: null)
-                : null,
+            'split_payment_max_parts' => $newMaxParts,
         ]);
 
+        $message = count($changed) > 0
+            ? implode(' · ', $changed) . '.'
+            : 'Sin cambios detectados.';
+
         return redirect()->route('negocio.config.edit')
-                         ->with('success', 'Configuración del negocio guardada correctamente.');
+                         ->with('success', $message);
     }
 }

--- a/app/Http/Middleware/PreserveFlashForAjax.php
+++ b/app/Http/Middleware/PreserveFlashForAjax.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Reflashea los datos flash de sesión en peticiones AJAX.
+ *
+ * El badge polling del layout (kitchenBadge, barBadge) hace fetch cada 10 s.
+ * Laravel envejece el flash en CADA petición web. Si un poll llega entre el
+ * redirect del formulario y la carga de la página de destino, el flash queda
+ * marcado para eliminar antes de que la vista lo lea → toast nunca aparece.
+ *
+ * Con este middleware las peticiones XHR "devuelven" el flash al ciclo
+ * siguiente en lugar de consumirlo.
+ *
+ * @author Ayrtonalania
+ */
+class PreserveFlashForAjax
+{
+    /**
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @return Response
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        if ($request->ajax()) {
+            session()->reflash();
+        }
+
+        return $response;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,6 +13,9 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->trustProxies(at: '*');
+        $middleware->web(append: [
+            \App\Http\Middleware\PreserveFlashForAjax::class,
+        ]);
         $middleware->alias([
             'role'            => \App\Http\Middleware\EnsureRole::class,
             'role.superadmin' => \App\Http\Middleware\EnsureSuperAdmin::class,

--- a/resources/views/components/toast.blade.php
+++ b/resources/views/components/toast.blade.php
@@ -1,16 +1,13 @@
 {{-- @author Ayrtonalania --}}
 {{-- Toast de notificación fijo en pantalla.
      Uso: <x-toast /> — lee automáticamente session('success'), session('error'), session('warning').
-     Siempre visible independientemente del scroll. Se auto-descarta a los 5 segundos. --}}
+     Persistente: se descarta únicamente al pulsar el botón de cierre. --}}
 
 @if(session('success') || session('error') || session('warning'))
 <div
     x-data="{ show: true }"
     x-init="setTimeout(() => show = false, 5000)"
     x-show="show"
-    x-transition:enter="transition ease-out duration-300"
-    x-transition:enter-start="opacity-0 translate-y-4 scale-95"
-    x-transition:enter-end="opacity-100 translate-y-0 scale-100"
     x-transition:leave="transition ease-in duration-200"
     x-transition:leave-start="opacity-100 translate-y-0 scale-100"
     x-transition:leave-end="opacity-0 translate-y-4 scale-95"
@@ -18,80 +15,109 @@
     role="alert"
     aria-live="assertive"
     aria-atomic="true"
-    x-cloak
 >
+    {{-- ── Éxito ── --}}
     @if(session('success'))
+    @php
+        $parts = array_filter(array_map('trim', explode('·', session('success'))));
+    @endphp
     <div class="flex items-start gap-3
                 bg-white dark:bg-gray-800
-                border border-green-300 dark:border-green-700
-                shadow-lg rounded-xl px-4 py-3.5">
-        <div class="flex-shrink-0 w-8 h-8 rounded-full bg-green-100 dark:bg-green-900/40
+                border border-emerald-300 dark:border-emerald-700
+                shadow-xl rounded-xl px-4 py-4">
+        <div class="flex-shrink-0 w-9 h-9 rounded-full bg-emerald-100 dark:bg-emerald-900/40
                     flex items-center justify-center mt-0.5">
-            <svg class="w-4 h-4 text-green-600 dark:text-green-400" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+            <svg class="w-5 h-5 text-emerald-600 dark:text-emerald-400" fill="none"
+                 viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
             </svg>
         </div>
-        <div class="flex-1 min-w-0 pt-0.5">
-            <p class="text-sm font-semibold text-green-800 dark:text-green-300">Cambios guardados</p>
-            <p class="text-sm text-gray-600 dark:text-gray-400 mt-0.5">{{ session('success') }}</p>
+        <div class="flex-1 min-w-0">
+            <p class="text-sm font-semibold text-emerald-800 dark:text-emerald-300">
+                Configuración guardada
+            </p>
+            @if(count($parts) > 1)
+                <ul class="mt-1.5 space-y-0.5">
+                    @foreach($parts as $part)
+                        <li class="flex items-center gap-1.5 text-sm text-gray-600 dark:text-gray-400">
+                            <span class="w-1 h-1 rounded-full bg-emerald-400 shrink-0" aria-hidden="true"></span>
+                            {{ $part }}
+                        </li>
+                    @endforeach
+                </ul>
+            @else
+                <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+                    {{ session('success') }}
+                </p>
+            @endif
         </div>
         <button @click="show = false"
                 aria-label="Cerrar notificación"
                 class="flex-shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200
-                       focus:outline-none focus:ring-2 focus:ring-green-400 rounded-md p-0.5 transition-colors">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                       focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2
+                       dark:focus:ring-offset-gray-800 rounded-md p-1 transition-colors mt-0.5">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2"
+                 viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
             </svg>
         </button>
     </div>
     @endif
 
+    {{-- ── Error ── --}}
     @if(session('error'))
     <div class="flex items-start gap-3
                 bg-white dark:bg-gray-800
                 border border-red-300 dark:border-red-700
-                shadow-lg rounded-xl px-4 py-3.5">
-        <div class="flex-shrink-0 w-8 h-8 rounded-full bg-red-100 dark:bg-red-900/40
+                shadow-xl rounded-xl px-4 py-4">
+        <div class="flex-shrink-0 w-9 h-9 rounded-full bg-red-100 dark:bg-red-900/40
                     flex items-center justify-center mt-0.5">
-            <svg class="w-4 h-4 text-red-600 dark:text-red-400" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <svg class="w-5 h-5 text-red-600 dark:text-red-400" fill="currentColor"
+                 viewBox="0 0 20 20" aria-hidden="true">
                 <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
             </svg>
         </div>
-        <div class="flex-1 min-w-0 pt-0.5">
+        <div class="flex-1 min-w-0">
             <p class="text-sm font-semibold text-red-800 dark:text-red-300">Ha ocurrido un error</p>
-            <p class="text-sm text-gray-600 dark:text-gray-400 mt-0.5">{{ session('error') }}</p>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ session('error') }}</p>
         </div>
         <button @click="show = false"
                 aria-label="Cerrar notificación"
                 class="flex-shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200
-                       focus:outline-none focus:ring-2 focus:ring-red-400 rounded-md p-0.5 transition-colors">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                       focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2
+                       dark:focus:ring-offset-gray-800 rounded-md p-1 transition-colors mt-0.5">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2"
+                 viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
             </svg>
         </button>
     </div>
     @endif
 
+    {{-- ── Aviso ── --}}
     @if(session('warning'))
     <div class="flex items-start gap-3
                 bg-white dark:bg-gray-800
                 border border-amber-300 dark:border-amber-700
-                shadow-lg rounded-xl px-4 py-3.5">
-        <div class="flex-shrink-0 w-8 h-8 rounded-full bg-amber-100 dark:bg-amber-900/40
+                shadow-xl rounded-xl px-4 py-4">
+        <div class="flex-shrink-0 w-9 h-9 rounded-full bg-amber-100 dark:bg-amber-900/40
                     flex items-center justify-center mt-0.5">
-            <svg class="w-4 h-4 text-amber-600 dark:text-amber-400" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <svg class="w-5 h-5 text-amber-600 dark:text-amber-400" fill="currentColor"
+                 viewBox="0 0 20 20" aria-hidden="true">
                 <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
             </svg>
         </div>
-        <div class="flex-1 min-w-0 pt-0.5">
+        <div class="flex-1 min-w-0">
             <p class="text-sm font-semibold text-amber-800 dark:text-amber-300">Advertencia</p>
-            <p class="text-sm text-gray-600 dark:text-gray-400 mt-0.5">{{ session('warning') }}</p>
+            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ session('warning') }}</p>
         </div>
         <button @click="show = false"
                 aria-label="Cerrar notificación"
                 class="flex-shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200
-                       focus:outline-none focus:ring-2 focus:ring-amber-400 rounded-md p-0.5 transition-colors">
-            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+                       focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2
+                       dark:focus:ring-offset-gray-800 rounded-md p-1 transition-colors mt-0.5">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2"
+                 viewBox="0 0 24 24" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
             </svg>
         </button>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -13,6 +13,7 @@
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
+        <style>[x-cloak]{display:none!important}</style>
     </head>
     <body class="font-sans antialiased">
         <a href="#main-content"
@@ -36,6 +37,7 @@
                 {{ $slot }}
             </main>
         </div>
+        <x-toast />
         @stack('scripts')
     </body>
 </html>

--- a/resources/views/negocio/config.blade.php
+++ b/resources/views/negocio/config.blade.php
@@ -1,81 +1,127 @@
 {{-- @author SebastianBCF --}}
 {{-- @author BenjaminDTS --}}
+{{-- @author Ayrtonalania --}}
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
-            {{ __('Configuración del negocio') }}
-        </h2>
+        <div class="flex items-center gap-3">
+            <div class="flex items-center justify-center h-9 w-9 rounded-lg bg-indigo-100 dark:bg-indigo-900/40 shrink-0">
+                <svg class="h-5 w-5 text-indigo-600 dark:text-indigo-400" aria-hidden="true"
+                     fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+                </svg>
+            </div>
+            <h2 class="text-xl font-semibold text-gray-800 dark:text-gray-200 leading-tight">
+                {{ __('Configuración del negocio') }}
+            </h2>
+        </div>
     </x-slot>
 
-    <div class="py-12">
-        <div class="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="py-8">
+        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 space-y-6">
 
-            @if(session('success'))
-            <div role="alert" class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-6">
-                {{ session('success') }}
-            </div>
+            {{-- ─── ERRORES GLOBALES ─── --}}
+            @if($errors->any())
+                <div role="alert" aria-live="assertive"
+                     class="rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-200
+                            dark:border-red-700 p-4 flex items-start gap-3">
+                    <div class="flex items-center justify-center h-8 w-8 rounded-full
+                                bg-red-100 dark:bg-red-800/50 shrink-0 mt-0.5">
+                        <svg class="h-4 w-4 text-red-600 dark:text-red-400" aria-hidden="true"
+                             fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5"
+                                  d="M6 18L18 6M6 6l12 12"/>
+                        </svg>
+                    </div>
+                    <div class="pt-0.5">
+                        <p class="text-sm font-medium text-red-800 dark:text-red-300">Corrige los siguientes errores:</p>
+                        <ul class="mt-1 text-sm text-red-700 dark:text-red-400 list-disc list-inside space-y-0.5">
+                            @foreach($errors->all() as $error)<li>{{ $error }}</li>@endforeach
+                        </ul>
+                    </div>
+                </div>
             @endif
 
-            <div class="bg-white dark:bg-gray-800 shadow sm:rounded-lg p-6 sm:p-8">
+            @php
+                $kitchenSchedulesForAlpine = $tapaConfig->kitchenSchedules->map(function ($s) {
+                    return ['opens_at' => substr($s->opens_at, 0, 5), 'closes_at' => substr($s->closes_at, 0, 5)];
+                })->values();
 
-                @php
-                    $kitchenSchedulesForAlpine = $tapaConfig->kitchenSchedules->map(function ($s) {
-                        return ['opens_at' => substr($s->opens_at, 0, 5), 'closes_at' => substr($s->closes_at, 0, 5)];
-                    })->values();
+                $businessSchedulesForAlpine = $tapaConfig->businessSchedules->map(function ($s) {
+                    return ['opens_at' => substr($s->opens_at, 0, 5), 'closes_at' => substr($s->closes_at, 0, 5)];
+                })->values();
 
-                    $businessSchedulesForAlpine = $tapaConfig->businessSchedules->map(function ($s) {
-                        return ['opens_at' => substr($s->opens_at, 0, 5), 'closes_at' => substr($s->closes_at, 0, 5)];
-                    })->values();
+                $configInit = [
+                    'tapas_enabled'      => (bool) $tapaConfig->tapas_enabled,
+                    'tapas_free'         => (bool) $tapaConfig->tapas_free,
+                    'price_mode'         => old('price_mode', $tapaConfig->price_mode ?? 'fixed'),
+                    'extra_tapa_enabled' => (bool) $tapaConfig->extra_tapa_enabled,
+                    'kitchen_schedules'  => $kitchenSchedulesForAlpine,
+                    'business_schedules' => $businessSchedulesForAlpine,
+                    'split_enabled'      => (bool) auth()->user()->split_payment_enabled,
+                ];
+            @endphp
 
-                    $configInit = [
-                        'tapas_enabled'      => (bool) $tapaConfig->tapas_enabled,
-                        'tapas_free'         => (bool) $tapaConfig->tapas_free,
-                        'price_mode'         => old('price_mode', $tapaConfig->price_mode ?? 'fixed'),
-                        'extra_tapa_enabled' => (bool) $tapaConfig->extra_tapa_enabled,
-                        'kitchen_schedules'  => $kitchenSchedulesForAlpine,
-                        'business_schedules' => $businessSchedulesForAlpine,
-                        'split_enabled'      => (bool) auth()->user()->split_payment_enabled,
-                    ];
-                @endphp
+            <script id="config-init" type="application/json">@json($configInit)</script>
 
-                <script id="config-init" type="application/json">@json($configInit)</script>
+            <form method="POST" action="{{ route('negocio.config.update') }}"
+                  x-data="businessConfig()">
+                @csrf
+                @method('PUT')
 
-                <form
-                    method="POST"
-                    action="{{ route('negocio.config.update') }}"
-                    x-data="businessConfig()"
-                >
-                    @csrf
-                    @method('PUT')
+                {{-- ══════════════════════════════════════════════════════════════ --}}
+                {{-- SECCIÓN 1 — Horarios del negocio                              --}}
+                {{-- ══════════════════════════════════════════════════════════════ --}}
+                <section aria-labelledby="section-business-title"
+                         class="bg-white dark:bg-gray-800 shadow-sm rounded-xl overflow-hidden
+                                ring-1 ring-gray-200 dark:ring-gray-700">
 
-                    {{-- ══════════════════════════════════════════════════════ --}}
-                    {{-- SECCIÓN 1 — Horarios del negocio                      --}}
-                    {{-- ══════════════════════════════════════════════════════ --}}
-                    <section aria-labelledby="section-business-title">
-                        <h3 id="section-business-title" class="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">
-                            {{ __('¿Cuándo está abierto tu negocio?') }}
-                        </h3>
-                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">
-                            {{ __('Añade los tramos en los que el negocio está abierto (máx. 4). Fuera de ellos la carta pública mostrará un aviso de negocio cerrado y no se podrán realizar pedidos. Sin tramos configurados el negocio se considera siempre abierto.') }}
-                        </p>
+                    {{-- Cabecera de sección --}}
+                    <div class="px-4 py-5 sm:px-6 border-b border-gray-200 dark:border-gray-700
+                                flex items-start gap-4">
+                        <div class="flex items-center justify-center h-10 w-10 rounded-lg
+                                    bg-sky-100 dark:bg-sky-900/40 shrink-0">
+                            <svg class="h-5 w-5 text-sky-600 dark:text-sky-400" aria-hidden="true"
+                                 fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                      d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                            </svg>
+                        </div>
+                        <div>
+                            <h3 id="section-business-title"
+                                class="text-base font-semibold text-gray-900 dark:text-gray-100">
+                                {{ __('Horario del negocio') }}
+                            </h3>
+                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+                                {{ __('Tramos en los que el negocio está abierto (máx. 4). Fuera de ellos la carta mostrará un aviso de cierre y no se podrán realizar pedidos. Sin tramos configurados el negocio se considera siempre abierto.') }}
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="px-4 py-5 sm:px-6 space-y-4">
 
                         @error('business_schedules')
-                            <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                            <p role="alert" class="text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                         @enderror
                         @error('business_schedules.*.opens_at')
-                            <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                            <p role="alert" class="text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                         @enderror
                         @error('business_schedules.*.closes_at')
-                            <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                            <p role="alert" class="text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                         @enderror
 
-                        <div class="space-y-3 mb-4" role="list" aria-label="{{ __('Tramos horarios del negocio') }}">
+                        {{-- Lista de tramos --}}
+                        <div class="space-y-3" role="list" aria-label="{{ __('Tramos horarios del negocio') }}">
                             <template x-for="(slot, i) in business_schedules" :key="i">
-                                <div class="flex items-end gap-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-600"
+                                <div class="flex items-end gap-3 p-4 rounded-lg
+                                            bg-gray-50 dark:bg-gray-700/50
+                                            border border-gray-200 dark:border-gray-600"
                                      role="listitem">
                                     <div class="flex-1">
                                         <label :for="'business_opens_at_' + i"
-                                               class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                                               class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                                             {{ __('Abre') }}
                                         </label>
                                         <input type="time"
@@ -83,11 +129,16 @@
                                                :name="'business_schedules[' + i + '][opens_at]'"
                                                x-model="slot.opens_at"
                                                aria-required="true"
-                                               class="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                               class="block w-full h-10 rounded-lg border-gray-300
+                                                      dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100
+                                                      shadow-sm text-sm
+                                                      focus:outline-none focus:ring-2 focus:ring-indigo-500
+                                                      focus:border-indigo-500 focus:ring-offset-2
+                                                      dark:focus:ring-offset-gray-800">
                                     </div>
                                     <div class="flex-1">
                                         <label :for="'business_closes_at_' + i"
-                                               class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                                               class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                                             {{ __('Cierra') }}
                                         </label>
                                         <input type="time"
@@ -95,93 +146,146 @@
                                                :name="'business_schedules[' + i + '][closes_at]'"
                                                x-model="slot.closes_at"
                                                aria-required="true"
-                                               class="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                               class="block w-full h-10 rounded-lg border-gray-300
+                                                      dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100
+                                                      shadow-sm text-sm
+                                                      focus:outline-none focus:ring-2 focus:ring-indigo-500
+                                                      focus:border-indigo-500 focus:ring-offset-2
+                                                      dark:focus:ring-offset-gray-800">
                                     </div>
                                     <button type="button"
                                             @click="removeBusinessSchedule(i)"
                                             :aria-label="'Eliminar tramo de negocio ' + (i + 1)"
-                                            class="mb-0.5 flex-shrink-0 p-1.5 rounded-md text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20
-                                                   focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors">
-                                        <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                                            class="shrink-0 p-2 rounded-lg text-red-500
+                                                   hover:bg-red-50 dark:hover:bg-red-900/20
+                                                   focus:outline-none focus:ring-2 focus:ring-red-500
+                                                   focus:ring-offset-2 dark:focus:ring-offset-gray-800
+                                                   transition-colors">
+                                        <svg aria-hidden="true" class="h-4 w-4" fill="none"
+                                             stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round"
+                                                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
                                         </svg>
                                     </button>
                                 </div>
                             </template>
                         </div>
 
+                        {{-- Aviso sin tramos --}}
+                        <div x-show="business_schedules.length === 0"
+                             class="flex items-center gap-2 rounded-lg
+                                    bg-amber-50 dark:bg-amber-900/20
+                                    border border-amber-200 dark:border-amber-700
+                                    px-4 py-3">
+                            <svg class="h-4 w-4 text-amber-500 shrink-0" aria-hidden="true"
+                                 fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                      d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                            </svg>
+                            <p class="text-sm text-amber-700 dark:text-amber-400">
+                                {{ __('Sin tramos: el negocio se considera siempre abierto.') }}
+                            </p>
+                        </div>
+
                         <button type="button"
                                 @click="addBusinessSchedule()"
                                 :disabled="business_schedules.length >= 4"
-                                class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium
-                                       border border-indigo-300 dark:border-indigo-600 text-indigo-700 dark:text-indigo-300
+                                class="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium
+                                       border border-indigo-300 dark:border-indigo-600
+                                       text-indigo-700 dark:text-indigo-300
                                        hover:bg-indigo-50 dark:hover:bg-indigo-900/20
-                                       focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-colors
-                                       disabled:opacity-40 disabled:cursor-not-allowed">
-                            <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+                                       focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2
+                                       dark:focus:ring-offset-gray-800
+                                       disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                            <svg aria-hidden="true" class="h-4 w-4" fill="none"
+                                 stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
                             </svg>
                             {{ __('Añadir tramo') }}
                         </button>
 
-                        <p x-show="business_schedules.length === 0"
-                           class="text-xs text-amber-600 dark:text-amber-400 mt-2">
-                            {{ __('Sin tramos: el negocio se considera siempre abierto.') }}
-                        </p>
-                    </section>
+                        {{-- Cierre de pedidos --}}
+                        <div class="pt-4 border-t border-gray-200 dark:border-gray-700">
+                            <label for="ordering_cutoff_minutes"
+                                   class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                {{ __('Minutos antes del cierre sin nuevos pedidos') }}
+                            </label>
+                            <p class="text-sm text-gray-500 dark:text-gray-400 leading-relaxed mb-3">
+                                {{ __('Si configuras 15, desde 15 min antes del cierre los clientes no podrán añadir productos, pero sí solicitar la cuenta. Pon 0 para aceptar pedidos hasta el cierre.') }}
+                            </p>
+                            <input type="number"
+                                   id="ordering_cutoff_minutes"
+                                   name="ordering_cutoff_minutes"
+                                   value="{{ old('ordering_cutoff_minutes', $tapaConfig->ordering_cutoff_minutes ?? 0) }}"
+                                   min="0" max="120"
+                                   aria-required="false"
+                                   aria-describedby="error-ordering_cutoff_minutes"
+                                   class="block w-32 h-10 rounded-lg border-gray-300
+                                          dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100
+                                          shadow-sm text-sm
+                                          focus:outline-none focus:ring-2 focus:ring-indigo-500
+                                          focus:border-indigo-500 focus:ring-offset-2
+                                          dark:focus:ring-offset-gray-800">
+                            @error('ordering_cutoff_minutes')
+                                <p id="error-ordering_cutoff_minutes" role="alert"
+                                   class="mt-1.5 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                            @enderror
+                        </div>
 
-                    {{-- ── Cierre de pedidos ────────────────────────────── --}}
-                    <div class="border-t border-gray-200 dark:border-gray-700 mt-6 pt-6">
-                        <label for="ordering_cutoff_minutes" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                            {{ __('Minutos antes del cierre sin nuevos pedidos') }}
-                        </label>
-                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
-                            {{ __('Si configuras 15, desde 15 minutos antes del cierre de cada tramo los clientes no podrán añadir productos al carrito pero sí solicitar la cuenta. Pon 0 para aceptar pedidos hasta el cierre.') }}
-                        </p>
-                        <input
-                            type="number"
-                            id="ordering_cutoff_minutes"
-                            name="ordering_cutoff_minutes"
-                            value="{{ old('ordering_cutoff_minutes', $tapaConfig->ordering_cutoff_minutes ?? 0) }}"
-                            min="0"
-                            max="120"
-                            aria-required="false"
-                            aria-describedby="error-ordering_cutoff_minutes"
-                            class="mt-1 block w-32 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                        >
-                        @error('ordering_cutoff_minutes')
-                            <p id="error-ordering_cutoff_minutes" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
-                        @enderror
+                    </div>
+                </section>
+
+                {{-- ══════════════════════════════════════════════════════════════ --}}
+                {{-- SECCIÓN 2 — Horarios de cocina                                --}}
+                {{-- ══════════════════════════════════════════════════════════════ --}}
+                <section aria-labelledby="section-kitchen-title"
+                         class="bg-white dark:bg-gray-800 shadow-sm rounded-xl overflow-hidden
+                                ring-1 ring-gray-200 dark:ring-gray-700">
+
+                    <div class="px-4 py-5 sm:px-6 border-b border-gray-200 dark:border-gray-700
+                                flex items-start gap-4">
+                        <div class="flex items-center justify-center h-10 w-10 rounded-lg
+                                    bg-orange-100 dark:bg-orange-900/40 shrink-0">
+                            <svg class="h-5 w-5 text-orange-600 dark:text-orange-400" aria-hidden="true"
+                                 fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                      d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10c0-2 .5-5 2.986-7C14 5 16.09 5.777 17.656 7.343A7.975 7.975 0 0120 13a7.975 7.975 0 01-2.343 5.657z"/>
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                      d="M9.879 16.121A3 3 0 1012.015 11L11 14H9c0 .768.293 1.536.879 2.121z"/>
+                            </svg>
+                        </div>
+                        <div>
+                            <h3 id="section-kitchen-title"
+                                class="text-base font-semibold text-gray-900 dark:text-gray-100">
+                                {{ __('Horario de la cocina') }}
+                            </h3>
+                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+                                {{ __('Tramos en los que la cocina está abierta (máx. 4). Fuera de estos tramos la carta solo mostrará bebidas. Sin tramos configurados la cocina se considera siempre disponible.') }}
+                            </p>
+                        </div>
                     </div>
 
-                    {{-- ══════════════════════════════════════════════════════ --}}
-                    {{-- SECCIÓN 2 — Horarios de cocina                        --}}
-                    {{-- ══════════════════════════════════════════════════════ --}}
-                    <section aria-labelledby="section-kitchen-title" class="border-t border-gray-200 dark:border-gray-700 mt-6 pt-6">
-                        <h3 id="section-kitchen-title" class="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">
-                            {{ __('¿Cuándo está abierta la cocina?') }}
-                        </h3>
-                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-4">
-                            {{ __('Añade los tramos en los que la cocina está abierta (máx. 4). Fuera de estos tramos la carta solo mostrará bebidas. Sin tramos configurados la cocina se considera siempre disponible.') }}
-                        </p>
+                    <div class="px-4 py-5 sm:px-6 space-y-4">
 
                         @error('kitchen_schedules')
-                            <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                            <p role="alert" class="text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                         @enderror
                         @error('kitchen_schedules.*.opens_at')
-                            <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                            <p role="alert" class="text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                         @enderror
                         @error('kitchen_schedules.*.closes_at')
-                            <p role="alert" class="mb-3 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                            <p role="alert" class="text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                         @enderror
 
-                        <div class="space-y-3 mb-4" role="list" aria-label="{{ __('Tramos horarios de cocina') }}">
+                        <div class="space-y-3" role="list" aria-label="{{ __('Tramos horarios de cocina') }}">
                             <template x-for="(slot, i) in kitchen_schedules" :key="i">
-                                <div class="flex items-end gap-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50 border border-gray-200 dark:border-gray-600"
+                                <div class="flex items-end gap-3 p-4 rounded-lg
+                                            bg-gray-50 dark:bg-gray-700/50
+                                            border border-gray-200 dark:border-gray-600"
                                      role="listitem">
                                     <div class="flex-1">
                                         <label :for="'kitchen_opens_at_' + i"
-                                               class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                                               class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                                             {{ __('Abre') }}
                                         </label>
                                         <input type="time"
@@ -189,11 +293,16 @@
                                                :name="'kitchen_schedules[' + i + '][opens_at]'"
                                                x-model="slot.opens_at"
                                                aria-required="true"
-                                               class="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                               class="block w-full h-10 rounded-lg border-gray-300
+                                                      dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100
+                                                      shadow-sm text-sm
+                                                      focus:outline-none focus:ring-2 focus:ring-indigo-500
+                                                      focus:border-indigo-500 focus:ring-offset-2
+                                                      dark:focus:ring-offset-gray-800">
                                     </div>
                                     <div class="flex-1">
                                         <label :for="'kitchen_closes_at_' + i"
-                                               class="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                                               class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                                             {{ __('Cierra') }}
                                         </label>
                                         <input type="time"
@@ -201,338 +310,458 @@
                                                :name="'kitchen_schedules[' + i + '][closes_at]'"
                                                x-model="slot.closes_at"
                                                aria-required="true"
-                                               class="block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+                                               class="block w-full h-10 rounded-lg border-gray-300
+                                                      dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100
+                                                      shadow-sm text-sm
+                                                      focus:outline-none focus:ring-2 focus:ring-indigo-500
+                                                      focus:border-indigo-500 focus:ring-offset-2
+                                                      dark:focus:ring-offset-gray-800">
                                     </div>
                                     <button type="button"
                                             @click="removeKitchenSchedule(i)"
                                             :aria-label="'Eliminar tramo de cocina ' + (i + 1)"
-                                            class="mb-0.5 flex-shrink-0 p-1.5 rounded-md text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20
-                                                   focus:outline-none focus:ring-2 focus:ring-red-500 transition-colors">
-                                        <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                                            class="shrink-0 p-2 rounded-lg text-red-500
+                                                   hover:bg-red-50 dark:hover:bg-red-900/20
+                                                   focus:outline-none focus:ring-2 focus:ring-red-500
+                                                   focus:ring-offset-2 dark:focus:ring-offset-gray-800
+                                                   transition-colors">
+                                        <svg aria-hidden="true" class="h-4 w-4" fill="none"
+                                             stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round"
+                                                  d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
                                         </svg>
                                     </button>
                                 </div>
                             </template>
                         </div>
 
+                        <div x-show="kitchen_schedules.length === 0"
+                             class="flex items-center gap-2 rounded-lg
+                                    bg-amber-50 dark:bg-amber-900/20
+                                    border border-amber-200 dark:border-amber-700
+                                    px-4 py-3">
+                            <svg class="h-4 w-4 text-amber-500 shrink-0" aria-hidden="true"
+                                 fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                      d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                            </svg>
+                            <p class="text-sm text-amber-700 dark:text-amber-400">
+                                {{ __('Sin tramos: la cocina se considera siempre disponible.') }}
+                            </p>
+                        </div>
+
                         <button type="button"
                                 @click="addKitchenSchedule()"
                                 :disabled="kitchen_schedules.length >= 4"
-                                class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium
-                                       border border-indigo-300 dark:border-indigo-600 text-indigo-700 dark:text-indigo-300
+                                class="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium
+                                       border border-indigo-300 dark:border-indigo-600
+                                       text-indigo-700 dark:text-indigo-300
                                        hover:bg-indigo-50 dark:hover:bg-indigo-900/20
-                                       focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-colors
-                                       disabled:opacity-40 disabled:cursor-not-allowed">
-                            <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
+                                       focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2
+                                       dark:focus:ring-offset-gray-800
+                                       disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                            <svg aria-hidden="true" class="h-4 w-4" fill="none"
+                                 stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
                             </svg>
                             {{ __('Añadir tramo') }}
                         </button>
 
-                        <p x-show="kitchen_schedules.length === 0"
-                           class="text-xs text-amber-600 dark:text-amber-400 mt-2">
-                            {{ __('Sin tramos: la cocina se considera siempre disponible.') }}
-                        </p>
-                    </section>
+                    </div>
+                </section>
 
-                    {{-- ══════════════════════════════════════════════════════ --}}
-                    {{-- SECCIÓN 3 — Tapas                                     --}}
-                    {{-- ══════════════════════════════════════════════════════ --}}
-                    <section aria-labelledby="section-tapas-title" class="border-t border-gray-200 dark:border-gray-700 mt-6 pt-6">
-                        <h3 id="section-tapas-title" class="text-base font-semibold text-gray-900 dark:text-gray-100 mb-4">
-                            {{ __('Sistema de tapas') }}
-                        </h3>
+                {{-- ══════════════════════════════════════════════════════════════ --}}
+                {{-- SECCIÓN 3 — Sistema de tapas                                   --}}
+                {{-- ══════════════════════════════════════════════════════════════ --}}
+                <section aria-labelledby="section-tapas-title"
+                         class="bg-white dark:bg-gray-800 shadow-sm rounded-xl overflow-hidden
+                                ring-1 ring-gray-200 dark:ring-gray-700">
 
-                        {{-- Activar tapas --}}
-                        <div class="flex items-center justify-between mb-6">
-                            <div>
-                                <label for="tapas_enabled_btn" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                    <div class="px-4 py-5 sm:px-6 border-b border-gray-200 dark:border-gray-700
+                                flex items-start gap-4">
+                        <div class="flex items-center justify-center h-10 w-10 rounded-lg
+                                    bg-amber-100 dark:bg-amber-900/40 shrink-0">
+                            <svg class="h-5 w-5 text-amber-600 dark:text-amber-400" aria-hidden="true"
+                                 fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                      d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z"/>
+                            </svg>
+                        </div>
+                        <div>
+                            <h3 id="section-tapas-title"
+                                class="text-base font-semibold text-gray-900 dark:text-gray-100">
+                                {{ __('Sistema de tapas') }}
+                            </h3>
+                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+                                {{ __('Permite ofrecer tapas a los clientes según las bebidas consumidas. Configura si son gratuitas, el precio y el número máximo de variantes.') }}
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="px-4 py-5 sm:px-6 space-y-6">
+
+                        {{-- Toggle: Activar tapas --}}
+                        <div class="flex items-start justify-between gap-4">
+                            <div class="flex-1">
+                                <label for="tapas_enabled_btn"
+                                       class="block text-sm font-medium text-gray-900 dark:text-gray-100">
                                     {{ __('Activar sistema de tapas') }}
                                 </label>
-                                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                                    {{ __('Cuando está activo, los clientes pueden elegir tapas según las bebidas consumidas.') }}
+                                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
+                                    {{ __('Los clientes podrán elegir tapas según las bebidas consumidas.') }}
                                 </p>
                             </div>
-                            <button
-                                id="tapas_enabled_btn"
-                                type="button"
-                                role="switch"
-                                :aria-checked="tapas_enabled.toString()"
-                                @click="tapas_enabled = !tapas_enabled"
-                                :class="tapas_enabled ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
-                                class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                            >
-                                <span
-                                    :class="tapas_enabled ? 'translate-x-6' : 'translate-x-1'"
-                                    class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform"
-                                ></span>
+                            <button id="tapas_enabled_btn"
+                                    type="button"
+                                    role="switch"
+                                    :aria-checked="tapas_enabled.toString()"
+                                    :aria-label="tapas_enabled ? 'Sistema de tapas activo, pulsa para desactivar' : 'Sistema de tapas inactivo, pulsa para activar'"
+                                    @click="tapas_enabled = !tapas_enabled"
+                                    :class="tapas_enabled ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+                                    class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full
+                                           transition-colors focus:outline-none focus:ring-2
+                                           focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 mt-0.5">
+                                <span :class="tapas_enabled ? 'translate-x-6' : 'translate-x-1'"
+                                      class="inline-block h-4 w-4 transform bg-white rounded-full
+                                             shadow transition-transform"></span>
                             </button>
                             <input type="hidden" name="tapas_enabled" :value="tapas_enabled ? '1' : '0'">
                         </div>
 
-                        <div x-show="tapas_enabled" x-transition class="space-y-6 border-t border-gray-200 dark:border-gray-700 pt-6">
+                        {{-- Sub-opciones (solo si tapas activas) --}}
+                        <div x-show="tapas_enabled" x-transition class="space-y-6">
 
-                            {{-- Gratuitas / de pago --}}
-                            <div class="flex items-center justify-between">
-                                <div>
-                                    <label for="tapas_free_btn" class="text-sm font-medium text-gray-700 dark:text-gray-300">
-                                        {{ __('Tapas gratuitas') }}
-                                    </label>
-                                    <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                                        {{ __('Desactiva para cobrar un precio fijo por tapa.') }}
-                                    </p>
-                                </div>
-                                <button
-                                    id="tapas_free_btn"
-                                    type="button"
-                                    role="switch"
-                                    :aria-checked="tapas_free.toString()"
-                                    @click="tapas_free = !tapas_free"
-                                    :class="tapas_free ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
-                                    class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                                >
-                                    <span
-                                        :class="tapas_free ? 'translate-x-6' : 'translate-x-1'"
-                                        class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform"
-                                    ></span>
-                                </button>
-                                <input type="hidden" name="tapas_free" :value="tapas_free ? '1' : '0'">
-                            </div>
+                            <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
 
-                            {{-- Modalidad de precio (solo si de pago) --}}
-                            <div x-show="!tapas_free" x-transition>
-                                <fieldset>
-                                    <legend class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                                        {{ __('Modalidad de precio') }}
-                                        <span aria-hidden="true" class="text-red-500 ml-0.5">*</span>
-                                    </legend>
-                                    <p id="price-mode-desc" class="text-xs text-gray-500 dark:text-gray-400 mb-3">
-                                        {{ __('Elige cómo se calcula el precio que ve el cliente para cada tapa.') }}
-                                    </p>
-                                    <div class="space-y-3" aria-describedby="price-mode-desc">
-                                        <label class="flex items-start gap-3 cursor-pointer">
-                                            <input
-                                                type="radio"
-                                                name="price_mode"
-                                                value="fixed"
-                                                x-model="price_mode"
-                                                class="mt-0.5 h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                                            >
-                                            <span>
-                                                <span class="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                                                    {{ __('Precio fijo para todas las tapas') }}
-                                                </span>
-                                                <span class="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                                                    {{ __('Configuras un único precio que aplica a todas las tapas del menú.') }}
-                                                </span>
-                                            </span>
+                                {{-- Toggle: Tapas gratuitas --}}
+                                <div class="flex items-start justify-between gap-4 mb-6">
+                                    <div class="flex-1">
+                                        <label for="tapas_free_btn"
+                                               class="block text-sm font-medium text-gray-900 dark:text-gray-100">
+                                            {{ __('Tapas gratuitas') }}
                                         </label>
-                                        <label class="flex items-start gap-3 cursor-pointer">
-                                            <input
-                                                type="radio"
-                                                name="price_mode"
-                                                value="per_product"
-                                                x-model="price_mode"
-                                                class="mt-0.5 h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                                            >
-                                            <span>
-                                                <span class="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                                                    {{ __('Precio individual por producto') }}
-                                                </span>
-                                                <span class="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                                                    {{ __('Cada tapa usa el precio configurado en su ficha de producto.') }}
-                                                </span>
-                                            </span>
-                                        </label>
+                                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
+                                            {{ __('Desactiva para cobrar un precio fijo por tapa.') }}
+                                        </p>
                                     </div>
-                                    @error('price_mode')
-                                        <p id="error-price_mode" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
-                                    @enderror
-                                </fieldset>
-                            </div>
+                                    <button id="tapas_free_btn"
+                                            type="button"
+                                            role="switch"
+                                            :aria-checked="tapas_free.toString()"
+                                            :aria-label="tapas_free ? 'Tapas gratuitas, pulsa para cobrar' : 'Tapas de pago, pulsa para hacerlas gratuitas'"
+                                            @click="tapas_free = !tapas_free"
+                                            :class="tapas_free ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+                                            class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full
+                                                   transition-colors focus:outline-none focus:ring-2
+                                                   focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 mt-0.5">
+                                        <span :class="tapas_free ? 'translate-x-6' : 'translate-x-1'"
+                                              class="inline-block h-4 w-4 transform bg-white rounded-full
+                                                     shadow transition-transform"></span>
+                                    </button>
+                                    <input type="hidden" name="tapas_free" :value="tapas_free ? '1' : '0'">
+                                </div>
 
-                            {{-- Precio fijo global --}}
-                            <div x-show="!tapas_free && price_mode === 'fixed'" x-transition>
-                                <label for="tapa_price" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                                    {{ __('Precio fijo por tapa (€)') }}
-                                    <span aria-hidden="true" class="text-red-500 ml-0.5">*</span>
-                                </label>
-                                <input
-                                    type="number"
-                                    id="tapa_price"
-                                    name="tapa_price"
-                                    value="{{ old('tapa_price', $tapaConfig->tapa_price) }}"
-                                    min="0"
-                                    max="999.99"
-                                    step="0.01"
-                                    aria-required="true"
-                                    aria-describedby="error-tapa_price"
-                                    class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                                    placeholder="0.00"
-                                >
-                                @error('tapa_price')
-                                    <p id="error-tapa_price" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
-                                @enderror
-                            </div>
+                                {{-- Modalidad de precio (solo si de pago) --}}
+                                <div x-show="!tapas_free" x-transition>
+                                    <fieldset>
+                                        <legend class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                            {{ __('Modalidad de precio') }}
+                                            <span aria-hidden="true" class="text-red-500 ml-0.5">*</span>
+                                            <span class="sr-only">(obligatorio)</span>
+                                        </legend>
+                                        <p id="price-mode-desc" class="text-sm text-gray-500 dark:text-gray-400
+                                                                        leading-relaxed mb-4">
+                                            {{ __('Elige cómo se calcula el precio que ve el cliente para cada tapa.') }}
+                                        </p>
+                                        <div class="space-y-3" aria-describedby="price-mode-desc">
+                                            <label class="flex items-start gap-3 cursor-pointer group">
+                                                <input type="radio"
+                                                       name="price_mode"
+                                                       value="fixed"
+                                                       x-model="price_mode"
+                                                       class="mt-0.5 h-4 w-4 border-gray-300 text-indigo-600
+                                                              focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2
+                                                              dark:focus:ring-offset-gray-800">
+                                                <span>
+                                                    <span class="block text-sm font-medium text-gray-900 dark:text-gray-100
+                                                                 group-hover:text-indigo-700 dark:group-hover:text-indigo-300 transition-colors">
+                                                        {{ __('Precio fijo para todas las tapas') }}
+                                                    </span>
+                                                    <span class="block text-sm text-gray-500 dark:text-gray-400 mt-0.5 leading-relaxed">
+                                                        {{ __('Configuras un único precio que aplica a todas las tapas del menú.') }}
+                                                    </span>
+                                                </span>
+                                            </label>
+                                            <label class="flex items-start gap-3 cursor-pointer group">
+                                                <input type="radio"
+                                                       name="price_mode"
+                                                       value="per_product"
+                                                       x-model="price_mode"
+                                                       class="mt-0.5 h-4 w-4 border-gray-300 text-indigo-600
+                                                              focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2
+                                                              dark:focus:ring-offset-gray-800">
+                                                <span>
+                                                    <span class="block text-sm font-medium text-gray-900 dark:text-gray-100
+                                                                 group-hover:text-indigo-700 dark:group-hover:text-indigo-300 transition-colors">
+                                                        {{ __('Precio individual por producto') }}
+                                                    </span>
+                                                    <span class="block text-sm text-gray-500 dark:text-gray-400 mt-0.5 leading-relaxed">
+                                                        {{ __('Cada tapa usa el precio configurado en su ficha de producto.') }}
+                                                    </span>
+                                                </span>
+                                            </label>
+                                        </div>
+                                        @error('price_mode')
+                                            <p id="error-price_mode" role="alert"
+                                               class="mt-2 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                                        @enderror
+                                    </fieldset>
 
-                            {{-- Aviso precio por producto --}}
-                            <div x-show="!tapas_free && price_mode === 'per_product'" x-transition>
-                                <p class="text-sm text-indigo-700 dark:text-indigo-300 bg-indigo-50 dark:bg-indigo-900/20 rounded-md px-3 py-2">
-                                    {{ __('El precio de cada tapa se configura en la ficha del producto dentro de la categoría "Tapas".') }}
-                                </p>
+                                    {{-- Precio fijo global --}}
+                                    <div x-show="price_mode === 'fixed'" x-transition class="mt-5">
+                                        <label for="tapa_price"
+                                               class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                            {{ __('Precio fijo por tapa (€)') }}
+                                            <span aria-hidden="true" class="text-red-500 ml-0.5">*</span>
+                                        </label>
+                                        <input type="number"
+                                               id="tapa_price"
+                                               name="tapa_price"
+                                               value="{{ old('tapa_price', $tapaConfig->tapa_price) }}"
+                                               min="0" max="999.99" step="0.01"
+                                               aria-required="true"
+                                               aria-describedby="error-tapa_price"
+                                               placeholder="0.00"
+                                               class="block w-40 h-10 rounded-lg border-gray-300
+                                                      dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100
+                                                      shadow-sm text-sm
+                                                      focus:outline-none focus:ring-2 focus:ring-indigo-500
+                                                      focus:border-indigo-500 focus:ring-offset-2
+                                                      dark:focus:ring-offset-gray-800">
+                                        @error('tapa_price')
+                                            <p id="error-tapa_price" role="alert"
+                                               class="mt-1.5 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                                        @enderror
+                                    </div>
+
+                                    {{-- Aviso precio por producto --}}
+                                    <div x-show="price_mode === 'per_product'" x-transition class="mt-4">
+                                        <div class="flex items-start gap-3 rounded-lg
+                                                    bg-indigo-50 dark:bg-indigo-900/20
+                                                    border border-indigo-200 dark:border-indigo-700
+                                                    px-4 py-3">
+                                            <svg class="h-4 w-4 text-indigo-500 shrink-0 mt-0.5" aria-hidden="true"
+                                                 fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                      d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                                            </svg>
+                                            <p class="text-sm text-indigo-700 dark:text-indigo-300 leading-relaxed">
+                                                {{ __('El precio de cada tapa se configura en la ficha del producto dentro de la categoría «Tapas».') }}
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+
                             </div>
 
                             {{-- Tapa extra --}}
                             <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
-                                <div class="flex items-center justify-between mb-4">
-                                    <div>
-                                        <label for="extra_tapa_enabled_btn" class="text-sm font-medium text-gray-700 dark:text-gray-300">
+
+                                <div class="flex items-start justify-between gap-4 mb-5">
+                                    <div class="flex-1">
+                                        <label for="extra_tapa_enabled_btn"
+                                               class="block text-sm font-medium text-gray-900 dark:text-gray-100">
                                             {{ __('Permitir tapa extra de pago') }}
                                         </label>
-                                        <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
                                             {{ __('El cliente puede pedir una tapa adicional con precio fijo aunque las tapas base sean gratuitas. No consume variante del límite.') }}
                                         </p>
                                     </div>
-                                    <button
-                                        id="extra_tapa_enabled_btn"
-                                        type="button"
-                                        role="switch"
-                                        :aria-checked="extra_tapa_enabled.toString()"
-                                        @click="extra_tapa_enabled = !extra_tapa_enabled"
-                                        :class="extra_tapa_enabled ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
-                                        class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                                    >
-                                        <span
-                                            :class="extra_tapa_enabled ? 'translate-x-6' : 'translate-x-1'"
-                                            class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform"
-                                        ></span>
+                                    <button id="extra_tapa_enabled_btn"
+                                            type="button"
+                                            role="switch"
+                                            :aria-checked="extra_tapa_enabled.toString()"
+                                            :aria-label="extra_tapa_enabled ? 'Tapa extra activa, pulsa para desactivar' : 'Tapa extra inactiva, pulsa para activar'"
+                                            @click="extra_tapa_enabled = !extra_tapa_enabled"
+                                            :class="extra_tapa_enabled ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+                                            class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full
+                                                   transition-colors focus:outline-none focus:ring-2
+                                                   focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 mt-0.5">
+                                        <span :class="extra_tapa_enabled ? 'translate-x-6' : 'translate-x-1'"
+                                              class="inline-block h-4 w-4 transform bg-white rounded-full
+                                                     shadow transition-transform"></span>
                                     </button>
                                     <input type="hidden" name="extra_tapa_enabled" :value="extra_tapa_enabled ? '1' : '0'">
                                 </div>
 
                                 <div x-show="extra_tapa_enabled" x-transition>
-                                    <label for="extra_tapa_price" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                    <label for="extra_tapa_price"
+                                           class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                                         {{ __('Precio de la tapa extra (€)') }}
                                         <span aria-hidden="true" class="text-red-500 ml-0.5">*</span>
                                     </label>
-                                    <input
-                                        type="number"
-                                        id="extra_tapa_price"
-                                        name="extra_tapa_price"
-                                        value="{{ old('extra_tapa_price', $tapaConfig->extra_tapa_price) }}"
-                                        min="0"
-                                        max="999.99"
-                                        step="0.01"
-                                        aria-required="true"
-                                        aria-describedby="error-extra_tapa_price"
-                                        class="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                                        placeholder="0.00"
-                                    >
+                                    <input type="number"
+                                           id="extra_tapa_price"
+                                           name="extra_tapa_price"
+                                           value="{{ old('extra_tapa_price', $tapaConfig->extra_tapa_price) }}"
+                                           min="0" max="999.99" step="0.01"
+                                           aria-required="true"
+                                           aria-describedby="error-extra_tapa_price"
+                                           placeholder="0.00"
+                                           class="block w-40 h-10 rounded-lg border-gray-300
+                                                  dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100
+                                                  shadow-sm text-sm
+                                                  focus:outline-none focus:ring-2 focus:ring-indigo-500
+                                                  focus:border-indigo-500 focus:ring-offset-2
+                                                  dark:focus:ring-offset-gray-800">
                                     @error('extra_tapa_price')
-                                        <p id="error-extra_tapa_price" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                                        <p id="error-extra_tapa_price" role="alert"
+                                           class="mt-1.5 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                                     @enderror
                                 </div>
                             </div>
 
                             {{-- Máximo de variantes --}}
                             <div class="border-t border-gray-200 dark:border-gray-700 pt-6">
-                                <label for="max_tapa_variants" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                                    {{ __('Máximo de variantes de tapa por mesa') }}
+                                <label for="max_tapa_variants"
+                                       class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                                    {{ __('Máximo de variantes por mesa') }}
                                 </label>
-                                <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
-                                    {{ __('Número máximo de tapas distintas que se pueden elegir en los pedidos activos de una mesa (ej. 3 significa que pueden elegir hasta 3 tapas diferentes).') }}
+                                <p class="text-sm text-gray-500 dark:text-gray-400 leading-relaxed mb-3">
+                                    {{ __('Número máximo de tapas distintas que se pueden elegir en los pedidos activos de una mesa.') }}
                                 </p>
-                                <input
-                                    type="number"
-                                    id="max_tapa_variants"
-                                    name="max_tapa_variants"
-                                    value="{{ old('max_tapa_variants', $tapaConfig->max_tapa_variants) }}"
-                                    min="1"
-                                    max="20"
-                                    aria-required="true"
-                                    aria-describedby="error-max_tapa_variants"
-                                    class="mt-1 block w-32 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                                >
+                                <input type="number"
+                                       id="max_tapa_variants"
+                                       name="max_tapa_variants"
+                                       value="{{ old('max_tapa_variants', $tapaConfig->max_tapa_variants) }}"
+                                       min="1" max="20"
+                                       aria-required="true"
+                                       aria-describedby="error-max_tapa_variants"
+                                       class="block w-32 h-10 rounded-lg border-gray-300
+                                              dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100
+                                              shadow-sm text-sm
+                                              focus:outline-none focus:ring-2 focus:ring-indigo-500
+                                              focus:border-indigo-500 focus:ring-offset-2
+                                              dark:focus:ring-offset-gray-800">
                                 @error('max_tapa_variants')
-                                    <p id="error-max_tapa_variants" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                                    <p id="error-max_tapa_variants" role="alert"
+                                       class="mt-1.5 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                                 @enderror
                             </div>
 
                         </div>
+                    </div>
+                </section>
 
-                    </section>
+                {{-- ══════════════════════════════════════════════════════════════ --}}
+                {{-- SECCIÓN 4 — Cobro partido                                      --}}
+                {{-- ══════════════════════════════════════════════════════════════ --}}
+                <section aria-labelledby="section-split-title"
+                         class="bg-white dark:bg-gray-800 shadow-sm rounded-xl overflow-hidden
+                                ring-1 ring-gray-200 dark:ring-gray-700">
 
-                    {{-- ════════════════════════════════════════════ --}}
-                    {{-- SECCIÓN: Cobro partido                     --}}
-                    {{-- ════════════════════════════════════════════ --}}
-                    <section aria-labelledby="split-payment-heading" class="pt-8 border-t border-gray-200 dark:border-gray-700">
-                        <h3 id="split-payment-heading" class="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">
-                            {{ __('Cobro partido') }}
-                        </h3>
-                        <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">
-                            {{ __('Permite a los clientes dividir la cuenta entre varios comensales desde la carta digital.') }}
-                        </p>
+                    <div class="px-4 py-5 sm:px-6 border-b border-gray-200 dark:border-gray-700
+                                flex items-start gap-4">
+                        <div class="flex items-center justify-center h-10 w-10 rounded-lg
+                                    bg-emerald-100 dark:bg-emerald-900/40 shrink-0">
+                            <svg class="h-5 w-5 text-emerald-600 dark:text-emerald-400" aria-hidden="true"
+                                 fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                      d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/>
+                            </svg>
+                        </div>
+                        <div>
+                            <h3 id="section-split-title"
+                                class="text-base font-semibold text-gray-900 dark:text-gray-100">
+                                {{ __('Cobro partido') }}
+                            </h3>
+                            <p class="mt-1 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+                                {{ __('Permite a los clientes dividir la cuenta entre varios comensales directamente desde la carta digital.') }}
+                            </p>
+                        </div>
+                    </div>
+
+                    <div class="px-4 py-5 sm:px-6 space-y-5">
 
                         {{-- Toggle --}}
-                        <div class="flex items-center justify-between mb-4">
-                            <label for="split_enabled_btn" class="text-sm font-medium text-gray-700 dark:text-gray-300">
-                                {{ __('Activar cobro partido') }}
-                            </label>
-                            <button
-                                id="split_enabled_btn"
-                                type="button"
-                                role="switch"
-                                :aria-checked="split_enabled.toString()"
-                                @click="split_enabled = !split_enabled"
-                                :class="split_enabled ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
-                                class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-                            >
-                                <span
-                                    :class="split_enabled ? 'translate-x-6' : 'translate-x-1'"
-                                    class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform"
-                                ></span>
+                        <div class="flex items-start justify-between gap-4">
+                            <div class="flex-1">
+                                <label for="split_enabled_btn"
+                                       class="block text-sm font-medium text-gray-900 dark:text-gray-100">
+                                    {{ __('Activar cobro partido') }}
+                                </label>
+                                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
+                                    {{ __('Los clientes podrán dividir la cuenta por ítems o en partes iguales.') }}
+                                </p>
+                            </div>
+                            <button id="split_enabled_btn"
+                                    type="button"
+                                    role="switch"
+                                    :aria-checked="split_enabled.toString()"
+                                    :aria-label="split_enabled ? 'Cobro partido activo, pulsa para desactivar' : 'Cobro partido inactivo, pulsa para activar'"
+                                    @click="split_enabled = !split_enabled"
+                                    :class="split_enabled ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+                                    class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full
+                                           transition-colors focus:outline-none focus:ring-2
+                                           focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 mt-0.5">
+                                <span :class="split_enabled ? 'translate-x-6' : 'translate-x-1'"
+                                      class="inline-block h-4 w-4 transform bg-white rounded-full
+                                             shadow transition-transform"></span>
                             </button>
                             <input type="hidden" name="split_payment_enabled" :value="split_enabled ? '1' : '0'">
                         </div>
 
-                        {{-- Máximo de partes (visible solo si activo) --}}
+                        {{-- Máximo de partes --}}
                         <div x-show="split_enabled" x-transition>
-                            <label for="split_payment_max_parts" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            <label for="split_payment_max_parts"
+                                   class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                                 {{ __('Máximo de partes por mesa') }}
                             </label>
-                            <p id="max-parts-desc" class="text-xs text-gray-500 dark:text-gray-400 mb-2">
+                            <p id="max-parts-desc" class="text-sm text-gray-500 dark:text-gray-400 leading-relaxed mb-3">
                                 {{ __('Deja vacío para no limitar el número de partes en que se puede dividir la cuenta.') }}
                             </p>
-                            <input
-                                type="number"
-                                id="split_payment_max_parts"
-                                name="split_payment_max_parts"
-                                value="{{ old('split_payment_max_parts', auth()->user()->split_payment_max_parts > 0 ? auth()->user()->split_payment_max_parts : '') }}"
-                                min="2"
-                                max="20"
-                                :disabled="!split_enabled"
-                                aria-describedby="max-parts-desc error-split_payment_max_parts"
-                                class="mt-1 block w-32 rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed"
-                                placeholder="{{ __('Sin límite') }}"
-                            >
+                            <input type="number"
+                                   id="split_payment_max_parts"
+                                   name="split_payment_max_parts"
+                                   value="{{ old('split_payment_max_parts', auth()->user()->split_payment_max_parts > 0 ? auth()->user()->split_payment_max_parts : '') }}"
+                                   min="2" max="20"
+                                   :disabled="!split_enabled"
+                                   aria-describedby="max-parts-desc error-split_payment_max_parts"
+                                   placeholder="{{ __('Sin límite') }}"
+                                   class="block w-40 h-10 rounded-lg border-gray-300
+                                          dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100
+                                          shadow-sm text-sm
+                                          focus:outline-none focus:ring-2 focus:ring-indigo-500
+                                          focus:border-indigo-500 focus:ring-offset-2
+                                          dark:focus:ring-offset-gray-800
+                                          disabled:opacity-50 disabled:cursor-not-allowed">
                             @error('split_payment_max_parts')
-                                <p id="error-split_payment_max_parts" role="alert" class="mt-1 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
+                                <p id="error-split_payment_max_parts" role="alert"
+                                   class="mt-1.5 text-sm text-red-600 dark:text-red-400">{{ $message }}</p>
                             @enderror
                         </div>
-                    </section>
 
-                    <div class="mt-8 flex justify-end">
-                        <button
-                            type="submit"
-                            class="inline-flex items-center px-5 py-2 bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 text-white text-sm font-medium rounded-md transition-colors"
-                        >
-                            {{ __('Guardar configuración') }}
-                        </button>
                     </div>
+                </section>
 
-                </form>
-            </div>
+                {{-- ─── ACCIÓN ─── --}}
+                <div class="flex justify-end pb-4">
+                    <button type="submit"
+                            class="inline-flex items-center justify-center gap-2 rounded-lg
+                                   bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm
+                                   hover:bg-indigo-500 active:bg-indigo-700
+                                   focus:outline-none focus:ring-2 focus:ring-indigo-500
+                                   focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition duration-150">
+                        <svg class="h-4 w-4 shrink-0" aria-hidden="true"
+                             fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5"
+                                  d="M5 13l4 4L19 7"/>
+                        </svg>
+                        <span>{{ __('Guardar configuración') }}</span>
+                    </button>
+                </div>
+
+            </form>
 
         </div>
     </div>

--- a/resources/views/negocio/config.blade.php
+++ b/resources/views/negocio/config.blade.php
@@ -44,6 +44,56 @@
                 </div>
             @endif
 
+            {{-- ─── RESUMEN DE CAMBIOS GUARDADOS ─── --}}
+            @if(session('success') && session('success') !== 'Sin cambios detectados.')
+            @php
+                $savedParts = array_filter(array_map('trim', explode('·', session('success'))));
+            @endphp
+            <div x-data="{ open: true }"
+                 x-show="open"
+                 x-transition:leave="transition ease-in duration-150"
+                 x-transition:leave-start="opacity-100"
+                 x-transition:leave-end="opacity-0"
+                 class="rounded-xl border border-emerald-200 dark:border-emerald-700
+                        bg-emerald-50 dark:bg-emerald-900/20
+                        px-4 py-4 flex items-start gap-4"
+                 role="status" aria-live="polite">
+                <div class="flex items-center justify-center h-9 w-9 rounded-full
+                            bg-emerald-100 dark:bg-emerald-800/50 shrink-0">
+                    <svg class="h-5 w-5 text-emerald-600 dark:text-emerald-400" aria-hidden="true"
+                         fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+                    </svg>
+                </div>
+                <div class="flex-1 min-w-0">
+                    <p class="text-sm font-semibold text-emerald-800 dark:text-emerald-300">
+                        Cambios guardados correctamente
+                    </p>
+                    <ul class="mt-2 space-y-1">
+                        @foreach($savedParts as $part)
+                            <li class="flex items-center gap-2 text-sm text-emerald-700 dark:text-emerald-400">
+                                <svg class="h-3.5 w-3.5 shrink-0 text-emerald-500" aria-hidden="true"
+                                     fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+                                </svg>
+                                {{ $part }}
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+                <button @click="open = false"
+                        aria-label="Cerrar resumen de cambios"
+                        class="shrink-0 text-emerald-400 hover:text-emerald-600 dark:hover:text-emerald-200
+                               focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2
+                               dark:focus:ring-offset-gray-900 rounded-md p-1 transition-colors">
+                    <svg class="h-4 w-4" aria-hidden="true" fill="none" stroke="currentColor"
+                         stroke-width="2" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                    </svg>
+                </button>
+            </div>
+            @endif
+
             @php
                 $kitchenSchedulesForAlpine = $tapaConfig->kitchenSchedules->map(function ($s) {
                     return ['opens_at' => substr($s->opens_at, 0, 5), 'closes_at' => substr($s->closes_at, 0, 5)];

--- a/resources/views/negocio/config.blade.php
+++ b/resources/views/negocio/config.blade.php
@@ -67,7 +67,8 @@
             <script id="config-init" type="application/json">@json($configInit)</script>
 
             <form method="POST" action="{{ route('negocio.config.update') }}"
-                  x-data="businessConfig()">
+                  x-data="businessConfig()"
+                  class="space-y-6">
                 @csrf
                 @method('PUT')
 

--- a/resources/views/negocio/config.blade.php
+++ b/resources/views/negocio/config.blade.php
@@ -531,6 +531,7 @@
                                                value="{{ old('tapa_price', $tapaConfig->tapa_price) }}"
                                                min="0" max="999.99" step="0.01"
                                                aria-required="true"
+                                               :disabled="tapas_free || price_mode !== 'fixed'"
                                                aria-describedby="error-tapa_price"
                                                placeholder="0.00"
                                                class="block w-40 h-10 rounded-lg border-gray-300
@@ -609,6 +610,7 @@
                                            aria-required="true"
                                            aria-describedby="error-extra_tapa_price"
                                            placeholder="0.00"
+                                           :disabled="!extra_tapa_enabled"
                                            class="block w-40 h-10 rounded-lg border-gray-300
                                                   dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100
                                                   shadow-sm text-sm


### PR DESCRIPTION
## Summary

- Rediseño completo de `/negocio/configuracion`: cada sección en su propia tarjeta con icono badge, tipografía accesible y focus rings completos
- Detección de cambios por sección en `TapasController` — el mensaje de guardado indica exactamente qué se modificó (horario del negocio, cocina, tapas, cobro partido)
- Banner inline verde encima del primer bloque que lista los cambios guardados, con botón de cierre
- Toast flotante rediseñado con lista de cambios y auto-dismiss a los 5 s
- Fix: `PreserveFlashForAjax` middleware evita que el badge polling consuma el flash antes de que la página lo lea
- Fix: `x-toast` y CSS `x-cloak` añadidos al layout de `main`
- Fix: `:disabled` en inputs de precio de tapas cuando están ocultos, evita error `required_if`
- Fix: eliminado `required_if` en `extra_tapa_price` para permitir guardar con precio vacío

## Test plan

- [ ] Cambiar solo horarios del negocio → banner muestra "Horario del negocio actualizado"
- [ ] Cambiar tapas y cobro partido → banner lista ambas secciones
- [ ] Sin cambios → no aparece banner, toast dice "Sin cambios detectados."
- [ ] Toast desaparece a los 5 s
- [ ] Banner persiste hasta pulsar X
- [ ] Activar tapa extra sin precio → no aparece error de validación
- [ ] Guardar con tapas desactivadas → no aparece error de precio