### PR TITLE
fix: ignorar archivos generados por debugbar en storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /public/storage
 /storage/*.key
 /storage/pail
+/storage/debugbar
 /vendor
 Homestead.json
 Homestead.yaml


### PR DESCRIPTION
## Summary

- Añade `/storage/debugbar` al `.gitignore` para que los JSON que genera `laravel-debugbar` en cada request no aparezcan como cambios en el repositorio

## Por qué

El paquete `laravel-debugbar` escribe un archivo JSON por cada request HTTP en `storage/debugbar/`. Al no estar ignorada esa carpeta, VS Code (y git) los detectaban como cientos de cambios sin trackear.

## Test plan

- [ ] Arrancar el servidor con `php artisan serve` y navegar varias páginas
- [ ] Verificar que `storage/debugbar/` no aparece en `git status` ni en el panel de VS Code