### PR TITLE
[perf] optimización de rendimiento — N+1, índices y caché

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,33 @@ php artisan make:factory NombreFactory --model=Nombre
 
 ---
 
+## Despliegue en producción
+
+Ejecutar estos comandos después de cada deploy para activar las optimizaciones de rendimiento de Laravel:
+
+```bash
+# Compilar assets
+npm run build
+
+# Cachés de framework (mejoran el arranque en producción)
+php artisan optimize
+php artisan config:cache
+php artisan route:cache
+php artisan view:cache
+php artisan event:cache
+
+# Migraciones
+php artisan migrate --force
+```
+
+Para limpiar todas las cachés durante el desarrollo o tras un deploy fallido:
+
+```bash
+php artisan optimize:clear
+```
+
+---
+
 ## Progreso del desarrollo
 
 **Progreso global: 89%** (63/71 sub-bloques completados)

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -6,6 +6,7 @@ use App\Models\Category;
 use App\Models\TapaConfig;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\View\View;
 use Illuminate\Http\RedirectResponse;
 
@@ -60,6 +61,7 @@ class CategoryController extends Controller
         // 2. Crear la categoría bajo el propietario del restaurante
         $ownerId = Auth::user()->ownerUserId();
         Category::create(array_merge($validated, ['user_id' => $ownerId]));
+        Cache::forget("menu:{$ownerId}");
 
         // 3. Redirigir al listado con mensaje de éxito
         return redirect()->route('categories.index')->with('success', 'Categoría creada correctamente.');
@@ -115,6 +117,7 @@ class CategoryController extends Controller
         }
 
         $category->update($validated);
+        Cache::forget("menu:{$category->user_id}");
 
         return redirect()->route('categories.index')->with('success', '¡Categoría actualizada correctamente!');
     }
@@ -137,7 +140,9 @@ class CategoryController extends Controller
             }
         }
 
+        $userId = $category->user_id;
         $category->delete();
+        Cache::forget("menu:{$userId}");
 
         return redirect()->route('categories.index')->with('success', 'Categoría eliminada.');
     }

--- a/app/Http/Controllers/IngredientController.php
+++ b/app/Http/Controllers/IngredientController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Ingredient;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Validation\Rule;
 
 /**
@@ -58,6 +59,7 @@ class IngredientController extends Controller
 
         $ownerId = Auth::user()->ownerUserId();
         Ingredient::create(array_merge($validated, ['user_id' => $ownerId]));
+        Cache::forget("menu:{$ownerId}");
 
         return redirect()->route('ingredients.index')->with('success', 'Ingrediente creado correctamente.');
     }
@@ -101,6 +103,7 @@ class IngredientController extends Controller
         ]);
 
         $ingredient->update($validated);
+        Cache::forget("menu:{$ingredient->user_id}");
 
         return redirect()->route('ingredients.index')->with('success', 'Ingrediente actualizado correctamente.');
     }
@@ -115,7 +118,9 @@ class IngredientController extends Controller
     {
         abort_if($ingredient->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
+        $userId = $ingredient->user_id;
         $ingredient->delete();
+        Cache::forget("menu:{$userId}");
 
         return redirect()->route('ingredients.index')->with('success', 'Ingrediente eliminado correctamente.');
     }

--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -62,7 +62,10 @@ class KitchenController extends Controller
     {
         abort_if(! Auth::user()->canAccessKitchen(), 403, 'Acceso denegado.');
 
-        $orders = $this->getActiveOrders()
+        $rawOrders    = $this->getActiveOrders();
+        $pendingCount = $rawOrders->where('status', 'pending')->count();
+
+        $orders = $rawOrders
             ->map(fn(Order $order) => [
                 'id'         => $order->id,
                 'table_name' => $order->table->name,
@@ -84,11 +87,6 @@ class KitchenController extends Controller
             ])
             ->filter(fn($order) => count($order['items']) > 0)
             ->values();
-
-        $ownerId      = Auth::user()->ownerUserId();
-        $pendingCount = Order::whereHas('table', fn($q) => $q->where('user_id', $ownerId))
-            ->where('status', 'pending')
-            ->count();
 
         return response()->json([
             'orders'        => $orders,

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -6,6 +6,7 @@ use App\Models\Category;
 use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\Table;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\View\View;
 
 /**
@@ -29,12 +30,11 @@ class MenuController extends Controller
      */
     public function show(string $hash): View
     {
-        $table  = Table::where('unique_hash', $hash)->where('is_service_point', true)->firstOrFail();
+        $table = Table::where('unique_hash', $hash)
+            ->where('is_service_point', true)
+            ->with(['user.tapaConfig.kitchenSchedules', 'user.tapaConfig.businessSchedules'])
+            ->firstOrFail();
         $config = $table->user->tapaConfig;
-
-        if ($config) {
-            $config->load(['kitchenSchedules', 'businessSchedules']);
-        }
 
         $businessOpen           = ! $config || $config->isBusinessOpen();
         $orderingAllowed        = ! $config || $config->isOrderingAllowed();
@@ -44,30 +44,35 @@ class MenuController extends Controller
         $kitchenOpen     = ! $config || $config->isKitchenOpen();
         $nextOpeningTime = ($config && ! $kitchenOpen) ? $config->nextOpeningTime() : null;
 
-        $categories = Category::where('user_id', $table->user_id)
-            ->when(! $kitchenOpen, fn ($q) => $q->where('destination', 'bar'))
-            ->when($config && $config->tapas_enabled, fn ($q) => $q->where('name', '!=', 'Tapas'))
-            ->with([
-                'products' => function ($query) {
-                    $query->where('is_active', true)
-                          ->with([
-                              'ingredients' => function ($q) {
-                                  $q->withPivot(['is_removable', 'is_extra', 'extra_price'])
-                                    ->select([
-                                        'ingredients.id',
-                                        'ingredients.name',
-                                        'ingredients.is_allergen',
-                                        'ingredients.allergen_type',
-                                    ]);
-                              },
-                              'variants',
-                          ])
-                          ->orderBy('name');
-                },
-            ])
-            ->orderBy('name')
-            ->get()
-            ->filter(fn ($category) => $category->products->isNotEmpty());
+        $allCategories = Cache::remember("menu:{$table->user_id}", 300, function () use ($table) {
+            return Category::where('user_id', $table->user_id)
+                ->with([
+                    'products' => function ($query) {
+                        $query->where('is_active', true)
+                              ->with([
+                                  'ingredients' => function ($q) {
+                                      $q->withPivot(['is_removable', 'is_extra', 'extra_price'])
+                                        ->select([
+                                            'ingredients.id',
+                                            'ingredients.name',
+                                            'ingredients.is_allergen',
+                                            'ingredients.allergen_type',
+                                        ]);
+                                  },
+                                  'variants',
+                              ])
+                              ->orderBy('name');
+                    },
+                ])
+                ->orderBy('name')
+                ->get();
+        });
+
+        $categories = $allCategories
+            ->filter(fn ($cat) => $kitchenOpen || $cat->destination === 'bar')
+            ->filter(fn ($cat) => ! ($config && $config->tapas_enabled) || $cat->name !== 'Tapas')
+            ->filter(fn ($cat) => $cat->products->isNotEmpty())
+            ->values();
 
         $allergens = $categories
             ->flatMap(fn ($c) => $c->products)

--- a/app/Http/Controllers/NotificationController.php
+++ b/app/Http/Controllers/NotificationController.php
@@ -26,21 +26,28 @@ class NotificationController extends Controller
      */
     public function ready(Request $request): JsonResponse
     {
-        $orders = Order::with(['table', 'items.product.category'])
+        $orders = Order::with([
+                'table:id,name',
+                'items' => fn($q) => $q
+                    ->where('destination', 'kitchen')
+                    ->select(['id', 'order_id', 'destination', 'quantity', 'product_id'])
+                    ->with([
+                        'product:id,name,category_id',
+                        'product.category:id,name',
+                    ]),
+            ])
+            ->select(['id', 'table_id', 'notification_ready'])
             ->where('notification_ready', true)
             ->whereHas('table', fn($q) => $q->where('user_id', Auth::user()->ownerUserId()))
             ->get()
             ->map(fn(Order $order) => [
                 'id'    => $order->id,
                 'table' => $order->table->name,
-                'items' => $order->items
-                    ->where('destination', 'kitchen')
-                    ->map(fn($item) => [
-                        'name'     => $item->product->name,
-                        'quantity' => $item->quantity,
-                        'is_tapa'  => $item->product->category?->name === 'Tapas',
-                    ])
-                    ->values(),
+                'items' => $order->items->map(fn($item) => [
+                    'name'     => $item->product->name,
+                    'quantity' => $item->quantity,
+                    'is_tapa'  => $item->product->category?->name === 'Tapas',
+                ])->values(),
             ])
             ->values();
 

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -11,6 +11,7 @@ use App\Models\Ingredient;
 use Illuminate\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
@@ -106,6 +107,8 @@ class ProductController extends Controller
         ->with('success', '¡Plato creado! Ahora configura sus ingredientes.');
     }
 
+    Cache::forget("menu:{$validatedData['user_id']}");
+
     return redirect()
       ->route('products.index')
       ->with('success', '¡Plato creado con éxito en la carta digital!');
@@ -199,6 +202,8 @@ class ProductController extends Controller
             }
         });
 
+        Cache::forget("menu:{$product->user_id}");
+
         return redirect()->route('products.index')->with('success', '¡Plato actualizado correctamente!');
 
     }
@@ -221,7 +226,9 @@ class ProductController extends Controller
 
         abort_if($product->user_id !== Auth::user()->ownerUserId(), 403);
 
+        $userId = $product->user_id;
         $product->delete();
+        Cache::forget("menu:{$userId}");
 
         return redirect()->route('products.index')->with('success', 'Plato retirado de la carta.');
 
@@ -272,6 +279,7 @@ class ProductController extends Controller
         );
 
         $product->ingredients()->sync($formatted);
+        Cache::forget("menu:{$product->user_id}");
 
         return redirect()
             ->route('products.edit', $product)

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -101,13 +101,13 @@ class ProductController extends Controller
       return $product;
     });
 
+    Cache::forget("menu:{$validatedData['user_id']}");
+
     if ($request->boolean('configure_ingredients')) {
       return redirect()
         ->route('products.ingredients.edit', $product)
         ->with('success', '¡Plato creado! Ahora configura sus ingredientes.');
     }
-
-    Cache::forget("menu:{$validatedData['user_id']}");
 
     return redirect()
       ->route('products.index')

--- a/app/Http/Controllers/TapasController.php
+++ b/app/Http/Controllers/TapasController.php
@@ -7,6 +7,7 @@ use App\Models\TapaConfig;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Validation\Rule;
 use Illuminate\View\View;
 
@@ -190,6 +191,8 @@ class TapasController extends Controller
             'split_payment_enabled'   => $splitEnabled,
             'split_payment_max_parts' => $newMaxParts,
         ]);
+
+        Cache::forget("menu:{$userId}");
 
         $message = count($changed) > 0
             ? implode(' · ', $changed) . '.'

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "stripe/stripe-php": "^20.1"
     },
     "require-dev": {
+        "barryvdh/laravel-debugbar": "^4.2",
         "fakerphp/faker": "^1.23",
         "laravel/breeze": "^2.3",
         "laravel/pail": "^1.2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79998162b37484093e2cdbe3cf1aea15",
+    "content-hash": "16be1d86022971d23426286ce73be9e1",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -6768,6 +6768,105 @@
     ],
     "packages-dev": [
         {
+            "name": "barryvdh/laravel-debugbar",
+            "version": "v4.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fruitcake/laravel-debugbar.git",
+                "reference": "799d70c1101d3f8840dd76ff68ff6a78f9352905"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fruitcake/laravel-debugbar/zipball/799d70c1101d3f8840dd76ff68ff6a78f9352905",
+                "reference": "799d70c1101d3f8840dd76ff68ff6a78f9352905",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/routing": "^11|^12|^13.0",
+                "illuminate/session": "^11|^12|^13.0",
+                "illuminate/support": "^11|^12|^13.0",
+                "php": "^8.2",
+                "php-debugbar/php-debugbar": "^3.7.2",
+                "php-debugbar/symfony-bridge": "^1.1"
+            },
+            "require-dev": {
+                "larastan/larastan": "^3",
+                "laravel/octane": "^2",
+                "laravel/pennant": "^1",
+                "laravel/pint": "^1",
+                "laravel/telescope": "^5.16",
+                "livewire/livewire": "^3.7|^4",
+                "mockery/mockery": "^1.3.3",
+                "orchestra/testbench-dusk": "^9|^10|^11",
+                "php-debugbar/twig-bridge": "^2.0",
+                "phpstan/phpstan-phpunit": "^2",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^11",
+                "shipmonk/phpstan-rules": "^4.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Debugbar": "Fruitcake\\LaravelDebugbar\\Facades\\Debugbar"
+                    },
+                    "providers": [
+                        "Fruitcake\\LaravelDebugbar\\ServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Fruitcake\\LaravelDebugbar\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fruitcake",
+                    "homepage": "https://fruitcake.nl"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "PHP Debugbar integration for Laravel",
+            "keywords": [
+                "barryvdh",
+                "debug",
+                "debugbar",
+                "dev",
+                "laravel",
+                "profiler",
+                "webprofiler"
+            ],
+            "support": {
+                "issues": "https://github.com/fruitcake/laravel-debugbar/issues",
+                "source": "https://github.com/fruitcake/laravel-debugbar/tree/v4.2.8"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-20T13:31:29+00:00"
+        },
+        {
             "name": "brianium/paratest",
             "version": "v7.8.5",
             "source": {
@@ -8238,6 +8337,174 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-debugbar/php-debugbar",
+            "version": "v3.7.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-debugbar/php-debugbar.git",
+                "reference": "1690ee1728827f9deb4b60457fa387cf44672c56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-debugbar/php-debugbar/zipball/1690ee1728827f9deb4b60457fa387cf44672c56",
+                "reference": "1690ee1728827f9deb4b60457fa387cf44672c56",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/var-dumper": "^5.4|^6|^7|^8"
+            },
+            "replace": {
+                "maximebf/debugbar": "self.version"
+            },
+            "require-dev": {
+                "dbrekelmans/bdi": "^1.4",
+                "friendsofphp/php-cs-fixer": "^3.92",
+                "monolog/monolog": "^3.9",
+                "php-debugbar/doctrine-bridge": "^3@dev",
+                "php-debugbar/monolog-bridge": "^1@dev",
+                "php-debugbar/symfony-bridge": "^1@dev",
+                "php-debugbar/twig-bridge": "^2@dev",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^10",
+                "predis/predis": "^3.3",
+                "shipmonk/phpstan-rules": "^4.3",
+                "symfony/browser-kit": "^6.4|7.0",
+                "symfony/dom-crawler": "^6.4|^7",
+                "symfony/event-dispatcher": "^5.4|^6.4|^7.3|^8.0",
+                "symfony/http-foundation": "^5.4|^6.4|^7.3|^8.0",
+                "symfony/mailer": "^5.4|^6.4|^7.3|^8.0",
+                "symfony/panther": "^1|^2.1",
+                "twig/twig": "^3.11.2"
+            },
+            "suggest": {
+                "php-debugbar/doctrine-bridge": "To integrate Doctrine with php-debugbar.",
+                "php-debugbar/monolog-bridge": "To integrate Monolog with php-debugbar.",
+                "php-debugbar/symfony-bridge": "To integrate Symfony with php-debugbar.",
+                "php-debugbar/twig-bridge": "To integrate Twig with php-debugbar."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DebugBar\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maxime Bouroumeau-Fuseau",
+                    "email": "maxime.bouroumeau@gmail.com",
+                    "homepage": "http://maximebf.com"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Debug bar in the browser for php application",
+            "homepage": "https://github.com/php-debugbar/php-debugbar",
+            "keywords": [
+                "debug",
+                "debug bar",
+                "debugbar",
+                "dev",
+                "profiler",
+                "toolbar"
+            ],
+            "support": {
+                "issues": "https://github.com/php-debugbar/php-debugbar/issues",
+                "source": "https://github.com/php-debugbar/php-debugbar/tree/v3.7.6"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-30T07:31:44+00:00"
+        },
+        {
+            "name": "php-debugbar/symfony-bridge",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-debugbar/symfony-bridge.git",
+                "reference": "e37d2debe5d316408b00d0ab2688d9c2cf59b5ad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-debugbar/symfony-bridge/zipball/e37d2debe5d316408b00d0ab2688d9c2cf59b5ad",
+                "reference": "e37d2debe5d316408b00d0ab2688d9c2cf59b5ad",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2",
+                "php-debugbar/php-debugbar": "^3.1",
+                "symfony/http-foundation": "^5.4|^6.4|^7.3|^8.0"
+            },
+            "require-dev": {
+                "dbrekelmans/bdi": "^1.4",
+                "phpunit/phpunit": "^10",
+                "symfony/browser-kit": "^6|^7",
+                "symfony/dom-crawler": "^6|^7",
+                "symfony/mailer": "^5.4|^6.4|^7.3|^8.0",
+                "symfony/panther": "^1|^2.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DebugBar\\Bridge\\Symfony\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maxime Bouroumeau-Fuseau",
+                    "email": "maxime.bouroumeau@gmail.com",
+                    "homepage": "http://maximebf.com"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Symfony bridge for PHP Debugbar",
+            "homepage": "https://github.com/php-debugbar/php-debugbar",
+            "keywords": [
+                "debugbar",
+                "dev",
+                "symfony"
+            ],
+            "support": {
+                "issues": "https://github.com/php-debugbar/symfony-bridge/issues",
+                "source": "https://github.com/php-debugbar/symfony-bridge/tree/v1.1.0"
+            },
+            "time": "2026-01-15T14:47:34+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",

--- a/database/migrations/2026_05_28_000001_add_performance_indexes.php
+++ b/database/migrations/2026_05_28_000001_add_performance_indexes.php
@@ -1,0 +1,84 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Añade índices en las columnas usadas frecuentemente en WHERE, JOIN y ORDER BY.
+ * Elimina full-table-scans en las rutas de polling y carta pública.
+ */
+return new class extends Migration
+{
+    /**
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->index('status');
+            $table->index('payment_status');
+            $table->index('notification_ready');
+            $table->index('bill_requested');
+            $table->index(['table_id', 'status'], 'orders_table_status_idx');
+            $table->index(['table_id', 'payment_status'], 'orders_table_payment_status_idx');
+        });
+
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->index('status');
+            $table->index('destination');
+            $table->index(['order_id', 'destination', 'status'], 'order_items_order_dest_status_idx');
+        });
+
+        Schema::table('products', function (Blueprint $table) {
+            $table->index('is_active');
+            $table->index(['user_id', 'is_active'], 'products_user_active_idx');
+        });
+
+        Schema::table('categories', function (Blueprint $table) {
+            $table->index('destination');
+            $table->index(['user_id', 'destination'], 'categories_user_dest_idx');
+        });
+
+        Schema::table('conversations', function (Blueprint $table) {
+            $table->index('status');
+            $table->index(['table_id', 'status'], 'conversations_table_status_idx');
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('conversations', function (Blueprint $table) {
+            $table->dropIndex('conversations_table_status_idx');
+            $table->dropIndex(['status']);
+        });
+
+        Schema::table('categories', function (Blueprint $table) {
+            $table->dropIndex('categories_user_dest_idx');
+            $table->dropIndex(['destination']);
+        });
+
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropIndex('products_user_active_idx');
+            $table->dropIndex(['is_active']);
+        });
+
+        Schema::table('order_items', function (Blueprint $table) {
+            $table->dropIndex('order_items_order_dest_status_idx');
+            $table->dropIndex(['destination']);
+            $table->dropIndex(['status']);
+        });
+
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropIndex('orders_table_payment_status_idx');
+            $table->dropIndex('orders_table_status_idx');
+            $table->dropIndex(['bill_requested']);
+            $table->dropIndex(['notification_ready']);
+            $table->dropIndex(['payment_status']);
+            $table->dropIndex(['status']);
+        });
+    }
+};

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2806,6 +2806,8 @@
                                         <div class="flex-shrink-0">
                                             <img src="{{ Storage::url($product->image) }}"
                                                  alt="Foto de {{ $product->name }}"
+                                                 loading="lazy"
+                                                 decoding="async"
                                                  class="h-20 w-20 sm:h-24 sm:w-24 object-cover rounded-lg">
                                         </div>
                                     @endif

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -29,7 +29,7 @@
           <tr>
             <td class="hidden sm:table-cell px-4 sm:px-6 py-4 whitespace-nowrap">
               @if($product->image)
-              <img src="{{ asset('storage/' . $product->image) }}" alt="Foto de {{ $product->name }}" class="h-10 w-10 sm:h-12 sm:w-12 object-cover rounded-md">
+              <img src="{{ asset('storage/' . $product->image) }}" alt="Foto de {{ $product->name }}" loading="lazy" decoding="async" class="h-10 w-10 sm:h-12 sm:w-12 object-cover rounded-md">
               @else
               <span class="text-gray-400 text-sm">Sin imagen</span>
               @endif


### PR DESCRIPTION
## Problemas encontrados y soluciones aplicadas

### N+1 queries corregidas

- **MenuController**: `Table::where(...)` ahora carga `user.tapaConfig.kitchenSchedules` y `user.tapaConfig.businessSchedules` con eager loading, eliminando 2–3 lazy loads por visita a la carta.
- **MenuController**: El bloque de categorías y productos activos ahora se cachea 5 minutos por `user_id` (`Cache::remember("menu:{userId}", 300, ...)`). Las consultas de filtro runtime (cocina abierta, tapas) se aplican sobre la colección en memoria.
- **KitchenController::pendingOrders()**: El `COUNT` separado de `pending_count` ha sido eliminado; ahora se calcula sobre la colección ya cargada (`$rawOrders->where('status', 'pending')->count()`).

### Índices añadidos

**Migración:** `2026_05_28_000001_add_performance_indexes.php`

| Tabla | Índices nuevos |
|---|---|
| `orders` | `status`, `payment_status`, `notification_ready`, `bill_requested`, `(table_id, status)`, `(table_id, payment_status)` |
| `order_items` | `status`, `destination`, `(order_id, destination, status)` |
| `products` | `is_active`, `(user_id, is_active)` |
| `categories` | `destination`, `(user_id, destination)` |
| `conversations` | `status`, `(table_id, status)` |

### Caché implementada

| Qué | TTL | Clave | Invalidación |
|---|---|---|---|
| Categorías + productos activos de la carta | 5 min | `menu:{user_id}` | CategoryController (store/update/destroy), ProductController (store/update/destroy/syncIngredients), IngredientController (store/update/destroy), TapasController (update) |

### Otras optimizaciones

- **NotificationController::ready()**: filtro `destination='kitchen'` movido a nivel BD; `select()` mínimo en orders e items para reducir datos transferidos.
- **Lazy loading en imágenes**: `loading="lazy" decoding="async"` en `menu/show.blade.php` y `products/index.blade.php`.
- **README**: sección de despliegue con `php artisan optimize`, `config:cache`, `route:cache`, `view:cache`, `event:cache`.

## Métricas comparativas

> Medición cualitativa con Debugbar instalado (barryvdh/laravel-debugbar --dev). Sin datos históricos de producción para comparativa numérica exacta.

| Ruta | Problema principal | Solución |
|---|---|---|
| `/menu/{hash}` | Lazy load user.tapaConfig + query completa de categorías en cada visita | Eager load + caché 5 min |
| `/kitchen` (polling 5 s) | Query COUNT duplicada en `pendingOrders()` | Eliminada, usa colección cargada |
| `/notifications/ready` (polling) | Cargaba todas las columnas de orders + items de todos destinos | select() mínimo + filtro BD |
| Todas las rutas con `orders.status` | Full table scan sin índice | Índice añadido |
| Polling cocina/barra | Full table scan en `(order_id, destination, status)` | Índice compuesto añadido |

## Checklist CLAUDE.md

- [x] `php artisan test` pasa al 100% — 992 tests, 2083 assertions
- [x] `npm run build` sin errores — 64 módulos transformados
- [x] `CACHE_STORE=array` ya existía en phpunit.xml, sin cambios
- [x] Un commit por archivo modificado
- [x] README actualizado con comandos de despliegue