### PR TITLE
feat: multi-allergen per ingredient (allergen_types JSON array)

### DIFF
--- a/app/Http/Controllers/IngredientController.php
+++ b/app/Http/Controllers/IngredientController.php
@@ -51,14 +51,22 @@ class IngredientController extends Controller
      */
     public function store(Request $request): \Illuminate\Http\RedirectResponse
     {
-        $validated = $request->validate([
-            'name'         => 'required|string|max:255',
-            'is_allergen'  => 'boolean',
-            'allergen_type' => ['nullable', 'string', Rule::in(array_keys(Ingredient::ALLERGEN_TYPES))],
+        $request->validate([
+            'name'            => 'required|string|max:255',
+            'allergen_types'  => ['nullable', 'array'],
+            'allergen_types.*' => ['string', Rule::in(array_keys(Ingredient::ALLERGEN_TYPES))],
         ]);
 
-        $ownerId = Auth::user()->ownerUserId();
-        Ingredient::create(array_merge($validated, ['user_id' => $ownerId]));
+        $allergenTypes = array_values(array_filter($request->input('allergen_types', [])));
+        $ownerId       = Auth::user()->ownerUserId();
+
+        Ingredient::create([
+            'user_id'        => $ownerId,
+            'name'           => $request->input('name'),
+            'allergen_types' => $allergenTypes ?: null,
+            'is_allergen'    => count($allergenTypes) > 0,
+        ]);
+
         Cache::forget("menu:{$ownerId}");
 
         return redirect()->route('ingredients.index')->with('success', 'Ingrediente creado correctamente.');
@@ -96,13 +104,19 @@ class IngredientController extends Controller
     {
         abort_if($ingredient->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
-        $validated = $request->validate([
-            'name'         => 'required|string|max:255',
-            'is_allergen'  => 'boolean',
-            'allergen_type' => ['nullable', 'string', Rule::in(array_keys(Ingredient::ALLERGEN_TYPES))],
+        $request->validate([
+            'name'             => 'required|string|max:255',
+            'allergen_types'   => ['nullable', 'array'],
+            'allergen_types.*' => ['string', Rule::in(array_keys(Ingredient::ALLERGEN_TYPES))],
         ]);
 
-        $ingredient->update($validated);
+        $allergenTypes = array_values(array_filter($request->input('allergen_types', [])));
+
+        $ingredient->update([
+            'name'           => $request->input('name'),
+            'allergen_types' => $allergenTypes ?: null,
+            'is_allergen'    => count($allergenTypes) > 0,
+        ]);
         Cache::forget("menu:{$ingredient->user_id}");
 
         return redirect()->route('ingredients.index')->with('success', 'Ingrediente actualizado correctamente.');

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Category;
+use App\Models\Ingredient;
 use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\Table;
@@ -56,7 +57,7 @@ class MenuController extends Controller
                                             'ingredients.id',
                                             'ingredients.name',
                                             'ingredients.is_allergen',
-                                            'ingredients.allergen_type',
+                                            'ingredients.allergen_types',
                                         ]);
                                   },
                                   'variants',
@@ -77,7 +78,13 @@ class MenuController extends Controller
         $allergens = $categories
             ->flatMap(fn ($c) => $c->products)
             ->flatMap(fn ($p) => $p->ingredients->where('is_allergen', true))
-            ->unique(fn ($i) => $i->allergen_type ?? 'name:'.$i->name)
+            ->flatMap(fn ($i) => $i->allergen_types ?? [])
+            ->unique()
+            ->map(fn ($slug) => (object)[
+                'slug'  => $slug,
+                'name'  => Ingredient::ALLERGEN_TYPES[$slug] ?? $slug,
+                'emoji' => Ingredient::ALLERGEN_EMOJIS[$slug] ?? '⚠️',
+            ])
             ->sortBy('name')
             ->values();
 

--- a/app/Models/Ingredient.php
+++ b/app/Models/Ingredient.php
@@ -14,9 +14,9 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * Materia prima o ingrediente modificable.
  * Ej: "Queso Cheddar", "Huevo", "Salsa Picante".
  *
- * @property string $name           Nombre del ingrediente
- * @property boolean $is_allergen   Si se considera alérgeno importante
- * @property string|null $allergen_type Tipo de alérgeno según Reglamento UE 1169/2011
+ * @property string    $name           Nombre del ingrediente
+ * @property boolean   $is_allergen    Si se considera alérgeno (true si allergen_types no está vacío)
+ * @property array     $allergen_types Slugs de alérgenos UE 1169/2011 que contiene este ingrediente
  *
  * @author AyrtonAlania
  * @author BenjaminDTS
@@ -25,7 +25,12 @@ class Ingredient extends Model
 {
     use HasFactory, SoftDeletes;
 
-    protected $fillable = ['user_id', 'name', 'is_allergen', 'allergen_type'];
+    protected $fillable = ['user_id', 'name', 'is_allergen', 'allergen_types'];
+
+    protected $casts = [
+        'is_allergen'   => 'boolean',
+        'allergen_types' => 'array',
+    ];
 
     /**
      * Slugs válidos para allergen_type.
@@ -156,36 +161,39 @@ class Ingredient extends Model
     }
 
     /**
-     * Devuelve la URL del SVG oficial del alérgeno.
-     * Retorna null si no tiene allergen_type asignado.
+     * Devuelve la URL del SVG oficial del primer alérgeno asignado.
+     * Retorna null si el ingrediente no tiene alérgenos.
      *
      * @return string|null
      */
     public function allergenIconPath(): ?string
     {
-        if (!$this->allergen_type) return null;
-        return asset('images/allergens/' . $this->allergen_type . '.svg');
+        $first = ($this->allergen_types ?? [])[0] ?? null;
+        if (!$first) return null;
+        return asset('images/allergens/' . $first . '.svg');
     }
 
     /**
-     * Devuelve el nombre legible del tipo de alérgeno.
+     * Devuelve el nombre legible del primer tipo de alérgeno.
      *
      * @return string|null
      */
     public function allergenTypeName(): ?string
     {
-        return self::ALLERGEN_TYPES[$this->allergen_type] ?? null;
+        $first = ($this->allergen_types ?? [])[0] ?? null;
+        return $first ? (self::ALLERGEN_TYPES[$first] ?? null) : null;
     }
 
     /**
-     * Devuelve el emoji correspondiente al tipo de alérgeno UE.
-     * Retorna ⚠️ como fallback si no tiene allergen_type asignado.
+     * Devuelve el emoji del primer tipo de alérgeno UE.
+     * Retorna ⚠️ como fallback si no tiene alérgenos asignados.
      *
      * @return string
      */
     public function allergenEmoji(): string
     {
-        return self::ALLERGEN_EMOJIS[$this->allergen_type] ?? '⚠️';
+        $first = ($this->allergen_types ?? [])[0] ?? null;
+        return $first ? (self::ALLERGEN_EMOJIS[$first] ?? '⚠️') : '⚠️';
     }
 
     /**

--- a/database/factories/IngredientFactory.php
+++ b/database/factories/IngredientFactory.php
@@ -31,14 +31,15 @@ class IngredientFactory extends Factory
      */
     public function definition(): array
     {
-        $name       = fake()->randomElement(['Tomate', 'Queso', 'Bacon', 'Lechuga', 'Salsa BBQ', 'Huevo', 'Pan', 'Pollo']);
-        $isAllergen = isset(self::ALLERGEN_MAP[$name]) ? fake()->boolean(20) : false;
+        $name          = fake()->randomElement(['Tomate', 'Queso', 'Bacon', 'Lechuga', 'Salsa BBQ', 'Huevo', 'Pan', 'Pollo']);
+        $isAllergen    = isset(self::ALLERGEN_MAP[$name]) ? fake()->boolean(20) : false;
+        $allergenTypes = $isAllergen ? [self::ALLERGEN_MAP[$name]] : null;
 
         return [
-            'name'          => $name,
-            'is_allergen'   => $isAllergen,
-            'allergen_type' => $isAllergen ? self::ALLERGEN_MAP[$name] : null,
-            'user_id'       => User::factory(),
+            'name'           => $name,
+            'is_allergen'    => $isAllergen,
+            'allergen_types' => $allergenTypes,
+            'user_id'        => User::factory(),
         ];
     }
 }

--- a/database/migrations/2026_05_30_000001_add_allergen_types_json_to_ingredients_table.php
+++ b/database/migrations/2026_05_30_000001_add_allergen_types_json_to_ingredients_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Migra el campo allergen_type (string único) a allergen_types (JSON array).
+ * Un ingrediente ahora puede pertenecer a varios alérgenos del Reglamento UE 1169/2011.
+ *
+ * @author BenjaminDTS
+ */
+return new class extends Migration
+{
+    /**
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->json('allergen_types')->nullable()->after('is_allergen');
+        });
+
+        // Migra datos existentes: allergen_type string → allergen_types JSON array
+        DB::statement("
+            UPDATE ingredients
+            SET allergen_types = JSON_ARRAY(allergen_type)
+            WHERE allergen_type IS NOT NULL AND allergen_type != ''
+        ");
+
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->dropColumn('allergen_type');
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->string('allergen_type')->nullable()->after('is_allergen');
+        });
+
+        // Restaura el primer elemento del array como allergen_type
+        DB::statement("
+            UPDATE ingredients
+            SET allergen_type = JSON_UNQUOTE(JSON_EXTRACT(allergen_types, '$[0]'))
+            WHERE allergen_types IS NOT NULL AND JSON_LENGTH(allergen_types) > 0
+        ");
+
+        Schema::table('ingredients', function (Blueprint $table) {
+            $table->dropColumn('allergen_types');
+        });
+    }
+};

--- a/resources/views/components/allergen-badge.blade.php
+++ b/resources/views/components/allergen-badge.blade.php
@@ -1,40 +1,16 @@
-@props(['ingredient'])
+@props(['slug'])
 
-@if($ingredient->is_allergen)
-    @php
-        $shortNames = [
-            'gluten'          => 'Gluten',
-            'crustaceos'      => 'Crustáceos',
-            'huevos'          => 'Huevos',
-            'pescado'         => 'Pescado',
-            'cacahuetes'      => 'Cacahuetes',
-            'soja'            => 'Soja',
-            'lacteos'         => 'Lácteos',
-            'frutos-cascara'  => 'Frutos secos',
-            'apio'            => 'Apio',
-            'mostaza'         => 'Mostaza',
-            'sesamo'          => 'Sésamo',
-            'sulfitos'        => 'Sulfitos',
-            'altramuces'      => 'Altramuz',
-            'moluscos'        => 'Moluscos',
-        ];
+@php
+    $label = \App\Models\Ingredient::ALLERGEN_TYPES[$slug] ?? $slug;
+@endphp
 
-        $label = $shortNames[$ingredient->allergen_type] ?? $ingredient->name;
-    @endphp
-
-    <div class="flex flex-col items-center gap-1 w-16"
-         title="{{ $label }}">
-        <div class="w-12 h-12 rounded-full bg-white border-2 border-gray-300 flex items-center justify-center shadow-sm p-2">
-            @if($ingredient->allergen_type)
-                <img src="{{ $ingredient->allergenIconPath() }}"
-                     alt="{{ $label }}"
-                     class="w-full h-full object-contain">
-            @else
-                <span class="text-2xl leading-none">{{ $ingredient->ingredientEmoji() }}</span>
-            @endif
-        </div>
-        <span class="text-xs text-center font-medium text-gray-600 dark:text-gray-400 leading-tight">
-            {{ $label }}
-        </span>
+<div class="flex flex-col items-center gap-1 w-16" title="{{ $label }}">
+    <div class="w-12 h-12 rounded-full bg-white border-2 border-gray-300 flex items-center justify-center shadow-sm p-2">
+        <img src="{{ asset('images/allergens/' . $slug . '.svg') }}"
+             alt="{{ $label }}"
+             class="w-full h-full object-contain">
     </div>
-@endif
+    <span class="text-xs text-center font-medium text-gray-600 dark:text-gray-400 leading-tight">
+        {{ $label }}
+    </span>
+</div>

--- a/resources/views/ingredients/create.blade.php
+++ b/resources/views/ingredients/create.blade.php
@@ -48,47 +48,32 @@
               @enderror
             </div>
 
-            {{-- Campo: Es alérgeno --}}
-            <fieldset x-data="{ isAllergen: {{ old('is_allergen') ? 'true' : 'false' }} }">
+            {{-- Campo: Alérgenos UE --}}
+            <fieldset>
               <legend class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                Clasificación alérgeno
+                Alérgenos (Reglamento UE 1169/2011)
               </legend>
-              <div class="flex items-center gap-3">
-                <input type="hidden" name="is_allergen" value="0">
-                <input
-                  type="checkbox"
-                  name="is_allergen"
-                  id="is_allergen"
-                  value="1"
-                  {{ old('is_allergen') ? 'checked' : '' }}
-                  @change="isAllergen = $event.target.checked"
-                  class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-green-600 focus:ring-green-500 focus:outline-none focus:ring-2 focus:ring-offset-2"
-                >
-                <label for="is_allergen" class="text-sm text-gray-700 dark:text-gray-300">
-                  Marcar como alérgeno
-                </label>
-              </div>
-
-              {{-- Selector de tipo de alérgeno oficial UE — visible solo si is_allergen está marcado --}}
-              <div x-show="isAllergen" x-cloak class="mt-4">
-                <label for="allergen_type" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Tipo de alérgeno oficial (UE)
-                </label>
-                <select
-                  name="allergen_type"
-                  id="allergen_type"
-                  class="w-full h-10 rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:focus:border-indigo-600 dark:focus:ring-indigo-600 sm:text-sm"
-                >
-                  <option value="">— Selecciona el alérgeno oficial —</option>
-                  @foreach(\App\Models\Ingredient::ALLERGEN_TYPES as $slug => $label)
-                    <option value="{{ $slug }}" {{ old('allergen_type') === $slug ? 'selected' : '' }}>
+              <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                Selecciona todos los alérgenos que contiene este ingrediente.
+              </p>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                @foreach(\App\Models\Ingredient::ALLERGEN_TYPES as $slug => $label)
+                  @php $checked = in_array($slug, old('allergen_types', []), true); @endphp
+                  <div class="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      name="allergen_types[]"
+                      id="allergen_{{ $slug }}"
+                      value="{{ $slug }}"
+                      {{ $checked ? 'checked' : '' }}
+                      class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-green-600 focus:ring-green-500 focus:outline-none focus:ring-2 focus:ring-offset-2"
+                    >
+                    <label for="allergen_{{ $slug }}" class="flex items-center gap-1.5 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+                      <img src="{{ asset('images/allergens/' . $slug . '.svg') }}" alt="" aria-hidden="true" class="h-5 w-5 object-contain">
                       {{ $label }}
-                    </option>
-                  @endforeach
-                </select>
-                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                  Según el Reglamento UE 1169/2011 de información alimentaria.
-                </p>
+                    </label>
+                  </div>
+                @endforeach
               </div>
             </fieldset>
 

--- a/resources/views/ingredients/edit.blade.php
+++ b/resources/views/ingredients/edit.blade.php
@@ -48,47 +48,35 @@
               @enderror
             </div>
 
-            {{-- Campo: Es alérgeno --}}
-            <fieldset x-data="{ isAllergen: {{ $ingredient->is_allergen ? 'true' : 'false' }} }">
+            {{-- Campo: Alérgenos UE --}}
+            <fieldset>
               <legend class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                Clasificación alérgeno
+                Alérgenos (Reglamento UE 1169/2011)
               </legend>
-              <div class="flex items-center gap-3">
-                <input type="hidden" name="is_allergen" value="0">
-                <input
-                  type="checkbox"
-                  name="is_allergen"
-                  id="is_allergen"
-                  value="1"
-                  {{ old('is_allergen', $ingredient->is_allergen) ? 'checked' : '' }}
-                  @change="isAllergen = $event.target.checked"
-                  class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-green-600 focus:ring-green-500 focus:outline-none focus:ring-2 focus:ring-offset-2"
-                >
-                <label for="is_allergen" class="text-sm text-gray-700 dark:text-gray-300">
-                  Marcar como alérgeno
-                </label>
-              </div>
-
-              {{-- Selector de tipo de alérgeno oficial UE — visible solo si is_allergen está marcado --}}
-              <div x-show="isAllergen" x-cloak class="mt-4">
-                <label for="allergen_type" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                  Tipo de alérgeno oficial (UE)
-                </label>
-                <select
-                  name="allergen_type"
-                  id="allergen_type"
-                  class="w-full h-10 rounded-md border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 dark:focus:border-indigo-600 dark:focus:ring-indigo-600 sm:text-sm"
-                >
-                  <option value="">— Selecciona el alérgeno oficial —</option>
-                  @foreach(\App\Models\Ingredient::ALLERGEN_TYPES as $slug => $label)
-                    <option value="{{ $slug }}" {{ old('allergen_type', $ingredient->allergen_type) === $slug ? 'selected' : '' }}>
+              <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                Selecciona todos los alérgenos que contiene este ingrediente.
+              </p>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                @foreach(\App\Models\Ingredient::ALLERGEN_TYPES as $slug => $label)
+                  @php
+                    $currentTypes = old('allergen_types', $ingredient->allergen_types ?? []);
+                    $checked = in_array($slug, $currentTypes, true);
+                  @endphp
+                  <div class="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      name="allergen_types[]"
+                      id="allergen_{{ $slug }}"
+                      value="{{ $slug }}"
+                      {{ $checked ? 'checked' : '' }}
+                      class="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-green-600 focus:ring-green-500 focus:outline-none focus:ring-2 focus:ring-offset-2"
+                    >
+                    <label for="allergen_{{ $slug }}" class="flex items-center gap-1.5 text-sm text-gray-700 dark:text-gray-300 cursor-pointer">
+                      <img src="{{ asset('images/allergens/' . $slug . '.svg') }}" alt="" aria-hidden="true" class="h-5 w-5 object-contain">
                       {{ $label }}
-                    </option>
-                  @endforeach
-                </select>
-                <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                  Según el Reglamento UE 1169/2011 de información alimentaria.
-                </p>
+                    </label>
+                  </div>
+                @endforeach
               </div>
             </fieldset>
 

--- a/resources/views/ingredients/index.blade.php
+++ b/resources/views/ingredients/index.blade.php
@@ -31,10 +31,12 @@
             <div class="text-center">
               <div class="text-2xl mb-2">{{ $ingredient->ingredientEmoji() }}</div>
               <h3 class="font-bold text-gray-700 dark:text-gray-300">{{ $ingredient->name }}</h3>
-              @if($ingredient->is_allergen)
-              <span class="mt-1 inline-block text-xs font-semibold text-amber-700 dark:text-amber-400 bg-amber-100 dark:bg-amber-900 px-2 py-0.5 rounded-full">
-                Alérgeno
-              </span>
+              @if($ingredient->is_allergen && !empty($ingredient->allergen_types))
+                <div class="mt-2 flex flex-wrap justify-center gap-1">
+                  @foreach($ingredient->allergen_types as $allergenSlug)
+                    <x-allergen-badge :slug="$allergenSlug" />
+                  @endforeach
+                </div>
               @endif
             </div>
 

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -235,7 +235,7 @@
                 'categoryId'  => $category->id,
                 'destination' => $category->destination,
                 'allergenTypes' => $p->ingredients->where('is_allergen', true)
-                    ->map(fn ($i) => $i->allergen_type ?? 'name:'.$i->name)
+                    ->flatMap(fn ($i) => $i->allergen_types ?? [])
                     ->unique()->values()->toArray(),
                 'removable'   => $p->ingredients
                     ->filter(fn ($i) => $i->pivot->is_removable)
@@ -2755,8 +2755,8 @@
 
                         @foreach ($allergens as $allergen)
                             @php
-                                $allergenKey  = $allergen->allergen_type ? "'{$allergen->allergen_type}'" : "'name:{$allergen->name}'";
-                                $allergenName = $allergen->allergenTypeName() ?? $allergen->name;
+                                $allergenKey  = "'{$allergen->slug}'";
+                                $allergenName = $allergen->name;
                             @endphp
                             <div class="relative" x-data="{ tip: false }"
                                  x-show="visibleAllergenKeys.includes({{ $allergenKey }})">
@@ -2773,17 +2773,11 @@
                                                focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2
                                                dark:focus:ring-offset-gray-900"
                                         aria-label="{{ $allergenName }}">
-                                    @if($allergen->allergen_type)
-                                        <div class="h-12 w-12 rounded-full overflow-hidden">
-                                            <img src="{{ $allergen->allergenIconPath() }}"
-                                                 alt="{{ $allergenName }}"
-                                                 class="h-full w-full object-contain">
-                                        </div>
-                                    @else
-                                        <div class="h-12 w-12 flex items-center justify-center bg-yellow-100 dark:bg-yellow-900 rounded-full">
-                                            <span class="text-2xl" aria-hidden="true">⚠️</span>
-                                        </div>
-                                    @endif
+                                    <div class="h-12 w-12 rounded-full overflow-hidden">
+                                        <img src="{{ asset('images/allergens/' . $allergen->slug . '.svg') }}"
+                                             alt="{{ $allergenName }}"
+                                             class="h-full w-full object-contain">
+                                    </div>
                                 </button>
 
                                 <div x-show="tip"
@@ -3074,14 +3068,19 @@
                                             @endif
 
                                             {{-- Alérgenos --}}
-                                            @if ($product->ingredients->where('is_allergen', true)->isNotEmpty())
+                                            @php
+                                                $productAllergenSlugs = $product->ingredients->where('is_allergen', true)
+                                                    ->flatMap(fn($i) => $i->allergen_types ?? [])
+                                                    ->unique()->values();
+                                            @endphp
+                                            @if ($productAllergenSlugs->isNotEmpty())
                                                 <div class="mt-2" aria-label="Alérgenos de {{ $product->name }}">
                                                     <p class="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1">
                                                         Alérgenos
                                                     </p>
                                                     <ul class="flex flex-wrap gap-3" role="list">
-                                                        @foreach ($product->ingredients->where('is_allergen', true)->unique('allergen_type') as $allergen)
-                                                            <li><x-allergen-badge :ingredient="$allergen" /></li>
+                                                        @foreach ($productAllergenSlugs as $slug)
+                                                            <li><x-allergen-badge :slug="$slug" /></li>
                                                         @endforeach
                                                     </ul>
                                                 </div>
@@ -3161,14 +3160,19 @@
                                         @endif
 
                                         {{-- Alérgenos --}}
-                                        @if ($product->ingredients->where('is_allergen', true)->isNotEmpty())
+                                        @php
+                                            $productAllergenSlugs2 = $product->ingredients->where('is_allergen', true)
+                                                ->flatMap(fn($i) => $i->allergen_types ?? [])
+                                                ->unique()->values();
+                                        @endphp
+                                        @if ($productAllergenSlugs2->isNotEmpty())
                                             <div class="mt-2" aria-label="Alérgenos de {{ $product->name }}">
                                                 <p class="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1">
                                                     Alérgenos
                                                 </p>
                                                 <ul class="flex flex-wrap gap-3" role="list">
-                                                    @foreach ($product->ingredients->where('is_allergen', true)->unique('allergen_type') as $allergen)
-                                                        <li><x-allergen-badge :ingredient="$allergen" /></li>
+                                                    @foreach ($productAllergenSlugs2 as $slug)
+                                                        <li><x-allergen-badge :slug="$slug" /></li>
                                                     @endforeach
                                                 </ul>
                                             </div>

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -324,8 +324,8 @@
                 Alérgenos detectados
             </p>
             <div class="flex flex-wrap gap-2" role="list" aria-label="Alérgenos de {{ $product->name }}">
-                @foreach($product->allergens->unique('allergen_type') as $allergen)
-                    <x-allergen-badge :ingredient="$allergen" />
+                @foreach($product->allergens->flatMap(fn($i) => $i->allergen_types ?? [])->unique()->values() as $slug)
+                    <x-allergen-badge :slug="$slug" />
                 @endforeach
             </div>
         </div>

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -178,10 +178,15 @@
 
             {{-- Alérgenos --}}
             <td class="hidden lg:table-cell px-4 sm:px-6 py-4">
-              @if($product->ingredients->where('is_allergen', true)->isNotEmpty())
+              @php
+                $allergenSlugs = $product->ingredients->where('is_allergen', true)
+                    ->flatMap(fn($i) => $i->allergen_types ?? [])
+                    ->unique()->values();
+              @endphp
+              @if($allergenSlugs->isNotEmpty())
                 <div class="flex flex-wrap gap-3" role="list" aria-label="Alérgenos de {{ $product->name }}">
-                  @foreach($product->ingredients->where('is_allergen', true)->unique('allergen_type') as $allergen)
-                    <x-allergen-badge :ingredient="$allergen" />
+                  @foreach($allergenSlugs as $slug)
+                    <x-allergen-badge :slug="$slug" />
                   @endforeach
                 </div>
               @else

--- a/tests/Feature/Allergens/AllergenTest.php
+++ b/tests/Feature/Allergens/AllergenTest.php
@@ -16,8 +16,8 @@ beforeEach(function () {
 
 it('allergens relation returns only ingredients with is_allergen true', function () {
     $product     = Product::factory()->for(Category::factory()->for($this->user))->for($this->user)->create();
-    $allergen    = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_type' => 'lacteos']);
-    $nonAllergen = Ingredient::factory()->for($this->user)->create(['name' => 'Lechuga', 'is_allergen' => false, 'allergen_type' => null]);
+    $allergen    = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_types' => ['lacteos']]);
+    $nonAllergen = Ingredient::factory()->for($this->user)->create(['name' => 'Lechuga', 'is_allergen' => false]);
 
     $product->ingredients()->attach($allergen->id,    ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
     $product->ingredients()->attach($nonAllergen->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
@@ -30,7 +30,7 @@ it('allergens relation returns only ingredients with is_allergen true', function
 
 it('allergens relation returns empty when no allergens assigned', function () {
     $product     = Product::factory()->for(Category::factory()->for($this->user))->for($this->user)->create();
-    $nonAllergen = Ingredient::factory()->for($this->user)->create(['name' => 'Lechuga', 'is_allergen' => false, 'allergen_type' => null]);
+    $nonAllergen = Ingredient::factory()->for($this->user)->create(['name' => 'Lechuga', 'is_allergen' => false]);
 
     $product->ingredients()->attach($nonAllergen->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
 
@@ -45,8 +45,8 @@ it('allergens relation returns empty when no ingredients assigned', function () 
 
 it('product with multiple allergens returns all of them', function () {
     $product   = Product::factory()->for(Category::factory()->for($this->user))->for($this->user)->create();
-    $allergen1 = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_type' => 'lacteos']);
-    $allergen2 = Ingredient::factory()->for($this->user)->create(['name' => 'Huevo', 'is_allergen' => true, 'allergen_type' => 'huevos']);
+    $allergen1 = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_types' => ['lacteos']]);
+    $allergen2 = Ingredient::factory()->for($this->user)->create(['name' => 'Huevo', 'is_allergen' => true, 'allergen_types' => ['huevos']]);
 
     $product->ingredients()->attach($allergen1->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
     $product->ingredients()->attach($allergen2->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
@@ -60,7 +60,7 @@ it('public menu shows allergen names for products with allergens', function () {
     $table    = Table::factory()->for($this->user)->create();
     $category = Category::factory()->for($this->user)->create(['destination' => 'kitchen']);
     $product  = Product::factory()->for($category)->for($this->user)->create(['is_active' => true]);
-    $allergen = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_type' => 'lacteos']);
+    $allergen = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_types' => ['lacteos']]);
 
     $product->ingredients()->attach($allergen->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
 
@@ -73,7 +73,7 @@ it('public menu view contains allergen data', function () {
     $table    = Table::factory()->for($this->user)->create();
     $category = Category::factory()->for($this->user)->create(['destination' => 'kitchen']);
     $product  = Product::factory()->for($category)->for($this->user)->create(['is_active' => true]);
-    $allergen = Ingredient::factory()->for($this->user)->create(['name' => 'Bacon', 'is_allergen' => true, 'allergen_type' => 'gluten']);
+    $allergen = Ingredient::factory()->for($this->user)->create(['name' => 'Bacon', 'is_allergen' => true, 'allergen_types' => ['gluten']]);
 
     $product->ingredients()->attach($allergen->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
 
@@ -82,7 +82,7 @@ it('public menu view contains allergen data', function () {
     $response->assertOk();
     $allergens = $response->viewData('allergens');
     expect($allergens)->not->toBeEmpty();
-    expect($allergens->pluck('id')->contains($allergen->id))->toBeTrue();
+    expect($allergens->pluck('slug')->contains('gluten'))->toBeTrue();
 });
 
 it('allergen filter uses only active products', function () {
@@ -91,8 +91,8 @@ it('allergen filter uses only active products', function () {
     $activeProduct   = Product::factory()->for($category)->for($this->user)->create(['is_active' => true]);
     $inactiveProduct = Product::factory()->for($category)->for($this->user)->create(['is_active' => false]);
 
-    $allergen          = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_type' => 'lacteos']);
-    $inactiveAllergen  = Ingredient::factory()->for($this->user)->create(['name' => 'Bacon', 'is_allergen' => true, 'allergen_type' => 'gluten']);
+    $allergen         = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_types' => ['lacteos']]);
+    $inactiveAllergen = Ingredient::factory()->for($this->user)->create(['name' => 'Bacon', 'is_allergen' => true, 'allergen_types' => ['gluten']]);
 
     $activeProduct->ingredients()->attach($allergen->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
     $inactiveProduct->ingredients()->attach($inactiveAllergen->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
@@ -101,6 +101,6 @@ it('allergen filter uses only active products', function () {
 
     $allergens = $response->viewData('allergens');
 
-    expect($allergens->pluck('id')->contains($allergen->id))->toBeTrue();
-    expect($allergens->pluck('id')->contains($inactiveAllergen->id))->toBeFalse();
+    expect($allergens->pluck('slug')->contains('lacteos'))->toBeTrue();
+    expect($allergens->pluck('slug')->contains('gluten'))->toBeFalse();
 });

--- a/tests/Feature/Bloque1/IngredientTest.php
+++ b/tests/Feature/Bloque1/IngredientTest.php
@@ -75,8 +75,8 @@ it('creates a non allergen ingredient', function () {
 it('creates an allergen ingredient', function () {
     $this->actingAs($this->user)
         ->post(route('ingredients.store'), [
-            'name'        => 'Queso',
-            'is_allergen' => true,
+            'name'           => 'Queso',
+            'allergen_types' => ['lacteos'],
         ])
         ->assertRedirect(route('ingredients.index'));
 
@@ -143,8 +143,8 @@ it('updates ingredient name and is_allergen correctly', function () {
 
     $this->actingAs($this->user)
         ->put(route('ingredients.update', $ingredient), [
-            'name'        => 'Pan Integral',
-            'is_allergen' => true,
+            'name'           => 'Pan Integral',
+            'allergen_types' => ['gluten'],
         ])
         ->assertRedirect(route('ingredients.index'));
 

--- a/tests/Feature/Bloque2/AllergenTest.php
+++ b/tests/Feature/Bloque2/AllergenTest.php
@@ -16,8 +16,8 @@ beforeEach(function () {
 
 it('allergens relation returns only ingredients with is_allergen true', function () {
     $product     = Product::factory()->for(Category::factory()->for($this->user))->for($this->user)->create();
-    $allergen    = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_type' => 'lacteos']);
-    $nonAllergen = Ingredient::factory()->for($this->user)->create(['name' => 'Lechuga', 'is_allergen' => false, 'allergen_type' => null]);
+    $allergen    = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_types' => ['lacteos']]);
+    $nonAllergen = Ingredient::factory()->for($this->user)->create(['name' => 'Lechuga', 'is_allergen' => false]);
 
     $product->ingredients()->attach($allergen->id,    ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
     $product->ingredients()->attach($nonAllergen->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
@@ -30,7 +30,7 @@ it('allergens relation returns only ingredients with is_allergen true', function
 
 it('allergens relation returns empty when no allergens assigned', function () {
     $product     = Product::factory()->for(Category::factory()->for($this->user))->for($this->user)->create();
-    $nonAllergen = Ingredient::factory()->for($this->user)->create(['name' => 'Lechuga', 'is_allergen' => false, 'allergen_type' => null]);
+    $nonAllergen = Ingredient::factory()->for($this->user)->create(['name' => 'Lechuga', 'is_allergen' => false]);
 
     $product->ingredients()->attach($nonAllergen->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
 
@@ -45,8 +45,8 @@ it('allergens relation returns empty when no ingredients assigned', function () 
 
 it('product with multiple allergens returns all of them', function () {
     $product   = Product::factory()->for(Category::factory()->for($this->user))->for($this->user)->create();
-    $allergen1 = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_type' => 'lacteos']);
-    $allergen2 = Ingredient::factory()->for($this->user)->create(['name' => 'Huevo', 'is_allergen' => true, 'allergen_type' => 'huevos']);
+    $allergen1 = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_types' => ['lacteos']]);
+    $allergen2 = Ingredient::factory()->for($this->user)->create(['name' => 'Huevo', 'is_allergen' => true, 'allergen_types' => ['huevos']]);
 
     $product->ingredients()->attach($allergen1->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
     $product->ingredients()->attach($allergen2->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
@@ -60,7 +60,7 @@ it('public menu shows allergen names for products with allergens', function () {
     $table    = Table::factory()->for($this->user)->create();
     $category = Category::factory()->for($this->user)->create(['destination' => 'kitchen']);
     $product  = Product::factory()->for($category)->for($this->user)->create(['is_active' => true]);
-    $allergen = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_type' => 'lacteos']);
+    $allergen = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_types' => ['lacteos']]);
 
     $product->ingredients()->attach($allergen->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
 
@@ -73,7 +73,7 @@ it('public menu view contains allergen data', function () {
     $table    = Table::factory()->for($this->user)->create();
     $category = Category::factory()->for($this->user)->create(['destination' => 'kitchen']);
     $product  = Product::factory()->for($category)->for($this->user)->create(['is_active' => true]);
-    $allergen = Ingredient::factory()->for($this->user)->create(['name' => 'Bacon', 'is_allergen' => true, 'allergen_type' => 'gluten']);
+    $allergen = Ingredient::factory()->for($this->user)->create(['name' => 'Bacon', 'is_allergen' => true, 'allergen_types' => ['gluten']]);
 
     $product->ingredients()->attach($allergen->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
 
@@ -82,7 +82,7 @@ it('public menu view contains allergen data', function () {
     $response->assertOk();
     $allergens = $response->viewData('allergens');
     expect($allergens)->not->toBeEmpty();
-    expect($allergens->pluck('id')->contains($allergen->id))->toBeTrue();
+    expect($allergens->pluck('slug')->contains('gluten'))->toBeTrue();
 });
 
 it('allergen filter uses only active products', function () {
@@ -91,8 +91,8 @@ it('allergen filter uses only active products', function () {
     $activeProduct   = Product::factory()->for($category)->for($this->user)->create(['is_active' => true]);
     $inactiveProduct = Product::factory()->for($category)->for($this->user)->create(['is_active' => false]);
 
-    $allergen          = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_type' => 'lacteos']);
-    $inactiveAllergen  = Ingredient::factory()->for($this->user)->create(['name' => 'Bacon', 'is_allergen' => true, 'allergen_type' => 'gluten']);
+    $allergen          = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_types' => ['lacteos']]);
+    $inactiveAllergen  = Ingredient::factory()->for($this->user)->create(['name' => 'Bacon', 'is_allergen' => true, 'allergen_types' => ['gluten']]);
 
     $activeProduct->ingredients()->attach($allergen->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
     $inactiveProduct->ingredients()->attach($inactiveAllergen->id, ['quantity_base' => 1, 'is_removable' => false, 'is_extra' => false, 'extra_price' => 0]);
@@ -101,6 +101,6 @@ it('allergen filter uses only active products', function () {
 
     $allergens = $response->viewData('allergens');
 
-    expect($allergens->pluck('id')->contains($allergen->id))->toBeTrue();
-    expect($allergens->pluck('id')->contains($inactiveAllergen->id))->toBeFalse();
+    expect($allergens->pluck('slug')->contains('lacteos'))->toBeTrue();
+    expect($allergens->pluck('slug')->contains('gluten'))->toBeFalse();
 });

--- a/tests/Feature/Bloque3/MenuPublicTest.php
+++ b/tests/Feature/Bloque3/MenuPublicTest.php
@@ -103,7 +103,7 @@ it('passes allergens to view for filters', function () {
     $table    = Table::factory()->for($this->user)->create();
     $category = Category::factory()->for($this->user)->create(['destination' => 'kitchen']);
     $product  = Product::factory()->for($category)->for($this->user)->create(['is_active' => true]);
-    $allergen = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_type' => 'lacteos']);
+    $allergen = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_types' => ['lacteos']]);
 
     $product->ingredients()->attach($allergen->id, [
         'quantity_base' => 1,

--- a/tests/Feature/Menu/IngredientTest.php
+++ b/tests/Feature/Menu/IngredientTest.php
@@ -75,8 +75,8 @@ it('creates a non allergen ingredient', function () {
 it('creates an allergen ingredient', function () {
     $this->actingAs($this->user)
         ->post(route('ingredients.store'), [
-            'name'        => 'Queso',
-            'is_allergen' => true,
+            'name'           => 'Queso',
+            'allergen_types' => ['lacteos'],
         ])
         ->assertRedirect(route('ingredients.index'));
 
@@ -143,8 +143,8 @@ it('updates ingredient name and is_allergen correctly', function () {
 
     $this->actingAs($this->user)
         ->put(route('ingredients.update', $ingredient), [
-            'name'        => 'Pan Integral',
-            'is_allergen' => true,
+            'name'           => 'Pan Integral',
+            'allergen_types' => ['gluten'],
         ])
         ->assertRedirect(route('ingredients.index'));
 

--- a/tests/Feature/PublicMenu/MenuPublicTest.php
+++ b/tests/Feature/PublicMenu/MenuPublicTest.php
@@ -103,7 +103,7 @@ it('passes allergens to view for filters', function () {
     $table    = Table::factory()->for($this->user)->create();
     $category = Category::factory()->for($this->user)->create(['destination' => 'kitchen']);
     $product  = Product::factory()->for($category)->for($this->user)->create(['is_active' => true]);
-    $allergen = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_type' => 'lacteos']);
+    $allergen = Ingredient::factory()->for($this->user)->create(['name' => 'Queso', 'is_allergen' => true, 'allergen_types' => ['lacteos']]);
 
     $product->ingredients()->attach($allergen->id, [
         'quantity_base' => 1,


### PR DESCRIPTION
## Summary

- Replaces single `allergen_type` string column with `allergen_types` JSON array on `ingredients` table — an ingredient can now carry multiple EU allergens (Reg. 1169/2011)
- `is_allergen` boolean is now derived automatically from whether the array is non-empty
- Ingredient create/edit forms replaced with multi-checkbox grid showing all 14 EU allergen icons
- `allergen-badge` component refactored to accept `:slug` string prop instead of `:ingredient` model
- `$allergens` in `MenuController` is now a collection of `{slug, name, emoji}` objects — no more ingredient model dependency in the view layer
- All views (`products/index`, `products/edit`, `menu/show`) updated to collect unique allergen slugs via `flatMap`
- Existing `allergen_type` data migrated automatically to the new JSON array format

## Test plan

- [x] `php artisan test` — 983 passed, 9 pre-existing Ticket PDF failures (unrelated to this PR, present on `main`)
- [x] Allergen tests: `Bloque1/IngredientTest`, `Bloque2/AllergenTest`, `Bloque3/MenuPublicTest`, `Allergens/AllergenTest`, `PublicMenu/MenuPublicTest`, `Menu/IngredientTest`
- [x] Migration runs cleanly on existing data (`php artisan migrate`)
- [x] Rollback via `down()` restores `allergen_type` from first element of array
