### PR TITLE
feat: Stripe Connect per restaurant — destination charges

### DIFF
--- a/app/Http/Controllers/Api/CardPaymentController.php
+++ b/app/Http/Controllers/Api/CardPaymentController.php
@@ -65,7 +65,7 @@ class CardPaymentController extends Controller
 
         $tip = (float) ($validated['tip'] ?? 0);
 
-        $table = Table::where('unique_hash', $hash)->firstOrFail();
+        $table = Table::with('user')->where('unique_hash', $hash)->firstOrFail();
 
         $order = Order::where('table_id', $table->id)
             ->whereIn('status', ['pending', 'cooking', 'ready'])
@@ -83,10 +83,15 @@ class CardPaymentController extends Controller
         $remaining  = max(0, $order->total - $order->getPaidAmountViaSplit());
         $grandTotal = $remaining + $tip;
 
+        $stripeAccountId = ($table->user->stripe_onboarding_completed && $table->user->stripe_account_id)
+            ? $table->user->stripe_account_id
+            : null;
+
         $result = $this->stripe->createPaymentIntent(
-            amount:   (int) round($grandTotal * 100),
-            currency: 'eur',
-            metadata: ['order_id' => $order->id, 'table_name' => $table->name, 'tip' => $tip],
+            amount:          (int) round($grandTotal * 100),
+            currency:        'eur',
+            metadata:        ['order_id' => $order->id, 'table_name' => $table->name, 'tip' => $tip],
+            stripeAccountId: $stripeAccountId,
         );
 
         return response()->json([

--- a/app/Http/Controllers/Api/MixedPaymentController.php
+++ b/app/Http/Controllers/Api/MixedPaymentController.php
@@ -33,7 +33,7 @@ class MixedPaymentController extends Controller
             'tip'         => 'nullable|numeric|min:0|max:500',
         ]);
 
-        $table = Table::where('unique_hash', $hash)->firstOrFail();
+        $table = Table::with('user')->where('unique_hash', $hash)->firstOrFail();
         $order = $this->activeOrder($table->id);
 
         if (! $order) {
@@ -54,15 +54,20 @@ class MixedPaymentController extends Controller
 
         $grandTotal = $cardAmount + $tip;
 
+        $stripeAccountId = ($table->user->stripe_onboarding_completed && $table->user->stripe_account_id)
+            ? $table->user->stripe_account_id
+            : null;
+
         $result = $this->stripe->createPaymentIntent(
-            amount:   (int) round($grandTotal * 100),
-            currency: 'eur',
-            metadata: [
+            amount:          (int) round($grandTotal * 100),
+            currency:        'eur',
+            metadata:        [
                 'order_id'    => $order->id,
                 'table_name'  => $table->name,
                 'cash_amount' => $cashAmount,
                 'tip'         => $tip,
             ],
+            stripeAccountId: $stripeAccountId,
         );
 
         return response()->json([

--- a/app/Http/Controllers/Api/SplitPaymentController.php
+++ b/app/Http/Controllers/Api/SplitPaymentController.php
@@ -117,12 +117,17 @@ class SplitPaymentController extends Controller
             $amount      = $items->sum(fn (OrderItem $i) => round($i->price * $i->quantity, 2));
             $grandAmount = $amount + $tip;
 
+            $stripeAccountId = ($table->user->stripe_onboarding_completed && $table->user->stripe_account_id)
+                ? $table->user->stripe_account_id
+                : null;
+
             $result = $this->stripe->createSplitPaymentIntent(
-                amount:      (int) round($grandAmount * 100),
-                mode:        'items',
-                partNumber:  1,
-                partsTotal:  1,
-                metadata:    ['order_id' => $order->id, 'table_name' => $table->name, 'tip' => $tip],
+                amount:          (int) round($grandAmount * 100),
+                mode:            'items',
+                partNumber:      1,
+                partsTotal:      1,
+                metadata:        ['order_id' => $order->id, 'table_name' => $table->name, 'tip' => $tip],
+                stripeAccountId: $stripeAccountId,
             );
 
             foreach ($items as $index => $item) {
@@ -194,12 +199,17 @@ class SplitPaymentController extends Controller
         $part        = round((float) $order->total / $people, 2);
         $grandAmount = $part + $tip;
 
+        $stripeAccountId = ($table->user->stripe_onboarding_completed && $table->user->stripe_account_id)
+            ? $table->user->stripe_account_id
+            : null;
+
         $result = $this->stripe->createSplitPaymentIntent(
-            amount:     (int) round($grandAmount * 100),
-            mode:       'equitative',
-            partNumber: $partNumber,
-            partsTotal: $people,
-            metadata:   ['order_id' => $order->id, 'table_name' => $table->name, 'tip' => $tip],
+            amount:          (int) round($grandAmount * 100),
+            mode:            'equitative',
+            partNumber:      $partNumber,
+            partsTotal:      $people,
+            metadata:        ['order_id' => $order->id, 'table_name' => $table->name, 'tip' => $tip],
+            stripeAccountId: $stripeAccountId,
         );
 
         OrderItemPayment::create([

--- a/app/Http/Controllers/StripeConnectController.php
+++ b/app/Http/Controllers/StripeConnectController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\StripeService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Gestiona el flujo de conexión de cuentas Stripe (Stripe Connect Express).
+ * Cada restaurante conecta su propia cuenta para recibir los pagos directamente
+ * mediante destination charges sin necesidad de pasar por la cuenta de la plataforma.
+ *
+ * @author BenjaminDTS
+ */
+class StripeConnectController extends Controller
+{
+    public function __construct(private readonly StripeService $stripe) {}
+
+    /**
+     * Inicia el onboarding de Stripe Connect Express.
+     * Crea una cuenta Express si el restaurante no tiene una,
+     * genera un Account Link y redirige al formulario de Stripe.
+     *
+     * @return RedirectResponse
+     */
+    public function connect(): RedirectResponse
+    {
+        $user = Auth::user();
+
+        if (! $user->stripe_account_id) {
+            $account = $this->stripe->createConnectAccount(
+                email:        $user->email,
+                businessName: $user->business_name,
+            );
+            $user->update(['stripe_account_id' => $account['id']]);
+        }
+
+        $url = $this->stripe->createAccountLink(
+            accountId:  $user->stripe_account_id,
+            refreshUrl: route('stripe.connect'),
+            returnUrl:  route('stripe.connect.callback'),
+        );
+
+        return redirect($url);
+    }
+
+    /**
+     * Callback de Stripe tras completar (o salir de) el onboarding.
+     * Consulta el estado real de la cuenta y actualiza el flag de onboarding.
+     *
+     * @return RedirectResponse
+     */
+    public function callback(): RedirectResponse
+    {
+        $user = Auth::user();
+
+        if ($user->stripe_account_id) {
+            $status = $this->stripe->getAccountStatus($user->stripe_account_id);
+            $user->update(['stripe_onboarding_completed' => $status['charges_enabled']]);
+            $user->refresh();
+        }
+
+        $message = $user->stripe_onboarding_completed
+            ? 'Cuenta de Stripe conectada. Los pagos con tarjeta se ingresarán en tu cuenta bancaria.'
+            : 'Onboarding de Stripe pendiente. Completa todos los datos para activar los cobros.';
+
+        return redirect()->route('negocio.config.edit')->with('success', $message);
+    }
+
+    /**
+     * Desconecta la cuenta de Stripe del restaurante.
+     * Los pagos pasarán a ir a la cuenta de la plataforma hasta que se reconecte.
+     *
+     * @return RedirectResponse
+     */
+    public function disconnect(): RedirectResponse
+    {
+        Auth::user()->update([
+            'stripe_account_id'           => null,
+            'stripe_onboarding_completed' => false,
+        ]);
+
+        return redirect()->route('negocio.config.edit')
+            ->with('success', 'Cuenta de Stripe desconectada.');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -40,6 +40,8 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property bool        $floors_enabled Si el sistema de plantas está activo
  * @property bool        $split_payment_enabled   Si el cobro partido está activo para este restaurante
  * @property int|null    $split_payment_max_parts Máximo de partes en que se puede dividir la cuenta (null = sin límite)
+ * @property string|null $stripe_account_id           ID de cuenta Stripe Connect Express del restaurante (acct_xxx)
+ * @property bool        $stripe_onboarding_completed Si el restaurante completó el onboarding de Stripe Connect
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
@@ -76,6 +78,8 @@ class User extends Authenticatable
         'floor_canvas_sizes',
         'split_payment_enabled',
         'split_payment_max_parts',
+        'stripe_account_id',
+        'stripe_onboarding_completed',
     ];
 
     /**
@@ -104,8 +108,9 @@ class User extends Authenticatable
             'floor_count'             => 'integer',
             'floors_enabled'          => 'boolean',
             'floor_canvas_sizes'      => 'array',
-            'split_payment_enabled'   => 'boolean',
-            'split_payment_max_parts' => 'integer',
+            'split_payment_enabled'        => 'boolean',
+            'split_payment_max_parts'      => 'integer',
+            'stripe_onboarding_completed'  => 'boolean',
         ];
     }
 

--- a/app/Services/StripeService.php
+++ b/app/Services/StripeService.php
@@ -6,6 +6,8 @@ use Stripe\StripeClient;
 
 /**
  * Servicio para interactuar con la API de Stripe.
+ * Soporta Stripe Connect Express: cada restaurante puede conectar su propia cuenta
+ * y recibir los pagos directamente mediante destination charges.
  * Siempre se debe mockear en tests — nunca hacer llamadas reales.
  *
  * @author BenjaminDTS
@@ -21,20 +23,34 @@ class StripeService
 
     /**
      * Crea un PaymentIntent en Stripe.
+     * Si se indica $stripeAccountId, el cobro se enruta a esa cuenta conectada
+     * mediante destination charge (los fondos van al restaurante directamente).
      *
-     * @param  int     $amount    Importe en céntimos (e.g. 1250 para 12,50 €)
-     * @param  string  $currency  Código ISO de la moneda (por defecto 'eur')
-     * @param  array   $metadata  Metadatos opcionales para el PaymentIntent
+     * @param  int          $amount          Importe en céntimos (e.g. 1250 para 12,50 €)
+     * @param  string       $currency        Código ISO de la moneda (por defecto 'eur')
+     * @param  array        $metadata        Metadatos opcionales para el PaymentIntent
+     * @param  string|null  $stripeAccountId ID de cuenta Connect del restaurante (acct_xxx)
      * @return array{id: string, client_secret: string, status: string}
      */
-    public function createPaymentIntent(int $amount, string $currency = 'eur', array $metadata = []): array
-    {
-        $intent = $this->client->paymentIntents->create([
+    public function createPaymentIntent(
+        int $amount,
+        string $currency = 'eur',
+        array $metadata = [],
+        ?string $stripeAccountId = null,
+    ): array {
+        $params = [
             'amount'                    => $amount,
             'currency'                  => $currency,
             'metadata'                  => $metadata,
             'automatic_payment_methods' => ['enabled' => true],
-        ]);
+        ];
+
+        if ($stripeAccountId) {
+            $params['on_behalf_of']  = $stripeAccountId;
+            $params['transfer_data'] = ['destination' => $stripeAccountId];
+        }
+
+        $intent = $this->client->paymentIntents->create($params);
 
         return [
             'id'            => $intent->id,
@@ -47,11 +63,12 @@ class StripeService
      * Crea un PaymentIntent parcial para cobro partido.
      * Igual que createPaymentIntent pero incluye metadata de split.
      *
-     * @param  int     $amount      Importe en céntimos
-     * @param  string  $mode        'items' o 'equitative'
-     * @param  int     $partNumber  Número de esta parte (1-based)
-     * @param  int     $partsTotal  Total de partes de la división
-     * @param  array   $metadata    Metadatos adicionales
+     * @param  int          $amount          Importe en céntimos
+     * @param  string       $mode            'items' o 'equitative'
+     * @param  int          $partNumber      Número de esta parte (1-based)
+     * @param  int          $partsTotal      Total de partes de la división
+     * @param  array        $metadata        Metadatos adicionales
+     * @param  string|null  $stripeAccountId ID de cuenta Connect del restaurante (acct_xxx)
      * @return array{id: string, client_secret: string, status: string}
      */
     public function createSplitPaymentIntent(
@@ -60,8 +77,9 @@ class StripeService
         int $partNumber,
         int $partsTotal,
         array $metadata = [],
+        ?string $stripeAccountId = null,
     ): array {
-        $intent = $this->client->paymentIntents->create([
+        $params = [
             'amount'                    => $amount,
             'currency'                  => 'eur',
             'metadata'                  => array_merge($metadata, [
@@ -70,7 +88,14 @@ class StripeService
                 'split_parts_total' => $partsTotal,
             ]),
             'automatic_payment_methods' => ['enabled' => true],
-        ]);
+        ];
+
+        if ($stripeAccountId) {
+            $params['on_behalf_of']  = $stripeAccountId;
+            $params['transfer_data'] = ['destination' => $stripeAccountId];
+        }
+
+        $intent = $this->client->paymentIntents->create($params);
 
         return [
             'id'            => $intent->id,
@@ -82,6 +107,8 @@ class StripeService
     /**
      * Recupera un PaymentIntent y devuelve su estado actual.
      * Se usa para verificar el pago en el servidor tras la confirmación del cliente.
+     * Con destination charges el PI existe en la cuenta de la plataforma,
+     * por lo que no se necesita el ID de cuenta conectada.
      *
      * @param  string  $paymentIntentId
      * @return array{id: string, status: string}
@@ -93,6 +120,72 @@ class StripeService
         return [
             'id'     => $intent->id,
             'status' => $intent->status,
+        ];
+    }
+
+    /**
+     * Crea una cuenta Express de Stripe Connect para un restaurante.
+     * El restaurante completará sus datos bancarios mediante el Account Link.
+     *
+     * @param  string       $email        Email del gerente del restaurante
+     * @param  string|null  $businessName Nombre del negocio (opcional)
+     * @return array{id: string}
+     */
+    public function createConnectAccount(string $email, ?string $businessName = null): array
+    {
+        $params = [
+            'type'         => 'express',
+            'email'        => $email,
+            'capabilities' => [
+                'card_payments' => ['requested' => true],
+                'transfers'     => ['requested' => true],
+            ],
+        ];
+
+        if ($businessName) {
+            $params['business_profile']['name'] = $businessName;
+        }
+
+        $account = $this->client->accounts->create($params);
+
+        return ['id' => $account->id];
+    }
+
+    /**
+     * Genera un enlace de onboarding de Stripe Connect para que el restaurante
+     * complete sus datos bancarios en la plataforma de Stripe.
+     *
+     * @param  string  $accountId   ID de cuenta Express (acct_xxx)
+     * @param  string  $refreshUrl  URL a la que redirigir si el enlace expira
+     * @param  string  $returnUrl   URL a la que redirigir tras completar el onboarding
+     * @return string               URL del formulario de onboarding de Stripe
+     */
+    public function createAccountLink(string $accountId, string $refreshUrl, string $returnUrl): string
+    {
+        $link = $this->client->accountLinks->create([
+            'account'     => $accountId,
+            'refresh_url' => $refreshUrl,
+            'return_url'  => $returnUrl,
+            'type'        => 'account_onboarding',
+        ]);
+
+        return $link->url;
+    }
+
+    /**
+     * Consulta el estado de una cuenta Connect de Stripe.
+     * Devuelve si la cuenta puede cobrar y si ha completado el onboarding.
+     *
+     * @param  string  $accountId  ID de cuenta Express (acct_xxx)
+     * @return array{charges_enabled: bool, details_submitted: bool}
+     */
+    public function getAccountStatus(string $accountId): array
+    {
+        $account = $this->client->accounts->retrieve($accountId);
+
+        return [
+            'charges_enabled'  => $account->charges_enabled,
+            'details_submitted' => $account->details_submitted,
         ];
     }
 }

--- a/database/migrations/2026_05_31_000001_add_stripe_connect_to_users_table.php
+++ b/database/migrations/2026_05_31_000001_add_stripe_connect_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('stripe_account_id')->nullable()->after('split_payment_max_parts');
+            $table->boolean('stripe_onboarding_completed')->default(false)->after('stripe_account_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['stripe_account_id', 'stripe_onboarding_completed']);
+        });
+    }
+};

--- a/resources/views/negocio/config.blade.php
+++ b/resources/views/negocio/config.blade.php
@@ -118,6 +118,132 @@
 
             <script id="config-init" type="application/json">@json($configInit)</script>
 
+            {{-- ══════════════════════════════════════════════════════════════ --}}
+            {{-- SECCIÓN STRIPE CONNECT — fuera del form (redirige a Stripe)     --}}
+            {{-- ══════════════════════════════════════════════════════════════ --}}
+            <section aria-labelledby="section-stripe-title"
+                     class="bg-white dark:bg-gray-800 shadow-sm rounded-xl overflow-hidden
+                            ring-1 ring-gray-200 dark:ring-gray-700">
+
+                <div class="px-4 py-5 sm:px-6 border-b border-gray-200 dark:border-gray-700
+                            flex items-start gap-4">
+                    <div class="flex items-center justify-center h-10 w-10 rounded-lg
+                                bg-violet-100 dark:bg-violet-900/40 shrink-0">
+                        <svg class="h-5 w-5 text-violet-600 dark:text-violet-400" aria-hidden="true"
+                             fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                  d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/>
+                        </svg>
+                    </div>
+                    <div>
+                        <h3 id="section-stripe-title"
+                            class="text-base font-semibold text-gray-900 dark:text-gray-100">
+                            {{ __('Cuenta bancaria (Stripe Connect)') }}
+                        </h3>
+                        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+                            {{ __('Conecta tu cuenta bancaria para recibir los pagos con tarjeta directamente. Sin esto, los cobros van a la cuenta de la plataforma.') }}
+                        </p>
+                    </div>
+                </div>
+
+                <div class="px-4 py-5 sm:px-6">
+
+                    @if(auth()->user()->stripe_onboarding_completed)
+                        {{-- Estado: conectado --}}
+                        <div class="flex items-center justify-between gap-4">
+                            <div class="flex items-center gap-3">
+                                <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full
+                                             bg-emerald-100 dark:bg-emerald-900/30
+                                             text-emerald-700 dark:text-emerald-400
+                                             text-xs font-semibold">
+                                    <svg class="h-3 w-3" aria-hidden="true" fill="currentColor" viewBox="0 0 8 8">
+                                        <circle cx="4" cy="4" r="3"/>
+                                    </svg>
+                                    {{ __('Cuenta conectada') }}
+                                </span>
+                                <span class="text-sm text-gray-500 dark:text-gray-400 font-mono">
+                                    {{ auth()->user()->stripe_account_id }}
+                                </span>
+                            </div>
+                            <form method="POST"
+                                  action="{{ route('stripe.connect.disconnect') }}"
+                                  onsubmit="return confirm('{{ __('¿Seguro que quieres desconectar tu cuenta de Stripe? Los pagos dejarán de ingresarse en tu cuenta bancaria.') }}')">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit"
+                                        class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg
+                                               text-sm font-medium text-red-600 dark:text-red-400
+                                               border border-red-300 dark:border-red-700
+                                               hover:bg-red-50 dark:hover:bg-red-900/20
+                                               focus:outline-none focus:ring-2 focus:ring-red-500
+                                               focus:ring-offset-2 dark:focus:ring-offset-gray-800
+                                               transition-colors">
+                                    <svg aria-hidden="true" class="h-4 w-4" fill="none"
+                                         stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round"
+                                              d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"/>
+                                    </svg>
+                                    {{ __('Desconectar') }}
+                                </button>
+                            </form>
+                        </div>
+
+                    @elseif(auth()->user()->stripe_account_id)
+                        {{-- Estado: cuenta creada pero onboarding pendiente --}}
+                        <div class="space-y-4">
+                            <div class="flex items-center gap-3 rounded-lg
+                                        bg-amber-50 dark:bg-amber-900/20
+                                        border border-amber-200 dark:border-amber-700
+                                        px-4 py-3">
+                                <svg class="h-4 w-4 text-amber-500 shrink-0" aria-hidden="true"
+                                     fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                          d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+                                </svg>
+                                <p class="text-sm text-amber-700 dark:text-amber-400">
+                                    {{ __('Onboarding pendiente. Completa tus datos bancarios en Stripe para activar los cobros.') }}
+                                </p>
+                            </div>
+                            <a href="{{ route('stripe.connect') }}"
+                               class="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-semibold
+                                      bg-violet-600 text-white shadow-sm
+                                      hover:bg-violet-500 active:bg-violet-700
+                                      focus:outline-none focus:ring-2 focus:ring-violet-500
+                                      focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                                <svg aria-hidden="true" class="h-4 w-4" fill="none"
+                                     stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                          d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/>
+                                </svg>
+                                {{ __('Completar onboarding en Stripe') }}
+                            </a>
+                        </div>
+
+                    @else
+                        {{-- Estado: sin cuenta --}}
+                        <div class="space-y-4">
+                            <p class="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+                                {{ __('Serás redirigido a Stripe para introducir tus datos bancarios. El proceso tarda menos de 5 minutos.') }}
+                            </p>
+                            <a href="{{ route('stripe.connect') }}"
+                               class="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-semibold
+                                      bg-violet-600 text-white shadow-sm
+                                      hover:bg-violet-500 active:bg-violet-700
+                                      focus:outline-none focus:ring-2 focus:ring-violet-500
+                                      focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors">
+                                <svg aria-hidden="true" class="h-4 w-4" fill="none"
+                                     stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                          d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/>
+                                </svg>
+                                {{ __('Conectar cuenta bancaria con Stripe') }}
+                            </a>
+                        </div>
+                    @endif
+
+                </div>
+            </section>
+
             <form method="POST" action="{{ route('negocio.config.update') }}"
                   x-data="businessConfig()"
                   class="space-y-6">

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\ProductController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\TableController;
+use App\Http\Controllers\StripeConnectController;
 use App\Http\Controllers\TicketConfigController;
 use App\Http\Controllers\TicketController;
 use App\Http\Controllers\ZoneController;
@@ -97,6 +98,11 @@ Route::middleware(['auth', 'business.active'])->group(function () {
         Route::post('/zonas', [ZoneController::class, 'store'])->name('zones.store');
         Route::patch('/zonas/{zone}', [ZoneController::class, 'update'])->name('zones.update');
         Route::delete('/zonas/{zone}', [ZoneController::class, 'destroy'])->name('zones.destroy');
+
+        // Stripe Connect — conexión de cuenta bancaria por restaurante
+        Route::get('/stripe/connect', [StripeConnectController::class, 'connect'])->name('stripe.connect');
+        Route::get('/stripe/connect/callback', [StripeConnectController::class, 'callback'])->name('stripe.connect.callback');
+        Route::delete('/stripe/connect/disconnect', [StripeConnectController::class, 'disconnect'])->name('stripe.connect.disconnect');
 
         // Menú del Día — gestión del gerente (Bloque 14.2)
         Route::resource('daily-menus', DailyMenuController::class)

--- a/tests/Feature/Bloque9/DashboardTest.php
+++ b/tests/Feature/Bloque9/DashboardTest.php
@@ -284,7 +284,7 @@ it('filters income by this month period', function () {
         'payment_method' => 'cash',
         'payment_status' => 'paid',
         'total'          => 99.00,
-        'updated_at'     => now()->subMonth(),
+        'updated_at'     => now()->subMonthNoOverflow(),
     ]);
 
     $summary = $this->actingAs($this->admin)
@@ -579,7 +579,7 @@ it('top table changes correctly when period filter changes', function () {
     Order::factory()->create([
         'table_id' => $table->id, 'payment_method' => 'cash',
         'payment_status' => 'paid', 'total' => 60.00,
-        'updated_at' => now()->subMonth()->startOfDay()->addHours(12),
+        'updated_at' => now()->subMonthNoOverflow()->startOfDay()->addHours(12),
     ]);
 
     $topTableMonth = $this->actingAs($this->admin)
@@ -592,8 +592,8 @@ it('top table changes correctly when period filter changes', function () {
     $topTableCustom = $this->actingAs($this->admin)
                            ->get(route('dashboard', [
                                'period' => 'custom',
-                               'from'   => now()->subMonth()->startOfMonth()->format('Y-m-d'),
-                               'to'     => now()->subMonth()->endOfMonth()->format('Y-m-d'),
+                               'from'   => now()->subMonthNoOverflow()->startOfMonth()->format('Y-m-d'),
+                               'to'     => now()->subMonthNoOverflow()->endOfMonth()->format('Y-m-d'),
                            ]))
                            ->assertOk()
                            ->viewData('topTable');
@@ -744,7 +744,7 @@ it('average ticket updates correctly when period filter changes', function () {
     Order::factory()->create([
         'table_id' => $table->id, 'payment_method' => 'cash', 'payment_status' => 'paid',
         'total' => 60.00, 'tip' => 0,
-        'updated_at' => now()->subMonth()->startOfDay()->addHours(12),
+        'updated_at' => now()->subMonthNoOverflow()->startOfDay()->addHours(12),
     ]);
 
     $avgTicketMonth = $this->actingAs($this->admin)
@@ -757,8 +757,8 @@ it('average ticket updates correctly when period filter changes', function () {
     $avgTicketCustom = $this->actingAs($this->admin)
                             ->get(route('dashboard', [
                                 'period' => 'custom',
-                                'from'   => now()->subMonth()->startOfMonth()->format('Y-m-d'),
-                                'to'     => now()->subMonth()->endOfMonth()->format('Y-m-d'),
+                                'from'   => now()->subMonthNoOverflow()->startOfMonth()->format('Y-m-d'),
+                                'to'     => now()->subMonthNoOverflow()->endOfMonth()->format('Y-m-d'),
                             ]))
                             ->assertOk()
                             ->viewData('avgTicket');


### PR DESCRIPTION
## Summary

- Add `stripe_account_id` and `stripe_onboarding_completed` columns to `users` table via migration
- Extend `StripeService` with Stripe Connect support: destination charges on `createPaymentIntent` / `createSplitPaymentIntent`, plus `createConnectAccount`, `createAccountLink` and `getAccountStatus` methods
- New `StripeConnectController`: Express account onboarding flow (`connect`, `callback`, `disconnect`)
- Route card, mixed and split payment PaymentIntents to the restaurant's connected account when onboarding is complete
- Add Stripe Connect section to `negocio/config` view showing connection status and onboarding/disconnect actions
- Fix `DashboardTest`: use `subMonthNoOverflow()` to prevent PHP month overflow on day 31 (`subMonth()` on May 31 overflows April 31 → May 1, falling inside the current month range)

## Test plan

- [ ] Run `php artisan migrate` — new columns appear in `users`
- [ ] Existing payments (no connected account) work unchanged — `stripeAccountId` is `null`, no destination charge
- [ ] Connect flow: `GET /stripe/connect` redirects to Stripe onboarding link
- [ ] Callback: `GET /stripe/connect/callback` marks `stripe_onboarding_completed = true` and stores `stripe_account_id`
- [ ] After connect: card/mixed/split PaymentIntents include `on_behalf_of` and `transfer_data` pointing to restaurant account
- [ ] Disconnect: `DELETE /stripe/connect/disconnect` clears both columns
- [ ] Config view shows correct badge (connected / not connected) and correct action button
- [ ] `php artisan test` passes at 100% (992 tests)

Generated with [Claude Code](https://claude.com/claude-code)