### PR TITLE
feat: Bloque 11.1 — Design system tokens (paleta Zampa, tipografía, dark mode)

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,25 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+    :root {
+        --zampa-50:  #FDF6EC;
+        --zampa-100: #FAE8CA;
+        --zampa-200: #F5CE93;
+        --zampa-300: #EFAD55;
+        --zampa-400: #E7922A;
+        --zampa-500: #D97B1A;
+        --zampa-600: #B86315;
+        --zampa-700: #944E12;
+        --zampa-800: #763E12;
+        --zampa-900: #5E3311;
+        --zampa-950: #341A08;
+
+        --surface-50:  #F9F8F7;
+        --surface-100: #F1EFEC;
+        --surface-200: #E4E0DA;
+        --surface-900: #2C2825;
+        --surface-950: #1A1714;
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -9,7 +9,7 @@
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+        <link href="https://fonts.bunny.net/css?family=plus-jakarta-sans:400,500,600,700|playfair-display:400,600,700&display=swap" rel="stylesheet" />
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -9,7 +9,7 @@
 
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
-        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+        <link href="https://fonts.bunny.net/css?family=plus-jakarta-sans:400,500,600,700|playfair-display:400,600,700&display=swap" rel="stylesheet" />
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,8 @@ import forms from '@tailwindcss/forms';
 
 /** @type {import('tailwindcss').Config} */
 export default {
+    darkMode: 'class',
+
     content: [
         './vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php',
         './storage/framework/views/*.php',
@@ -12,7 +14,45 @@ export default {
     theme: {
         extend: {
             fontFamily: {
-                sans: ['Figtree', ...defaultTheme.fontFamily.sans],
+                sans:    ['Plus Jakarta Sans', ...defaultTheme.fontFamily.sans],
+                display: ['Playfair Display',  ...defaultTheme.fontFamily.serif],
+            },
+
+            colors: {
+                // ── Zampa brand — cognac amber ─────────────────────────────
+                zampa: {
+                    50:  '#FDF6EC',
+                    100: '#FAE8CA',
+                    200: '#F5CE93',
+                    300: '#EFAD55',
+                    400: '#E7922A',
+                    500: '#D97B1A',   // main brand color
+                    600: '#B86315',
+                    700: '#944E12',
+                    800: '#763E12',
+                    900: '#5E3311',
+                    950: '#341A08',
+                },
+                // ── Surface — warm UI grays (sidebar, cards, panels) ───────
+                surface: {
+                    50:  '#F9F8F7',
+                    100: '#F1EFEC',
+                    200: '#E4E0DA',
+                    300: '#CBC4BB',
+                    400: '#AFA69A',
+                    500: '#8F847A',
+                    600: '#746B62',
+                    700: '#5F5650',
+                    800: '#4A4440',
+                    900: '#2C2825',
+                    950: '#1A1714',
+                },
+            },
+
+            boxShadow: {
+                card:      '0 1px 3px 0 rgb(0 0 0 / 0.08), 0 1px 2px -1px rgb(0 0 0 / 0.08)',
+                'card-md': '0 4px 6px -1px rgb(0 0 0 / 0.07), 0 2px 4px -2px rgb(0 0 0 / 0.07)',
+                'card-lg': '0 10px 15px -3px rgb(0 0 0 / 0.07), 0 4px 6px -4px rgb(0 0 0 / 0.07)',
             },
         },
     },


### PR DESCRIPTION
## Resumen

Define la identidad visual de Zampa en `tailwind.config.js` y los layouts base.

- Paleta de colores `zampa` (cognac amber) y `surface` (warm grays) como tokens propios en Tailwind
- Tipografía: reemplaza Figtree → **Plus Jakarta Sans** (UI) + **Playfair Display** (display/brand)
- `darkMode: 'class'` activado explícitamente en la configuración
- Sombras de card (`card`, `card-md`, `card-lg`) para componentes
- CSS custom properties (`--zampa-*`, `--surface-*`) en `app.css` via `@layer base`
- La app deja de ser reconocible como "Laravel por defecto"

## Cambios

| Archivo | Descripción |
|---|---|
| `tailwind.config.js` | Tokens de color, tipografía, sombras y darkMode |
| `resources/views/layouts/app.blade.php` | Fuentes actualizadas desde bunny.net |
| `resources/views/layouts/guest.blade.php` | Fuentes actualizadas desde bunny.net |
| `resources/css/app.css` | CSS custom properties de la paleta Zampa |

## Test plan

- [ ] `npm run build` sin errores ✅
- [ ] Las clases `zampa-*` y `surface-*` generan utilidades Tailwind válidas
- [ ] Las fuentes Plus Jakarta Sans y Playfair Display cargan en el navegador
- [ ] El dark mode sigue funcionando con `darkMode: 'class'`
- [ ] No hay regresiones visuales en vistas existentes

## Parte de

Bloque 11 — UI/UX Redesign

🤖 Generated with [Claude Code](https://claude.com/claude-code)