### PR TITLE
feat: add search bar and category filter to admin indexes

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -26,10 +26,17 @@ class CategoryController extends Controller
      *
      * @return View Retorna la vista 'categories.index' con los datos.
      */
-    public function index(): View
+    /**
+     * @param Request $request
+     * @return View
+     */
+    public function index(Request $request): View
     {
         $ownerId    = Auth::user()->ownerUserId();
-        $categories = Category::where('user_id', $ownerId)->paginate(15);
+        $categories = Category::where('user_id', $ownerId)
+            ->when($request->filled('search'), fn ($q) => $q->where('name', 'like', '%' . $request->search . '%'))
+            ->paginate(15)
+            ->withQueryString();
 
         return view('categories.index', compact('categories'));
     }

--- a/app/Http/Controllers/IngredientController.php
+++ b/app/Http/Controllers/IngredientController.php
@@ -25,10 +25,17 @@ class IngredientController extends Controller
      *
      * @return \Illuminate\View\View Vista con la rejilla de ingredientes.
      */
-    public function index(): \Illuminate\View\View
+    /**
+     * @param Request $request
+     * @return \Illuminate\View\View
+     */
+    public function index(Request $request): \Illuminate\View\View
     {
         $ownerId     = Auth::user()->ownerUserId();
-        $ingredients = Ingredient::where('user_id', $ownerId)->paginate(15);
+        $ingredients = Ingredient::where('user_id', $ownerId)
+            ->when($request->filled('search'), fn ($q) => $q->where('name', 'like', '%' . $request->search . '%'))
+            ->paginate(15)
+            ->withQueryString();
 
         return view('ingredients.index', compact('ingredients'));
     }

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -29,11 +29,23 @@ class ProductController extends Controller
    *
    * @return View Vista con la tabla de productos.
    */
-  public function index(): View
+  /**
+   * @param Request $request
+   * @return View
+   */
+  public function index(Request $request): View
   {
-    $ownerId  = Auth::user()->ownerUserId();
-    $products = Product::where('user_id', $ownerId)->with(['allergens', 'variants'])->paginate(15);
-    return view('products.index', compact('products'));
+    $ownerId    = Auth::user()->ownerUserId();
+    $categories = Category::where('user_id', $ownerId)->orderBy('name')->get();
+
+    $products = Product::where('user_id', $ownerId)
+      ->with(['allergens', 'variants', 'category'])
+      ->when($request->filled('search'), fn ($q) => $q->where('name', 'like', '%' . $request->search . '%'))
+      ->when($request->filled('category'), fn ($q) => $q->where('category_id', $request->category))
+      ->paginate(15)
+      ->withQueryString();
+
+    return view('products.index', compact('products', 'categories'));
   }
 
   /**

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -29,6 +29,38 @@
       </a>
     </div>
 
+    {{-- Búsqueda --}}
+    <form method="GET" action="{{ route('categories.index') }}"
+          class="mb-6 flex flex-col sm:flex-row gap-3 items-stretch sm:items-center"
+          role="search" aria-label="Buscar categorías">
+      <div class="relative flex-1">
+        <svg class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 105 11a6 6 0 0012 0z"/>
+        </svg>
+        <input type="text" name="search" id="search" value="{{ request('search') }}"
+               placeholder="Buscar categoría..."
+               aria-label="Buscar categoría por nombre"
+               class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 py-2 pl-9 pr-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+      </div>
+      <button type="submit"
+              class="inline-flex items-center justify-center gap-1.5 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-sm py-2.5 px-4 rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors">
+        <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 105 11a6 6 0 0012 0z"/>
+        </svg>
+        Buscar
+      </button>
+      @if(request()->filled('search'))
+        <a href="{{ route('categories.index') }}"
+           class="inline-flex items-center justify-center gap-1.5 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-semibold text-sm py-2.5 px-4 rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors"
+           aria-label="Limpiar búsqueda">
+          <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+          </svg>
+          Limpiar
+        </a>
+      @endif
+    </form>
+
     {{-- Flash de éxito --}}
     @if(session('success'))
     <div role="alert" aria-live="polite"

--- a/resources/views/ingredients/index.blade.php
+++ b/resources/views/ingredients/index.blade.php
@@ -20,8 +20,35 @@
         </div>
         @endif
 
-        <div class="flex justify-end mb-4">
-          <a href="{{ route('ingredients.create') }}" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded">
+        <div class="flex flex-col sm:flex-row justify-between gap-3 mb-4">
+          {{-- Búsqueda --}}
+          <form method="GET" action="{{ route('ingredients.index') }}"
+                class="flex flex-1 gap-3 items-center"
+                role="search" aria-label="Buscar ingredientes">
+            <div class="relative flex-1 max-w-sm">
+              <svg class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 105 11a6 6 0 0012 0z"/>
+              </svg>
+              <input type="text" name="search" id="search" value="{{ request('search') }}"
+                     placeholder="Buscar ingrediente..."
+                     aria-label="Buscar ingrediente por nombre"
+                     class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 py-2 pl-9 pr-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+            </div>
+            <button type="submit"
+                    class="inline-flex items-center gap-1.5 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-sm py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition">
+              Buscar
+            </button>
+            @if(request()->filled('search'))
+              <a href="{{ route('ingredients.index') }}"
+                 class="inline-flex items-center gap-1.5 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-semibold text-sm py-2 px-3 rounded focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 transition"
+                 aria-label="Limpiar búsqueda">
+                <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+                </svg>
+              </a>
+            @endif
+          </form>
+          <a href="{{ route('ingredients.create') }}" class="inline-flex items-center gap-1.5 bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition">
             + Nuevo Ingrediente
           </a>
         </div>

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -23,6 +23,52 @@
       </a>
     </div>
 
+    {{-- Filtros: búsqueda y categoría --}}
+    <form method="GET" action="{{ route('products.index') }}"
+          class="mb-4 flex flex-col sm:flex-row gap-3 items-stretch sm:items-center"
+          role="search" aria-label="Filtrar platos">
+      <div class="relative flex-1">
+        <svg class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 105 11a6 6 0 0012 0z"/>
+        </svg>
+        <input type="text" name="search" id="search" value="{{ request('search') }}"
+               placeholder="Buscar plato..."
+               aria-label="Buscar plato por nombre"
+               class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 py-2 pl-9 pr-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+      </div>
+      <div class="relative">
+        <select name="category" id="category" aria-label="Filtrar por categoría"
+                class="w-full sm:w-48 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 py-2 pl-3 pr-8 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 appearance-none">
+          <option value="">Todas las categorías</option>
+          @foreach($categories as $cat)
+            <option value="{{ $cat->id }}" {{ request('category') == $cat->id ? 'selected' : '' }}>
+              {{ $cat->name }}
+            </option>
+          @endforeach
+        </select>
+        <svg class="absolute right-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+        </svg>
+      </div>
+      <button type="submit"
+              class="inline-flex items-center justify-center gap-1.5 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-sm py-2 px-4 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition">
+        <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 105 11a6 6 0 0012 0z"/>
+        </svg>
+        Filtrar
+      </button>
+      @if(request()->hasAny(['search', 'category']))
+        <a href="{{ route('products.index') }}"
+           class="inline-flex items-center justify-center gap-1.5 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-semibold text-sm py-2 px-4 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition"
+           aria-label="Limpiar filtros">
+          <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+          </svg>
+          Limpiar
+        </a>
+      @endif
+    </form>
+
     {{-- Flash de éxito --}}
     @if(session('success'))
     <div role="alert" aria-live="polite"


### PR DESCRIPTION
## Summary

- Add search bar (by name) to products, categories, and ingredients admin indexes
- Add category filter dropdown to products index
- Pagination links preserve active filters via `withQueryString()`
- Fix N+1: add `category` to eager load in `ProductController@index`

## Test plan

- [ ] Search filters results correctly in products, categories, and ingredients
- [ ] Category dropdown filters products by category
- [ ] Pagination works while filters are active (query string preserved)
- [ ] "Limpiar" button resets filters, only shows when filter is active
- [ ] `php artisan test` passes at 100%