### PR TITLE
style: carta digital pública — reescritura completa con Design System (Bloque 11.4)

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -153,7 +153,7 @@ class MenuController extends Controller
                 ->toArray()
             : [];
 
-        $theme = $table->user->menu_style ?? 'modern';
+        $theme = 'modern';
 
         return view('menu.show', compact(
             'theme', 'table', 'categories', 'allergens',

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -153,8 +153,10 @@ class MenuController extends Controller
                 ->toArray()
             : [];
 
+        $theme = $table->user->menu_style ?? 'modern';
+
         return view('menu.show', compact(
-            'table', 'categories', 'allergens',
+            'theme', 'table', 'categories', 'allergens',
             'tapaConfig', 'barItemsCount', 'kitchenOpen', 'nextOpeningTime',
             'tapaVariantsUsed', 'tapaProducts', 'shouldSuggest',
             'hasActiveOrder', 'activeOrderTotal', 'originalOrderTotal', 'billRequested', 'stripePublicKey',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -80,6 +80,7 @@ class User extends Authenticatable
         'split_payment_max_parts',
         'stripe_account_id',
         'stripe_onboarding_completed',
+        'menu_style',
     ];
 
     /**

--- a/public/css/carta/colors_and_type.css
+++ b/public/css/carta/colors_and_type.css
@@ -1,0 +1,309 @@
+/* ============================================================
+   ZAMPA — Carta Digital Pública
+   Design tokens: typography + colors (light + dark)
+   ------------------------------------------------------------
+   - Light mode is the PRIMARY surface (clean, appetising,
+     green-accented, what a guest sees by default).
+   - Dark mode reuses the Zampi chatbot's Night Blue palette
+     so the carta and Zampi feel like one product.
+   - Some tokens are invariable across modes (gold prices,
+     green cart bar, red delete pill) — they live in :root.
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&family=Space+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap');
+
+:root {
+  /* ─────────────────────────────────────────
+     RAW PALETTES (always available by name)
+     ───────────────────────────────────────── */
+
+  /* Greens — light-mode CTA & cart bar */
+  --color-green-50:  #F0FDF4;
+  --color-green-100: #DCFCE7;
+  --color-green-200: #BBF7D0;
+  --color-green-400: #4ADE80;
+  --color-green-500: #22C55E;
+  --color-green-600: #16A34A;   /* primary CTA */
+  --color-green-700: #15803D;
+  --color-green-800: #0F3D2A;   /* cart bar gradient start */
+  --color-green-900: #0A2E1F;   /* cart bar gradient end */
+
+  /* Amber — prices & allergen badges (invariable) */
+  --color-amber-100: #FEF3C7;
+  --color-amber-200: #FDE68A;
+  --color-amber-300: #FBBF24;   /* price gold */
+  --color-amber-400: #F59E0B;
+  --color-amber-800: #92400E;
+
+  /* Reds — delete pill & qty "−" border */
+  --color-red-400:   #EF4444;
+  --color-red-600:   #DC2626;
+  --color-red-800:   #991B1B;
+
+  /* Neutrals — light mode UI */
+  --color-gray-50:   #F9FAFB;
+  --color-gray-100:  #F3F4F6;
+  --color-gray-200:  #E5E7EB;
+  --color-gray-300:  #D1D5DB;
+  --color-gray-400:  #9CA3AF;
+  --color-gray-500:  #6B7280;
+  --color-gray-600:  #4B5563;
+  --color-gray-700:  #374151;
+  --color-gray-800:  #1F2937;
+  --color-gray-900:  #111827;
+
+  /* Night Blue — Zampi palette (dark mode + chatbot) */
+  --color-night-900: #01040E;   /* base bg          */
+  --color-night-800: #050B1F;
+  --color-night-700: #0A1430;
+  --color-night-600: #0E1A38;   /* surface / cards  */
+  --color-night-500: #162648;   /* elevated         */
+  --color-blue-500:  #1A3380;   /* accent secondary */
+  --color-blue-400:  #2E50B0;   /* accent primary   */
+  --color-blue-300:  #5478D0;
+  --color-blue-200:  #8FA8E8;   /* fg secondary     */
+  --color-blue-100:  #C8D8FF;   /* fg primary       */
+  --color-cyan-400:  #22D3EE;
+
+  /* ─────────────────────────────────────────
+     INVARIABLES (same in light & dark)
+     ───────────────────────────────────────── */
+  --price-gold:           var(--color-amber-300);
+  --allergen-bg:          var(--color-amber-100);
+  --allergen-fg:          var(--color-amber-800);
+  --allergen-active-bg:   var(--color-amber-300);
+  --allergen-active-fg:   #5A2F00;
+
+  --cart-bar-from:        var(--color-green-800);
+  --cart-bar-to:          var(--color-green-900);
+  --cart-bar-border:      var(--color-green-500);
+
+  --delete-pill-bg:       var(--color-red-800);
+  --delete-pill-border:   var(--color-red-400);
+
+  --badge-count:          var(--color-red-400);   /* red qty bubble */
+  --cta-view-order:       var(--color-green-600); /* "Ver pedido"   */
+  --qty-minus-border:     var(--color-red-400);
+  --qty-plus-border:      var(--color-green-500);
+
+  /* ─────────────────────────────────────────
+     LIGHT MODE (default — the carta)
+     ───────────────────────────────────────── */
+  --bg-base:        #FFFFFF;
+  --bg-canvas:      var(--color-gray-50);
+  --bg-surface:     #FFFFFF;
+  --bg-elevated:    #FFFFFF;
+  --bg-overlay:     rgba(17, 24, 39, 0.45);
+  --bg-chip:        var(--color-gray-100);
+  --bg-chip-active: var(--color-green-600);
+
+  --fg-primary:     var(--color-gray-900);
+  --fg-secondary:   var(--color-gray-600);
+  --fg-muted:       var(--color-gray-500);
+  --fg-on-accent:   #FFFFFF;
+
+  --border-subtle:  var(--color-gray-200);
+  --border-strong:  var(--color-gray-300);
+  --border-focus:   var(--color-green-600);
+
+  --brand-primary:    var(--color-green-600);
+  --brand-primary-hover: var(--color-green-700);
+
+  --shadow-card:    0 1px 2px rgba(17, 24, 39, 0.04), 0 4px 12px rgba(17, 24, 39, 0.06);
+  --shadow-pop:     0 8px 28px rgba(17, 24, 39, 0.12);
+  --shadow-fab:     0 10px 30px rgba(22, 163, 74, 0.35);
+
+  --scrollbar-thumb: rgba(17, 24, 39, 0.18);
+
+  /* Glassmorphism — liquid glass effect (light mode) */
+  --glass-bg-base: rgba(255, 255, 255, 0.85);
+  --glass-bg-surface: rgba(255, 255, 255, 0.7);
+  --glass-bg-elevated: rgba(255, 255, 255, 0.6);
+  --glass-border: rgba(255, 255, 255, 0.35);
+  --glass-shadow: 0 8px 32px rgba(17, 24, 39, 0.05), inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  --glass-shadow-lg: 0 20px 64px rgba(17, 24, 39, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.7);
+}
+
+/* ─────────────────────────────────────────
+   DARK MODE (toggled via [data-theme="dark"]
+   on <html> or any ancestor — uses Zampi)
+   ───────────────────────────────────────── */
+[data-theme="dark"] {
+  --bg-base:        var(--color-night-900);
+  --bg-canvas:      var(--color-night-900);
+  --bg-surface:     var(--color-night-600);
+  --bg-elevated:    var(--color-night-500);
+  --bg-overlay:     rgba(1, 4, 14, 0.7);
+  --bg-chip:        rgba(46, 80, 176, 0.18);
+  --bg-chip-active: var(--color-blue-400);
+
+  --fg-primary:     var(--color-blue-100);
+  --fg-secondary:   var(--color-blue-200);
+  --fg-muted:       var(--color-blue-200);
+  --fg-on-accent:   #FFFFFF;
+
+  --border-subtle:  rgba(46, 80, 176, 0.35);
+  --border-strong:  rgba(46, 80, 176, 0.70);
+  --border-focus:   var(--color-cyan-400);
+
+  --brand-primary:        var(--color-blue-400);
+  --brand-primary-hover:  var(--color-blue-300);
+
+  --shadow-card:  0 2px 8px rgba(1, 4, 14, 0.45);
+  --shadow-pop:   0 8px 40px rgba(1, 4, 14, 0.65);
+  --shadow-fab:   0 10px 30px rgba(46, 80, 176, 0.55);
+
+  --scrollbar-thumb: rgba(46, 80, 176, 0.5);
+
+  /* Glassmorphism — liquid glass effect (dark mode) */
+  --glass-bg-base: rgba(5, 11, 31, 0.8);
+  --glass-bg-surface: rgba(10, 20, 48, 0.7);
+  --glass-bg-elevated: rgba(14, 26, 56, 0.6);
+  --glass-border: rgba(46, 80, 176, 0.25);
+  --glass-shadow: 0 8px 32px rgba(1, 4, 14, 0.25), inset 0 1px 0 rgba(46, 80, 176, 0.25);
+  --glass-shadow-lg: 0 20px 64px rgba(1, 4, 14, 0.35), inset 0 1px 0 rgba(46, 80, 176, 0.25);
+}
+
+/* ─────────────────────────────────────────
+   TYPOGRAPHY
+   ───────────────────────────────────────── */
+:root {
+  --font-display: 'Nunito', 'Segoe UI', system-ui, sans-serif;
+  --font-body:    'Space Grotesk', 'Segoe UI', system-ui, sans-serif;
+  --font-mono:    'Space Mono', 'Courier New', monospace;
+
+  /* Type scale */
+  --text-xs:    12px;
+  --text-sm:    13px;
+  --text-base:  15px;
+  --text-md:    17px;
+  --text-lg:    20px;
+  --text-xl:    24px;
+  --text-2xl:   30px;
+  --text-3xl:   38px;
+  --text-4xl:   48px;
+
+  --leading-tight:  1.15;
+  --leading-snug:   1.3;
+  --leading-normal: 1.5;
+  --leading-loose:  1.7;
+
+  --weight-regular:  400;
+  --weight-medium:   500;
+  --weight-semibold: 600;
+  --weight-bold:     700;
+  --weight-extra:    800;
+  --weight-black:    900;
+
+  --tracking-tight:  -0.02em;
+  --tracking-normal:  0em;
+  --tracking-wide:    0.04em;
+  --tracking-widest:  0.1em;
+
+  /* Spacing */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  20px;
+  --space-6:  24px;
+  --space-8:  32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* Radius */
+  --radius-xs:   4px;
+  --radius-sm:   6px;
+  --radius-md:   10px;
+  --radius-lg:   16px;
+  --radius-xl:   24px;
+  --radius-2xl:  32px;
+  --radius-full: 9999px;
+
+  /* Motion */
+  --ease-bounce:  cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-smooth:  cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-out:     cubic-bezier(0, 0, 0.2, 1);
+  --duration-fast:   150ms;
+  --duration-normal: 250ms;
+  --duration-slow:   400ms;
+}
+
+/* ─────────────────────────────────────────
+   ELEMENT DEFAULTS
+   ───────────────────────────────────────── */
+html, body {
+  background: var(--bg-canvas);
+  color: var(--fg-primary);
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+}
+
+h1, .h1 {
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-black);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-primary);
+}
+h2, .h2 {
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-extra);
+  line-height: var(--leading-tight);
+  color: var(--fg-primary);
+}
+h3, .h3 {
+  font-family: var(--font-display);
+  font-size: var(--text-xl);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-snug);
+  color: var(--fg-primary);
+}
+h4, .h4 {
+  font-family: var(--font-body);
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  line-height: var(--leading-snug);
+  color: var(--fg-primary);
+}
+p, .body {
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--fg-secondary);
+}
+.caption {
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  letter-spacing: var(--tracking-wide);
+  color: var(--fg-muted);
+}
+.label {
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.price {
+  font-family: var(--font-display);
+  font-weight: var(--weight-extra);
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-tight);
+  color: var(--price-gold);
+  font-variant-numeric: tabular-nums;
+}
+code, .code {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  background: var(--bg-chip);
+  color: var(--fg-primary);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+}

--- a/public/css/carta/colors_and_type.css
+++ b/public/css/carta/colors_and_type.css
@@ -307,3 +307,471 @@ code, .code {
   padding: 2px 6px;
   border-radius: var(--radius-sm);
 }
+
+/* ─────────────────────────────────────────
+   TEMA CLÁSICO
+   ───────────────────────────────────────── */
+[data-theme="classic"] {
+  --font-display: 'Marcellus', Georgia, 'Times New Roman', serif;
+  --font-body:    'Spectral', Georgia, 'Times New Roman', serif;
+  --font-mono:    'Spectral', Georgia, serif;
+
+  --bg-base:        #FFFDF6;
+  --bg-canvas:      #F4ECDA;
+  --bg-surface:     #FBF4E4;
+  --bg-elevated:    #FFFDF6;
+  --bg-overlay:     rgba(46, 32, 19, 0.45);
+  --bg-chip:        #ECE0C7;
+  --bg-chip-active: #7C5326;
+
+  --fg-primary:     #2E2013;
+  --fg-secondary:   #5C4A33;
+  --fg-muted:       #8A7355;
+  --fg-on-accent:   #FFFDF6;
+
+  --border-subtle:  #E3D6BB;
+  --border-strong:  #C9B690;
+  --border-focus:   #7C5326;
+
+  --brand-primary:        #7C5326;
+  --brand-primary-hover:  #5E3D1B;
+
+  --select-accent:      #7C5326;
+  --select-accent-fg:   #FFFDF6;
+  --select-accent-soft: rgba(124, 83, 38, 0.12);
+
+  --price-gold:         #A6791E;
+  --allergen-bg:        #EFE2C4;
+  --allergen-fg:        #6E4A12;
+  --allergen-active-bg: #A6791E;
+  --allergen-active-fg: #2E2013;
+
+  --cart-bar-from:   #4A3420;
+  --cart-bar-to:     #2E2013;
+  --cart-bar-border: #A6791E;
+
+  --delete-pill-bg:     #7C2D17;
+  --delete-pill-border: #C4633F;
+
+  --badge-count:      #8C2F1D;
+  --cta-view-order:   #7C5326;
+  --qty-minus-border: #B85C3C;
+  --qty-plus-border:  #7C5326;
+
+  --shadow-card: 0 1px 2px rgba(74, 52, 32, 0.07);
+  --shadow-pop:  0 14px 34px rgba(46, 32, 19, 0.16);
+  --shadow-fab:  0 8px 22px rgba(74, 52, 32, 0.28);
+
+  --scrollbar-thumb: rgba(124, 83, 38, 0.32);
+
+  --glass-bg-base:    #FBF4E4;
+  --glass-bg-surface: #FBF4E4;
+  --glass-bg-elevated:#FFFDF6;
+  --glass-border:     #E3D6BB;
+  --glass-shadow:     0 1px 2px rgba(74, 52, 32, 0.07);
+  --glass-shadow-lg:  0 14px 34px rgba(46, 32, 19, 0.14);
+}
+
+/* Zampi conserva su paleta azul noche independientemente del tema */
+[data-theme="classic"] .chat-panel {
+  --font-display: 'Nunito', 'Segoe UI', system-ui, sans-serif;
+  --font-body:    'Space Grotesk', 'Segoe UI', system-ui, sans-serif;
+  --font-mono:    'Space Mono', 'Courier New', monospace;
+  --price-gold:   var(--color-amber-300);
+  --badge-count:  var(--color-red-400);
+}
+
+/* Modo oscuro clásico: espresso/carbón + crema + dorado */
+[data-theme="classic"] .carta[data-theme="dark"] {
+  --bg-base:        #211913;
+  --bg-canvas:      #1A130D;
+  --bg-surface:     #2A211A;
+  --bg-elevated:    #33291F;
+  --bg-overlay:     rgba(10, 6, 3, 0.62);
+  --bg-chip:        #352A20;
+  --bg-chip-active: #C79A4A;
+
+  --fg-primary:     #F2E7D2;
+  --fg-secondary:   #CDBBA0;
+  --fg-muted:       #9C8970;
+  --fg-on-accent:   #1A130D;
+
+  --border-subtle:  #3D3024;
+  --border-strong:  #574635;
+  --border-focus:   #C79A4A;
+
+  --brand-primary:        #C79A4A;
+  --brand-primary-hover:  #D9B36A;
+
+  --select-accent:      #C79A4A;
+  --select-accent-fg:   #1A130D;
+  --select-accent-soft: rgba(199, 154, 74, 0.16);
+
+  --price-gold:         #E0B864;
+  --allergen-bg:        #3A2E16;
+  --allergen-fg:        #E6C77E;
+  --allergen-active-bg: #E0B864;
+  --allergen-active-fg: #1A130D;
+
+  --cart-bar-from:   #3A2A1A;
+  --cart-bar-to:     #211913;
+  --cart-bar-border: #C79A4A;
+
+  --delete-pill-bg:     #5A2417;
+  --delete-pill-border: #C4633F;
+
+  --badge-count:      #C77B4A;
+  --cta-view-order:   #C79A4A;
+  --qty-minus-border: #C77B4A;
+  --qty-plus-border:  #C79A4A;
+
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.40);
+  --shadow-pop:  0 16px 38px rgba(0, 0, 0, 0.58);
+  --shadow-fab:  0 8px 22px rgba(0, 0, 0, 0.50);
+
+  --scrollbar-thumb: rgba(199, 154, 74, 0.35);
+
+  --glass-bg-base:    #2A211A;
+  --glass-bg-surface: #2A211A;
+  --glass-bg-elevated:#33291F;
+  --glass-border:     #3D3024;
+  --glass-shadow:     0 1px 2px rgba(0, 0, 0, 0.40);
+  --glass-shadow-lg:  0 16px 38px rgba(0, 0, 0, 0.55);
+}
+
+/* Skin clásico: bordes rectos, sin cristal */
+[data-theme="classic"] .viewport,
+[data-theme="classic"] .carta { border-radius: 4px; }
+[data-theme="classic"] .header {
+  backdrop-filter: none;
+  background: var(--bg-base);
+  border-bottom: 1px solid var(--brand-primary);
+  box-shadow: 0 2px 0 var(--price-gold);
+}
+[data-theme="classic"] .header__logo {
+  border-radius: 3px;
+  background: linear-gradient(135deg, #4A3420, #2E2013);
+  border: 1px solid var(--price-gold);
+}
+[data-theme="classic"] .theme-toggle {
+  border-radius: 3px;
+  backdrop-filter: none;
+  background: var(--bg-chip);
+  border: 1px solid var(--border-strong);
+}
+[data-theme="classic"] .carta[data-theme="dark"] .header {
+  background: var(--bg-base);
+  border-bottom: 1px solid var(--brand-primary);
+  box-shadow: 0 2px 0 rgba(224, 184, 100, 0.5);
+}
+[data-theme="classic"] .carta[data-theme="dark"] .header__logo {
+  background: linear-gradient(135deg, #33291F, #1A130D);
+}
+[data-theme="classic"] .pcard { border-radius: 4px; backdrop-filter: none; background: var(--bg-surface); border: 1px solid var(--border-strong); box-shadow: var(--shadow-card); }
+[data-theme="classic"] .pcard__photo { border-bottom: 1px solid var(--border-subtle); }
+[data-theme="classic"] .pcard__photo--food-1 { background: linear-gradient(135deg, #F2E2BC, #E6C68B); }
+[data-theme="classic"] .pcard__photo--food-2 { background: linear-gradient(135deg, #EED9C4, #D9B08C); }
+[data-theme="classic"] .pcard__photo--food-3 { background: linear-gradient(135deg, #E8E0C6, #C9BD8E); }
+[data-theme="classic"] .pcard__photo--food-4 { background: linear-gradient(135deg, #F3E6BE, #E3C277); }
+[data-theme="classic"] .pcard__photo--food-5 { background: linear-gradient(135deg, #EFDCC8, #D7AE8E); }
+[data-theme="classic"] .pcard__photo--food-6 { background: linear-gradient(135deg, #E9E2CC, #C7BC92); }
+[data-theme="classic"] .carta[data-theme="dark"] .pcard__photo--food-1 { background: linear-gradient(135deg, #4A3A22, #6B4F2A); }
+[data-theme="classic"] .carta[data-theme="dark"] .pcard__photo--food-2 { background: linear-gradient(135deg, #4A332A, #6B4438); }
+[data-theme="classic"] .carta[data-theme="dark"] .pcard__photo--food-3 { background: linear-gradient(135deg, #3E3A22, #585231); }
+[data-theme="classic"] .carta[data-theme="dark"] .pcard__photo--food-4 { background: linear-gradient(135deg, #4D3C1C, #6E5424); }
+[data-theme="classic"] .carta[data-theme="dark"] .pcard__photo--food-5 { background: linear-gradient(135deg, #4A3528, #6B4A38); }
+[data-theme="classic"] .carta[data-theme="dark"] .pcard__photo--food-6 { background: linear-gradient(135deg, #3F3A26, #585234); }
+[data-theme="classic"] .btn-add { border-radius: 3px; box-shadow: var(--shadow-fab); font-family: var(--font-display); }
+[data-theme="classic"] .carta[data-theme="dark"] .btn-add { background: var(--brand-primary); color: var(--fg-on-accent); }
+[data-theme="classic"] .qty { border-radius: 3px; }
+[data-theme="classic"] .qty button { border-radius: 2px; }
+[data-theme="classic"] .chip,
+[data-theme="classic"] .allergen-chip { border-radius: 3px; backdrop-filter: none; background: var(--bg-chip); }
+[data-theme="classic"] .chip--active,
+[data-theme="classic"] .chip--active:hover { background: var(--select-accent); color: var(--select-accent-fg); font-weight: 700; border-color: var(--select-accent); box-shadow: 0 1px 2px rgba(74, 52, 32, 0.20); }
+[data-theme="classic"] .dest-toggle { border-radius: 4px; }
+[data-theme="classic"] .dest-toggle button { border-radius: 2px; }
+[data-theme="classic"] .dest-toggle button.active { background: var(--select-accent); color: var(--select-accent-fg); font-weight: 700; box-shadow: none; }
+[data-theme="classic"] .filter-list__item { border-radius: 3px; }
+[data-theme="classic"] .filter-list__check { border-radius: 2px; }
+[data-theme="classic"] .kitchen-pill { border-radius: 3px; }
+[data-theme="classic"] .filter-section__label { font-family: var(--font-display); font-weight: 600; letter-spacing: 0.14em; color: var(--brand-primary); }
+[data-theme="classic"] .filter-section__label::before { width: 100%; height: 1px; border-radius: 0; background: linear-gradient(90deg, var(--price-gold), transparent); order: 2; margin-left: 8px; }
+[data-theme="classic"] .filter-list:not(.filter-list--allergens) .filter-list__item--active { background: var(--select-accent-soft); color: var(--brand-primary-hover); font-weight: 700; box-shadow: inset 3px 0 0 var(--select-accent); padding-left: 13px; }
+[data-theme="classic"] .filter-list:not(.filter-list--allergens) .filter-list__item--active .filter-list__check { background: var(--select-accent); border-color: var(--select-accent); color: var(--select-accent-fg); }
+[data-theme="classic"] .carta__filters .filter-list--allergens .filter-list__item--active { background: var(--price-gold); color: #2E2013; font-weight: 700; }
+[data-theme="classic"] .carta__filters .filter-list--allergens .filter-list__item--active .filter-list__check,
+[data-theme="classic"] .carta__filters .filter-list--allergens .filter-list__item--active .allergen { background: #2E2013; border-color: #2E2013; color: var(--price-gold); }
+[data-theme="classic"] .allergen { background: var(--allergen-bg); color: var(--allergen-fg); }
+[data-theme="classic"] .allergen-chip--active { background: var(--price-gold); color: #2E2013; }
+[data-theme="classic"] .allergen-chip--active .allergen { background: #2E2013; color: var(--price-gold); }
+[data-theme="classic"] .filter-bar__pinned--on { background: var(--price-gold); color: #2E2013; border-color: var(--price-gold); }
+[data-theme="classic"] .filter-bar__pinned--on .filter-bar__count,
+[data-theme="classic"] .filter-bar__pinned:not(.filter-bar__pinned--on) .filter-bar__count { background: #2E2013; color: var(--price-gold); }
+[data-theme="classic"] .cart-bar { background: linear-gradient(180deg, #8A5A22, #5A3A12); border-color: #D4A017; color: #F3E7CC; box-shadow: 0 12px 30px rgba(74, 52, 32, 0.46); border-radius: 5px; }
+[data-theme="classic"] .cart-bar__icon { background: rgba(255, 248, 230, 0.18); }
+[data-theme="classic"] .cart-bar__icon svg { color: #FFE6A6; }
+[data-theme="classic"] .cart-bar__total { color: #FFD45C; }
+[data-theme="classic"] .cart-bar__count { background: #D24A1A; }
+[data-theme="classic"] .cart-bar__cta { background: linear-gradient(135deg, #E6AC2A, #C88A16); color: #2E2013; font-weight: 800; border-radius: 3px; }
+[data-theme="classic"] .carta[data-theme="dark"] .cart-bar__cta { color: #1A130D; }
+[data-theme="classic"] .cart-foot__cta { border-radius: 4px; background: linear-gradient(135deg, #9A6420 0%, #6E4518 100%); color: #FFFDF6; box-shadow: 0 0 0 1px #D4A017 inset, inset 0 1px 0 rgba(255,255,255,0.18), 0 8px 22px rgba(110,69,24,0.40); }
+[data-theme="classic"] .drawer { border-radius: 6px 6px 0 0; }
+[data-theme="classic"] .modal__panel { border-radius: 6px; }
+[data-theme="classic"] .btn-primary,
+[data-theme="classic"] .btn-secondary { border-radius: 3px; backdrop-filter: none; }
+[data-theme="classic"] .citem { border-radius: 4px; }
+[data-theme="classic"] .bill__method { border-radius: 5px; backdrop-filter: none; }
+[data-theme="classic"] .icon-btn { border-radius: 3px; backdrop-filter: none; }
+[data-theme="classic"] .header__bizname,
+[data-theme="classic"] .pcard__name,
+[data-theme="classic"] .pcard__price,
+[data-theme="classic"] .price,
+[data-theme="classic"] .cart-bar__total,
+[data-theme="classic"] .modal__title,
+[data-theme="classic"] .filter-section__label,
+[data-theme="classic"] h1, [data-theme="classic"] h2,
+[data-theme="classic"] h3, [data-theme="classic"] h4 { font-weight: 400; }
+[data-theme="classic"] .header__bizname { letter-spacing: 0.02em; }
+/* Menú del día en clásico: cartel colgante */
+[data-theme="classic"] .dm-banner {
+  position: sticky; top: 26px; overflow: visible;
+  margin: 30px 0 18px; border-radius: 4px;
+  background: radial-gradient(120% 80% at 50% 0%, rgba(255,253,246,0.65), transparent 62%), linear-gradient(180deg, #F4E8CB 0%, #ECDBB4 55%, #E1CC9D 100%);
+  border: 2px solid #4A3420;
+  box-shadow: 0 0 0 1px #A6791E inset, 0 2px 0 rgba(255,255,255,0.45) inset, 0 18px 30px rgba(46,32,19,0.32);
+  color: #2E2013;
+  transform-origin: 50% -25px;
+  animation: dm-hang-in 640ms cubic-bezier(0.34, 1.56, 0.64, 1) both, dm-sway 5.6s ease-in-out 640ms infinite;
+}
+[data-theme="classic"] .filter-bar { padding-bottom: 4px; }
+[data-theme="classic"] .carta__body { padding-top: 6px; }
+[data-theme="classic"] .dm-banner::before {
+  content: ""; position: absolute; top: -25px; left: 5%; right: 5%; height: 13px; border-radius: 3px;
+  background: repeating-linear-gradient(90deg, rgba(0,0,0,0.12) 0 2px, transparent 2px 11px), linear-gradient(180deg, #6E4D2C 0%, #3E2A17 100%);
+  box-shadow: 0 4px 7px rgba(46,32,19,0.42), inset 0 1px 0 rgba(255,255,255,0.18);
+  pointer-events: none; z-index: 2;
+}
+[data-theme="classic"] .dm-banner::after {
+  content: ""; position: absolute; top: -12px; left: 0; right: 0; height: 17px;
+  pointer-events: none; z-index: 1;
+  background-image: repeating-linear-gradient(48deg, #7C5326 0 2px, #C8945A 2px 4px), repeating-linear-gradient(48deg, #7C5326 0 2px, #C8945A 2px 4px), radial-gradient(circle, #C9A24A 30%, #6E4D2C 34%, transparent 40%), radial-gradient(circle, #C9A24A 30%, #6E4D2C 34%, transparent 40%), radial-gradient(circle, #C9A24A 30%, #6E4D2C 34%, transparent 40%), radial-gradient(circle, #C9A24A 30%, #6E4D2C 34%, transparent 40%);
+  background-size: 5px 12px, 5px 12px, 9px 9px, 9px 9px, 9px 9px, 9px 9px;
+  background-position: 15% 0px, 85% 0px, 15% -2px, 85% -2px, 15% 10px, 85% 10px;
+  background-repeat: no-repeat;
+}
+[data-theme="classic"] .dm-banner__title   { color: #2E2013; font-family: var(--font-display); }
+[data-theme="classic"] .dm-banner__tagline { color: #5C4A33; opacity: 1; }
+[data-theme="classic"] .dm-banner__date     { color: #8A5A2B; opacity: 1; }
+[data-theme="classic"] .dm-banner__price    { color: #A6791E; }
+[data-theme="classic"] .dm-banner__close { background: rgba(74,52,32,0.10); color: #5E3D1B; border-color: rgba(74,52,32,0.25); }
+[data-theme="classic"] .dm-banner--stuck { box-shadow: 0 0 0 1px #A6791E inset, 0 2px 0 rgba(255,255,255,0.45) inset, 0 22px 40px rgba(46,32,19,0.42); }
+[data-theme="classic"] .dm-banner--exit { animation: dm-banner-out 280ms cubic-bezier(0.4, 0, 0.2, 1) forwards; }
+[data-theme="classic"] .carta[data-bp="mobile"] .dm-banner { margin: 30px 12px 16px; }
+@keyframes dm-hang-in {
+  0%   { transform: rotate(-7deg); opacity: 0; }
+  55%  { transform: rotate(3.5deg); }
+  80%  { transform: rotate(-1.5deg); }
+  100% { transform: rotate(0deg); opacity: 1; }
+}
+@keyframes dm-sway {
+  0%, 100% { transform: rotate(-0.9deg); }
+  50%      { transform: rotate(0.9deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-theme="classic"] .dm-banner { animation: dm-hang-in 1ms both; }
+}
+
+/* ─────────────────────────────────────────
+   TEMA MINIMALISTA
+   ───────────────────────────────────────── */
+[data-theme="minimal"] {
+  --font-display: 'IBM Plex Mono', ui-monospace, monospace;
+  --font-body:    'Archivo', system-ui, sans-serif;
+  --font-mono:    'IBM Plex Mono', ui-monospace, monospace;
+
+  --bg-base:        #FFFFFF;
+  --bg-canvas:      #FFFFFF;
+  --bg-surface:     #FFFFFF;
+  --bg-elevated:    #FFFFFF;
+  --bg-overlay:     rgba(9, 9, 11, 0.40);
+  --bg-chip:        #F4F4F5;
+  --bg-chip-active: #111111;
+
+  --fg-primary:     #111111;
+  --fg-secondary:   #52525B;
+  --fg-muted:       #A1A1AA;
+  --fg-on-accent:   #FFFFFF;
+
+  --border-subtle:  #ECECEE;
+  --border-strong:  #D4D4D8;
+  --border-focus:   #111111;
+
+  --brand-primary:        #111111;
+  --brand-primary-hover:  #000000;
+
+  --select-accent:      #111111;
+  --select-accent-fg:   #FFFFFF;
+  --select-accent-soft: rgba(17, 17, 17, 0.06);
+
+  --dm-paper:    #FFFFFF;
+  --dm-ink:      #111111;
+  --dm-gold-50:  #F7F7F8;
+  --dm-gold-100: #F4F4F5;
+  --dm-gold-200: #E4E4E7;
+  --dm-gold-300: #D4D4D8;
+  --dm-gold-500: #52525B;
+  --dm-gold-700: #111111;
+  --dm-gold-ink: #FFFFFF;
+
+  --price-gold:         #111111;
+  --allergen-bg:        #F4F4F5;
+  --allergen-fg:        #52525B;
+  --allergen-active-bg: #111111;
+  --allergen-active-fg: #FFFFFF;
+
+  --cart-bar-from:   #18181B;
+  --cart-bar-to:     #09090B;
+  --cart-bar-border: #18181B;
+
+  --delete-pill-bg:     #18181B;
+  --delete-pill-border: #3F3F46;
+
+  --badge-count:    #111111;
+  --cta-view-order: #111111;
+  --qty-minus-border: #111111;
+  --qty-plus-border:  #111111;
+
+  --shadow-card: none;
+  --shadow-pop:  0 12px 40px rgba(9, 9, 11, 0.08);
+  --shadow-fab:  none;
+
+  --scrollbar-thumb: #D4D4D8;
+
+  --glass-bg-base:    #FFFFFF;
+  --glass-bg-surface: #FFFFFF;
+  --glass-bg-elevated:#FFFFFF;
+  --glass-border:     #ECECEE;
+  --glass-shadow:     none;
+  --glass-shadow-lg:  0 12px 40px rgba(9, 9, 11, 0.06);
+}
+
+[data-theme="minimal"] .chat-panel {
+  --font-display: 'Nunito', 'Segoe UI', system-ui, sans-serif;
+  --font-body:    'Space Grotesk', 'Segoe UI', system-ui, sans-serif;
+  --font-mono:    'Space Mono', 'Courier New', monospace;
+  --price-gold:   var(--color-amber-300);
+  --badge-count:  var(--color-red-400);
+}
+
+/* Modo oscuro minimalista: negro/grafito monocromo */
+[data-theme="minimal"] .carta[data-theme="dark"] {
+  --bg-base:        #0E0E10;
+  --bg-canvas:      #0A0A0B;
+  --bg-surface:     #141416;
+  --bg-elevated:    #1A1A1D;
+  --bg-overlay:     rgba(0, 0, 0, 0.62);
+  --bg-chip:        #1C1C1F;
+  --bg-chip-active: #FAFAFA;
+
+  --fg-primary:     #FAFAFA;
+  --fg-secondary:   #A1A1AA;
+  --fg-muted:       #71717A;
+  --fg-on-accent:   #0A0A0B;
+
+  --border-subtle:  #232327;
+  --border-strong:  #34343A;
+  --border-focus:   #FAFAFA;
+
+  --brand-primary:        #FAFAFA;
+  --brand-primary-hover:  #FFFFFF;
+
+  --select-accent:      #FAFAFA;
+  --select-accent-fg:   #0A0A0B;
+  --select-accent-soft: #1C1C1F;
+
+  --dm-paper:    #141416;
+  --dm-ink:      #FAFAFA;
+  --dm-gold-50:  #1C1C1F;
+  --dm-gold-100: #1C1C1F;
+  --dm-gold-200: #232327;
+  --dm-gold-300: #34343A;
+  --dm-gold-500: #A1A1AA;
+  --dm-gold-700: #FAFAFA;
+  --dm-gold-ink: #0A0A0B;
+
+  --price-gold:         #FAFAFA;
+  --allergen-bg:        #1C1C1F;
+  --allergen-fg:        #A1A1AA;
+  --allergen-active-bg: #FAFAFA;
+  --allergen-active-fg: #0A0A0B;
+
+  --cart-bar-from:   #1C1C1F;
+  --cart-bar-to:     #141416;
+  --cart-bar-border: #34343A;
+
+  --delete-pill-bg:     #1C1C1F;
+  --delete-pill-border: #34343A;
+
+  --badge-count:    #52525B;
+  --cta-view-order: #FAFAFA;
+  --qty-minus-border: #A1A1AA;
+  --qty-plus-border:  #FAFAFA;
+
+  --shadow-card: none;
+  --shadow-pop:  0 16px 44px rgba(0, 0, 0, 0.6);
+  --shadow-fab:  none;
+
+  --scrollbar-thumb: #34343A;
+
+  --glass-bg-base:    #0E0E10;
+  --glass-bg-surface: #141416;
+  --glass-bg-elevated:#1A1A1D;
+  --glass-border:     #232327;
+  --glass-shadow:     none;
+  --glass-shadow-lg:  0 16px 44px rgba(0, 0, 0, 0.5);
+}
+
+/* Skin minimalista: sin sombras, bordes finos, geometría limpia */
+[data-theme="minimal"] .header { backdrop-filter: none; background: var(--bg-base); border-bottom: 1px solid var(--border-subtle); box-shadow: none; }
+[data-theme="minimal"] .header__logo { border-radius: 2px; background: var(--fg-primary); color: var(--bg-base); }
+[data-theme="minimal"] .carta[data-theme="dark"] .header__logo { background: #FAFAFA; color: #0A0A0B; }
+[data-theme="minimal"] .theme-toggle { border-radius: 2px; backdrop-filter: none; }
+[data-theme="minimal"] .pcard { border-radius: 2px; backdrop-filter: none; background: var(--bg-surface); border: 1px solid var(--border-subtle); box-shadow: none; }
+[data-theme="minimal"] .pcard:hover { border-color: var(--border-strong); box-shadow: none; }
+[data-theme="minimal"] .pcard__photo--food-1,
+[data-theme="minimal"] .pcard__photo--food-2,
+[data-theme="minimal"] .pcard__photo--food-3,
+[data-theme="minimal"] .pcard__photo--food-4,
+[data-theme="minimal"] .pcard__photo--food-5,
+[data-theme="minimal"] .pcard__photo--food-6 { background: var(--bg-chip); }
+[data-theme="minimal"] .carta[data-theme="dark"] .pcard__photo--food-1,
+[data-theme="minimal"] .carta[data-theme="dark"] .pcard__photo--food-2,
+[data-theme="minimal"] .carta[data-theme="dark"] .pcard__photo--food-3,
+[data-theme="minimal"] .carta[data-theme="dark"] .pcard__photo--food-4,
+[data-theme="minimal"] .carta[data-theme="dark"] .pcard__photo--food-5,
+[data-theme="minimal"] .carta[data-theme="dark"] .pcard__photo--food-6 { background: #141416; }
+[data-theme="minimal"] .btn-add { border-radius: 2px; box-shadow: none; background: var(--brand-primary); color: var(--fg-on-accent); }
+[data-theme="minimal"] .carta[data-theme="dark"] .btn-add { background: var(--brand-primary); color: var(--fg-on-accent); }
+[data-theme="minimal"] .carta[data-theme="dark"] .btn-primary { background: #FAFAFA; color: #0A0A0B; }
+[data-theme="minimal"] .qty { border-radius: 2px; }
+[data-theme="minimal"] .qty button { border-radius: 1px; }
+[data-theme="minimal"] .chip,
+[data-theme="minimal"] .allergen-chip { border-radius: 2px; backdrop-filter: none; }
+[data-theme="minimal"] .chip--active,
+[data-theme="minimal"] .chip--active:hover { background: var(--select-accent); color: var(--select-accent-fg); }
+[data-theme="minimal"] .dest-toggle { border-radius: 2px; }
+[data-theme="minimal"] .dest-toggle button { border-radius: 1px; }
+[data-theme="minimal"] .dest-toggle button.active { background: var(--select-accent); color: var(--select-accent-fg); box-shadow: none; }
+[data-theme="minimal"] .filter-list__item { border-radius: 2px; }
+[data-theme="minimal"] .filter-list__check { border-radius: 2px; }
+[data-theme="minimal"] .filter-list:not(.filter-list--allergens) .filter-list__item--active { background: var(--select-accent-soft); color: var(--brand-primary); font-weight: 700; }
+[data-theme="minimal"] .filter-list:not(.filter-list--allergens) .filter-list__item--active .filter-list__check { background: var(--select-accent); border-color: var(--select-accent); color: var(--select-accent-fg); }
+[data-theme="minimal"] .cart-bar { border-radius: 2px; box-shadow: none; }
+[data-theme="minimal"] .cart-bar__cta { border-radius: 2px; }
+[data-theme="minimal"] .drawer { border-radius: 4px 4px 0 0; }
+[data-theme="minimal"] .modal__panel { border-radius: 4px; }
+[data-theme="minimal"] .btn-primary,
+[data-theme="minimal"] .btn-secondary { border-radius: 2px; backdrop-filter: none; box-shadow: none; }
+[data-theme="minimal"] .icon-btn { border-radius: 2px; backdrop-filter: none; }
+[data-theme="minimal"] .filter-section__label::before { background: var(--brand-primary); }

--- a/public/css/carta/styles.css
+++ b/public/css/carta/styles.css
@@ -1,0 +1,6268 @@
+/* =========================================================
+   Carta Digital Pública — interactive UI kit styles
+   Imports the project tokens, then defines carta layout.
+   ========================================================= */
+
+@import url('./colors_and_type.css');
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  height: 100%;
+  background: #1a1a1f;
+  font-family: var(--font-body);
+  -webkit-font-smoothing: antialiased;
+  color-scheme: light;
+}
+
+#app-root {
+  width: 100%;
+  height: 100%;
+}
+
+/* ----- Stage frame (shows the carta as if on a device) ----- */
+.stage {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  gap: 12px;
+  background: radial-gradient(1200px 800px at 50% 30%, #2a2a35, #0e0e15);
+  overflow: hidden;
+}
+
+.stage__chrome {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #6b7280;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.stage__chrome .dot { width: 6px; height: 6px; border-radius: 50%; background: #4b5563; }
+
+.viewport {
+  background: var(--bg-canvas);
+  border-radius: 18px;
+  overflow: hidden;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  isolation: isolate;
+  flex-shrink: 0;
+  transition: width 250ms var(--ease-smooth), height 250ms var(--ease-smooth);
+  transform: scale(var(--stage-zoom, 1));
+  transform-origin: center center;
+}
+.stage__scaler {
+  display: flex; align-items: center; justify-content: center;
+}
+[data-theme="dark"] .viewport,
+.viewport[data-theme="dark"] { color-scheme: dark; }
+
+/* viewport sizes (set via JS) */
+.viewport--mobile  { width: 390px; height: 780px; }
+.viewport--tablet  { width: 820px; height: 660px; }
+.viewport--desktop { width: 1180px; height: 740px; }
+
+/* =========================================================
+   CARTA  (lives inside .viewport)
+   ========================================================= */
+.carta {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  background: var(--bg-canvas);
+  color: var(--fg-primary);
+  position: relative;
+  overflow: hidden;
+  font-family: var(--font-body);
+}
+
+/* ----- Header ----- */
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: var(--glass-bg-base);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--glass-border);
+  z-index: 20;
+  flex-shrink: 0;
+}
+.header__brand { display: flex; align-items: center; gap: 10px; min-width: 0; flex: 1 1 auto; }
+.header__brand > div:nth-child(2) { flex: 1 1 auto; min-width: 0; }
+.header__bizname { white-space: nowrap; }
+.header__table { white-space: nowrap; }
+.header__logo {
+  width: 36px; height: 36px; border-radius: 8px;
+  background: linear-gradient(135deg, #0F3D2A, #0A2E1F);
+  display: inline-flex; align-items: center; justify-content: center;
+  color: #FBBF24; font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  flex-shrink: 0;
+}
+.header__bizname {
+  font-family: var(--font-display); font-weight: 900; font-size: 16px;
+  letter-spacing: -0.01em; line-height: 1; color: var(--fg-primary);
+}
+.header__table {
+  font-family: var(--font-body); font-weight: 500; font-size: 12px;
+  color: var(--fg-muted); margin-top: 2px;
+}
+.header__actions { display: flex; align-items: center; gap: 8px; }
+.kitchen-pill {
+  display: inline-flex; align-items: center; gap: 6px; white-space: nowrap;
+  font-family: var(--font-body); font-size: 12px; font-weight: 600;
+  padding: 6px 10px; border-radius: 9999px;
+  background: var(--color-green-100); color: var(--color-green-700);
+}
+[data-theme="dark"] .kitchen-pill { background: rgba(34, 197, 94, 0.12); color: var(--color-green-400); }
+.kitchen-pill__dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; flex-shrink: 0; }
+.kitchen-pill--closed { background: var(--color-amber-100); color: var(--color-amber-800); }
+[data-theme="dark"] .kitchen-pill--closed { background: rgba(251, 191, 36, 0.12); color: var(--color-amber-300); }
+.kitchen-pill__stack {
+  display: inline-flex; flex-direction: column;
+  line-height: 1.15; text-align: left;
+}
+.kitchen-pill__l1 { font-weight: 700; font-size: 12px; }
+.kitchen-pill__l2 { font-weight: 500; font-size: 11px; opacity: 0.85; font-variant-numeric: tabular-nums; }
+/* Make the closed pill align its dot with the first line, not centered */
+.kitchen-pill--closed { align-items: flex-start; padding: 8px 12px; }
+.kitchen-pill--closed .kitchen-pill__dot { margin-top: 5px; }
+
+/* Theme toggle */
+.theme-toggle {
+  width: 36px; height: 36px; border-radius: 9999px;
+  border: 1px solid var(--glass-border); background: var(--glass-bg-surface);
+  backdrop-filter: blur(6px);
+  display: inline-flex; align-items: center; justify-content: center;
+  cursor: pointer; color: var(--fg-secondary);
+  transition: background-color var(--duration-fast), color var(--duration-fast), border-color var(--duration-fast);
+}
+.theme-toggle:hover { background: var(--bg-chip); color: var(--fg-primary); }
+
+/* ----- Main layout (responsive via [data-bp]) ----- */
+.carta__main { flex: 1; min-height: 0; display: flex; overflow: hidden; }
+.carta__filters {
+  flex-shrink: 0; overflow-y: auto;
+  background: var(--glass-bg-base);
+  backdrop-filter: blur(12px);
+  border-right: 1px solid var(--glass-border);
+  padding: 16px;
+}
+.carta__body {
+  flex: 1; min-width: 0; overflow-y: auto;
+  --carta-fade: 0px;
+  -webkit-mask-image: linear-gradient(to bottom, #000 0, #000 calc(100% - var(--carta-fade)), transparent 100%);
+          mask-image: linear-gradient(to bottom, #000 0, #000 calc(100% - var(--carta-fade)), transparent 100%);
+}
+.carta__cartCol { flex-shrink: 0; border-left: 1px solid var(--border-subtle); background: var(--bg-base); display: flex; flex-direction: column; }
+
+/* Mobile breakpoint adjustments */
+.carta[data-bp="mobile"] .carta__filters { display: none; }
+.carta[data-bp="mobile"] .carta__cartCol { display: none; }
+
+/* Tablet: sidebar filters, no cart col */
+.carta[data-bp="tablet"] .carta__filters { width: 220px; }
+.carta[data-bp="tablet"] .carta__cartCol { display: none; }
+
+/* Desktop: sidebar only — order is accessed from the bottom bar */
+.carta[data-bp="desktop"] .carta__filters { width: 240px; }
+.carta[data-bp="desktop"] .carta__cartCol { display: none; }
+
+/* ----- Mobile filter bar (horizontal-scroll categories + pinned allergens trigger) ----- */
+.filter-bar {
+  display: none;
+  position: relative;
+  padding: 12px 16px;
+  gap: 10px;
+  align-items: center;
+  background: var(--bg-base);
+  border-bottom: 1px solid var(--border-subtle);
+  flex-shrink: 0;
+}
+.carta[data-bp="mobile"] .filter-bar { display: flex; }
+
+.filter-row {
+  display: flex;
+  gap: 8px;
+  flex: 1; min-width: 0;
+  overflow-x: auto; scrollbar-width: none;
+  /* Fade out the right edge to hint there's more content scrollable to the right */
+  -webkit-mask-image: linear-gradient(to right, black calc(100% - 28px), transparent);
+          mask-image: linear-gradient(to right, black calc(100% - 28px), transparent);
+  padding-right: 18px;
+  /* Within the bar, no separate background or border */
+  background: transparent;
+  border: none;
+  padding: 0 18px 0 0;
+}
+.filter-row::-webkit-scrollbar { display: none; }
+
+.filter-bar__pinned {
+  flex-shrink: 0;
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 8px 14px;
+  border-radius: 9999px;
+  background: var(--bg-chip);
+  color: var(--fg-primary);
+  border: 1px solid var(--border-subtle);
+  font-family: var(--font-body); font-size: 13px; font-weight: 600;
+  white-space: nowrap; cursor: pointer; position: relative;
+  box-shadow: -8px 0 12px var(--bg-base);
+}
+.filter-bar__pinned:hover { border-color: var(--border-strong); }
+.filter-bar__pinned--on {
+  background: var(--color-amber-300);
+  color: #5A2F00;
+  border-color: var(--color-amber-300);
+}
+[data-theme="dark"] .filter-bar__pinned--on { background: var(--color-amber-300); color: #5A2F00; }
+.filter-bar__count {
+  min-width: 18px; height: 18px;
+  background: #5A2F00; color: var(--color-amber-300);
+  border-radius: 9999px;
+  font-family: var(--font-display); font-weight: 800; font-size: 10px;
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 0 5px; line-height: 1;
+}
+.filter-bar__pinned:not(.filter-bar__pinned--on) .filter-bar__count {
+  background: var(--color-amber-300); color: #5A2F00;
+}
+
+/* Allergens quick-sheet */
+.drawer--allergens { height: auto; max-height: 78%; }
+.allergens-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}
+.allergens-grid .allergen-chip {
+  width: 100%; justify-content: flex-start;
+  padding: 10px 14px 10px 8px;
+  font-size: 13px;
+}
+
+/* Chip */
+.chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 8px 14px; border-radius: 9999px;
+  background: var(--glass-bg-surface);
+  backdrop-filter: blur(6px);
+  color: var(--fg-primary);
+  font-family: var(--font-body); font-size: 13px; font-weight: 500;
+  border: 1px solid var(--glass-border);
+  cursor: pointer; white-space: nowrap;
+  transition: background-color var(--duration-fast), color var(--duration-fast);
+}
+.chip:hover { background: var(--border-subtle); }
+.chip--active {
+  background: var(--brand-primary); color: var(--fg-on-accent); font-weight: 600;
+}
+[data-theme="dark"] .chip--active { background: var(--color-blue-400); }
+.chip--small { padding: 6px 10px; font-size: 12px; }
+
+/* Filter section in sidebar */
+.filter-section + .filter-section { margin-top: 20px; padding-top: 20px; border-top: 1px solid var(--border-subtle); }
+.filter-section__label {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--font-body); font-weight: 800;
+  font-size: 12px; letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--fg-secondary); margin-bottom: 12px;
+}
+.filter-section__label::before {
+  content: ""; flex: 0 0 auto;
+  width: 14px; height: 3px; border-radius: 9999px;
+  background: var(--brand-primary);
+}
+.filter-list { display: flex; flex-direction: column; gap: 4px; }
+.filter-list__item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 10px; border-radius: 8px; cursor: pointer;
+  font-family: var(--font-body); font-size: 14px; font-weight: 500;
+  color: var(--fg-secondary);
+  transition: background-color var(--duration-fast), color var(--duration-fast);
+}
+.filter-list__item:hover { background: var(--bg-chip); color: var(--fg-primary); }
+.filter-list__item--active { background: var(--bg-chip); color: var(--fg-primary); font-weight: 600; }
+.filter-list__count { margin-left: auto; font-size: 11px; color: var(--fg-muted); font-variant-numeric: tabular-nums; }
+.filter-list__check {
+  width: 16px; height: 16px; border-radius: 4px;
+  border: 1.5px solid var(--border-strong); flex-shrink: 0;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.filter-list__item--active .filter-list__check {
+  background: var(--brand-primary); border-color: var(--brand-primary); color: var(--fg-on-accent);
+}
+
+/* Allergen list active state — matches the mobile amber chip look */
+.carta__filters .filter-list--allergens .filter-list__item--active {
+  background: #FBBF24; color: #5A2F00; font-weight: 600;
+}
+.carta__filters .filter-list--allergens .filter-list__item--active .filter-list__check {
+  background: #5A2F00; border-color: #5A2F00; color: var(--color-amber-300);
+}
+.carta__filters .filter-list--allergens .filter-list__item--active .allergen {
+  background: #5A2F00; color: var(--color-amber-300);
+}
+
+/* destination toggle */
+.dest-toggle { display: flex; background: var(--bg-chip); border-radius: 9999px; padding: 3px; }
+.dest-toggle button {
+  flex: 1; padding: 6px 10px; border-radius: 9999px; border: none; background: transparent;
+  font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--fg-secondary);
+  cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 4px;
+}
+.dest-toggle button.active { background: var(--bg-base); color: var(--fg-primary); box-shadow: var(--shadow-card); }
+
+/* ----- Body / product grid -----
+   Bottom padding clears the floating FABs (bottom: 92 + 56 height = 148) and
+   the cart bar below them. Just enough so the last row of plates sits a hair
+   above the FABs when scrolled to the end — no empty void below. */
+.carta__body { padding: 20px 18px 156px; }
+.carta[data-bp="mobile"] .carta__body { padding: 16px 14px 156px; }
+
+/* Mobile: en el grid de 2 columnas la fila precio + stepper se desbordaba
+   ~3px y recortaba el "+" contra el borde de la tarjeta. Apretamos hueco,
+   relleno y tamaño de los botones para que quepa con margen en todos los temas. */
+.carta[data-bp="mobile"] .pcard__foot { gap: 6px; }
+.carta[data-bp="mobile"] .pcard__price { font-size: 16px; }
+.carta[data-bp="mobile"] .qty { padding: 1px; }
+.carta[data-bp="mobile"] .qty button { width: 24px; height: 24px; font-size: 14px; }
+
+.category { margin-bottom: 28px; }
+.category__head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 12px; }
+.category__name { font-family: var(--font-display); font-weight: 900; font-size: 22px; letter-spacing: -0.01em; color: var(--fg-primary); }
+.category__count { font-family: var(--font-body); font-size: 12px; color: var(--fg-muted); font-variant-numeric: tabular-nums; }
+
+.product-grid {
+  display: grid; gap: 14px;
+  grid-template-columns: repeat(2, 1fr);
+}
+.carta[data-bp="tablet"] .product-grid { grid-template-columns: repeat(3, 1fr); }
+.carta[data-bp="desktop"] .product-grid { grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.carta[data-bp="desktop"][data-chat="open"] .carta__cartCol { display: none; }
+
+/* ----- Product card ----- */
+.pcard {
+  background: var(--glass-bg-surface);
+  backdrop-filter: blur(8px);
+  border-radius: 16px;
+  box-shadow: var(--glass-shadow);
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  border: 1px solid var(--glass-border);
+  transition: border-color var(--duration-fast), box-shadow var(--duration-fast), transform var(--duration-fast);
+}
+[data-theme="dark"] .pcard { border-color: var(--border-subtle); }
+.pcard__photo {
+  aspect-ratio: 4 / 3;
+  background: var(--bg-chip);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 48px; line-height: 1; position: relative;
+}
+.pcard__photo--food-1 { background: linear-gradient(135deg, #FCE7AA, #FDB76A); }
+.pcard__photo--food-2 { background: linear-gradient(135deg, #FEE2E2, #FCA5A5); }
+.pcard__photo--food-3 { background: linear-gradient(135deg, #DCFCE7, #86EFAC); }
+.pcard__photo--food-4 { background: linear-gradient(135deg, #FEF3C7, #FBBF24); }
+.pcard__photo--food-5 { background: linear-gradient(135deg, #FCE7F3, #F9A8D4); }
+.pcard__photo--food-6 { background: linear-gradient(135deg, #E0E7FF, #A5B4FC); }
+[data-theme="dark"] .pcard__photo { background: linear-gradient(135deg, var(--color-night-500), var(--color-night-700)); }
+
+.pcard__body { padding: 12px 14px 14px; display: flex; flex-direction: column; gap: 8px; }
+.pcard__badges { display: flex; gap: 4px; min-height: 22px; }
+.pcard__name { font-family: var(--font-body); font-weight: 600; font-size: 15px; line-height: 1.3; color: var(--fg-primary); }
+.pcard__desc { font-family: var(--font-body); font-size: 12px; font-weight: 400; color: var(--fg-muted); line-height: 1.4; display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.pcard__foot { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: 4px; min-width: 0; }
+.pcard__price { font-family: var(--font-display); font-weight: 800; font-size: 18px; color: var(--price-gold); font-variant-numeric: tabular-nums; letter-spacing: -0.01em; white-space: nowrap; flex-shrink: 0; }
+
+/* Plus button */
+.btn-add {
+  width: 34px; height: 34px; border-radius: 9999px;
+  background: var(--brand-primary); color: var(--fg-on-accent);
+  border: none; cursor: pointer;
+  font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  line-height: 1;
+  box-shadow: var(--shadow-fab);
+  transition: transform var(--duration-fast) var(--ease-bounce);
+}
+.btn-add:hover { transform: scale(1.08); }
+.btn-add:active { transform: scale(0.94); }
+[data-theme="dark"] .btn-add {
+  background: linear-gradient(135deg, var(--color-green-500), var(--color-green-700));
+  color: #fff;
+}
+
+/* Allergen badge */
+.allergen {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px; border-radius: 50%;
+  background: var(--color-amber-100); color: var(--color-amber-800);
+  font-family: var(--font-display); font-weight: 800; font-size: 10px;
+  line-height: 1; flex-shrink: 0;
+}
+.allergen--emoji { background: transparent; font-size: 16px; }
+.allergen--lg { width: 26px; height: 26px; font-size: 11px; }
+
+/* New: official EU allergen icons as inline images */
+.allergen-img {
+  width: 22px; height: 22px; flex-shrink: 0; display: inline-block;
+  vertical-align: middle;
+}
+.allergen-img--lg { width: 28px; height: 28px; }
+
+/* Allergen chip in filter (with text label) */
+.allergen-chip {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 12px 6px 6px; border-radius: 9999px;
+  background: var(--bg-chip); color: var(--fg-primary);
+  font-family: var(--font-body); font-size: 13px; font-weight: 500;
+  cursor: pointer; border: 1px solid transparent; white-space: nowrap;
+}
+.allergen-chip:hover { background: var(--border-subtle); }
+.allergen-chip--active { background: var(--color-amber-300); color: #5A2F00; font-weight: 600; }
+.allergen-chip--active .allergen { background: #5A2F00; color: var(--color-amber-300); }
+[data-theme="dark"] .allergen-chip--active { background: var(--color-amber-300); color: #5A2F00; }
+
+/* Qty control — tightened so it doesn't crowd the price on small
+   product cards. Total pill width ~86px (was ~106px). */
+.qty {
+  display: inline-flex; align-items: center; padding: 2px;
+  background: var(--bg-base); border: 1px solid var(--border-subtle);
+  border-radius: 9999px; flex-shrink: 0;
+}
+.qty button {
+  width: 26px; height: 26px; border-radius: 9999px;
+  border: 1.5px solid transparent;
+  cursor: pointer;
+  font-family: var(--font-display); font-weight: 900; font-size: 15px; line-height: 1;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: transform 180ms var(--ease-bounce, cubic-bezier(.34,1.56,.64,1)),
+              background-color var(--duration-fast),
+              border-color var(--duration-fast),
+              box-shadow var(--duration-fast);
+}
+
+/* Solid, semantic fills — red for minus (quitar), green for plus (añadir).
+   Soft tint by default so the button reads as colored without screaming,
+   then saturates fully on hover/active with a tiny bounce. */
+.qty button.qty-minus {
+  background: linear-gradient(180deg, #FCA5A5, #F87171);
+  color: #FFFFFF;
+  border-color: transparent;
+  box-shadow: 0 1px 3px rgba(239,68,68,0.30);
+}
+.qty button.qty-plus {
+  background: linear-gradient(180deg, #86EFAC, #22C55E);
+  color: #FFFFFF;
+  border-color: transparent;
+  box-shadow: 0 1px 3px rgba(34,197,94,0.38);
+}
+.qty button.qty-minus:hover {
+  background: linear-gradient(180deg, #FB7185, #DC2626);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 0 0 4px color-mix(in oklab, var(--color-red-400) 22%, transparent);
+  transform: scale(1.12);
+}
+.qty button.qty-plus:hover {
+  background: linear-gradient(180deg, #4ADE80, #16A34A);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 0 0 4px color-mix(in oklab, var(--color-green-500) 22%, transparent);
+  transform: scale(1.12);
+}
+.qty button:active { transform: scale(0.92); transition-duration: 80ms; }
+
+/* Pulse animation — fires once when React swaps the qty value.
+   Triggered by re-keying via the qty-n text change; we attach the
+   animation to the buttons themselves so each tap reads as a quick
+   "highlight". */
+@keyframes qty-pulse-minus {
+  0%   { box-shadow: 0 0 0 0 color-mix(in oklab, var(--color-red-400) 55%, transparent); }
+  100% { box-shadow: 0 0 0 10px color-mix(in oklab, var(--color-red-400) 0%, transparent); }
+}
+@keyframes qty-pulse-plus {
+  0%   { box-shadow: 0 0 0 0 color-mix(in oklab, var(--color-green-500) 55%, transparent); }
+  100% { box-shadow: 0 0 0 10px color-mix(in oklab, var(--color-green-500) 0%, transparent); }
+}
+.qty button.qty-minus:focus-visible { animation: qty-pulse-minus 420ms var(--ease-out, ease-out); outline: none; }
+.qty button.qty-plus:focus-visible  { animation: qty-pulse-plus  420ms var(--ease-out, ease-out); outline: none; }
+
+/* Dark mode: gradientes ligeramente más saturados sobre night-blue. */
+[data-theme="dark"] .qty button.qty-minus {
+  background: linear-gradient(180deg, #EF4444, #B91C1C);
+  color: #FFFFFF;
+  border-color: transparent;
+}
+[data-theme="dark"] .qty button.qty-plus {
+  background: linear-gradient(180deg, #22C55E, #15803D);
+  color: #FFFFFF;
+  border-color: transparent;
+}
+
+/* The number in the middle gets a subtle "bump" when it changes. */
+.qty .qty-n {
+  padding: 0 6px; font-family: var(--font-display); font-weight: 800; font-size: 14px;
+  min-width: 18px; text-align: center; font-variant-numeric: tabular-nums;
+  color: var(--fg-primary);
+  animation: qty-bump 280ms var(--ease-bounce, cubic-bezier(.34,1.56,.64,1));
+}
+@keyframes qty-bump {
+  0%   { transform: scale(1); }
+  40%  { transform: scale(1.25); }
+  100% { transform: scale(1); }
+}
+
+/* ----- Cart bar (mobile + tablet) ----- */
+.cart-bar {
+  position: absolute; left: 16px; right: 16px; bottom: 16px; z-index: 30;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 14px 12px 12px;
+  border-radius: 24px;
+  background: linear-gradient(180deg, var(--cart-bar-from), var(--cart-bar-to));
+  border: 1px solid var(--cart-bar-border);
+  color: #BBF7D0;
+  font-family: var(--font-body); font-size: 13px; font-weight: 500;
+  box-shadow: 0 10px 30px rgba(15, 61, 42, 0.45);
+  animation: slide-up 220ms var(--ease-out);
+}
+@keyframes slide-up { from { transform: translateY(100%); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+.cart-bar__left { display: flex; align-items: center; gap: 10px; }
+.cart-bar__icon { width: 36px; height: 36px; border-radius: 9999px; background: rgba(34, 197, 94, 0.18); display: inline-flex; align-items: center; justify-content: center; position: relative; }
+.cart-bar__icon svg { width: 18px; height: 18px; }
+.cart-bar__count { position: absolute; top: -3px; right: -3px; min-width: 18px; height: 18px; background: var(--badge-count); color: white; border-radius: 9999px; font-family: var(--font-display); font-weight: 800; font-size: 10px; display: inline-flex; align-items: center; justify-content: center; padding: 0 4px; line-height: 1; }
+.cart-bar__total { color: var(--price-gold); font-family: var(--font-display); font-weight: 800; font-size: 15px; font-variant-numeric: tabular-nums; }
+.cart-bar__cta { background: var(--cta-view-order); color: white; padding: 8px 16px; border-radius: 9999px; font-weight: 600; font-size: 13px; border: none; cursor: pointer; font-family: var(--font-body); }
+
+/* Carta with chat open: cart bar hides */
+.carta[data-chat="open"] .cart-bar { display: none; }
+.carta[data-chat="open"] .fab-bill { display: none; }
+
+/* FAB stack (bottom-right) */
+.fab {
+  position: absolute; z-index: 30;
+  width: 56px; height: 56px; border-radius: 9999px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: none; cursor: pointer;
+  box-shadow: var(--shadow-fab);
+  color: white;
+}
+.fab--chat {
+  right: 16px; bottom: 92px;
+  background: linear-gradient(135deg, #2E50B0, #1A3380);
+  overflow: hidden;
+}
+.fab--chat img { width: 48px; height: 48px; }
+.fab--bill {
+  /* Horizontal pill so the "Cuenta" label reads at first glance.
+     Width is intrinsic — grows with the label, fixed height. */
+  left: 16px; bottom: 92px;
+  width: auto; height: 44px;
+  padding: 0 18px 0 14px;
+  border-radius: 9999px;
+  flex-direction: row; gap: 8px;
+  background: linear-gradient(135deg, var(--color-red-400), var(--color-red-600));
+  color: #FFFFFF;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  font-family: var(--font-body); font-size: 14px; font-weight: 700;
+  letter-spacing: 0.01em;
+  box-shadow: 0 10px 24px rgba(220, 38, 38, 0.45), 0 0 0 0 rgba(239, 68, 68, 0.55);
+  animation: fab-attention 5.5s var(--ease-smooth) 1.6s infinite;
+}
+.fab--bill:hover { filter: brightness(1.06); }
+.fab--bill svg { color: #FFFFFF; width: 18px; height: 18px; }
+
+@keyframes fab-attention {
+  0%, 70%, 100% { transform: translateY(0) scale(1);    box-shadow: 0 10px 24px rgba(220, 38, 38, 0.45), 0 0 0 0 rgba(239, 68, 68, 0.55); }
+  78%           { transform: translateY(-8px) scale(1.04); box-shadow: 0 16px 32px rgba(220, 38, 38, 0.55), 0 0 0 8px rgba(239, 68, 68, 0.18); }
+  86%           { transform: translateY(0) scale(1);    box-shadow: 0 10px 24px rgba(220, 38, 38, 0.45), 0 0 0 14px rgba(239, 68, 68, 0); }
+  92%           { transform: translateY(-3px) scale(1.02); }
+  98%           { transform: translateY(0) scale(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .fab--bill { animation: none; }
+}
+
+/* On tablet & desktop, keep the bottom-overlay UI (cart bar, bill FAB, delete pill)
+   inside the product panel only — don't cover the left filter sidebar. */
+.carta[data-bp="tablet"]  .cart-bar     { left: 236px; }
+.carta[data-bp="desktop"] .cart-bar     { left: 256px; }
+.carta[data-bp="tablet"]  .fab--bill    { left: 236px; }
+.carta[data-bp="desktop"] .fab--bill    { left: 256px; }
+.carta[data-bp="tablet"]  .fab-cluster  { left: 236px; }
+.carta[data-bp="desktop"] .fab-cluster  { left: 256px; }
+.carta[data-bp="tablet"]  .delete-pill  { left: 236px; }
+.carta[data-bp="desktop"] .delete-pill  { left: 256px; }
+
+/* Mobile: taller header so a long restaurant name can breathe next to the
+   two-line "Cocina cerrada / abre HH:MM" pill. */
+.carta[data-bp="mobile"] .header {
+  padding: 12px 14px;
+  min-height: 68px;
+  align-items: center;
+}
+.carta[data-bp="mobile"] .header__bizname {
+  white-space: normal;
+  line-height: 1.15;
+  font-size: 15px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* ----- Cart column (desktop persistent) ----- */
+.cart-col__head {
+  padding: 18px 18px 12px; border-bottom: 1px solid var(--glass-border);
+}
+.cart-col__title { font-family: var(--font-display); font-weight: 900; font-size: 18px; color: var(--fg-primary); }
+.cart-col__sub { font-family: var(--font-body); font-size: 12px; color: var(--fg-muted); margin-top: 2px; }
+.cart-col__list { flex: 1; overflow-y: auto; padding: 12px 14px; display: flex; flex-direction: column; gap: 10px; }
+.cart-col__empty { padding: 32px 18px; text-align: center; color: var(--fg-muted); font-family: var(--font-body); font-size: 13px; line-height: 1.5; }
+.cart-col__empty .emoji { font-size: 40px; margin-bottom: 10px; }
+.cart-col__foot { border-top: 1px solid var(--glass-border); padding: 14px 18px; display: flex; flex-direction: column; gap: 10px; }
+.cart-col__total { display: flex; align-items: baseline; justify-content: space-between; }
+.cart-col__total .lab { font-family: var(--font-body); font-size: 12px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; color: var(--fg-muted); }
+.cart-col__total .val { font-family: var(--font-display); font-weight: 900; font-size: 24px; color: var(--price-gold); font-variant-numeric: tabular-nums; white-space: nowrap; }
+
+/* Cart item */
+.citem {
+  display: flex; flex-direction: column;
+  gap: 10px;
+  padding: 14px 16px;
+  background: var(--bg-chip); border-radius: 14px;
+}
+.citem__top {
+  display: flex; align-items: center; gap: 12px;
+}
+.citem__photo { width: 44px; height: 44px; border-radius: 8px; background: var(--bg-elevated); display: inline-flex; align-items: center; justify-content: center; font-size: 22px; flex-shrink: 0; }
+.citem__main { flex: 1; min-width: 0; }
+.citem__name { font-family: var(--font-body); font-size: 14px; font-weight: 700; color: var(--fg-primary); line-height: 1.3; }
+.citem__unit { font-family: var(--font-body); font-size: 12px; color: var(--fg-muted); margin-top: 2px; font-variant-numeric: tabular-nums; }
+.citem__custom { font-family: var(--font-body); font-size: 11px; color: var(--fg-muted); margin-top: 2px; line-height: 1.4; }
+.citem__row { display: flex; align-items: center; justify-content: space-between; margin-top: 8px; }
+.citem__price { font-family: var(--font-display); font-weight: 800; font-size: 15px; color: var(--price-gold); font-variant-numeric: tabular-nums; white-space: nowrap; min-width: 64px; text-align: right; }
+
+.citem__quitar {
+  display: flex; flex-direction: column; gap: 8px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border-subtle);
+}
+.citem__quitarLabel {
+  font-family: var(--font-body); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.citem__chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.chip-quitar {
+  padding: 6px 12px; border-radius: 9999px;
+  background: var(--bg-base); color: var(--fg-secondary);
+  font-family: var(--font-body); font-size: 12px; font-weight: 500;
+  border: 1px solid var(--border-subtle); cursor: pointer; white-space: nowrap;
+  transition: background-color var(--duration-fast), color var(--duration-fast), border-color var(--duration-fast);
+}
+.chip-quitar:hover { border-color: var(--border-strong); color: var(--fg-primary); }
+.chip-quitar--on {
+  background: var(--color-amber-100); color: var(--color-amber-800);
+  border-color: var(--color-amber-300); font-weight: 600;
+}
+[data-theme="dark"] .chip-quitar--on {
+  background: rgba(251, 191, 36, 0.15); color: var(--color-amber-300);
+  border-color: rgba(251, 191, 36, 0.35);
+}
+
+.btn-primary {
+  width: 100%; padding: 12px 16px; border-radius: 12px;
+  background: var(--cta-view-order); color: white;
+  border: none; cursor: pointer;
+  font-family: var(--font-body); font-weight: 700; font-size: 14px;
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  box-shadow: var(--shadow-fab);
+  transition: filter var(--duration-fast);
+}
+.btn-primary:hover { filter: brightness(1.05); }
+.btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+.btn-secondary {
+  width: 100%; padding: 10px 16px; border-radius: 12px;
+  background: var(--glass-bg-surface);
+  backdrop-filter: blur(8px);
+  color: var(--fg-primary);
+  border: 1px solid var(--glass-border); cursor: pointer;
+  font-family: var(--font-body); font-weight: 600; font-size: 13px;
+}
+
+/* ----- Mobile / tablet cart drawer ----- */
+.scrim {
+  position: absolute; inset: 0; z-index: 40;
+  background: var(--bg-overlay);
+  backdrop-filter: blur(10px) saturate(120%);
+  -webkit-backdrop-filter: blur(10px) saturate(120%);
+  display: flex;
+  align-items: flex-end;
+  animation: fade-in 180ms var(--ease-out);
+}
+@keyframes fade-in { from { opacity: 0; } to { opacity: 1; } }
+
+/* Bottom sheet — used at every breakpoint.
+   Slides up, occupies a bit more than half of the carta height. */
+.drawer {
+  background: var(--glass-bg-base);
+  backdrop-filter: blur(20px);
+  color: var(--fg-primary);
+  display: flex; flex-direction: column;
+  width: 100%;
+  height: 62%;
+  border-radius: 20px 20px 0 0;
+  border-top: 1px solid var(--glass-border);
+  box-shadow: 0 -20px 60px rgba(0, 0, 0, 0.12), inset 0 1px 0 var(--glass-border);
+  animation: drawer-up 280ms var(--ease-smooth);
+}
+@keyframes drawer-up { from { transform: translateY(100%); } to { transform: translateY(0); } }
+@keyframes drawer-down { from { transform: translateY(0); } to { transform: translateY(100%); } }
+@keyframes fade-out { from { opacity: 1; } to { opacity: 0; } }
+
+.scrim.is-closing { animation: fade-out 240ms var(--ease-out) forwards; pointer-events: none; }
+.drawer.is-closing { animation: drawer-down 260ms var(--ease-smooth) forwards; }
+
+/* On mobile let it grow a touch more since the viewport is taller relative to width */
+.carta[data-bp="mobile"] .drawer { height: 70%; }
+
+/* Grabber handle at the top of the bottom sheet */
+.drawer__grabber {
+  width: 44px; height: 5px; border-radius: 9999px;
+  background: var(--border-strong); opacity: 0.5;
+  margin: 8px auto 2px;
+  flex-shrink: 0;
+}
+
+.drawer__head { padding: 16px 18px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--glass-border); }
+.drawer__title { font-family: var(--font-display); font-weight: 900; font-size: 20px; color: var(--fg-primary); }
+.icon-btn--back { margin-right: 4px; }
+.icon-btn--back:hover { background: var(--border-strong, var(--border-subtle)); }
+.icon-btn { width: 32px; height: 32px; border-radius: 9999px; background: var(--glass-bg-surface); backdrop-filter: blur(6px); border: 1px solid var(--glass-border); cursor: pointer; display: inline-flex; align-items: center; justify-content: center; color: var(--fg-primary); }
+.icon-btn:hover { background: var(--border-subtle); }
+
+/* Delete pill */
+.delete-pill {
+  position: absolute; left: 16px; right: 16px; bottom: 86px; z-index: 35;
+  display: inline-flex; align-items: center; gap: 10px; justify-content: center;
+  padding: 10px 16px; border-radius: 9999px;
+  background: var(--delete-pill-bg); color: #FECACA; border: 1px solid var(--delete-pill-border);
+  font-family: var(--font-body); font-size: 13px; font-weight: 500;
+  animation: pill-in 200ms var(--ease-out);
+}
+@keyframes pill-in { from { transform: translateY(20px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+.delete-pill strong { color: white; font-weight: 700; }
+
+/* ----- Chat panel ----- */
+.chat-panel {
+  position: absolute; right: 0; top: 0; bottom: 0; z-index: 50;
+  background: var(--color-night-900); color: var(--color-blue-100);
+  display: flex; flex-direction: column;
+  box-shadow: -20px 0 60px rgba(0, 0, 0, 0.4);
+  animation: chat-in 250ms var(--ease-smooth);
+}
+@keyframes chat-in { from { transform: translateX(100%); } to { transform: translateX(0); } }
+.carta[data-bp="mobile"] .chat-panel { width: 100%; left: 0; }
+.carta[data-bp="tablet"] .chat-panel { width: 380px; }
+.carta[data-bp="desktop"] .chat-panel { width: 420px; }
+
+.chat-panel__head {
+  display: flex; align-items: center; gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(46, 80, 176, 0.35);
+  background: var(--color-night-800);
+}
+.chat-panel__avatar { width: 40px; height: 40px; border-radius: 50%; flex-shrink: 0; }
+.chat-panel__name { font-family: var(--font-display); font-weight: 900; font-size: 16px; color: var(--color-blue-100); line-height: 1.1; }
+.chat-panel__biz { font-family: var(--font-body); font-size: 11px; color: var(--color-blue-200); margin-top: 2px; }
+.chat-panel__close { margin-left: auto; }
+
+.chat-log { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 10px; }
+.bubble { max-width: 80%; padding: 10px 14px; border-radius: 16px; font-family: var(--font-body); font-size: 14px; line-height: 1.4; }
+.bubble--bot { background: var(--color-night-600); border: 1px solid rgba(46, 80, 176, 0.35); color: var(--color-blue-100); align-self: flex-start; border-bottom-left-radius: 6px; }
+.bubble--user { background: linear-gradient(180deg, #2E50B0, #1A3380); color: white; align-self: flex-end; border-bottom-right-radius: 6px; }
+.bubble__time { font-family: var(--font-body); font-size: 10px; color: var(--color-blue-200); margin-top: 4px; }
+.bubble--user .bubble__time { color: rgba(200, 216, 255, 0.7); }
+
+.typing { background: var(--color-night-600); border: 1px solid rgba(46, 80, 176, 0.35); padding: 12px 16px; border-radius: 16px; border-bottom-left-radius: 6px; align-self: flex-start; display: inline-flex; gap: 4px; }
+.typing span { width: 6px; height: 6px; background: var(--color-blue-200); border-radius: 50%; animation: blink 1.4s infinite both; }
+.typing span:nth-child(2) { animation-delay: 0.2s; }
+.typing span:nth-child(3) { animation-delay: 0.4s; }
+@keyframes blink { 0%, 80%, 100% { opacity: 0.3; } 40% { opacity: 1; transform: translateY(-2px); } }
+
+/* Chat product carousel */
+.chat-carousel { display: flex; gap: 10px; overflow-x: auto; padding-bottom: 4px; margin-top: 4px; align-self: stretch; scrollbar-width: thin; scrollbar-color: rgba(46,80,176,0.5) transparent; }
+.chat-pcard { width: 160px; flex-shrink: 0; background: var(--color-night-600); border: 1px solid rgba(46,80,176,0.35); border-radius: 12px; overflow: hidden; }
+.chat-pcard__photo { aspect-ratio: 1; background: linear-gradient(135deg, #162648, #0A1430); display: flex; align-items: center; justify-content: center; font-size: 36px; }
+.chat-pcard__body { padding: 8px 10px; display: flex; flex-direction: column; gap: 4px; }
+.chat-pcard__name { font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--color-blue-100); line-height: 1.2; }
+.chat-pcard__row { display: flex; align-items: center; justify-content: space-between; margin-top: 2px; }
+.chat-pcard__price { font-family: var(--font-display); font-weight: 800; font-size: 14px; color: var(--price-gold); font-variant-numeric: tabular-nums; }
+.chat-pcard__add { width: 24px; height: 24px; border-radius: 9999px; background: linear-gradient(135deg, #2E50B0, #1A3380); color: white; border: none; cursor: pointer; font-family: var(--font-display); font-weight: 900; font-size: 14px; line-height: 1; }
+
+/* Quick replies */
+.quick-row { display: flex; flex-wrap: wrap; gap: 6px; align-self: flex-start; max-width: 90%; }
+.quick {
+  padding: 6px 12px; border-radius: 9999px;
+  background: rgba(46, 80, 176, 0.15); color: var(--color-blue-100);
+  border: 1px solid rgba(46, 80, 176, 0.35);
+  font-family: var(--font-body); font-size: 12px; font-weight: 500; cursor: pointer;
+}
+.quick:hover { background: rgba(46, 80, 176, 0.3); }
+
+/* Live "Tu pedido" card in chat */
+.live-cart {
+  background: var(--color-night-500); border: 1px solid rgba(46,80,176,0.5);
+  border-radius: 14px; padding: 12px 14px; align-self: stretch;
+}
+.live-cart__head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.live-cart__title { font-family: var(--font-display); font-weight: 800; font-size: 13px; color: var(--color-blue-100); }
+.live-cart__count { font-family: var(--font-body); font-size: 11px; color: var(--color-blue-200); }
+.live-cart__items { font-family: var(--font-body); font-size: 12px; color: var(--color-blue-200); line-height: 1.6; }
+.live-cart__total { display: flex; justify-content: space-between; margin-top: 10px; padding-top: 10px; border-top: 1px solid rgba(46,80,176,0.35); }
+.live-cart__total .lab { font-family: var(--font-body); font-size: 11px; font-weight: 600; color: var(--color-blue-200); }
+.live-cart__total .val { font-family: var(--font-display); font-weight: 800; font-size: 16px; color: var(--price-gold); font-variant-numeric: tabular-nums; }
+
+/* Chat composer */
+.chat-composer { padding: 12px 16px; border-top: 1px solid rgba(46, 80, 176, 0.35); background: var(--color-night-800); display: flex; gap: 8px; align-items: center; }
+.chat-input {
+  flex: 1; background: var(--color-night-600); border: 1px solid rgba(46, 80, 176, 0.35);
+  border-radius: 9999px; padding: 10px 16px;
+  font-family: var(--font-body); font-size: 14px; color: var(--color-blue-100);
+  outline: none;
+}
+.chat-input::placeholder { color: var(--color-blue-200); opacity: 0.7; }
+.chat-input:focus { border-color: var(--color-cyan-400); }
+.chat-send {
+  width: 40px; height: 40px; border-radius: 9999px; border: none; cursor: pointer;
+  background: linear-gradient(135deg, #2E50B0, #1A3380); color: white;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+
+/* ----- Modal (tapas) ----- */
+.modal {
+  position: absolute; inset: 0; z-index: 60;
+  background: var(--bg-overlay);
+  display: flex; align-items: flex-end; justify-content: center;
+  animation: fade-in 180ms var(--ease-out);
+}
+.carta[data-bp="tablet"] .modal,
+.carta[data-bp="desktop"] .modal { align-items: center; }
+.modal__panel {
+  background: var(--glass-bg-base);
+  backdrop-filter: blur(20px); color: var(--fg-primary);
+  width: 100%; max-width: 480px;
+  border-radius: 20px 20px 0 0;
+  padding: 18px;
+  box-shadow: var(--shadow-pop);
+  animation: drawer-up 220ms var(--ease-smooth);
+  display: flex; flex-direction: column; gap: 14px;
+  max-height: 85%; overflow: auto;
+}
+.carta[data-bp="tablet"] .modal__panel,
+.carta[data-bp="desktop"] .modal__panel { border-radius: 20px; }
+.modal__head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+.modal__title { font-family: var(--font-display); font-weight: 900; font-size: 20px; line-height: 1.2; }
+.modal__sub { font-family: var(--font-body); font-size: 13px; color: var(--fg-muted); margin-top: 4px; line-height: 1.5; }
+
+/* Tapa option */
+.tapa { display: flex; align-items: center; gap: 12px; padding: 10px; border: 1px solid var(--border-subtle); border-radius: 12px; cursor: pointer; background: var(--bg-surface); }
+.tapa:hover { border-color: var(--border-strong); }
+.tapa--selected { border-color: var(--brand-primary); background: var(--color-green-50); }
+[data-theme="dark"] .tapa--selected { background: rgba(34, 197, 94, 0.1); }
+.tapa__photo { width: 44px; height: 44px; border-radius: 8px; background: var(--bg-chip); display: inline-flex; align-items: center; justify-content: center; font-size: 22px; }
+.tapa__main { flex: 1; min-width: 0; }
+.tapa__name { font-family: var(--font-body); font-weight: 600; font-size: 14px; color: var(--fg-primary); }
+.tapa__price { font-family: var(--font-display); font-weight: 800; font-size: 13px; color: var(--price-gold); font-variant-numeric: tabular-nums; }
+.tapa__price--free { color: var(--color-green-600); }
+[data-theme="dark"] .tapa__price--free { color: var(--color-green-400); }
+
+/* ----- Bill flow ----- */
+/* ----- Bill flow (bottom-sheet variant of the drawer) ----- */
+.drawer--bill { height: auto; max-height: 70%; }
+
+/* Mobile: the bill drawer must stay in the lower thumb-zone.
+   The cart drawer rule above pins .drawer to 70% on mobile, which is
+   too tall for the bill (only 2 short steps). Override to a compact
+   auto-height capped under half the carta height. */
+.carta[data-bp="mobile"] .drawer--bill {
+  height: auto;
+  max-height: 48%;
+}
+.drawer__total {
+  display: flex; flex-direction: column;
+  align-items: flex-end; text-align: right;
+  margin-left: auto; padding-right: 14px;
+  line-height: 1.1;
+}
+.drawer__total .lab {
+  font-family: var(--font-body); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--fg-muted); margin-bottom: 3px;
+  white-space: nowrap;
+}
+.drawer__total .val {
+  font-family: var(--font-display); font-weight: 900; font-size: 22px;
+  color: var(--price-gold); font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.drawer__body { flex: 1; min-height: 0; overflow-y: auto; padding: 14px 18px 18px; display: flex; flex-direction: column; gap: 14px; }
+.drawer__foot { border-top: 1px solid var(--glass-border); padding: 14px 18px; display: flex; flex-direction: column; gap: 10px; }
+.btn-text {
+  width: 100%; padding: 12px 16px; border-radius: 12px;
+  background: transparent; color: var(--fg-secondary);
+  border: none; cursor: pointer;
+  font-family: var(--font-body); font-weight: 600; font-size: 14px;
+}
+.btn-text:hover { color: var(--fg-primary); }
+
+.bill__methods { 
+  display: grid; 
+  grid-template-columns: 1fr;
+  gap: 12px;
+}
+.carta[data-bp="tablet"] .bill__methods {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.carta[data-bp="desktop"] .bill__methods {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.bill__method {
+  padding: 22px 14px; border: 1px solid var(--glass-border); border-radius: 16px;
+  background: var(--glass-bg-surface);
+  backdrop-filter: blur(8px); cursor: pointer;
+  display: flex; flex-direction: column; align-items: center; gap: 10px;
+  text-align: center;
+  font-family: var(--font-body); color: var(--fg-primary);
+  transition: border-color var(--duration-fast), background-color var(--duration-fast), transform var(--duration-fast);
+}
+.bill__method:hover { border-color: var(--brand-primary); transform: translateY(-1px); }
+.bill__method .ic { width: 48px; height: 48px; border-radius: 50%; background: var(--bg-chip); display: inline-flex; align-items: center; justify-content: center; }
+.bill__method .nm { font-family: var(--font-body); font-weight: 700; font-size: 15px; color: var(--fg-primary); }
+.bill__method .ds { font-family: var(--font-body); font-size: 11px; color: var(--fg-muted); }
+
+/* Payment-method colour coding — high-contrast, unambiguous.
+   Efectivo → verde (asociación universal con monedas / billetes).
+   Tarjeta  → celeste / cian (banca / pago digital, alto contraste
+              tanto en light como en dark mode).
+   El tinte de fondo es deliberadamente lavado (~3% en light, ~6%
+   en dark) para reforzar la asociación sin saturar la superficie. */
+.bill__method--cash {
+  background: color-mix(in oklab, var(--color-green-500) 4%, var(--bg-surface));
+  border-color: color-mix(in oklab, var(--color-green-500) 22%, var(--border-subtle));
+}
+.bill__method--cash .ic {
+  background: var(--color-green-100);
+  color: var(--color-green-700);
+}
+.bill__method--cash:hover { border-color: var(--color-green-500); }
+
+.bill__method--card {
+  background: color-mix(in oklab, var(--color-cyan-400) 4%, var(--bg-surface));
+  border-color: color-mix(in oklab, var(--color-cyan-400) 22%, var(--border-subtle));
+}
+.bill__method--card .ic {
+  background: rgba(34, 211, 238, 0.14);
+  color: #0891B2; /* cyan-600 — legible sobre fondo claro */
+}
+.bill__method--card:hover { border-color: var(--color-cyan-400); }
+
+[data-theme="dark"] .bill__method--cash {
+  background: color-mix(in oklab, var(--color-green-400) 8%, var(--bg-surface));
+  border-color: color-mix(in oklab, var(--color-green-400) 28%, var(--border-subtle));
+}
+[data-theme="dark"] .bill__method--cash .ic {
+  background: rgba(74, 222, 128, 0.18);
+  color: var(--color-green-400);
+}
+[data-theme="dark"] .bill__method--card {
+  background: color-mix(in oklab, var(--color-cyan-400) 8%, var(--bg-surface));
+  border-color: color-mix(in oklab, var(--color-cyan-400) 28%, var(--border-subtle));
+}
+[data-theme="dark"] .bill__method--card .ic {
+  background: rgba(34, 211, 238, 0.22);
+  color: var(--color-cyan-400);
+}
+
+.bill__done { display: flex; flex-direction: column; align-items: center; gap: 10px; padding: 18px 0; }
+
+/* ════════════════════════════════════════════════════════════════
+   PAYMENT SUCCESS — pantalla de éxito post-pago (celebración ligera)
+   ════════════════════════════════════════════════════════════════ */
+.ps {
+  display: flex; flex-direction: column; align-items: center; text-align: center;
+  padding: 8px 4px 4px;
+}
+.ps__head {
+  font-family: var(--font-display); font-weight: 900; font-size: 24px; line-height: 1.05;
+  color: var(--fg-primary); margin: 18px 0 0;
+  letter-spacing: -0.01em;
+  animation: ps-rise 460ms 120ms var(--ease-bounce) both;
+}
+
+/* ── Importe destacado ── */
+.ps__amount {
+  display: flex; flex-direction: column; align-items: center; gap: 1px; margin-top: 12px;
+  animation: ps-rise 460ms 200ms var(--ease-bounce) both;
+}
+.ps__amountLab { font-family: var(--font-body); font-size: 12px; font-weight: 700; letter-spacing: 0.07em; text-transform: uppercase; color: var(--fg-muted); }
+.ps__amountVal { font-family: var(--font-display); font-weight: 900; font-size: 40px; line-height: 1; color: var(--fg-primary); font-variant-numeric: tabular-nums; }
+.ps__amountTip { font-family: var(--font-body); font-size: 12px; color: var(--color-green-700); margin-top: 4px; }
+[data-theme="dark"] .ps__amountTip { color: var(--color-green-400); }
+
+/* ── Cobro partido: progreso + total mesa ── */
+.ps__split {
+  width: 100%; max-width: 320px; margin-top: 16px;
+  display: flex; flex-direction: column; gap: 8px;
+  animation: ps-rise 460ms 240ms var(--ease-bounce) both;
+}
+.ps__splitBar { height: 8px; border-radius: 999px; background: var(--bg-chip); overflow: hidden; }
+.ps__splitFill {
+  height: 100%; border-radius: 999px;
+  background: linear-gradient(90deg, var(--color-green-500), var(--color-green-400));
+  transition: width 700ms var(--ease-bounce);
+}
+.ps__splitRow { display: flex; justify-content: space-between; font-family: var(--font-body); font-size: 13px; color: var(--fg-muted); }
+.ps__splitRow strong { color: var(--fg-primary); font-variant-numeric: tabular-nums; }
+
+/* ── Chips de meta (mesa · pedido · método) ── */
+.ps__meta {
+  display: flex; flex-wrap: wrap; justify-content: center; gap: 7px; margin-top: 16px;
+  animation: ps-rise 460ms 280ms var(--ease-bounce) both;
+}
+.ps__chip {
+  font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--fg-secondary);
+  background: var(--bg-chip); border: 1px solid var(--border-subtle);
+  padding: 5px 11px; border-radius: 999px; white-space: nowrap;
+}
+.ps__chip--method { color: var(--color-green-700); border-color: var(--color-green-200); background: var(--color-green-50); }
+[data-theme="dark"] .ps__chip--method { color: var(--color-green-400); background: rgba(34,197,94,0.12); border-color: rgba(34,197,94,0.25); }
+
+.ps__note {
+  font-family: var(--font-body); font-size: 13px; line-height: 1.45; color: var(--fg-muted);
+  max-width: 300px; margin: 14px 0 0; text-wrap: pretty;
+  animation: ps-rise 460ms 320ms var(--ease-bounce) both;
+}
+
+/* ── CTAs ── */
+.ps__cta {
+  width: 100%; max-width: 340px; display: flex; flex-direction: column; gap: 9px; margin-top: 22px;
+  animation: ps-rise 460ms 380ms var(--ease-bounce) both;
+}
+.ps__btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  width: 100%; padding: 14px 18px; border-radius: 13px; cursor: pointer;
+  font-family: var(--font-body); font-weight: 700; font-size: 15px;
+  border: none; transition: filter var(--duration-fast), transform var(--duration-fast), background var(--duration-fast);
+}
+.ps__btn:active { transform: translateY(1px); }
+.ps__btn--primary { background: var(--cta-view-order); color: #fff; box-shadow: 0 6px 18px -8px var(--cta-view-order); }
+.ps__btn--primary:hover { filter: brightness(1.06); }
+.ps__btn--soft { background: var(--bg-chip); color: var(--fg-primary); border: 1.5px solid var(--border-strong); box-shadow: none; }
+.ps__btn--soft:hover { background: var(--bg-canvas); border-color: var(--brand-primary); filter: none; }
+.ps__btn--ghost { background: transparent; color: var(--fg-secondary); border: 1.5px solid var(--border-subtle); }
+.ps__btn--ghost:hover { color: var(--fg-primary); border-color: var(--fg-muted); }
+.ps__locked {
+  display: flex; align-items: center; gap: 8px; justify-content: center; text-align: left;
+  font-family: var(--font-body); font-size: 12.5px; line-height: 1.35; color: var(--fg-muted);
+  background: var(--bg-chip); border: 1px dashed var(--border-strong);
+  padding: 12px 14px; border-radius: 12px;
+}
+.ps__locked svg { flex: 0 0 auto; }
+
+@keyframes ps-rise { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: none; } }
+
+/* ── Medallón celebratorio ── */
+.ps-medal { position: relative; width: 88px; height: 88px; display: grid; place-items: center; }
+.ps-medal__disc {
+  position: relative; z-index: 2;
+  width: 76px; height: 76px; border-radius: 50%;
+  display: grid; place-items: center;
+  background: var(--color-green-100); color: var(--color-green-600);
+  animation: ps-pop 520ms var(--ease-bounce) both;
+}
+.ps-medal--cash .ps-medal__disc { background: var(--price-gold-soft, #FBEFD0); color: var(--price-gold); }
+.ps-medal--cheers .ps-medal__disc { background: var(--color-green-100); }
+[data-theme="dark"] .ps-medal__disc { background: rgba(34,197,94,0.16); color: var(--color-green-400); }
+[data-theme="dark"] .ps-medal--cash .ps-medal__disc { background: rgba(212,160,46,0.18); }
+.ps-medal__emoji { font-size: 34px; line-height: 1; }
+.ps-medal__svg { width: 52px; height: 52px; }
+.ps-medal__tick {
+  stroke-dasharray: 48; stroke-dashoffset: 48;
+  animation: ps-draw 420ms 360ms cubic-bezier(0.65,0,0.35,1) forwards;
+}
+.ps-medal__ring {
+  position: absolute; z-index: 1; inset: 6px; border-radius: 50%;
+  border: 2px solid var(--color-green-500);
+  opacity: 0; animation: ps-ring 700ms 200ms ease-out forwards;
+}
+.ps-medal--cash .ps-medal__ring { border-color: var(--price-gold); }
+.ps-medal__confetti { position: absolute; inset: 0; z-index: 0; pointer-events: none; }
+.ps-medal__confetti span {
+  position: absolute; left: 50%; top: 50%; border-radius: 2px;
+  transform: translate(-50%, -50%) scale(0);
+  animation: ps-confetti 620ms var(--cd, 0ms) cubic-bezier(0.2,0.7,0.3,1) forwards;
+}
+@keyframes ps-pop { 0% { transform: scale(0.4); opacity: 0; } 60% { transform: scale(1.08); opacity: 1; } 100% { transform: scale(1); } }
+@keyframes ps-draw { to { stroke-dashoffset: 0; } }
+@keyframes ps-ring { 0% { transform: scale(0.7); opacity: 0.8; } 100% { transform: scale(1.5); opacity: 0; } }
+@keyframes ps-confetti {
+  0% { transform: translate(-50%, -50%) scale(0); opacity: 0; }
+  35% { opacity: 1; }
+  100% { transform: translate(calc(-50% + var(--cx)), calc(-50% + var(--cy))) scale(1) rotate(140deg); opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ps__head, .ps__amount, .ps__split, .ps__meta, .ps__note, .ps__cta,
+  .ps-medal__disc, .ps-medal__tick, .ps-medal__ring, .ps-medal__confetti span { animation: none !important; }
+  .ps-medal__tick { stroke-dashoffset: 0; }
+  .ps__head, .ps__amount, .ps__split, .ps__meta, .ps__note, .ps__cta { opacity: 1; transform: none; }
+}
+
+/* ── Chip persistente en el header: re-descargar ticket ── */
+.ticket-badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 11px 6px 8px; border-radius: 999px; cursor: pointer;
+  background: var(--color-green-50); color: var(--color-green-700);
+  border: 1px solid var(--color-green-200);
+  font-family: var(--font-body); font-weight: 700; font-size: 12.5px;
+  transition: filter var(--duration-fast), transform var(--duration-fast);
+  animation: ps-rise 360ms var(--ease-bounce) both;
+}
+.ticket-badge:hover { filter: brightness(0.97); }
+.ticket-badge:active { transform: translateY(1px); }
+.ticket-badge__ic { display: inline-flex; }
+[data-theme="dark"] .ticket-badge { background: rgba(34,197,94,0.14); color: var(--color-green-400); border-color: rgba(34,197,94,0.28); }
+.carta[data-bp="mobile"] .ticket-badge__txt { display: none; }
+.carta[data-bp="mobile"] .ticket-badge { padding: 7px; }
+
+.bill__done2 { display: flex; flex-direction: column; align-items: center; gap: 10px; padding: 18px 0; }
+.bill__doneMsg {
+  display: flex; flex-direction: column; gap: 2px; align-items: center; text-align: center;
+  font-family: var(--font-body); font-size: 13px; color: var(--fg-default);
+}
+.bill__doneMsg strong { font-weight: 700; }
+.bill__doneMsg span { color: var(--fg-muted); font-size: 12px; }
+
+.bill__cashConfirm {
+  display: flex; flex-direction: column; align-items: stretch; gap: 14px;
+  padding: 6px 0 4px;
+}
+.bill__cashHead {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 12px 14px;
+  background: var(--color-green-100);
+  border: 1px solid color-mix(in oklab, var(--color-green-700) 18%, transparent);
+  border-radius: 12px;
+}
+[data-theme="dark"] .bill__cashHead {
+  background: rgba(34, 197, 94, 0.10);
+  border-color: rgba(34, 197, 94, 0.28);
+}
+.bill__cashIntro {
+  display: flex; flex-direction: column; gap: 4px;
+  font-family: var(--font-body); font-size: 13px; color: var(--fg-default);
+  line-height: 1.4; min-width: 0;
+}
+.bill__cashIntro strong {
+  font-family: var(--font-display); font-weight: 800; font-size: 14px;
+  color: var(--color-green-700);
+}
+[data-theme="dark"] .bill__cashIntro strong { color: var(--color-green-400); }
+.bill__cashIntro span { color: var(--fg-muted); font-size: 12.5px; }
+.bill__cashIntro em { font-style: normal; font-weight: 700; color: var(--fg-default); }
+.bill__cashIc {
+  width: 44px; height: 44px; border-radius: 50%;
+  background: var(--bg-base); color: var(--color-green-700);
+  display: grid; place-items: center;
+  flex: 0 0 44px;
+  border: 1px solid color-mix(in oklab, var(--color-green-700) 22%, transparent);
+}
+[data-theme="dark"] .bill__cashIc { background: rgba(34, 197, 94, 0.20); color: var(--color-green-400); border-color: transparent; }
+.bill__cashSteps {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; flex-direction: column; gap: 8px;
+  width: 100%;
+  font-family: var(--font-body); font-size: 13px; color: var(--fg-default);
+}
+.bill__cashSteps li {
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 12px;
+  background: var(--bg-chip);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+}
+.bill__cashSteps .t { flex: 1; min-width: 0; }
+[data-theme="dark"] .bill__cashSteps li {
+  background: rgba(255,255,255,0.04);
+  border-color: rgba(255,255,255,0.08);
+}
+.bill__cashSteps .n {
+  flex: 0 0 22px; height: 22px;
+  display: grid; place-items: center;
+  border-radius: 50%;
+  background: var(--color-green-700); color: #fff;
+  font-family: var(--font-display); font-size: 12px; font-weight: 800;
+}
+.bill__cashSteps strong { font-weight: 700; color: var(--color-green-700); }
+[data-theme="dark"] .bill__cashSteps strong { color: var(--color-green-400); }
+
+.bill__footRow { display: flex; gap: 8px; width: 100%; align-items: center; }
+.bill__footRow > .btn-primary { flex: 1 1 auto; width: auto; }
+.bill__footRow > .btn-secondary { flex: 0 0 auto; width: auto; }
+.bill__footRow > .btn-text { flex: 0 0 auto; width: auto; margin-right: auto; }
+.bill__cancelNotice { color: var(--fg-muted); }
+.bill__callWaiter { display: inline-flex; align-items: center; justify-content: center; gap: 8px; }
+.bill__doneAmt { color: var(--price-gold); font-variant-numeric: tabular-nums; }
+
+/* Bill drawer header — responsive guard so the title/total never collide.
+   At narrow widths the subtitle truncates, the total label stays one line,
+   and the heading flexes to swallow remaining space. */
+.drawer--bill .drawer__head { gap: 10px; padding-right: 14px; }
+.drawer--bill .drawer__head .drawer__heading { flex: 1 1 auto; min-width: 0; padding-right: 4px; }
+.drawer--bill .drawer__head .drawer__heading .drawer__title { font-size: 18px; }
+.drawer--bill .drawer__head .drawer__total { flex: 0 0 auto; margin-left: 0; padding-right: 8px; }
+.drawer--bill .drawer__head .drawer__total .val { font-size: 18px; }
+.carta[data-bp="mobile"] .drawer--bill .drawer__head { padding: 12px 12px; gap: 8px; }
+.carta[data-bp="mobile"] .drawer--bill .drawer__head .drawer__heading .drawer__title { font-size: 16px; }
+.carta[data-bp="mobile"] .drawer--bill .drawer__head .drawer__total .val { font-size: 16px; }
+.carta[data-bp="mobile"] .drawer--bill .drawer__head .drawer__subtitle { font-size: 11.5px; }
+.bill__doneIc {
+  width: 72px; height: 72px; border-radius: 50%;
+  background: var(--color-green-100); color: var(--color-green-700);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 36px; font-weight: 900; font-family: var(--font-display);
+}
+[data-theme="dark"] .bill__doneIc { background: rgba(34, 197, 94, 0.15); color: var(--color-green-400); }
+
+/* ════════════════════════════════════════════════════════════════
+   REDISEÑO · Flujo de pago en EFECTIVO
+   - Picker de métodos como lista (filas con desc + chevron)
+   - Pantalla de propina con chips %, input libre, resumen e info
+   - CTA dinámica con/sin propina
+   - Responsive para móvil, tablet y desktop
+   ════════════════════════════════════════════════════════════════ */
+
+/* ---- Picker de métodos: lista vertical (mobile) / grid 2x2 (tablet+desktop) ---- */
+.method-list { display: flex; flex-direction: column; gap: 10px; }
+.carta[data-bp="tablet"] .method-list,
+.carta[data-bp="desktop"] .method-list {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.method {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 44px 1fr auto;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  background: var(--glass-bg-surface);
+  backdrop-filter: blur(8px);
+  border: 1px solid var(--glass-border);
+  border-radius: 14px;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-body);
+  color: var(--fg-primary);
+  box-shadow: var(--glass-shadow);
+  transition: transform 160ms var(--ease-out, ease),
+              border-color 200ms var(--ease-out, ease),
+              background-color 200ms var(--ease-out, ease),
+              box-shadow 200ms var(--ease-out, ease);
+}
+/* En grid 2x2 las tarjetas se apilan: icono arriba, texto centrado, sin chevron */
+.carta[data-bp="tablet"] .method-list .method,
+.carta[data-bp="desktop"] .method-list .method {
+  grid-template-columns: 1fr;
+  justify-items: center;
+  text-align: center;
+  gap: 10px;
+  padding: 24px 16px;
+}
+.carta[data-bp="tablet"] .method-list .method__chev,
+.carta[data-bp="desktop"] .method-list .method__chev { display: none; }
+.carta[data-bp="tablet"] .method-list .method__txt,
+.carta[data-bp="desktop"] .method-list .method__txt { align-items: center; text-align: center; }
+.method:hover {
+  border-color: color-mix(in oklab, var(--fg-primary) 18%, var(--border-subtle));
+  transform: translateY(-1px);
+  box-shadow: 0 1px 0 rgba(20,18,14,0.04), 0 4px 14px -6px rgba(20,18,14,0.10);
+}
+.method:focus-visible {
+  outline: 3px solid color-mix(in oklab, var(--brand-primary) 50%, transparent);
+  outline-offset: 2px;
+}
+.method__ic {
+  width: 44px; height: 44px;
+  border-radius: 12px;
+  display: inline-grid; place-items: center;
+  background: var(--bg-chip); color: var(--fg-primary);
+  flex-shrink: 0;
+}
+.method__txt { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.method__nm {
+  font-family: var(--font-display); font-weight: 800; font-size: 16px;
+  line-height: 1.2; letter-spacing: -0.005em; color: var(--fg-primary);
+}
+.method__ds {
+  font-family: var(--font-body); font-size: 12.5px; color: var(--fg-muted);
+  line-height: 1.35;
+}
+.method__chev {
+  color: var(--fg-muted);
+  display: inline-flex; align-items: center;
+  transition: transform 200ms var(--ease-out, ease), color 200ms var(--ease-out, ease);
+}
+.method:hover .method__chev { transform: translateX(3px); color: var(--fg-primary); }
+
+/* Acentos suaves por método (tinte + ic color) */
+.method--cash .method__ic  { background: var(--color-green-100);  color: var(--color-green-700); }
+.method--card .method__ic  { background: rgba(34, 211, 238, 0.14); color: #0891B2; }
+.method--mixed .method__ic { background: var(--color-amber-100); color: var(--color-amber-800); }
+.method--split .method__ic { background: rgba(46, 80, 176, 0.10); color: var(--color-blue-400); }
+[data-theme="dark"] .method--cash .method__ic  { background: rgba(74,222,128,0.18);  color: var(--color-green-400); }
+[data-theme="dark"] .method--card .method__ic  { background: rgba(34,211,238,0.20); color: var(--color-cyan-400); }
+[data-theme="dark"] .method--mixed .method__ic { background: rgba(251,191,36,0.18); color: var(--color-amber-300); }
+[data-theme="dark"] .method--split .method__ic { background: rgba(46,80,176,0.25);  color: var(--color-blue-300); }
+
+/* Mobile: filas algo más compactas pero descripciones siguen visibles */
+.carta[data-bp="mobile"] .method { padding: 12px 14px; gap: 12px; grid-template-columns: 40px 1fr auto; }
+.carta[data-bp="mobile"] .method__ic { width: 40px; height: 40px; border-radius: 10px; }
+.carta[data-bp="mobile"] .method__nm { font-size: 15px; }
+.carta[data-bp="mobile"] .method__ds { font-size: 12px; }
+
+/* ---- CashTip: hero + secciones + chips + input + summary + info ---- */
+.cashTip { display: flex; flex-direction: column; gap: 16px; }
+
+.cashTip__hero {
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  padding: 6px 0 12px;
+  border-bottom: 1px dashed var(--border-subtle);
+}
+.cashTip__hero .lab {
+  font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.18em;
+  text-transform: uppercase; color: var(--fg-muted);
+}
+.cashTip__hero .val {
+  font-family: var(--font-display); font-weight: 900; font-size: 38px;
+  line-height: 1; letter-spacing: -0.03em; color: var(--fg-primary);
+  font-variant-numeric: tabular-nums;
+}
+
+.cashTip__section { display: flex; flex-direction: column; gap: 10px; }
+.cashTip__label {
+  display: flex; align-items: baseline; justify-content: space-between;
+  font-family: var(--font-body); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-muted);
+}
+.cashTip__label .hint {
+  font-weight: 500; font-size: 11px; letter-spacing: 0; text-transform: none;
+  color: var(--fg-muted);
+}
+
+.cashTip__grid {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px;
+}
+.cashTip__chip {
+  appearance: none;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  padding: 12px 6px 10px;
+  cursor: pointer;
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  transition: border-color 150ms var(--ease-out, ease),
+              background-color 150ms var(--ease-out, ease),
+              transform 150ms var(--ease-out, ease);
+  font-family: var(--font-body);
+}
+.cashTip__chip:hover {
+  border-color: color-mix(in oklab, var(--fg-primary) 18%, var(--border-subtle));
+  transform: translateY(-1px);
+}
+.cashTip__chip:focus-visible {
+  outline: 3px solid color-mix(in oklab, var(--brand-primary) 45%, transparent);
+  outline-offset: 2px;
+}
+.cashTip__pct {
+  font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  letter-spacing: -0.01em; color: var(--fg-primary); line-height: 1;
+}
+.cashTip__amt {
+  font-family: var(--font-mono); font-size: 10.5px; letter-spacing: 0.04em;
+  color: var(--fg-muted); font-variant-numeric: tabular-nums;
+}
+.cashTip__chip.is-active,
+.cashTip__chip[aria-pressed="true"] {
+  background: var(--color-green-700);
+  border-color: var(--color-green-700);
+}
+.cashTip__chip.is-active .cashTip__pct,
+.cashTip__chip[aria-pressed="true"] .cashTip__pct { color: #FFFFFF; }
+.cashTip__chip.is-active .cashTip__amt,
+.cashTip__chip[aria-pressed="true"] .cashTip__amt { color: rgba(255,255,255,0.78); }
+[data-theme="dark"] .cashTip__chip.is-active,
+[data-theme="dark"] .cashTip__chip[aria-pressed="true"] {
+  background: var(--color-green-600, #16A34A);
+  border-color: var(--color-green-500, #22C55E);
+}
+
+/* Custom amount input */
+.cashTip__input {
+  display: grid; grid-template-columns: 1fr auto; align-items: stretch;
+  border: 1px solid var(--border-subtle); border-radius: 14px;
+  background: var(--bg-surface); overflow: hidden;
+  transition: border-color 150ms var(--ease-out, ease);
+}
+.cashTip__input:focus-within { border-color: var(--color-green-600, var(--brand-primary)); }
+.cashTip__input input {
+  border: none; background: transparent;
+  padding: 14px 14px 14px 16px;
+  font-family: var(--font-display); font-weight: 800; font-size: 18px;
+  color: var(--fg-primary); font-variant-numeric: tabular-nums;
+  width: 100%; outline: none; min-width: 0;
+}
+.cashTip__input input::placeholder { color: var(--fg-muted); font-weight: 500; }
+/* Hide number-spinners (cleaner UX in a sheet) */
+.cashTip__input input::-webkit-outer-spin-button,
+.cashTip__input input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+.cashTip__input input[type=number] { -moz-appearance: textfield; }
+.cashTip__currency {
+  display: inline-flex; align-items: center;
+  padding: 0 18px;
+  font-family: var(--font-display); font-weight: 800; font-size: 16px;
+  color: var(--fg-muted);
+  border-left: 1px solid var(--border-subtle);
+}
+
+/* Summary block */
+.cashTip__summary {
+  padding: 14px 16px; border-radius: 14px;
+  background: var(--bg-chip);
+  display: grid; gap: 6px;
+  font-family: var(--font-body); font-size: 14px;
+}
+.cashTip__row {
+  display: flex; align-items: baseline; justify-content: space-between;
+  color: var(--fg-muted);
+}
+.cashTip__row .v {
+  font-family: var(--font-display); font-weight: 800;
+  font-variant-numeric: tabular-nums; letter-spacing: -0.01em;
+  color: var(--fg-primary);
+}
+.cashTip__row--tip { color: var(--color-green-700); font-weight: 600; }
+.cashTip__row--tip .v { color: var(--color-green-700); }
+[data-theme="dark"] .cashTip__row--tip,
+[data-theme="dark"] .cashTip__row--tip .v { color: var(--color-green-400); }
+.cashTip__row--total {
+  padding-top: 8px; margin-top: 2px;
+  border-top: 1px solid var(--border-subtle);
+  color: var(--fg-primary);
+}
+.cashTip__row--total .v { font-size: 18px; color: var(--price-gold); }
+
+/* Info notice */
+.cashTip__info {
+  margin: 0;
+  padding: 10px 14px;
+  background: var(--color-green-50, color-mix(in oklab, var(--color-green-700) 8%, transparent));
+  border: 1px solid color-mix(in oklab, var(--color-green-700) 16%, transparent);
+  border-radius: 12px;
+  display: flex; align-items: flex-start; gap: 10px;
+  font-family: var(--font-body); font-size: 12.5px;
+  color: var(--color-green-700); line-height: 1.4;
+}
+.cashTip__info svg { flex-shrink: 0; margin-top: 1px; }
+[data-theme="dark"] .cashTip__info {
+  background: rgba(34,197,94,0.10);
+  border-color: rgba(34,197,94,0.28);
+  color: var(--color-green-400);
+}
+
+/* CTA — etiqueta interna "con/sin propina" un poco más sutil */
+.cashTip__cta { display: inline-flex; align-items: center; justify-content: center; gap: 8px; flex-wrap: wrap; }
+.cashTip__ctaTag {
+  font-family: var(--font-body); font-weight: 600; font-size: 12px;
+  opacity: 0.82; letter-spacing: 0.01em;
+  padding: 2px 8px; border-radius: 9999px;
+  background: rgba(255,255,255,0.18);
+}
+.cashTip__spin {
+  width: 16px; height: 16px;
+  border: 2px solid rgba(255,255,255,0.35);
+  border-top-color: #FFFFFF;
+  border-radius: 50%;
+  animation: cashTip-spin 0.8s linear infinite;
+}
+@keyframes cashTip-spin { to { transform: rotate(360deg); } }
+
+/* Stacked footer modifier — primary CTA on top, secondary below */
+.bill__footRow--stack {
+  flex-direction: column; align-items: stretch; gap: 8px;
+}
+.bill__footRow--stack > .btn-primary,
+.bill__footRow--stack > .btn-secondary { width: 100%; }
+
+/* Mobile compaction inside cashTip */
+.carta[data-bp="mobile"] .cashTip { gap: 14px; }
+.carta[data-bp="mobile"] .cashTip__hero .val { font-size: 32px; }
+.carta[data-bp="mobile"] .cashTip__grid { gap: 6px; }
+.carta[data-bp="mobile"] .cashTip__chip { padding: 10px 4px 8px; border-radius: 12px; }
+.carta[data-bp="mobile"] .cashTip__pct { font-size: 16px; }
+.carta[data-bp="mobile"] .cashTip__amt { font-size: 10px; }
+.carta[data-bp="mobile"] .cashTip__input input { font-size: 16px; padding: 12px 12px 12px 14px; }
+.carta[data-bp="mobile"] .cashTip__currency { padding: 0 14px; font-size: 15px; }
+.carta[data-bp="mobile"] .cashTip__summary { padding: 12px 14px; font-size: 13px; }
+.carta[data-bp="mobile"] .cashTip__row--total .v { font-size: 17px; }
+.carta[data-bp="mobile"] .cashTip__info { padding: 9px 12px; font-size: 12px; }
+.carta[data-bp="mobile"] .cashTip__ctaTag { font-size: 11px; padding: 2px 7px; }
+/* Very narrow phones — hide CTA tag if it pushes a line break that hurts readability */
+@media (max-width: 360px) {
+  .cashTip__ctaTag { display: none; }
+}
+
+.bill__doneTipNote {
+  font-style: normal; color: var(--color-green-700);
+  font-weight: 600;
+}
+[data-theme="dark"] .bill__doneTipNote { color: var(--color-green-400); }
+
+.tip-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+.tip { padding: 12px 8px; border-radius: 12px; border: 1px solid var(--border-subtle); background: var(--bg-surface); cursor: pointer; text-align: center; }
+.tip--selected { border-color: var(--brand-primary); background: var(--color-green-50); }
+[data-theme="dark"] .tip--selected { background: rgba(34, 197, 94, 0.1); }
+.tip .pct { font-family: var(--font-display); font-weight: 800; font-size: 16px; color: var(--fg-primary); }
+.tip .amt { font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted); margin-top: 2px; }
+.tip--selected .pct { color: var(--brand-primary); }
+[data-theme="dark"] .tip--selected .pct { color: var(--color-green-400); }
+
+.stripe-mock {
+  background: var(--bg-surface); border: 1px solid var(--border-subtle);
+  border-radius: 12px; padding: 14px; display: flex; flex-direction: column; gap: 10px;
+}
+[data-theme="dark"] .stripe-mock { background: var(--color-night-600); border-color: rgba(46,80,176,0.35); }
+.stripe-mock__row { display: flex; align-items: center; gap: 10px; padding: 10px 12px; background: var(--bg-base); border: 1px solid var(--border-subtle); border-radius: 8px; font-family: var(--font-mono); font-size: 13px; color: var(--fg-muted); }
+.stripe-mock__row .glyph { color: var(--fg-primary); }
+
+/* Kitchen closed banner */
+.banner-closed {
+  margin: 12px 16px 0; padding: 14px 16px; border-radius: 14px;
+  background: var(--color-amber-100); color: var(--color-amber-800);
+  display: flex; align-items: center; gap: 12px;
+}
+[data-theme="dark"] .banner-closed { background: rgba(251, 191, 36, 0.12); color: var(--color-amber-300); }
+.banner-closed__ic { font-size: 28px; line-height: 1; }
+.banner-closed__title { font-family: var(--font-display); font-weight: 800; font-size: 15px; }
+.banner-closed__sub { font-family: var(--font-body); font-size: 12px; margin-top: 2px; line-height: 1.4; }
+
+/* utility */
+.sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }
+
+/* ----- Overscroll bounce ----- */
+@keyframes overscroll-top {
+  0%   { transform: translateY(0); }
+  35%  { transform: translateY(14px); }
+  70%  { transform: translateY(-3px); }
+  100% { transform: translateY(0); }
+}
+@keyframes overscroll-bottom {
+  0%   { transform: translateY(0); }
+  35%  { transform: translateY(-14px); }
+  70%  { transform: translateY(3px); }
+  100% { transform: translateY(0); }
+}
+.is-bouncing-top    { animation: overscroll-top    380ms cubic-bezier(.2,.7,.3,1) both; }
+.is-bouncing-bottom { animation: overscroll-bottom 380ms cubic-bezier(.2,.7,.3,1) both; }
+@media (prefers-reduced-motion: reduce) {
+  .is-bouncing-top, .is-bouncing-bottom { animation: none; }
+}
+
+
+/* ════════════════════════════════════════════════════════════════
+   PRODUCT DETAIL MODAL · responsive
+   - Móvil  → bottom sheet a pantalla completa
+   - Tablet → bottom sheet centrado, anchura limitada
+   - Desktop → modal centrado en 2 columnas (foto + info)
+   ════════════════════════════════════════════════════════════════ */
+
+/* Scrim centrado (en desktop / tablet) vs anclado abajo (móvil) */
+.scrim.scrim--center { align-items: center; justify-content: center; }
+.carta[data-bp="mobile"] .scrim.scrim--center { align-items: flex-end; justify-content: stretch; }
+
+/* Contenedor del modal */
+.pdetail {
+  position: relative;
+  background: var(--bg-base);
+  color: var(--fg-primary);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.45), 0 2px 8px rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--border-subtle);
+  width: 100%;
+}
+
+/* ─── Móvil: bottom sheet a casi pantalla completa ─── */
+.carta[data-bp="mobile"] .pdetail {
+  width: 100%;
+  height: 92%;
+  border-radius: 20px 20px 0 0;
+  border-bottom: none;
+  animation: drawer-up 320ms var(--ease-smooth);
+}
+.carta[data-bp="mobile"] .pdetail.is-closing { animation: drawer-down 260ms var(--ease-smooth) forwards; }
+
+/* ─── Tablet: bottom sheet centrado ─── */
+.carta[data-bp="tablet"] .pdetail {
+  width: min(560px, 92%);
+  max-height: 90%;
+  border-radius: 22px;
+  animation: pdetail-pop 280ms var(--ease-smooth);
+}
+.carta[data-bp="tablet"] .pdetail.is-closing { animation: pdetail-pop-out 220ms var(--ease-out) forwards; }
+
+/* ─── Desktop: modal centrado de 2 columnas ─── */
+.carta[data-bp="desktop"] .pdetail {
+  width: min(760px, 90%);
+  max-height: 86%;
+  border-radius: 24px;
+  animation: pdetail-pop 280ms var(--ease-smooth);
+}
+.carta[data-bp="desktop"] .pdetail.is-closing { animation: pdetail-pop-out 220ms var(--ease-out) forwards; }
+
+@keyframes pdetail-pop {
+  from { opacity: 0; transform: translateY(8px) scale(0.96); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes pdetail-pop-out {
+  from { opacity: 1; transform: translateY(0) scale(1); }
+  to   { opacity: 0; transform: translateY(6px) scale(0.97); }
+}
+
+/* Layout interior */
+.pdetail__layout {
+  flex: 1; min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.carta[data-bp="desktop"] .pdetail__layout {
+  flex-direction: row;
+}
+
+/* Botón cerrar flotante */
+.pdetail__close {
+  position: absolute;
+  top: 10px; right: 10px;
+  width: 36px; height: 36px;
+  border-radius: 9999px;
+  background: rgba(15, 15, 20, 0.55);
+  color: #fff;
+  border: 1px solid rgba(255,255,255,0.18);
+  cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+  z-index: 4;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition: background-color var(--duration-fast);
+}
+.pdetail__close:hover { background: rgba(0,0,0,0.75); }
+
+/* Foto / hero */
+.pdetail__photo {
+  position: relative;
+  flex-shrink: 0;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  display: flex; align-items: center; justify-content: center;
+  overflow: hidden;
+}
+.carta[data-bp="mobile"]  .pdetail__photo { aspect-ratio: 16 / 11; }
+.carta[data-bp="tablet"]  .pdetail__photo { aspect-ratio: 16 / 9; }
+.carta[data-bp="desktop"] .pdetail__photo {
+  width: 44%;
+  aspect-ratio: auto;
+  height: auto;
+  align-self: stretch;
+  flex-shrink: 0;
+}
+
+.pdetail__photo--food-1 { background: linear-gradient(135deg, #FCE7AA, #FDB76A); }
+.pdetail__photo--food-2 { background: linear-gradient(135deg, #FEE2E2, #FCA5A5); }
+.pdetail__photo--food-3 { background: linear-gradient(135deg, #DCFCE7, #86EFAC); }
+.pdetail__photo--food-4 { background: linear-gradient(135deg, #FEF3C7, #FBBF24); }
+.pdetail__photo--food-5 { background: linear-gradient(135deg, #FCE7F3, #F9A8D4); }
+.pdetail__photo--food-6 { background: linear-gradient(135deg, #E0E7FF, #A5B4FC); }
+[data-theme="dark"] .pdetail__photo { filter: brightness(0.78) saturate(0.9); }
+
+.pdetail__photo-emoji {
+  font-size: 120px;
+  line-height: 1;
+  filter: drop-shadow(0 8px 18px rgba(0,0,0,0.18));
+  transform: rotate(-4deg);
+}
+.carta[data-bp="mobile"] .pdetail__photo-emoji { font-size: 96px; }
+
+/* Velo inferior para legibilidad de chip */
+.pdetail__photo-fade {
+  position: absolute; inset: auto 0 0 0; height: 50%;
+  background: linear-gradient(to bottom, transparent, rgba(0,0,0,0.28));
+  pointer-events: none;
+}
+
+.pdetail__chip-row {
+  position: absolute; left: 14px; bottom: 12px;
+  display: flex; gap: 6px; flex-wrap: wrap;
+}
+.pdetail__catchip {
+  padding: 5px 10px;
+  border-radius: 9999px;
+  background: rgba(255,255,255,0.92);
+  color: #1a1a1f;
+  font-family: var(--font-body);
+  font-size: 11px; font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  backdrop-filter: blur(4px);
+}
+.pdetail__catchip--warn { background: rgba(252, 211, 77, 0.95); color: #5A2F00; }
+
+/* Grabber sólo en móvil */
+.pdetail__grabber {
+  display: none;
+  position: absolute; top: 8px; left: 50%; transform: translateX(-50%);
+  width: 44px; height: 5px; border-radius: 9999px;
+  background: rgba(255,255,255,0.7);
+  z-index: 2;
+}
+.carta[data-bp="mobile"] .pdetail__grabber { display: block; }
+
+/* ── Contenido ─────────────────────────────────────────── */
+.pdetail__content {
+  flex: 1; min-height: 0;
+  display: flex; flex-direction: column;
+}
+.carta[data-bp="desktop"] .pdetail__content { width: 56%; }
+
+.pdetail__scroll {
+  flex: 1; min-height: 0;
+  overflow-y: auto;
+  padding: 20px 22px 8px;
+  display: flex; flex-direction: column; gap: 14px;
+}
+.carta[data-bp="mobile"] .pdetail__scroll { padding: 16px 18px 8px; gap: 12px; }
+.carta[data-bp="desktop"] .pdetail__scroll { padding: 28px 28px 12px; gap: 16px; }
+
+.pdetail__name {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 26px;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--fg-primary);
+  margin: 0;
+  text-wrap: pretty;
+}
+.carta[data-bp="mobile"]  .pdetail__name { font-size: 22px; }
+.carta[data-bp="desktop"] .pdetail__name { font-size: 30px; }
+
+.pdetail__price {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 22px;
+  color: var(--price-gold);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+  margin-top: -6px;
+}
+
+.pdetail__desc {
+  font-family: var(--font-body);
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--fg-secondary);
+  margin: 0;
+  text-wrap: pretty;
+}
+
+.pdetail__section { display: flex; flex-direction: column; gap: 8px; }
+
+.pdetail__label {
+  font-family: var(--font-body);
+  font-weight: 700;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+/* Lista de alérgenos con texto */
+.pdetail__allergens {
+  display: flex; flex-wrap: wrap; gap: 6px;
+}
+.pdetail__allergen {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 5px 12px 5px 5px;
+  border-radius: 9999px;
+  background: var(--bg-chip);
+  color: var(--fg-secondary);
+  font-family: var(--font-body);
+  font-size: 12px; font-weight: 500;
+  border: 1px solid var(--border-subtle);
+  text-transform: capitalize;
+}
+
+/* Chips de ingredientes quitables */
+.pdetail__chips {
+  display: flex; flex-wrap: wrap; gap: 8px;
+}
+.pdetail__chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 8px 14px 8px 10px;
+  border-radius: 9999px;
+  background: var(--bg-chip);
+  color: var(--fg-primary);
+  border: 1.5px solid var(--border-subtle);
+  font-family: var(--font-body);
+  font-size: 13px; font-weight: 500;
+  cursor: pointer;
+  transition: background-color var(--duration-fast), color var(--duration-fast), border-color var(--duration-fast), opacity var(--duration-fast);
+}
+.pdetail__chip-x {
+  font-family: var(--font-display);
+  font-weight: 900; font-size: 12px;
+  width: 18px; height: 18px;
+  border-radius: 9999px;
+  background: var(--bg-base);
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.pdetail__chip:hover { border-color: var(--border-strong); }
+.pdetail__chip--off {
+  background: color-mix(in oklab, var(--color-red-400) 14%, var(--bg-base));
+  color: var(--color-red-700, var(--color-red-600));
+  border-color: color-mix(in oklab, var(--color-red-400) 50%, transparent);
+  text-decoration: line-through;
+  text-decoration-thickness: 1.5px;
+  opacity: 0.85;
+}
+.pdetail__chip--off .pdetail__chip-x {
+  background: var(--color-red-600, #DC2626);
+  color: white;
+}
+
+/* Extras como lista de filas */
+.pdetail__extras { display: flex; flex-direction: column; gap: 6px; }
+.pdetail__extra {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  background: var(--bg-chip);
+  border: 1.5px solid transparent;
+  border-radius: 12px;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color var(--duration-fast), background-color var(--duration-fast);
+  font-family: var(--font-body);
+}
+.pdetail__extra:hover { border-color: var(--border-subtle); }
+.pdetail__extra--on {
+  border-color: var(--brand-primary, #0F3D2A);
+  background: color-mix(in oklab, var(--brand-primary, #0F3D2A) 8%, var(--bg-surface));
+}
+.pdetail__extra-name {
+  font-size: 14px; font-weight: 600; color: var(--fg-primary);
+}
+.pdetail__extra-price {
+  font-family: var(--font-display);
+  font-weight: 800; font-size: 13px;
+  color: var(--price-gold);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.pdetail__check {
+  width: 22px; height: 22px;
+  border-radius: 9999px;
+  background: var(--bg-base);
+  border: 1.5px solid var(--border-strong);
+  display: inline-flex; align-items: center; justify-content: center;
+  color: transparent;
+  font-family: var(--font-display); font-weight: 900; font-size: 13px;
+  transition: background-color var(--duration-fast), color var(--duration-fast), border-color var(--duration-fast);
+}
+.pdetail__check--on {
+  background: var(--brand-primary, #0F3D2A);
+  border-color: var(--brand-primary, #0F3D2A);
+  color: white;
+}
+
+/* ── Pie con qty + CTA ─────────────────────────────────── */
+.pdetail__foot {
+  flex-shrink: 0;
+  padding: 14px 18px calc(14px + env(safe-area-inset-bottom, 0px));
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-base);
+  display: flex; align-items: center; gap: 10px;
+}
+.carta[data-bp="desktop"] .pdetail__foot { padding: 16px 22px; }
+
+.pdetail__qty {
+  display: inline-flex; align-items: center;
+  background: var(--bg-chip);
+  border: 1px solid var(--border-subtle);
+  border-radius: 9999px;
+  padding: 4px;
+  flex-shrink: 0;
+}
+.pdetail__qtybtn {
+  width: 36px; height: 36px;
+  border-radius: 9999px;
+  border: none; cursor: pointer;
+  font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--bg-base); color: var(--fg-primary);
+  transition: transform 160ms var(--ease-bounce, cubic-bezier(.34,1.56,.64,1));
+}
+.pdetail__qtybtn:hover { transform: scale(1.08); }
+.pdetail__qtybtn:active { transform: scale(0.94); }
+.pdetail__qtyn {
+  padding: 0 14px;
+  font-family: var(--font-display);
+  font-weight: 900; font-size: 16px;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-primary);
+  min-width: 28px; text-align: center;
+  animation: qty-bump 280ms var(--ease-bounce, cubic-bezier(.34,1.56,.64,1));
+}
+
+.pdetail__cta {
+  flex: 1;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px;
+  border-radius: 9999px;
+  background: var(--cta-view-order);
+  color: white;
+  border: none; cursor: pointer;
+  font-family: var(--font-body); font-weight: 700; font-size: 14px;
+  box-shadow: 0 10px 24px rgba(0,0,0,0.18);
+  transition: filter var(--duration-fast), transform 160ms var(--ease-bounce, cubic-bezier(.34,1.56,.64,1));
+}
+.pdetail__cta:hover:not(:disabled) { filter: brightness(1.06); transform: translateY(-1px); }
+.pdetail__cta:active:not(:disabled) { transform: translateY(0); }
+.pdetail__cta:disabled { opacity: 0.5; cursor: not-allowed; }
+.pdetail__cta-lab { white-space: nowrap; }
+.pdetail__cta-price {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 16px;
+  font-variant-numeric: tabular-nums;
+  background: rgba(0,0,0,0.18);
+  padding: 4px 10px;
+  border-radius: 9999px;
+  white-space: nowrap;
+}
+
+/* Tarjeta clicable: hover sutil */
+.pcard { cursor: pointer; transition: transform var(--duration-fast) var(--ease-out), box-shadow var(--duration-fast), border-color var(--duration-fast); }
+.pcard:hover { transform: translateY(-2px); box-shadow: var(--glass-shadow-lg); border-color: var(--glass-border); }
+.pcard:focus-visible { outline: 2px solid var(--brand-primary, #0F3D2A); outline-offset: 2px; }
+.pcard:active { transform: translateY(0); }
+
+
+/* ════════════════════════════════════════════════════════════
+   Orders surfaces: bottom-left FAB cluster, OrdersWindow with
+   list ↔ detail sub-views, and order-confirmed popup.
+   ════════════════════════════════════════════════════════════ */
+
+/* Bottom-left FAB cluster. When the user has sent ≥1 order,
+   the red "Cuenta" pill becomes the head of a cluster with a
+   charcoal "Mis pedidos" pill beside it. */
+.fab-cluster {
+  position: absolute;
+  left: 16px; bottom: 92px;
+  z-index: 30;
+  display: flex; align-items: center;
+  gap: 10px;
+  animation: cluster-in 320ms var(--ease-smooth);
+}
+@keyframes cluster-in {
+  from { transform: translateY(8px); opacity: 0; }
+  to   { transform: translateY(0); opacity: 1; }
+}
+.fab--in-cluster {
+  position: static;
+  left: auto; bottom: auto;
+  animation: none;
+}
+.carta[data-chat="open"] .fab-cluster { display: none; }
+
+.fab--orders {
+  position: static;
+  width: auto; height: 44px;
+  padding: 0 14px 0 6px;
+  border-radius: 9999px;
+  display: inline-flex; align-items: center; gap: 8px;
+  background: var(--bg-base);
+  color: var(--fg-primary);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-fab);
+  font-family: var(--font-body); font-size: 13.5px; font-weight: 700;
+  letter-spacing: 0.005em;
+  cursor: pointer;
+  animation: orders-in 360ms var(--ease-smooth);
+}
+.fab--orders:hover {
+  background: var(--bg-surface);
+  border-color: var(--border-strong);
+}
+/* Dark: --bg-chip is semi-transparent blue, which made the pill see-through.
+   Force a solid night-blue surface for the hover state. */
+[data-theme="dark"] .fab--orders:hover {
+  background: var(--color-night-700);
+  border-color: rgba(46, 80, 176, 0.55);
+}
+@keyframes orders-in {
+  from { transform: translateX(-6px) scale(0.96); opacity: 0; }
+  to   { transform: translateX(0) scale(1); opacity: 1; }
+}
+.fab--orders__count {
+  flex-shrink: 0;
+  min-width: 32px; height: 32px;
+  padding: 0 8px;
+  border-radius: 9999px;
+  background: var(--brand-primary); color: var(--fg-on-accent);
+  font-family: var(--font-display); font-weight: 900; font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  display: inline-flex; align-items: center; justify-content: center;
+  line-height: 1;
+}
+[data-theme="dark"] .fab--orders__count { background: var(--color-green-500); color: #0A1430; }
+.fab--orders__label { white-space: nowrap; }
+
+/* ── "Mi ticket" pill — green, sits to the right of "Cuenta" ── */
+.fab__ic { display: inline-flex; align-items: center; }
+.fab__label { white-space: nowrap; }
+.fab--ticket {
+  position: static;
+  width: auto; height: 44px;
+  padding: 0 16px 0 13px;
+  border-radius: 9999px;
+  flex-direction: row; gap: 8px;
+  background: linear-gradient(135deg, var(--color-green-500), var(--color-green-600));
+  color: #FFFFFF;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  font-family: var(--font-body); font-size: 14px; font-weight: 700;
+  letter-spacing: 0.01em;
+  box-shadow: var(--shadow-fab);
+  animation: none;
+}
+.fab--ticket:hover { filter: brightness(1.06); }
+.fab--ticket svg { color: #FFFFFF; width: 18px; height: 18px; }
+
+/* ── Mobile: the three cluster pills collapse to icon-only buttons
+   and expand to reveal their label on hover / tap / focus. Tablet
+   and desktop keep every label visible at all times. ── */
+.carta[data-bp="mobile"] .fab-cluster .fab {
+  transition: padding .3s var(--ease-smooth);
+}
+.carta[data-bp="mobile"] .fab--bill,
+.carta[data-bp="mobile"] .fab--ticket {
+  padding: 0 13px; gap: 0;
+}
+.carta[data-bp="mobile"] .fab--orders {
+  padding: 0 6px; gap: 0;
+}
+.carta[data-bp="mobile"] .fab-cluster .fab__label,
+.carta[data-bp="mobile"] .fab-cluster .fab--orders__label {
+  max-width: 0; margin-left: 0; opacity: 0;
+  overflow: hidden; white-space: nowrap;
+  transition: max-width .3s var(--ease-smooth),
+              opacity .2s ease,
+              margin-left .3s var(--ease-smooth);
+}
+.carta[data-bp="mobile"] .fab-cluster .fab:hover .fab__label,
+.carta[data-bp="mobile"] .fab-cluster .fab:focus-visible .fab__label,
+.carta[data-bp="mobile"] .fab-cluster .fab:active .fab__label,
+.carta[data-bp="mobile"] .fab-cluster .fab:hover .fab--orders__label,
+.carta[data-bp="mobile"] .fab-cluster .fab:focus-visible .fab--orders__label,
+.carta[data-bp="mobile"] .fab-cluster .fab:active .fab--orders__label {
+  max-width: 150px; margin-left: 8px; opacity: 1;
+}
+.carta[data-bp="mobile"] .fab--orders:hover,
+.carta[data-bp="mobile"] .fab--orders:focus-visible,
+.carta[data-bp="mobile"] .fab--orders:active {
+  padding-right: 14px;
+}
+.carta[data-bp="mobile"] .fab--bill:hover,
+.carta[data-bp="mobile"] .fab--bill:focus-visible,
+.carta[data-bp="mobile"] .fab--bill:active,
+.carta[data-bp="mobile"] .fab--ticket:hover,
+.carta[data-bp="mobile"] .fab--ticket:focus-visible,
+.carta[data-bp="mobile"] .fab--ticket:active {
+  padding-right: 16px;
+}
+
+/* ── Orders window (drawer variant) ──────────────────────── */
+.drawer--orders { height: auto; max-height: 78%; }
+.carta[data-bp="mobile"]  .drawer--orders { height: 78%; max-height: 78%; }
+.carta[data-bp="tablet"]  .drawer--orders,
+.carta[data-bp="desktop"] .drawer--orders { max-height: 70%; }
+
+.orders-body {
+  flex: 1; min-height: 0; overflow-y: auto;
+  padding: 12px 14px 4px;
+  display: flex; flex-direction: column;
+}
+.orders-list { display: flex; flex-direction: column; gap: 8px; }
+
+.order-row {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: var(--bg-chip);
+  border: 1px solid transparent;
+  border-radius: 14px;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit; color: inherit;
+  transition: border-color var(--duration-fast),
+              background-color var(--duration-fast),
+              transform var(--duration-fast);
+}
+.order-row:hover { border-color: var(--border-strong); background: var(--bg-base); }
+.order-row:active { transform: scale(0.995); }
+
+.order-row__num {
+  flex-shrink: 0;
+  width: 42px; height: 42px;
+  border-radius: 12px;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--bg-base);
+  border: 1px solid var(--border-subtle);
+  font-family: var(--font-display); font-weight: 900;
+  font-size: 14px; color: var(--fg-primary);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+.order-row__main { flex: 1; min-width: 0; }
+.order-row__title {
+  font-family: var(--font-display); font-weight: 900;
+  font-size: 16px; color: var(--fg-primary); line-height: 1.1;
+}
+.order-row__meta {
+  margin-top: 4px;
+  font-family: var(--font-body); font-size: 12px;
+  color: var(--fg-muted);
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.order-row__dot { opacity: 0.6; }
+.order-row__price {
+  font-family: var(--font-display); font-weight: 900; font-size: 16px;
+  color: var(--price-gold); font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.order-row__chev {
+  flex-shrink: 0; opacity: 0.5;
+  display: inline-flex; align-items: center;
+  color: var(--fg-muted);
+}
+
+.orders-foot {
+  border-top: 1px solid var(--border-subtle);
+  padding: 14px 18px;
+  display: flex; flex-direction: column; gap: 10px;
+}
+.orders-foot__total {
+  display: flex; align-items: baseline; justify-content: space-between;
+}
+.orders-foot__total .lab {
+  font-family: var(--font-body); font-size: 12px; font-weight: 700;
+  letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.orders-foot__total .val {
+  font-family: var(--font-display); font-weight: 900; font-size: 24px;
+  color: var(--price-gold); font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* ── Order detail sub-view ───────────────────────────────── */
+.orders-detail { display: flex; flex-direction: column; gap: 14px; padding-bottom: 8px; }
+.orders-back {
+  align-self: flex-start;
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 10px 6px 6px;
+  background: var(--bg-chip);
+  border: 1px solid var(--border-subtle);
+  border-radius: 9999px;
+  color: var(--fg-secondary);
+  font-family: var(--font-body); font-size: 12px; font-weight: 600;
+  cursor: pointer;
+}
+.orders-back:hover { background: var(--bg-base); color: var(--fg-primary); }
+.orders-back svg { color: var(--fg-muted); }
+
+.orders-detail__head {
+  display: flex; align-items: center; gap: 12px;
+  padding: 4px 4px 8px;
+}
+.orders-detail__num {
+  flex-shrink: 0;
+  width: 48px; height: 48px;
+  border-radius: 14px;
+  background: var(--brand-primary); color: var(--fg-on-accent);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-display); font-weight: 900; font-size: 16px;
+  letter-spacing: -0.02em;
+}
+[data-theme="dark"] .orders-detail__num {
+  background: var(--color-green-500); color: #0A1430;
+}
+.orders-detail__title {
+  font-family: var(--font-display); font-weight: 900;
+  font-size: 18px; color: var(--fg-primary); line-height: 1.1;
+}
+.orders-detail__meta {
+  margin-top: 3px; font-family: var(--font-body); font-size: 12px;
+  color: var(--fg-muted);
+}
+
+.orders-detail__items { display: flex; flex-direction: column; gap: 10px; }
+.orders-line {
+  display: flex; gap: 12px;
+  padding: 12px 14px;
+  background: var(--bg-chip);
+  border-radius: 12px;
+}
+.orders-line__qty {
+  flex-shrink: 0; min-width: 28px;
+  font-family: var(--font-display); font-weight: 900; font-size: 15px;
+  color: var(--fg-primary); font-variant-numeric: tabular-nums;
+}
+.orders-line__body { flex: 1; min-width: 0; }
+.orders-line__name {
+  font-family: var(--font-body); font-size: 14px; font-weight: 600;
+  color: var(--fg-primary); line-height: 1.3;
+}
+.orders-line__mods { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px; }
+.orders-line__mod {
+  font-family: var(--font-body); font-size: 11px; font-weight: 500;
+  color: var(--fg-muted);
+  padding: 2px 8px;
+  background: var(--bg-base);
+  border: 1px solid var(--border-subtle);
+  border-radius: 9999px;
+}
+.orders-line__mod--add { color: var(--color-green-700); }
+[data-theme="dark"] .orders-line__mod--add { color: var(--color-green-400); }
+.orders-line__price {
+  font-family: var(--font-display); font-weight: 800; font-size: 14px;
+  color: var(--price-gold); font-variant-numeric: tabular-nums;
+  white-space: nowrap; align-self: center;
+}
+
+.orders-detail__sub {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 12px 14px;
+  border-top: 1px dashed var(--border-subtle);
+  margin-top: 4px;
+}
+.orders-detail__sub .lab {
+  font-family: var(--font-body); font-size: 12px; font-weight: 700;
+  letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.orders-detail__sub .val {
+  font-family: var(--font-display); font-weight: 900; font-size: 20px;
+  color: var(--price-gold); font-variant-numeric: tabular-nums;
+}
+
+/* ── Order-confirmed popup ────────────────────────────────── */
+.scrim.order-confirmed,
+.carta[data-bp="mobile"] .scrim.order-confirmed {
+  align-items: center; justify-content: center;
+  padding: 18px;
+}
+.order-confirmed__panel {
+  position: relative;
+  background: var(--bg-base); color: var(--fg-primary);
+  width: 100%; max-width: 360px;
+  border-radius: 22px;
+  padding: 22px 22px 18px;
+  box-shadow: var(--shadow-pop, 0 24px 60px rgba(0,0,0,0.35));
+  display: flex; flex-direction: column; gap: 12px; align-items: stretch;
+  animation: confirmed-in 380ms var(--ease-smooth);
+  max-height: 80%;
+  overflow: auto;
+}
+@keyframes confirmed-in {
+  from { transform: translateY(14px) scale(0.96); opacity: 0; }
+  to   { transform: translateY(0) scale(1); opacity: 1; }
+}
+.order-confirmed__panel.is-closing {
+  animation: confirmed-out 200ms var(--ease-out) forwards;
+}
+@keyframes confirmed-out {
+  from { transform: scale(1); opacity: 1; }
+  to   { transform: scale(0.96); opacity: 0; }
+}
+.order-confirmed__x { position: absolute; top: 12px; right: 12px; }
+.order-confirmed__badge {
+  align-self: center;
+  width: 64px; height: 64px;
+  border-radius: 9999px;
+  background: var(--brand-primary);
+  color: var(--fg-on-accent);
+  display: inline-flex; align-items: center; justify-content: center;
+  box-shadow: 0 10px 26px color-mix(in oklab, var(--brand-primary) 50%, transparent);
+  animation: badge-pop 520ms cubic-bezier(.34,1.56,.64,1) 60ms both;
+}
+[data-theme="dark"] .order-confirmed__badge {
+  background: var(--color-green-500); color: #0A1430;
+}
+@keyframes badge-pop {
+  0%   { transform: scale(0.4); opacity: 0; }
+  60%  { transform: scale(1.12); opacity: 1; }
+  100% { transform: scale(1); }
+}
+.order-confirmed__num {
+  align-self: center;
+  font-family: var(--font-body); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--fg-muted);
+  margin-top: 2px;
+}
+.order-confirmed__title {
+  text-align: center;
+  font-family: var(--font-display); font-weight: 900;
+  font-size: 22px; line-height: 1.15;
+  color: var(--fg-primary);
+}
+.order-confirmed__sub {
+  text-align: center;
+  font-family: var(--font-body); font-size: 13px; line-height: 1.45;
+  color: var(--fg-secondary);
+  margin-bottom: 4px;
+}
+.order-confirmed__items {
+  display: flex; flex-direction: column; gap: 6px;
+  background: var(--bg-chip);
+  border-radius: 12px;
+  padding: 10px 12px;
+}
+.order-confirmed__row {
+  display: grid;
+  grid-template-columns: 24px 1fr auto;
+  gap: 8px;
+  align-items: baseline;
+  font-family: var(--font-body); font-size: 13px;
+  color: var(--fg-primary);
+}
+.order-confirmed__row .qty {
+  font-family: var(--font-display); font-weight: 900;
+  font-variant-numeric: tabular-nums; color: var(--fg-secondary);
+}
+.order-confirmed__row .name { line-height: 1.3; }
+.order-confirmed__row .price {
+  font-family: var(--font-display); font-weight: 800; font-size: 13px;
+  color: var(--price-gold); font-variant-numeric: tabular-nums;
+}
+.order-confirmed__more {
+  font-family: var(--font-body); font-size: 12px; color: var(--fg-muted);
+  padding-left: 32px;
+}
+.order-confirmed__sub-total {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 2px 4px 6px;
+}
+.order-confirmed__sub-total .lab {
+  font-family: var(--font-body); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.order-confirmed__sub-total .val {
+  font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  color: var(--price-gold); font-variant-numeric: tabular-nums;
+}
+
+
+/* ════════════════════════════════════════════════════════════════
+   MENÚ DEL DÍA · módulo opcional
+   - Anuncio de entrada (sticky bajo el header, auto-dismiss)
+   - Chip diferenciado en la barra de filtros
+   - Diálogo de exclusividad
+   - Stepper / wizard con progreso
+   Paleta: ámbar/oro como acento (variant: --price-gold) sin
+   competir con el verde del CTA principal.
+   ════════════════════════════════════════════════════════════════ */
+
+:root {
+  --dm-gold-50:  #FFF8E6;
+  --dm-gold-100: #FCEFC9;
+  --dm-gold-200: #F5DC92;
+  --dm-gold-300: #ECC25A;
+  --dm-gold-500: #B47B19;
+  --dm-gold-700: #6E4710;
+  --dm-gold-ink: #3B260A;     /* texto sobre dorado */
+  --dm-ink:      var(--fg-primary);
+  --dm-paper:    var(--bg-base);
+}
+[data-theme="dark"] {
+  --dm-gold-50:  rgba(251, 191, 36, 0.08);
+  --dm-gold-100: rgba(251, 191, 36, 0.14);
+  --dm-gold-200: rgba(251, 191, 36, 0.32);
+  --dm-gold-300: #ECC25A;
+  --dm-gold-500: #F5DC92;
+  --dm-gold-700: #FCEFC9;
+  --dm-gold-ink: #FFF8E6;
+}
+
+/* ── Banner / anuncio de entrada ────────────────────────────── */
+.dm-banner {
+  position: sticky;
+  top: 0;
+  margin: 0 0 14px;
+  padding: 14px 14px 14px 18px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 14px;
+  border-radius: 16px;
+  background:
+    linear-gradient(135deg, var(--dm-gold-50) 0%, #FFFFFF 50%, var(--dm-gold-50) 100%);
+  border: 1px solid var(--dm-gold-200);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.6) inset,
+    0 12px 32px rgba(180, 123, 25, 0.18),
+    0 0 0 4px rgba(251, 191, 36, 0.05);
+  color: var(--dm-ink);
+  overflow: hidden;
+  isolation: isolate;
+  animation: dm-banner-in 380ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  z-index: 18;
+  transition: box-shadow 200ms var(--ease-smooth);
+}
+[data-theme="dark"] .dm-banner {
+  /* Base sólida primero, luego un tinte oro encima — así no se ve a través
+     cuando hace sticky sobre el contenido scrolleado. */
+  background:
+    linear-gradient(135deg, rgba(251, 191, 36, 0.14) 0%, rgba(251, 191, 36, 0.04) 50%, rgba(251, 191, 36, 0.12) 100%),
+    var(--color-night-600);
+  border-color: rgba(251, 191, 36, 0.32);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.4);
+}
+/* Cuando ya no está en su posición inicial, refuerza la sombra para
+   que se note que "cuelga" sobre el contenido detrás. */
+.dm-banner--stuck {
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.6) inset,
+    0 18px 44px rgba(180, 123, 25, 0.28),
+    0 0 0 4px rgba(251, 191, 36, 0.06);
+}
+[data-theme="dark"] .dm-banner--stuck {
+  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.55);
+}
+.dm-banner::before {
+  /* decorative serif underline behind the title */
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 3px;
+  background: linear-gradient(90deg, transparent, var(--dm-gold-300), transparent);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+@keyframes dm-banner-in {
+  from { transform: translateY(-12px); opacity: 0; }
+  to   { transform: translateY(0);     opacity: 1; }
+}
+@keyframes dm-banner-out {
+  from { transform: translateY(0);    opacity: 1; max-height: 200px; margin-top: 12px; padding-top: 14px; padding-bottom: 14px; }
+  to   { transform: translateY(-10px); opacity: 0; max-height: 0;   margin-top: 0;     padding-top: 0;    padding-bottom: 0; }
+}
+.dm-banner--exit { animation: dm-banner-out 280ms cubic-bezier(0.4, 0, 0.2, 1) forwards; }
+
+/* El anuncio completo es clicable (salvo agotado): cursor + realce al hover */
+.dm-banner--clickable { cursor: pointer; }
+.dm-banner--clickable:hover {
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.6) inset,
+    0 16px 38px rgba(180, 123, 25, 0.24),
+    0 0 0 4px rgba(251, 191, 36, 0.10);
+}
+[data-theme="dark"] .dm-banner--clickable:hover {
+  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.55);
+}
+.dm-banner--clickable:focus-visible {
+  outline: 2px solid var(--dm-gold-400, #D9A521);
+  outline-offset: 2px;
+}
+
+.dm-banner__stamp {
+  display: flex; flex-direction: column; align-items: center;
+  padding: 8px 10px;
+  border: 1px dashed var(--dm-gold-300);
+  border-radius: 10px;
+  background: var(--dm-paper);
+  color: var(--dm-gold-700);
+  min-width: 64px;
+  transform: rotate(-3deg);
+}
+[data-theme="dark"] .dm-banner__stamp { background: rgba(1,4,14,0.5); color: var(--dm-gold-500); }
+.dm-banner__stampMark {
+  font-family: var(--font-display); font-weight: 900; font-size: 22px;
+  line-height: 1; color: var(--dm-gold-300);
+}
+.dm-banner__stampLabel {
+  font-family: var(--font-mono); font-size: 8px; font-weight: 700;
+  letter-spacing: 0.12em; margin-top: 4px; white-space: nowrap;
+}
+
+.dm-banner__body { min-width: 0; }
+.dm-banner__date {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--dm-gold-500);
+  margin-bottom: 2px;
+}
+.dm-banner__title {
+  font-family: var(--font-display); font-weight: 900; font-size: 19px;
+  letter-spacing: -0.01em; line-height: 1.1;
+  color: var(--dm-ink);
+}
+[data-theme="dark"] .dm-banner__title { color: var(--dm-gold-300); }
+[data-theme="dark"] .dm-banner__tagline { color: var(--dm-gold-500); opacity: 0.9; }
+[data-theme="dark"] .dm-banner__date { color: var(--dm-gold-300); opacity: 0.85; }
+.dm-banner__tagline {
+  font-family: var(--font-body); font-size: 12px; color: var(--fg-secondary);
+  margin-top: 3px; line-height: 1.35;
+  display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
+}
+
+.dm-banner__side {
+  display: flex; flex-direction: column; align-items: flex-end; gap: 6px;
+  flex-shrink: 0;
+}
+.dm-banner__price {
+  font-family: var(--font-display); font-weight: 900; font-size: 22px;
+  color: var(--price-gold); font-variant-numeric: tabular-nums; line-height: 1;
+  letter-spacing: -0.01em;
+}
+.dm-banner__cta {
+  appearance: none; border: 0; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 9px 14px;
+  border-radius: 9999px;
+  background: linear-gradient(180deg, #2B2118 0%, #0F0A05 100%);
+  color: var(--dm-gold-300);
+  font-family: var(--font-body); font-weight: 700; font-size: 13px;
+  letter-spacing: 0.01em;
+  box-shadow: 0 6px 16px rgba(15, 10, 5, 0.35), inset 0 1px 0 rgba(236, 194, 90, 0.3);
+  transition: transform 150ms var(--ease-bounce), filter 150ms;
+}
+.dm-banner__cta:hover { transform: translateY(-1px); filter: brightness(1.15); }
+.dm-banner__cta:active { transform: translateY(0); }
+
+.dm-banner__agotado {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 10px;
+  border-radius: 9999px;
+  background: var(--color-gray-100);
+  color: var(--color-gray-600);
+  font-family: var(--font-body); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.02em;
+}
+[data-theme="dark"] .dm-banner__agotado { background: rgba(255,255,255,0.06); color: var(--color-blue-200); }
+.dm-banner__agotadoDot {
+  width: 6px; height: 6px; border-radius: 50%; background: currentColor; opacity: 0.7;
+}
+.dm-banner__close {
+  position: absolute; top: 8px; right: 8px;
+  width: 24px; height: 24px; border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.6); color: var(--dm-gold-700);
+  border: 1px solid var(--dm-gold-200);
+  display: inline-flex; align-items: center; justify-content: center;
+  cursor: pointer; opacity: 0.7;
+}
+[data-theme="dark"] .dm-banner__close { background: rgba(1,4,14,0.55); color: var(--dm-gold-500); border-color: rgba(251,191,36,0.2); }
+.dm-banner__close:hover { opacity: 1; }
+
+/* mobile: stamp queda más pequeño y se mantiene grid 3-col */
+.carta[data-bp="mobile"] .dm-banner {
+  margin: 10px 12px 0;
+  padding: 12px 12px 12px 14px;
+  gap: 10px;
+}
+.carta[data-bp="mobile"] .dm-banner__stamp { min-width: 56px; padding: 6px 8px; }
+.carta[data-bp="mobile"] .dm-banner__stampMark { font-size: 18px; }
+.carta[data-bp="mobile"] .dm-banner__title { font-size: 16px; }
+.carta[data-bp="mobile"] .dm-banner__tagline { font-size: 11px; -webkit-line-clamp: 1; line-clamp: 1; }
+.carta[data-bp="mobile"] .dm-banner__price { font-size: 18px; }
+.carta[data-bp="mobile"] .dm-banner__cta { padding: 7px 11px; font-size: 12px; }
+
+/* ── Chip persistente en filtros ─────────────────────────────── */
+.dm-chip {
+  appearance: none;
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 8px 14px 8px 10px;
+  border-radius: 12px;
+  border: 1px solid var(--dm-gold-300);
+  background: var(--dm-paper);
+  color: var(--dm-ink);
+  cursor: pointer;
+  font-family: var(--font-body);
+  position: relative;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.5) inset, 0 4px 10px rgba(180, 123, 25, 0.08);
+  transition: transform 150ms var(--ease-bounce), border-color 150ms, background 150ms;
+}
+[data-theme="dark"] .dm-chip {
+  background: rgba(251, 191, 36, 0.08);
+  border-color: rgba(251, 191, 36, 0.4);
+  color: var(--color-blue-100);
+}
+.dm-chip:hover:not(:disabled) {
+  transform: translateY(-1px);
+  background: var(--dm-gold-50);
+  border-color: var(--dm-gold-500);
+}
+.dm-chip:active:not(:disabled) { transform: translateY(0); }
+
+.dm-chip__mark {
+  width: 28px; height: 28px; border-radius: 8px;
+  background: linear-gradient(180deg, var(--dm-gold-100), var(--dm-gold-200));
+  color: var(--dm-gold-700);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-display); font-weight: 900; font-size: 16px;
+  flex-shrink: 0;
+}
+[data-theme="dark"] .dm-chip__mark {
+  background: linear-gradient(180deg, rgba(251,191,36,0.25), rgba(251,191,36,0.12));
+  color: var(--dm-gold-500);
+}
+.dm-chip__main { display: flex; flex-direction: column; align-items: flex-start; line-height: 1.1; min-width: 0; }
+.dm-chip__top {
+  font-family: var(--font-display); font-weight: 800; font-size: 13px;
+  letter-spacing: -0.005em; color: var(--dm-ink);
+}
+[data-theme="dark"] .dm-chip__top { color: var(--color-blue-100); }
+.dm-chip__sub {
+  font-family: var(--font-body); font-size: 11px; font-weight: 600;
+  color: var(--dm-gold-500); margin-top: 2px;
+  font-variant-numeric: tabular-nums;
+}
+[data-theme="dark"] .dm-chip__sub { color: var(--dm-gold-300); }
+
+/* compact (horizontal mobile chip) */
+.dm-chip--compact {
+  padding: 6px 12px 6px 6px;
+  gap: 8px;
+  border-radius: 9999px;
+  flex-shrink: 0;
+}
+.dm-chip--compact .dm-chip__mark { width: 22px; height: 22px; font-size: 13px; border-radius: 6px; }
+.dm-chip--compact .dm-chip__top { font-size: 12px; }
+.dm-chip--compact .dm-chip__price {
+  font-family: var(--font-display); font-weight: 800; font-size: 11px;
+  color: var(--dm-gold-700); padding: 2px 6px;
+  background: var(--dm-gold-100); border-radius: 9999px;
+  font-variant-numeric: tabular-nums;
+}
+[data-theme="dark"] .dm-chip--compact .dm-chip__price { background: rgba(251,191,36,0.18); color: var(--dm-gold-500); }
+
+.dm-chip--agotado {
+  opacity: 0.55;
+  cursor: not-allowed;
+  background: var(--color-gray-50);
+  border-color: var(--border-subtle);
+  box-shadow: none;
+}
+[data-theme="dark"] .dm-chip--agotado { background: rgba(255,255,255,0.04); border-color: var(--border-subtle); }
+.dm-chip--agotado .dm-chip__mark { filter: grayscale(0.6); }
+
+/* sidebar variant: full-width, sits at top of filters */
+.filter-section--dm { margin-bottom: 18px; }
+.filter-section--dm .dm-chip { width: 100%; }
+
+/* ── Diálogo de exclusividad ─────────────────────────────────── */
+.modal--center { align-items: center; }
+.carta[data-bp="mobile"] .modal--center { align-items: center; padding: 0 16px; }
+.modal__panel--narrow {
+  max-width: 360px;
+  border-radius: 18px;
+  padding: 22px 22px 18px;
+}
+.dm-excl {
+  display: flex; flex-direction: column; align-items: center; text-align: center;
+  gap: 10px;
+}
+.dm-excl__ic {
+  width: 48px; height: 48px; border-radius: 50%;
+  background: var(--color-amber-100); color: var(--color-amber-800);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-display); font-weight: 900; font-size: 22px;
+  border: 2px solid var(--color-amber-300);
+}
+[data-theme="dark"] .dm-excl__ic {
+  background: rgba(251,191,36,0.18); color: var(--color-amber-300);
+  border-color: rgba(251,191,36,0.4);
+}
+.dm-excl__title {
+  font-family: var(--font-display); font-weight: 900; font-size: 19px;
+  letter-spacing: -0.01em; color: var(--fg-primary);
+}
+.dm-excl__copy {
+  font-family: var(--font-body); font-size: 13px; line-height: 1.5;
+  color: var(--fg-secondary); max-width: 280px;
+}
+.dm-excl__copy strong { color: var(--fg-primary); font-weight: 700; }
+.dm-excl__actions {
+  display: flex; gap: 8px; width: 100%; margin-top: 8px;
+}
+.dm-excl__actions > * { flex: 1; }
+.dm-excl__btnPrimary {
+  background: var(--color-amber-400);
+  box-shadow: 0 8px 20px rgba(245, 158, 11, 0.35);
+  color: #3B260A;
+}
+.dm-excl__btnPrimary:hover { background: var(--color-amber-300); filter: none; }
+
+/* ── Stepper modal ───────────────────────────────────────────── */
+.scrim--dm {
+  align-items: flex-end;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(8px) saturate(120%);
+  -webkit-backdrop-filter: blur(8px) saturate(120%);
+}
+.carta[data-bp="tablet"] .scrim--dm,
+.carta[data-bp="desktop"] .scrim--dm { align-items: center; }
+
+.dm-modal {
+  background: var(--bg-base);
+  color: var(--fg-primary);
+  display: flex; flex-direction: column;
+  width: 100%;
+  overflow: hidden;
+  position: relative;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.5);
+}
+.carta[data-bp="mobile"] .dm-modal {
+  height: 94%;
+  border-radius: 22px 22px 0 0;
+  animation: drawer-up 320ms var(--ease-smooth);
+}
+.carta[data-bp="mobile"] .dm-modal.is-closing { animation: drawer-down 240ms var(--ease-smooth) forwards; }
+
+.carta[data-bp="tablet"] .dm-modal {
+  width: min(580px, 92%);
+  max-height: 90%;
+  border-radius: 22px;
+  animation: pdetail-pop 280ms var(--ease-smooth);
+}
+.carta[data-bp="desktop"] .dm-modal {
+  width: min(720px, 90%);
+  max-height: 86%;
+  border-radius: 24px;
+  animation: pdetail-pop 280ms var(--ease-smooth);
+}
+.carta[data-bp="tablet"] .dm-modal.is-closing,
+.carta[data-bp="desktop"] .dm-modal.is-closing { animation: pdetail-pop-out 220ms var(--ease-out) forwards; }
+
+.dm-modal__head {
+  flex-shrink: 0;
+  position: relative;
+  padding: 18px 56px 16px 22px;
+  background:
+    linear-gradient(180deg, var(--dm-gold-50), transparent),
+    var(--bg-base);
+  border-bottom: 1px solid var(--border-subtle);
+}
+[data-theme="dark"] .dm-modal__head {
+  background: linear-gradient(180deg, rgba(251,191,36,0.08), transparent), var(--bg-base);
+}
+.dm-modal__brandRow {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--dm-gold-700);
+}
+[data-theme="dark"] .dm-modal__brandRow { color: var(--dm-gold-500); }
+.dm-modal__mark {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px;
+  background: var(--dm-gold-200);
+  color: var(--dm-gold-700);
+  border-radius: 7px;
+  font-family: var(--font-display); font-size: 15px; font-weight: 900;
+  letter-spacing: 0;
+}
+[data-theme="dark"] .dm-modal__mark { background: rgba(251,191,36,0.22); color: var(--dm-gold-500); }
+.dm-modal__brand { letter-spacing: 0.14em; }
+.dm-modal__date {
+  margin-left: auto;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 500;
+  letter-spacing: 0.04em; text-transform: none;
+  color: var(--fg-muted);
+}
+.dm-modal__close {
+  position: absolute; top: 14px; right: 14px;
+}
+
+.dm-modal__progress {
+  padding: 10px 22px 14px;
+  background: var(--bg-base);
+}
+.dm-modal__progressBar {
+  height: 6px; background: var(--bg-chip); border-radius: 9999px;
+  overflow: hidden;
+}
+.dm-modal__progressFill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--dm-gold-300), var(--dm-gold-500));
+  border-radius: 9999px;
+  transition: width 320ms var(--ease-smooth);
+}
+.dm-modal__progressLabel {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--fg-muted);
+  margin-top: 6px;
+}
+
+.dm-modal__body {
+  flex: 1 1 auto; min-height: 0;
+  overflow-y: auto;
+  padding: 6px 22px 18px;
+}
+.carta[data-bp="mobile"] .dm-modal__body { padding: 6px 16px 16px; }
+
+.dm-modal__foot {
+  flex-shrink: 0;
+  border-top: 1px solid var(--border-subtle);
+  padding: 14px 18px;
+  display: flex; gap: 10px;
+  background: var(--bg-base);
+}
+.dm-modal__foot .btn-primary { flex: 1; }
+.dm-modal__foot .btn-text {
+  width: auto; padding: 12px 16px; flex-shrink: 0;
+}
+
+/* ── Step inner ─────────────────────────────────────────────── */
+.dm-step { display: flex; flex-direction: column; gap: 14px; }
+.dm-step__head { padding: 6px 0 2px; }
+.dm-step__title {
+  font-family: var(--font-display); font-weight: 900; font-size: 22px;
+  letter-spacing: -0.01em; margin: 0;
+  color: var(--fg-primary);
+}
+.dm-step__hint {
+  font-family: var(--font-body); font-size: 12px;
+  color: var(--fg-muted); margin: 4px 0 0;
+}
+
+.dm-step__options {
+  display: flex; flex-direction: column; gap: 8px;
+}
+
+/* Option row */
+.dm-opt {
+  appearance: none; border: none; background: var(--bg-surface);
+  display: flex; align-items: center; gap: 12px; text-align: left;
+  padding: 10px 14px 10px 12px;
+  border-radius: 14px;
+  border: 1.5px solid var(--border-subtle);
+  cursor: pointer;
+  font-family: var(--font-body);
+  color: var(--fg-primary);
+  transition: border-color 150ms, background 150ms, transform 120ms;
+  width: 100%;
+}
+.dm-opt:hover { border-color: var(--dm-gold-300); }
+.dm-opt:focus-visible {
+  outline: 2px solid var(--dm-gold-300);
+  outline-offset: 2px;
+}
+.dm-opt--on {
+  border-color: var(--dm-gold-500);
+  background: var(--dm-gold-50);
+  box-shadow: 0 4px 14px rgba(180, 123, 25, 0.18);
+}
+[data-theme="dark"] .dm-opt--on { background: rgba(251, 191, 36, 0.08); }
+.dm-opt--off { opacity: 0.45; cursor: not-allowed; }
+.dm-opt--off:hover { border-color: var(--border-subtle); }
+
+.dm-opt__radio, .dm-opt__check {
+  flex-shrink: 0;
+  width: 22px; height: 22px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 50%;
+  border: 2px solid var(--border-strong);
+  background: var(--bg-base);
+  transition: background 150ms, border-color 150ms;
+  color: white;
+}
+.dm-opt__check { border-radius: 6px; }
+.dm-opt__radio > span {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: transparent; transition: background 150ms;
+}
+.dm-opt__radio.is-on, .dm-opt__check.is-on {
+  background: var(--dm-gold-500);
+  border-color: var(--dm-gold-500);
+}
+.dm-opt__radio.is-on > span { background: white; }
+[data-theme="dark"] .dm-opt__radio.is-on, [data-theme="dark"] .dm-opt__check.is-on {
+  background: var(--dm-gold-300); border-color: var(--dm-gold-300);
+  color: var(--dm-gold-ink);
+}
+[data-theme="dark"] .dm-opt__radio.is-on > span { background: var(--dm-gold-ink); }
+
+.dm-opt__photo {
+  width: 46px; height: 46px; border-radius: 10px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 24px; flex-shrink: 0;
+  background: var(--bg-chip);
+}
+.dm-opt__photo--food-1 { background: linear-gradient(135deg, #FCE7AA, #FDB76A); }
+.dm-opt__photo--food-2 { background: linear-gradient(135deg, #FEE2E2, #FCA5A5); }
+.dm-opt__photo--food-3 { background: linear-gradient(135deg, #DCFCE7, #86EFAC); }
+.dm-opt__photo--food-4 { background: linear-gradient(135deg, #FEF3C7, #FBBF24); }
+.dm-opt__photo--food-5 { background: linear-gradient(135deg, #FCE7F3, #F9A8D4); }
+.dm-opt__photo--food-6 { background: linear-gradient(135deg, #E0E7FF, #A5B4FC); }
+[data-theme="dark"] .dm-opt__photo { background: linear-gradient(135deg, var(--color-night-500), var(--color-night-700)); }
+
+.dm-opt__body { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+.dm-opt__nameRow { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.dm-opt__name {
+  font-family: var(--font-body); font-weight: 700; font-size: 14px;
+  color: var(--fg-primary);
+}
+.dm-opt__badge {
+  font-family: var(--font-mono); font-size: 9px; font-weight: 700;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  background: var(--color-gray-200); color: var(--color-gray-700);
+  padding: 2px 6px; border-radius: 4px;
+}
+[data-theme="dark"] .dm-opt__badge { background: rgba(255,255,255,0.08); color: var(--color-blue-200); }
+.dm-opt__desc {
+  font-family: var(--font-body); font-size: 12px; color: var(--fg-muted);
+  line-height: 1.4;
+}
+.dm-opt__allergens { display: inline-flex; gap: 4px; margin-top: 2px; }
+
+/* Skip option */
+.dm-skip {
+  appearance: none; border: 1px dashed var(--border-strong);
+  background: transparent; cursor: pointer;
+  padding: 10px 14px; border-radius: 12px;
+  display: inline-flex; align-items: center; gap: 10px;
+  font-family: var(--font-body); font-size: 13px; font-weight: 600;
+  color: var(--fg-secondary);
+  align-self: flex-start;
+  transition: background 150ms, color 150ms, border-color 150ms;
+}
+.dm-skip:hover { background: var(--bg-chip); color: var(--fg-primary); }
+.dm-skip--on {
+  background: var(--dm-gold-50); color: var(--dm-gold-700);
+  border-color: var(--dm-gold-300); border-style: solid;
+}
+[data-theme="dark"] .dm-skip--on { color: var(--dm-gold-500); background: rgba(251,191,36,0.1); }
+.dm-skip__check {
+  width: 16px; height: 16px; border-radius: 4px;
+  border: 1.5px solid currentColor; opacity: 0.6;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.dm-skip__check.is-on { background: currentColor; opacity: 1; color: var(--dm-gold-700); }
+.dm-skip__check.is-on svg { color: var(--dm-gold-50); }
+
+/* Timing step */
+.dm-timing { display: flex; flex-direction: column; gap: 18px; padding-top: 8px; }
+.dm-timing__row {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  padding: 14px 16px;
+}
+.dm-timing__top {
+  display: flex; align-items: baseline; justify-content: space-between;
+  margin-bottom: 6px;
+}
+.dm-timing__label {
+  font-family: var(--font-body); font-size: 13px; font-weight: 700;
+  color: var(--fg-primary);
+}
+.dm-timing__val {
+  font-family: var(--font-display); font-weight: 900; font-size: 22px;
+  color: var(--dm-gold-500); font-variant-numeric: tabular-nums;
+}
+.dm-timing__slider {
+  width: 100%; height: 4px; appearance: none; -webkit-appearance: none;
+  background: linear-gradient(90deg, var(--dm-gold-300), var(--dm-gold-500));
+  border-radius: 9999px; outline: none;
+  margin: 8px 0 4px;
+}
+.dm-timing__slider::-webkit-slider-thumb {
+  -webkit-appearance: none; appearance: none;
+  width: 22px; height: 22px; border-radius: 50%;
+  background: var(--bg-base); border: 2px solid var(--dm-gold-500);
+  box-shadow: 0 4px 10px rgba(180, 123, 25, 0.3);
+  cursor: pointer;
+}
+.dm-timing__slider::-moz-range-thumb {
+  width: 22px; height: 22px; border-radius: 50%;
+  background: var(--bg-base); border: 2px solid var(--dm-gold-500);
+  box-shadow: 0 4px 10px rgba(180, 123, 25, 0.3);
+}
+.dm-timing__ticks {
+  display: flex; justify-content: space-between;
+  font-family: var(--font-mono); font-size: 9px; font-weight: 600;
+  letter-spacing: 0.05em; color: var(--fg-muted);
+  padding: 0 2px;
+}
+
+/* Summary / confirm */
+.dm-summary {
+  display: flex; flex-direction: column;
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  overflow: hidden;
+  background: var(--bg-surface);
+}
+.dm-summary__row {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 14px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-subtle);
+  align-items: baseline;
+}
+.dm-summary__row:last-of-type { border-bottom: none; }
+.dm-summary__row--inset {
+  background: var(--bg-chip);
+}
+.dm-summary__lab {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.dm-summary__val {
+  font-family: var(--font-body); font-size: 14px; font-weight: 600;
+  color: var(--fg-primary); line-height: 1.4;
+}
+.dm-summary__muted { color: var(--fg-muted); font-weight: 500; font-style: italic; }
+.dm-summary__includes {
+  display: flex; gap: 14px;
+  padding: 10px 16px;
+  background: var(--dm-gold-50);
+  border-top: 1px solid var(--dm-gold-200);
+  font-family: var(--font-body); font-size: 12px;
+  color: var(--dm-gold-700);
+  align-items: baseline;
+}
+[data-theme="dark"] .dm-summary__includes {
+  background: rgba(251,191,36,0.08); color: var(--dm-gold-500);
+  border-top-color: rgba(251,191,36,0.2);
+}
+.dm-summary__includesLab {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  min-width: 86px;
+}
+.dm-summary__total {
+  display: flex; align-items: baseline; justify-content: space-between;
+  margin-top: 14px;
+  padding: 12px 16px;
+  background: linear-gradient(180deg, var(--dm-gold-50), var(--dm-gold-100));
+  border-radius: 14px;
+  border: 1px solid var(--dm-gold-200);
+}
+[data-theme="dark"] .dm-summary__total {
+  background: linear-gradient(180deg, rgba(251,191,36,0.1), rgba(251,191,36,0.05));
+  border-color: rgba(251,191,36,0.25);
+}
+.dm-summary__totalLab {
+  font-family: var(--font-body); font-size: 12px; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--dm-gold-700);
+}
+[data-theme="dark"] .dm-summary__totalLab { color: var(--dm-gold-500); }
+.dm-summary__totalVal {
+  font-family: var(--font-display); font-weight: 900; font-size: 28px;
+  color: var(--dm-gold-700); font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+[data-theme="dark"] .dm-summary__totalVal { color: var(--dm-gold-500); }
+
+/* Submit button: gold, distinct from green CTA */
+.dm-step__submit {
+  background: linear-gradient(180deg, #D69430 0%, #B47B19 100%);
+  color: #FFFAEC;
+  box-shadow: 0 10px 24px rgba(180, 123, 25, 0.45);
+}
+.dm-step__submit:hover { filter: brightness(1.08); }
+
+/* Done step */
+.dm-step--done {
+  display: flex; flex-direction: column; align-items: center;
+  padding: 36px 16px 24px;
+  text-align: center; gap: 12px;
+}
+.dm-step__doneIc {
+  width: 72px; height: 72px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--color-green-100); color: var(--color-green-700);
+  border: 3px solid var(--color-green-500);
+  animation: dm-done-pop 480ms var(--ease-bounce);
+}
+[data-theme="dark"] .dm-step__doneIc {
+  background: rgba(34,197,94,0.18); color: var(--color-green-400);
+  border-color: var(--color-green-500);
+}
+@keyframes dm-done-pop {
+  0% { transform: scale(0.6); opacity: 0; }
+  60% { transform: scale(1.1); opacity: 1; }
+  100% { transform: scale(1); }
+}
+.dm-step__doneTitle {
+  font-family: var(--font-display); font-weight: 900; font-size: 22px;
+  letter-spacing: -0.01em; margin: 4px 0 0;
+}
+.dm-step__doneCopy {
+  font-family: var(--font-body); font-size: 13px; line-height: 1.55;
+  color: var(--fg-secondary); max-width: 320px; margin: 0;
+}
+
+/* Mobile filter row: dm chip after Cocina/Barra, with its own gap */
+.dm-filter-sep {
+  width: 1px; align-self: stretch;
+  background: var(--border-subtle); margin: 4px 2px;
+  flex-shrink: 0;
+}
+
+
+/* ════════════════════════════════════════════════════════════════
+   MENÚ DEL DÍA · presentación dentro de "Mis pedidos"
+   ════════════════════════════════════════════════════════════════ */
+
+/* Row en la lista — variante dorada */
+.order-row--dm {
+  background: linear-gradient(180deg, var(--dm-gold-50), var(--bg-surface) 70%);
+  border-color: var(--dm-gold-200);
+}
+[data-theme="dark"] .order-row--dm {
+  background: linear-gradient(180deg, rgba(251,191,36,0.10), var(--bg-surface) 70%);
+  border-color: rgba(251,191,36,0.3);
+}
+.order-row__num--dm {
+  background: linear-gradient(180deg, var(--dm-gold-200), var(--dm-gold-300));
+  color: var(--dm-gold-700);
+  font-family: var(--font-display); font-weight: 900;
+}
+[data-theme="dark"] .order-row__num--dm {
+  background: linear-gradient(180deg, rgba(251,191,36,0.3), rgba(251,191,36,0.18));
+  color: var(--dm-gold-500);
+}
+.order-row__dmMark { font-size: 20px; line-height: 1; }
+.order-row__dmTag {
+  display: inline-block;
+  font-family: var(--font-mono); font-size: 9px; font-weight: 700;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--dm-gold-700);
+  background: var(--dm-gold-100);
+  padding: 2px 6px; border-radius: 4px;
+  margin-left: 8px;
+  vertical-align: 2px;
+}
+[data-theme="dark"] .order-row__dmTag {
+  color: var(--dm-gold-500); background: rgba(251,191,36,0.18);
+}
+
+/* Detail — encabezado dorado */
+.orders-detail__head--dm {
+  background: linear-gradient(180deg, var(--dm-gold-50), transparent);
+  border-radius: 12px;
+  padding: 10px;
+  margin: -2px -2px 8px;
+}
+[data-theme="dark"] .orders-detail__head--dm {
+  background: linear-gradient(180deg, rgba(251,191,36,0.10), transparent);
+}
+.orders-detail__num--dm {
+  background: linear-gradient(180deg, var(--dm-gold-200), var(--dm-gold-300));
+  color: var(--dm-gold-700);
+  font-family: var(--font-display); font-weight: 900; font-size: 22px;
+}
+[data-theme="dark"] .orders-detail__num--dm {
+  background: linear-gradient(180deg, rgba(251,191,36,0.3), rgba(251,191,36,0.18));
+  color: var(--dm-gold-500);
+}
+
+/* Line — variante para menú */
+.orders-line--dm {
+  background: linear-gradient(180deg, var(--dm-gold-50), var(--bg-surface) 70%);
+  border-color: var(--dm-gold-200);
+}
+[data-theme="dark"] .orders-line--dm {
+  background: linear-gradient(180deg, rgba(251,191,36,0.08), var(--bg-surface) 70%);
+  border-color: rgba(251,191,36,0.25);
+}
+.orders-line--dm .orders-line__qty {
+  background: var(--dm-gold-200); color: var(--dm-gold-700);
+}
+[data-theme="dark"] .orders-line--dm .orders-line__qty {
+  background: rgba(251,191,36,0.22); color: var(--dm-gold-500);
+}
+.orders-line--dm .orders-line__price {
+  color: var(--dm-gold-700); font-weight: 900;
+}
+[data-theme="dark"] .orders-line--dm .orders-line__price { color: var(--dm-gold-500); }
+
+/* Picks list shared component */
+.orders-dm__picks {
+  display: flex; flex-direction: column;
+  margin-top: 6px;
+  border-top: 1px dashed var(--dm-gold-200);
+  padding-top: 6px;
+}
+[data-theme="dark"] .orders-dm__picks { border-top-color: rgba(251,191,36,0.22); }
+.orders-dm__pickRow {
+  display: grid;
+  grid-template-columns: 92px 1fr;
+  gap: 10px;
+  padding: 3px 0;
+  align-items: baseline;
+}
+.orders-dm__pickLab {
+  font-family: var(--font-mono); font-size: 9px; font-weight: 700;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--dm-gold-700);
+}
+[data-theme="dark"] .orders-dm__pickLab { color: var(--dm-gold-500); }
+.orders-dm__pickVal {
+  font-family: var(--font-body); font-size: 12px; font-weight: 600;
+  color: var(--fg-primary); line-height: 1.4;
+}
+.orders-dm__pickMuted { font-style: italic; font-weight: 500; color: var(--fg-muted); }
+
+/* includes + timings rows below picks */
+.orders-dm__includes, .orders-dm__timings {
+  display: flex; gap: 10px;
+  margin-top: 6px; padding-top: 4px;
+  font-family: var(--font-body); font-size: 11px;
+  color: var(--fg-secondary);
+  align-items: baseline;
+}
+.orders-dm__includesLab {
+  font-family: var(--font-mono); font-size: 9px; font-weight: 700;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--fg-muted);
+  min-width: 82px;
+}
+
+/* Confirmed popup — variante de menú */
+.order-confirmed__panel--dm {
+  background:
+    radial-gradient(800px 240px at 50% 0%, rgba(236, 194, 90, 0.18), transparent 60%),
+    var(--bg-base);
+  border: 1px solid var(--dm-gold-200);
+}
+[data-theme="dark"] .order-confirmed__panel--dm {
+  background:
+    radial-gradient(800px 240px at 50% 0%, rgba(251, 191, 36, 0.15), transparent 60%),
+    var(--bg-base);
+  border-color: rgba(251,191,36,0.3);
+}
+.order-confirmed__badge--dm {
+  background: linear-gradient(180deg, var(--dm-gold-200), var(--dm-gold-300));
+  color: var(--dm-gold-700);
+  box-shadow: 0 8px 24px rgba(180, 123, 25, 0.35);
+}
+[data-theme="dark"] .order-confirmed__badge--dm {
+  background: linear-gradient(180deg, rgba(251,191,36,0.35), rgba(251,191,36,0.18));
+  color: var(--dm-gold-500);
+}
+.order-confirmed__dmTag {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--dm-gold-700);
+}
+[data-theme="dark"] .order-confirmed__dmTag { color: var(--dm-gold-500); }
+.order-confirmed__panel--dm .order-confirmed__items {
+  background: var(--dm-gold-50);
+  border: 1px solid var(--dm-gold-200);
+  border-radius: 12px;
+  padding: 10px 12px;
+}
+[data-theme="dark"] .order-confirmed__panel--dm .order-confirmed__items {
+  background: rgba(251,191,36,0.08);
+  border-color: rgba(251,191,36,0.25);
+}
+.order-confirmed__panel--dm .orders-dm__picks { border-top: none; padding-top: 0; margin-top: 0; }
+.order-confirmed__panel--dm .order-confirmed__sub-total .val {
+  color: var(--dm-gold-700);
+}
+[data-theme="dark"] .order-confirmed__panel--dm .order-confirmed__sub-total .val {
+  color: var(--dm-gold-500);
+}
+
+
+/* ════════════════════════════════════════════════════════════════
+   ACCESIBILIDAD · estados de selección en modo OSCURO
+   ----------------------------------------------------------------
+   En modo oscuro la "soft blue" del hover y la "active blue" eran
+   demasiado parecidas. Aquí los estados seleccionados ganan un
+   acento cian (#22D3EE) bien diferenciado del hover, manteniendo
+   los colores semánticos (oro = menú del día, verde = CTA/propina,
+   ámbar = alérgenos) que ya están bien diferenciados.
+   ════════════════════════════════════════════════════════════════ */
+
+/* Token único de "acento de selección" — en oscuro es cian de alta
+   visibilidad; en claro mantiene el verde primario del sistema. */
+:root         { --select-accent: var(--color-green-600); --select-accent-fg: #FFFFFF; --select-accent-soft: var(--color-green-50); }
+[data-theme="dark"] {
+  --select-accent:      #22D3EE;            /* cyan-400 */
+  --select-accent-fg:   #001823;            /* navy oscuro, contraste AAA sobre cyan */
+  --select-accent-soft: rgba(34, 211, 238, 0.14);
+}
+
+/* ════════════════════════════════════════════════════════════════
+   ACCESIBILIDAD · estados de selección en modo CLARO
+   ----------------------------------------------------------------
+   En claro, el activo de categoría y servicio era casi idéntico al
+   hover (mismo gris). Aquí reforzamos con el verde de marca para que
+   "lo seleccionado" destaque en móvil, tablet y desktop por igual.
+   ════════════════════════════════════════════════════════════════ */
+
+/* Chips horizontales (Cocina / Barra / Todas / categorías) — móvil */
+[data-theme="light"] .chip--active {
+  background: var(--select-accent);
+  color: var(--select-accent-fg);
+  font-weight: 700;
+  box-shadow: 0 0 0 1px rgba(22, 163, 74, 0.55), 0 6px 16px rgba(22, 163, 74, 0.28);
+}
+[data-theme="light"] .chip--active:hover {
+  background: var(--select-accent);
+  color: var(--select-accent-fg);
+  filter: brightness(1.04);
+}
+
+/* Toggle Servicio (Todo / 🍳 / 🍺) — sidebar tablet+desktop */
+[data-theme="light"] .dest-toggle button.active {
+  background: var(--select-accent);
+  color: var(--select-accent-fg);
+  font-weight: 800;
+  box-shadow:
+    0 0 0 1px rgba(22, 163, 74, 0.5) inset,
+    0 3px 8px rgba(22, 163, 74, 0.28);
+}
+
+/* Lista de Categorías (sidebar) — NO los alérgenos (siguen en ámbar) */
+[data-theme="light"] .filter-list:not(.filter-list--allergens) .filter-list__item--active {
+  background: var(--select-accent-soft);
+  color: var(--color-green-800);
+  font-weight: 700;
+  box-shadow: inset 3px 0 0 var(--select-accent);
+  padding-left: 13px;   /* compensa la barra para que el texto no salte */
+}
+[data-theme="light"] .filter-list:not(.filter-list--allergens) .filter-list__item--active .filter-list__count {
+  color: var(--brand-primary);
+  font-weight: 700;
+}
+[data-theme="light"] .filter-list:not(.filter-list--allergens) .filter-list__item--active .filter-list__check {
+  background: var(--select-accent);
+  border-color: var(--select-accent);
+  color: var(--select-accent-fg);
+}
+
+/* ── Chips horizontales (Cocina / Barra / Todas / categorías) ── */
+[data-theme="dark"] .chip {
+  /* Reforzar el reposo para que tenga distancia con el activo */
+  background: rgba(46, 80, 176, 0.20);
+  color: var(--color-blue-100);
+}
+[data-theme="dark"] .chip:hover {
+  background: rgba(46, 80, 176, 0.34);
+  color: #FFFFFF;
+}
+[data-theme="dark"] .chip--active {
+  background: var(--select-accent);
+  color: var(--select-accent-fg);
+  font-weight: 700;
+  box-shadow: 0 0 0 1px rgba(34, 211, 238, 0.5), 0 6px 16px rgba(34, 211, 238, 0.25);
+}
+[data-theme="dark"] .chip--active:hover {
+  background: var(--select-accent);
+  color: var(--select-accent-fg);
+  filter: brightness(1.08);
+}
+
+/* ── Toggle Servicio (Todo / 🍳 / 🍺) en sidebar ─────────────── */
+[data-theme="dark"] .dest-toggle {
+  background: rgba(255, 255, 255, 0.04);
+}
+[data-theme="dark"] .dest-toggle button {
+  color: var(--color-blue-200);
+}
+[data-theme="dark"] .dest-toggle button:hover { color: #FFFFFF; }
+[data-theme="dark"] .dest-toggle button.active {
+  background: var(--select-accent);
+  color: var(--select-accent-fg);
+  font-weight: 800;
+  box-shadow:
+    0 0 0 1px rgba(34, 211, 238, 0.6) inset,
+    0 4px 10px rgba(34, 211, 238, 0.25);
+}
+
+/* ── Lista de Categorías y Alérgenos (sidebar) ──────────────── */
+[data-theme="dark"] .filter-list__item {
+  /* hover diferente para que no se confunda con seleccionado */
+  position: relative;
+}
+[data-theme="dark"] .filter-list__item:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+[data-theme="dark"] .filter-list__item--active {
+  /* Selección: fondo soft-cyan + barra lateral cian saturada */
+  background: var(--select-accent-soft);
+  color: #FFFFFF;
+  font-weight: 700;
+  box-shadow: inset 3px 0 0 var(--select-accent);
+  padding-left: 13px;   /* compensa la barra para que el texto no salte */
+}
+[data-theme="dark"] .filter-list__item--active .filter-list__count {
+  color: var(--select-accent);
+  font-weight: 700;
+}
+/* Caja del check de alérgenos también en cian al estar activa */
+[data-theme="dark"] .filter-list__item--active .filter-list__check {
+  background: var(--select-accent);
+  border-color: var(--select-accent);
+  color: var(--select-accent-fg);
+}
+
+/* ── Mobile filter row: refuerzo de chip activo y separadores ── */
+[data-theme="dark"] .dm-filter-sep { background: rgba(255,255,255,0.10); }
+
+/* ── Allergen-chip activo (filtro de alérgenos) ─────────────── */
+/* Ya usa ámbar saturado en oscuro — está bien diferenciado. */
+
+/* ── Tapas seleccionada / tip seleccionado ──────────────────── */
+[data-theme="dark"] .tapa {
+  background: rgba(255,255,255,0.03);
+}
+[data-theme="dark"] .tapa--selected {
+  background: rgba(34, 197, 94, 0.18);
+  border-color: var(--color-green-500);
+  box-shadow: 0 0 0 1px var(--color-green-500) inset;
+}
+[data-theme="dark"] .tip--selected {
+  background: rgba(34, 197, 94, 0.18);
+  border-color: var(--color-green-500);
+  box-shadow: 0 0 0 1px var(--color-green-500) inset;
+}
+[data-theme="dark"] .tip--selected .pct { color: #4ADE80; }
+
+/* ── Menú del día · opciones seleccionables ─────────────────── */
+[data-theme="dark"] .dm-opt {
+  background: rgba(255, 255, 255, 0.025);
+  border-color: rgba(251, 191, 36, 0.18);
+}
+[data-theme="dark"] .dm-opt:hover {
+  background: rgba(255, 255, 255, 0.045);
+  border-color: rgba(251, 191, 36, 0.35);
+}
+[data-theme="dark"] .dm-opt--on {
+  background: rgba(251, 191, 36, 0.18);
+  border-color: var(--dm-gold-300);
+  box-shadow:
+    0 0 0 1px var(--dm-gold-300) inset,
+    0 6px 16px rgba(251, 191, 36, 0.22);
+}
+[data-theme="dark"] .dm-opt--on .dm-opt__name {
+  color: #FFFAEC;
+}
+
+/* Skip ("Sin postre, gracias") seleccionado en oscuro */
+[data-theme="dark"] .dm-skip {
+  border-color: rgba(255, 255, 255, 0.15);
+  color: var(--color-blue-200);
+}
+[data-theme="dark"] .dm-skip:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: #FFFFFF;
+}
+[data-theme="dark"] .dm-skip--on {
+  background: rgba(251, 191, 36, 0.18);
+  color: var(--dm-gold-50);
+  border-color: var(--dm-gold-300);
+  border-style: solid;
+}
+
+/* ── Chip "quitar ingrediente" activo en carrito ────────────── */
+[data-theme="dark"] .chip-quitar {
+  background: rgba(255,255,255,0.04);
+  border-color: rgba(255,255,255,0.10);
+  color: var(--color-blue-200);
+}
+[data-theme="dark"] .chip-quitar:hover {
+  border-color: rgba(255,255,255,0.25); color: #FFFFFF;
+}
+/* Ya tiene ámbar en oscuro — está bien diferenciado. */
+
+/* ── Chip del Menú del día en filtros (oscuro) ──────────────── */
+/* Ya usa oro saturado — accesible. */
+
+/* ── Focus visible para teclado en oscuro ───────────────────── */
+[data-theme="dark"] .chip:focus-visible,
+[data-theme="dark"] .dest-toggle button:focus-visible,
+[data-theme="dark"] .filter-list__item:focus-visible,
+[data-theme="dark"] .dm-opt:focus-visible,
+[data-theme="dark"] .tapa:focus-visible,
+[data-theme="dark"] .tip:focus-visible {
+  outline: 2px solid var(--select-accent);
+  outline-offset: 2px;
+}
+
+
+/* ════════════════════════════════════════════════════════════════
+   ACCESIBILIDAD · refuerzo daltonismo (modo oscuro)
+   ----------------------------------------------------------------
+   Aseguramos que cada estado seleccionable distinga por al menos
+   DOS canales:
+     a) cromático (cian / oro / verde / ámbar)
+     b) luminancia (texto y/o fondo cambian de claro a oscuro)
+     c) forma (barra lateral, halo, glifo, peso de fuente)
+   ════════════════════════════════════════════════════════════════ */
+
+/* Sidebar: el activo necesita más luminancia y borde lateral más grueso */
+[data-theme="dark"] .filter-list__item--active {
+  background: rgba(34, 211, 238, 0.22);
+  box-shadow:
+    inset 4px 0 0 var(--select-accent),
+    inset 0 0 0 1px rgba(34, 211, 238, 0.35);
+  padding-left: 12px;
+}
+
+/* Allergens keep the amber look in dark mode too (matches mobile chip) */
+[data-theme="dark"] .carta__filters .filter-list--allergens .filter-list__item--active {
+  background: var(--color-amber-300);
+  color: #5A2F00;
+  box-shadow:
+    inset 4px 0 0 #5A2F00,
+    0 0 0 1px #2A1B05;
+  padding-left: 12px;
+}
+[data-theme="dark"] .carta__filters .filter-list--allergens .filter-list__item--active .filter-list__check {
+  background: #5A2F00; border-color: #5A2F00; color: var(--color-amber-300);
+}
+[data-theme="dark"] .carta__filters .filter-list--allergens .filter-list__item--active .allergen {
+  background: #5A2F00; color: var(--color-amber-300);
+}
+[data-theme="dark"] .carta__filters .filter-list--allergens .filter-list__item--active .filter-list__count {
+  color: #5A2F00;
+}
+
+/* Chip horizontal activo: añadimos un anillo oscuro 1px alrededor
+   para que en simulación deuteran/protanópica destaque por silueta. */
+[data-theme="dark"] .chip--active {
+  background: var(--select-accent);
+  color: var(--select-accent-fg);
+  border: 1px solid #001823;        /* anillo oscuro = cue de forma */
+  box-shadow:
+    0 0 0 2px rgba(34, 211, 238, 0.45),
+    0 6px 16px rgba(34, 211, 238, 0.25);
+}
+
+/* dest-toggle activo: mismo refuerzo + peso visible */
+[data-theme="dark"] .dest-toggle button.active {
+  background: var(--select-accent);
+  color: var(--select-accent-fg);
+  font-weight: 900;
+  outline: 1px solid #001823;
+  outline-offset: -1px;
+  box-shadow:
+    0 0 0 2px rgba(34, 211, 238, 0.45),
+    0 4px 10px rgba(34, 211, 238, 0.30);
+}
+
+/* Daily-menu option seleccionada en oscuro: el radio/check pasa de
+   borde a relleno; añadimos halo gold detrás para que la "forma"
+   del seleccionado se distinga del solo "hover" para alguien con
+   tritanopía (donde azul-amarillo es el eje afectado, el oro puede
+   verse más apagado). */
+[data-theme="dark"] .dm-opt--on {
+  background: rgba(251, 191, 36, 0.20);
+  border-width: 2px;
+  border-color: var(--dm-gold-300);
+  box-shadow:
+    inset 0 0 0 1px var(--dm-gold-300),
+    0 6px 20px rgba(251, 191, 36, 0.28);
+}
+[data-theme="dark"] .dm-opt--on .dm-opt__radio.is-on,
+[data-theme="dark"] .dm-opt--on .dm-opt__check.is-on {
+  /* Marca interna en navy para contraste AAA sobre oro */
+  background: var(--dm-gold-300);
+  border-color: var(--dm-gold-300);
+  color: #2A1B05;
+  box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.35);
+}
+[data-theme="dark"] .dm-opt--on .dm-opt__radio.is-on > span {
+  background: #2A1B05;              /* punto interior navy = doble cue */
+}
+
+/* Selección verde (tapas/tip): mismos refuerzos para deuteran/protan */
+[data-theme="dark"] .tapa--selected,
+[data-theme="dark"] .tip--selected {
+  border-width: 2px;
+  background: rgba(34, 197, 94, 0.22);
+  box-shadow:
+    inset 0 0 0 1px var(--color-green-500),
+    0 4px 14px rgba(34, 197, 94, 0.25);
+}
+
+/* Allergen chip activo (ámbar) en oscuro: borde oscuro para silueta */
+[data-theme="dark"] .allergen-chip--active {
+  border: 1px solid #2A1B05;
+  box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.35);
+}
+
+/* Focus visible — outline cian sobre dark navy 2px (ya estaba),
+   subimos a outline-offset 3px para que no se solape con el chip. */
+[data-theme="dark"] .chip:focus-visible,
+[data-theme="dark"] .dest-toggle button:focus-visible,
+[data-theme="dark"] .filter-list__item:focus-visible,
+[data-theme="dark"] .dm-opt:focus-visible,
+[data-theme="dark"] .tapa:focus-visible,
+[data-theme="dark"] .tip:focus-visible,
+[data-theme="dark"] .allergen-chip:focus-visible {
+  outline: 2px solid var(--select-accent);
+  outline-offset: 3px;
+}
+
+/* Comprobación rápida de contraste (luminancia, no croma):
+   cyan #22D3EE ↔ navy #001823  → 12.6:1  (AAA)
+   gold #ECC25A ↔ navy #2A1B05  → 11.2:1  (AAA)
+   green#22C55E ↔ ink  #052e16  → 6.4:1   (AA-AAA según tamaño)
+   amber#FBBF24 ↔ ink  #2A1B05  → 11.4:1  (AAA)
+   Pasan los pares vitales bajo deuteran/protan/tritan simulado:
+   la diferencia se conserva por luminancia y/o forma. */
+
+
+/* =========================================================
+   NEW FLOWS — Horarios, Tapas v2, Cobro partido, Cobro mixto
+   Appended to extend the existing carta styles.
+   ========================================================= */
+
+/* ---- 1) Cutoff strip (cocina cierra pronto) ---- */
+.cutoff-strip {
+  position: relative;
+  background: linear-gradient(180deg, var(--color-amber-100), color-mix(in oklab, var(--color-amber-200) 70%, var(--color-amber-100)));
+  border-bottom: 1px solid color-mix(in oklab, var(--color-amber-400) 30%, var(--border-subtle));
+  overflow: hidden;
+  flex-shrink: 0;
+}
+[data-theme="dark"] .cutoff-strip {
+  background: linear-gradient(180deg, rgba(251,191,36,0.10), rgba(251,191,36,0.05));
+  border-bottom-color: rgba(251,191,36,0.30);
+}
+.cutoff-strip__bar {
+  position: absolute; inset: 0 auto 0 0; height: 100%;
+  background: linear-gradient(90deg, rgba(245,158,11,0.20), rgba(245,158,11,0.05));
+  transition: width 600ms var(--ease-smooth);
+}
+[data-theme="dark"] .cutoff-strip__bar {
+  background: linear-gradient(90deg, rgba(251,191,36,0.18), rgba(251,191,36,0.03));
+}
+.cutoff-strip__row {
+  position: relative;
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 16px;
+}
+.cutoff-strip__pulse {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: var(--color-amber-400);
+  box-shadow: 0 0 0 4px rgba(245,158,11,0.25);
+  animation: cutoffPulse 1.4s ease-in-out infinite;
+  flex-shrink: 0;
+}
+@keyframes cutoffPulse {
+  0%,100% { box-shadow: 0 0 0 0 rgba(245,158,11,0.45); }
+  50%     { box-shadow: 0 0 0 8px rgba(245,158,11,0); }
+}
+.cutoff-strip__copy { flex: 1; min-width: 0; line-height: 1.25; }
+.cutoff-strip__copy strong {
+  display: block;
+  font-family: var(--font-display); font-weight: 800;
+  font-size: 13px; color: var(--color-amber-800);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.cutoff-strip__copy span {
+  display: block;
+  font-family: var(--font-body); font-size: 11.5px;
+  color: color-mix(in oklab, var(--color-amber-800) 75%, var(--fg-secondary));
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+[data-theme="dark"] .cutoff-strip__copy strong { color: var(--color-amber-300); }
+[data-theme="dark"] .cutoff-strip__copy span { color: color-mix(in oklab, var(--color-amber-300) 75%, var(--fg-secondary)); }
+.cutoff-strip__chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 10px; border-radius: 9999px;
+  background: rgba(245,158,11,0.18);
+  color: var(--color-amber-800);
+  font-family: var(--font-body); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.02em; white-space: nowrap;
+}
+.cutoff-strip__chip .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+[data-theme="dark"] .cutoff-strip__chip { background: rgba(251,191,36,0.18); color: var(--color-amber-300); }
+
+/* ---- 1b) Business closed overlay ---- */
+.biz-closed {
+  position: absolute; inset: 0; z-index: 80;
+  background: rgba(17,24,39,0.55);
+  backdrop-filter: blur(2px);
+  display: flex; align-items: stretch; justify-content: center;
+  pointer-events: auto;
+  animation: bizFade 320ms var(--ease-smooth);
+}
+[data-theme="dark"] .biz-closed { background: rgba(1,4,14,0.78); }
+@keyframes bizFade { from { opacity: 0 } to { opacity: 1 } }
+.biz-closed__blind {
+  width: 100%;
+  background: linear-gradient(180deg, #2d1b09 0%, #1a0f04 100%);
+  border-bottom: none;
+  display: flex; flex-direction: column; align-items: center;
+  padding: 0;
+  position: relative;
+  animation: blindDown 480ms var(--ease-smooth);
+  transform-origin: top;
+  color: var(--color-amber-300);
+  /* sutil patron de listones horizontales */
+  background-image:
+    linear-gradient(180deg, rgba(255,255,255,0.05), transparent 60%),
+    repeating-linear-gradient(180deg, transparent 0 32px, rgba(0,0,0,0.20) 32px 33px);
+}
+@keyframes blindDown {
+  from { transform: scaleY(0.05); opacity: 0; }
+  to   { transform: scaleY(1);    opacity: 1; }
+}
+.biz-closed__teeth {
+  position: absolute; left: 0; right: 0; bottom: -10px;
+  height: 12px; display: flex;
+  pointer-events: none;
+}
+.biz-closed__teeth span {
+  flex: 1;
+  background: inherit;
+  background-color: #1a0f04;
+  clip-path: polygon(0 0, 100% 0, 50% 100%);
+}
+.biz-closed__card {
+  margin: auto;
+  background: #0F0905;
+  border: 1px solid rgba(251,191,36,0.35);
+  border-radius: 16px;
+  padding: 28px 30px;
+  max-width: 380px; width: calc(100% - 48px);
+  text-align: center;
+  color: var(--color-amber-200);
+  box-shadow: 0 16px 50px rgba(0,0,0,0.45);
+}
+.biz-closed__clock {
+  margin: 0 auto 14px;
+  width: 64px; height: 64px; border-radius: 50%;
+  background: rgba(251,191,36,0.10);
+  display: inline-flex; align-items: center; justify-content: center;
+  color: var(--color-amber-300);
+}
+.biz-closed__h1 {
+  font-family: var(--font-display); font-weight: 900;
+  font-size: 22px; color: var(--color-amber-300);
+  letter-spacing: -0.01em; margin-bottom: 8px;
+}
+.biz-closed__p {
+  font-family: var(--font-body); font-size: 13.5px;
+  color: var(--color-amber-200); opacity: 0.85;
+  line-height: 1.5; margin-bottom: 18px;
+}
+.biz-closed__p strong { color: var(--color-amber-300); font-weight: 700; }
+.biz-closed__row {
+  display: flex; gap: 8px; justify-content: center;
+  margin-bottom: 18px;
+}
+.biz-closed__tag {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 5px 10px; border-radius: 9999px;
+  background: rgba(251,191,36,0.10);
+  color: var(--color-amber-200);
+  font-family: var(--font-body); font-size: 11px; font-weight: 600;
+}
+.biz-closed__btn {
+  width: 100%; padding: 12px 16px;
+  background: var(--color-amber-300); color: #2A1B05;
+  border: none; border-radius: 12px;
+  font-family: var(--font-body); font-weight: 700;
+  font-size: 14px; cursor: pointer;
+  transition: transform 120ms var(--ease-bounce), background-color var(--duration-fast);
+}
+.biz-closed__btn:hover { background: var(--color-amber-400); }
+.biz-closed__btn:active { transform: scale(0.97); }
+
+/* ---- 2) Tapas indicator pill ---- */
+.tapas-indicator {
+  display: inline-flex; align-items: center; gap: 12px;
+  align-self: flex-start;
+  margin: 10px 16px 12px;
+  padding: 6px 14px 6px 6px;
+  background: linear-gradient(135deg, var(--color-amber-100), color-mix(in oklab, var(--color-amber-200) 70%, var(--color-amber-100)));
+  border: 1px solid color-mix(in oklab, var(--color-amber-400) 35%, var(--border-subtle));
+  border-radius: 9999px;
+  font-family: var(--font-body);
+  color: var(--color-amber-800);
+  cursor: pointer;
+  flex-shrink: 0;
+  width: auto; max-width: 100%;
+  transition: transform 120ms var(--ease-bounce), box-shadow var(--duration-fast);
+  box-shadow: 0 2px 8px rgba(245,158,11,0.12);
+}
+[data-theme="dark"] .tapas-indicator {
+  background: linear-gradient(135deg, rgba(251,191,36,0.12), rgba(251,191,36,0.04));
+  border-color: rgba(251,191,36,0.35);
+  color: var(--color-amber-300);
+}
+.tapas-indicator:hover { transform: translateY(-1px); box-shadow: 0 4px 14px rgba(245,158,11,0.20); }
+.tapas-indicator__glyph {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: var(--color-amber-300); color: #5A2F00;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 16px; flex-shrink: 0;
+}
+.tapas-indicator__copy { display: inline-flex; align-items: baseline; gap: 6px; line-height: 1; min-width: 0; }
+.tapas-indicator__copy strong {
+  font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  color: var(--color-amber-800); letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums; line-height: 1;
+}
+.tapas-indicator__copy span {
+  font-size: 12.5px; font-weight: 600; line-height: 1;
+  color: color-mix(in oklab, var(--color-amber-800) 80%, var(--fg-secondary));
+}
+[data-theme="dark"] .tapas-indicator__copy strong { color: var(--color-amber-300); }
+[data-theme="dark"] .tapas-indicator__copy span { color: color-mix(in oklab, var(--color-amber-300) 80%, var(--fg-secondary)); }
+.tapas-indicator__tokens { display: inline-flex; gap: 3px; padding: 0 4px; align-items: center; flex-shrink: 0; }
+.tapas-indicator__tokens .tk {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--color-amber-300);
+  box-shadow: 0 0 0 1px rgba(0,0,0,0.05) inset;
+}
+.tapas-indicator__tokens .tk--used {
+  background: transparent;
+  border: 1px dashed color-mix(in oklab, var(--color-amber-400) 60%, transparent);
+  box-shadow: none;
+}
+.tapas-indicator__cta {
+  font-family: var(--font-body); font-size: 11.5px; font-weight: 700;
+  padding: 4px 10px; border-radius: 9999px;
+  background: var(--color-amber-300); color: #5A2F00;
+  white-space: nowrap;
+}
+[data-theme="dark"] .tapas-indicator__cta { background: var(--color-amber-300); color: #2A1B05; }
+
+/* ---- 2b) Tapas modal v2 ---- */
+.modal__panel--tapas {
+  max-width: 460px;
+  padding: 0;
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  max-height: 88%;
+}
+.tapas-head {
+  padding: 18px 18px 14px;
+  background: linear-gradient(180deg, color-mix(in oklab, var(--color-amber-100) 90%, var(--bg-surface)), var(--bg-surface));
+  border-bottom: 1px solid var(--border-subtle);
+}
+[data-theme="dark"] .tapas-head {
+  background: linear-gradient(180deg, rgba(251,191,36,0.10), var(--bg-surface));
+}
+.tapas-head__row { display: flex; align-items: start; justify-content: space-between; gap: 12px; }
+.tapas-head__title {
+  font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  color: var(--fg-primary); letter-spacing: -0.01em;
+}
+.tapas-head__sub {
+  font-family: var(--font-body); font-size: 12.5px;
+  color: var(--fg-muted); margin-top: 2px; line-height: 1.4;
+}
+.tapas-tokens {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  margin-top: 14px; padding: 10px 12px;
+  background: var(--bg-base); border: 1px dashed var(--border-strong);
+  border-radius: 10px;
+}
+.tapa-token {
+  width: 32px; height: 32px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 17px; flex-shrink: 0;
+  background: var(--color-amber-100);
+  border: 1.5px solid var(--color-amber-300);
+  transition: transform 200ms var(--ease-bounce);
+}
+[data-theme="dark"] .tapa-token { background: rgba(251,191,36,0.15); border-color: var(--color-amber-300); }
+.tapa-token--used {
+  background: transparent;
+  border-style: dashed;
+  opacity: 0.45;
+  filter: grayscale(0.8);
+}
+.tapa-token--locked { background: transparent; border-style: dashed; border-color: var(--border-strong); opacity: 0.5; }
+.tapa-token--paid { box-shadow: inset 0 0 0 2px var(--color-amber-400); }
+.tapas-tokens__rule {
+  margin-left: auto;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: 10.5px;
+  color: var(--fg-muted); white-space: nowrap;
+}
+.tapas-tokens__rule .dot { width: 4px; height: 4px; border-radius: 50%; background: currentColor; }
+.tapas-variants {
+  display: flex; align-items: center; gap: 8px;
+  margin-top: 10px;
+  font-family: var(--font-body); font-size: 11.5px; color: var(--fg-muted);
+}
+.tapas-variants__pips { display: inline-flex; gap: 4px; }
+.tapas-variants__pips .pip {
+  width: 14px; height: 5px; border-radius: 9999px; background: var(--bg-chip);
+}
+.tapas-variants__pips .pip--on { background: var(--color-amber-300); }
+.tapas-variants__num { margin-left: auto; font-family: var(--font-mono); font-weight: 700; color: var(--fg-primary); }
+
+.tapas-list {
+  flex: 1; min-height: 0; overflow-y: auto;
+  padding: 12px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.tapas-list[data-disabled="true"] { opacity: 0.55; pointer-events: none; }
+.tapa-card {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px; border: 1.5px solid var(--border-subtle);
+  border-radius: 14px; background: var(--bg-surface);
+  cursor: pointer; text-align: left;
+  font: inherit; color: inherit;
+  transition: border-color var(--duration-fast), transform 120ms var(--ease-bounce);
+}
+.tapa-card:hover:not(:disabled) { border-color: var(--border-strong); transform: translateY(-1px); }
+.tapa-card:disabled { cursor: not-allowed; opacity: 0.5; }
+.tapa-card--selected {
+  border-color: var(--color-amber-400);
+  background: color-mix(in oklab, var(--color-amber-100) 60%, var(--bg-surface));
+  box-shadow: 0 0 0 3px rgba(251,191,36,0.18);
+}
+[data-theme="dark"] .tapa-card--selected {
+  background: rgba(251,191,36,0.10);
+  box-shadow: 0 0 0 3px rgba(251,191,36,0.20);
+}
+.tapa-card__photo {
+  width: 48px; height: 48px; border-radius: 10px;
+  background: var(--bg-chip); display: inline-flex; align-items: center; justify-content: center;
+  font-size: 26px; flex-shrink: 0;
+}
+.tapa-card__main { flex: 1; min-width: 0; }
+.tapa-card__name {
+  font-family: var(--font-body); font-weight: 700; font-size: 14px;
+  color: var(--fg-primary); margin-bottom: 4px;
+}
+.tapa-card__row { display: flex; align-items: center; gap: 8px; }
+.tapa-card__pill {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 3px 8px; border-radius: 9999px;
+  font-family: var(--font-display); font-weight: 800; font-size: 11px;
+  letter-spacing: 0.02em;
+}
+.tapa-card__pill--free {
+  background: var(--color-green-100); color: var(--color-green-700);
+}
+[data-theme="dark"] .tapa-card__pill--free { background: rgba(34,197,94,0.18); color: var(--color-green-400); }
+.tapa-card__pill--paid {
+  background: var(--color-amber-100); color: var(--color-amber-800);
+}
+[data-theme="dark"] .tapa-card__pill--paid { background: rgba(251,191,36,0.18); color: var(--color-amber-300); }
+.tapa-card__check {
+  font-family: var(--font-body); font-weight: 700; font-size: 11px;
+  color: var(--color-amber-800);
+}
+[data-theme="dark"] .tapa-card__check { color: var(--color-amber-300); }
+
+.tapa-extra {
+  margin: 0 12px;
+  border: 1px dashed var(--border-strong);
+  border-radius: 12px;
+  background: var(--bg-base);
+  overflow: hidden;
+}
+.tapa-extra__head {
+  width: 100%;
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 12px;
+  background: transparent;
+  border: none; cursor: pointer; text-align: left;
+  font: inherit; color: inherit;
+}
+.tapa-extra__head:hover { background: var(--bg-chip); }
+.tapa-extra__glyph {
+  width: 32px; height: 32px; border-radius: 8px;
+  background: color-mix(in oklab, var(--color-blue-400) 14%, var(--bg-base));
+  color: var(--color-blue-400);
+  display: inline-flex; align-items: center; justify-content: center; font-size: 16px;
+  flex-shrink: 0;
+}
+.tapa-extra__copy { display: flex; flex-direction: column; flex: 1; line-height: 1.25; }
+.tapa-extra__copy strong { font-family: var(--font-body); font-weight: 700; font-size: 13px; color: var(--fg-primary); }
+.tapa-extra__copy span { font-family: var(--font-body); font-size: 11.5px; color: var(--fg-muted); }
+.tapa-extra__chev {
+  font-family: var(--font-display); font-weight: 900; font-size: 18px; color: var(--fg-muted);
+  width: 22px; text-align: center;
+}
+.tapa-extra__body {
+  padding: 0 12px 12px;
+  display: flex; flex-direction: column; gap: 10px;
+  border-top: 1px dashed var(--border-strong);
+  padding-top: 12px;
+}
+.tapa-extra__body p {
+  font-family: var(--font-body); font-size: 12px; color: var(--fg-muted);
+  margin: 0; line-height: 1.45;
+}
+
+.tapas-foot {
+  padding: 12px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-base);
+  display: flex; gap: 8px;
+}
+.tapas-foot .btn-secondary, .tapas-foot .btn-primary { flex: 1; }
+
+/* ---- 3) Cobro partido — common ---- */
+.drawer--wide { max-height: 86%; height: auto; }
+.carta[data-bp="mobile"] .drawer--wide { max-height: 88%; }
+.drawer--bill.drawer--wide .drawer__body { padding-top: 8px; }
+
+.split-flow, .mixed-flow { display: flex; flex-direction: column; gap: 16px; }
+
+/* Avatar */
+.avatar {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; border-radius: 50%;
+  color: #fff; font-family: var(--font-display); font-weight: 900;
+  font-size: 11px;
+  border: 2px solid var(--bg-surface);
+  flex-shrink: 0;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.15);
+}
+.avatar--you {
+  outline: 2px solid var(--color-green-500); outline-offset: 1px;
+}
+.avatar--more {
+  background: var(--bg-chip); color: var(--fg-muted);
+  font-size: 9px; font-weight: 800;
+}
+.avatar--ghost { opacity: 0.7; }
+
+/* Stage: intro */
+.split-intro { display: flex; flex-direction: column; gap: 18px; padding-bottom: 8px; }
+.split-intro__head { text-align: center; }
+.split-intro__title {
+  font-family: var(--font-display); font-weight: 900; font-size: 20px;
+  color: var(--fg-primary); letter-spacing: -0.01em;
+}
+.split-intro__sub {
+  font-family: var(--font-body); font-size: 13px;
+  color: var(--fg-muted); margin-top: 4px; line-height: 1.45;
+}
+.split-intro__modes {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+}
+.carta[data-bp="mobile"] .split-intro__modes { grid-template-columns: 1fr; }
+.split-mode {
+  border: 1.5px solid var(--border-subtle);
+  border-radius: 16px; background: var(--bg-surface);
+  padding: 20px 16px; text-align: left;
+  cursor: pointer;
+  display: flex; flex-direction: column; gap: 8px;
+  font: inherit; color: inherit;
+  transition: border-color var(--duration-fast), transform 120ms var(--ease-bounce);
+  position: relative; overflow: hidden;
+}
+.split-mode:hover { transform: translateY(-2px); border-color: var(--border-strong); }
+.split-mode__art { height: 60px; position: relative; color: var(--fg-secondary); margin-bottom: 8px; }
+.split-mode--items .split-mode__art .rect {
+  position: absolute; width: 38px; height: 14px;
+  border-radius: 5px; background: var(--bg-chip);
+  border: 1px solid var(--border-strong);
+}
+.split-mode--items .split-mode__art .rect--a { top: 4px; left: 6px; }
+.split-mode--items .split-mode__art .rect--b { top: 22px; left: 14px; background: color-mix(in oklab, var(--color-blue-400) 35%, var(--bg-chip)); border-color: var(--color-blue-400); }
+.split-mode--items .split-mode__art .rect--c { top: 40px; left: 6px; background: color-mix(in oklab, var(--color-amber-400) 35%, var(--bg-chip)); border-color: var(--color-amber-400); }
+.split-mode--items .split-mode__art .tag {
+  position: absolute; right: 6px; top: 8px;
+  width: 22px; height: 22px; border-radius: 50%;
+  background: var(--color-blue-400); color: #fff;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-display); font-weight: 900; font-size: 10px;
+  border: 2px solid var(--bg-surface);
+}
+.split-mode--items .split-mode__art .tag--b { top: 30px; right: 16px; background: var(--color-amber-400); color: #5A2F00; }
+.split-mode--equit .split-mode__art { display: flex; justify-content: flex-start; align-items: center; color: var(--brand-primary); }
+[data-theme="dark"] .split-mode--equit .split-mode__art { color: var(--color-blue-400); }
+
+.split-mode__h {
+  font-family: var(--font-display); font-weight: 900; font-size: 16px;
+  color: var(--fg-primary); letter-spacing: -0.01em;
+}
+.split-mode__p {
+  font-family: var(--font-body); font-size: 12.5px;
+  color: var(--fg-muted); line-height: 1.45;
+}
+.split-mode--items:hover { border-color: var(--color-blue-400); }
+.split-mode--equit:hover { border-color: var(--brand-primary); }
+
+/* Stage: items */
+.split-items { display: flex; flex-direction: column; gap: 14px; }
+.split-items__head {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px;
+}
+.back {
+  font: inherit; background: transparent; border: none;
+  color: var(--fg-secondary); cursor: pointer;
+  font-family: var(--font-body); font-size: 12.5px; font-weight: 600;
+  padding: 4px 0;
+}
+.back:hover { color: var(--fg-primary); }
+.split-items__diners { display: flex; align-items: center; gap: 8px; }
+.split-items__diners .lab {
+  font-family: var(--font-body); font-size: 11px; font-weight: 600;
+  color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.08em;
+}
+.split-items__diners .val {
+  font-family: var(--font-display); font-weight: 900; font-size: 15px;
+  color: var(--fg-primary); font-variant-numeric: tabular-nums;
+}
+.split-items__diners .avatars { display: inline-flex; }
+.split-items__diners .avatars .avatar { margin-left: -6px; }
+.split-items__diners .avatars .avatar:first-child { margin-left: 0; }
+
+.split-items__status {
+  background: var(--bg-base); border: 1px solid var(--border-subtle);
+  border-radius: 12px; padding: 10px 12px;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.split-items__progress {
+  display: flex; align-items: center; gap: 10px;
+}
+.split-items__progress .bar {
+  flex: 1; height: 8px; border-radius: 9999px;
+  background: var(--bg-chip); overflow: hidden;
+}
+.split-items__progress .bar__fill {
+  height: 100%; border-radius: 9999px;
+  background: linear-gradient(90deg, var(--color-green-500), var(--color-green-600));
+  transition: width 320ms var(--ease-smooth);
+}
+.split-items__progress .ct {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
+  color: var(--fg-secondary); font-variant-numeric: tabular-nums; white-space: nowrap;
+}
+.split-items__legend {
+  font-family: var(--font-body); font-size: 11.5px; color: var(--fg-muted);
+  line-height: 1.4;
+}
+
+.split-items__list {
+  display: flex; flex-direction: column; gap: 8px;
+  max-height: 260px; overflow-y: auto; padding: 2px;
+}
+.split-line {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 12px;
+  background: var(--bg-surface); border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+}
+.split-line__photo {
+  width: 44px; height: 44px; border-radius: 10px;
+  background: var(--bg-chip);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 22px; flex-shrink: 0;
+}
+.split-line__main { flex: 1; min-width: 0; }
+.split-line__name {
+  font-family: var(--font-body); font-weight: 700; font-size: 14px;
+  color: var(--fg-primary); line-height: 1.2;
+}
+.split-line__price {
+  font-family: var(--font-display); font-weight: 800; font-size: 13px;
+  color: var(--price-gold); margin-top: 3px;
+  font-variant-numeric: tabular-nums;
+}
+.split-line__price span {
+  font-family: var(--font-body); font-weight: 500; color: var(--fg-muted);
+  font-size: 11px; margin-left: 2px;
+}
+.split-line__slots { display: inline-flex; gap: 6px; flex-shrink: 0; }
+.slot {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: var(--bg-base);
+  border: 2px dashed var(--border-strong);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-display); font-weight: 900; font-size: 12px;
+  color: var(--fg-muted); cursor: pointer;
+  transition: transform 160ms var(--ease-bounce), background-color var(--duration-fast), border-color var(--duration-fast);
+}
+.slot:hover:not(:disabled) { border-color: var(--brand-primary); color: var(--brand-primary); }
+.slot--you, .slot--other {
+  background: var(--c, var(--brand-primary));
+  border-style: solid;
+  border-color: rgba(0,0,0,0.10);
+  color: #fff;
+}
+[data-theme="dark"] .slot--you, [data-theme="dark"] .slot--other { border-color: rgba(255,255,255,0.10); }
+.slot--you { outline: 2px solid var(--color-green-500); outline-offset: 1px; }
+.slot--other { cursor: not-allowed; }
+.slot--just { animation: slotPop 480ms var(--ease-bounce); }
+@keyframes slotPop {
+  0%   { transform: scale(0.5); box-shadow: 0 0 0 0 rgba(34,197,94,0.6); }
+  60%  { transform: scale(1.18); box-shadow: 0 0 0 8px rgba(34,197,94,0); }
+  100% { transform: scale(1); }
+}
+
+.split-items__foot {
+  display: flex; flex-direction: column; gap: 10px;
+  padding: 12px;
+  background: var(--bg-base);
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+}
+.split-items__yourTotal {
+  display: flex; align-items: baseline; justify-content: space-between;
+}
+.split-items__yourTotal .lab {
+  font-family: var(--font-body); font-size: 12px; font-weight: 600;
+  color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.08em;
+}
+.split-items__yourTotal .val {
+  font-family: var(--font-display); font-weight: 900; font-size: 24px;
+  color: var(--fg-primary); font-variant-numeric: tabular-nums;
+}
+.split-items__hint {
+  font-family: var(--font-body); font-size: 12px; color: var(--color-green-700);
+  text-align: center;
+}
+[data-theme="dark"] .split-items__hint { color: var(--color-green-400); }
+
+/* Stage: equit */
+.split-equit { display: flex; flex-direction: column; gap: 14px; align-items: center; }
+.split-equit > * { width: 100%; }
+.split-equit__pie {
+  display: flex; justify-content: center; padding: 8px 0 4px;
+}
+.split-equit__pie .slice { transition: transform 180ms var(--ease-bounce); }
+.split-equit__pie .slice:hover { transform: scale(1.02); }
+.split-equit__pie .slice--mine path { filter: drop-shadow(0 4px 12px rgba(34,197,94,0.35)); }
+.split-equit__pie .slice--paid path { opacity: 1; }
+
+.split-equit__stepper {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 14px;
+  background: var(--bg-surface); border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+}
+.split-equit__stepper .lab {
+  font-family: var(--font-body); font-weight: 700; font-size: 13px; color: var(--fg-primary);
+  flex: 1;
+}
+.split-equit__stepper .step {
+  display: inline-flex; align-items: center; gap: 4px;
+  background: var(--bg-base); border: 1px solid var(--border-strong);
+  border-radius: 9999px; padding: 4px;
+}
+.split-equit__stepper .step button {
+  width: 32px; height: 32px; border-radius: 50%;
+  background: transparent; border: none; cursor: pointer;
+  font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  color: var(--fg-primary);
+}
+.split-equit__stepper .step button:hover:not(:disabled) { background: var(--bg-chip); }
+.split-equit__stepper .step button:disabled { opacity: 0.3; cursor: not-allowed; }
+.split-equit__stepper .step__num {
+  min-width: 24px; text-align: center;
+  font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  color: var(--fg-primary); font-variant-numeric: tabular-nums;
+}
+.split-equit__stepper .hint {
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-muted);
+}
+
+.split-equit__live {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 12px;
+  background: var(--bg-base); border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  font-family: var(--font-body); font-size: 12.5px; color: var(--fg-secondary);
+}
+.split-equit__live .dots { display: inline-flex; gap: 4px; margin-left: auto; }
+.split-equit__live .dots .dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: var(--bg-chip);
+  border: 1.5px solid var(--border-strong);
+}
+.split-equit__live .dots .dot--paid {
+  background: var(--color-green-500); border-color: var(--color-green-600);
+}
+.split-equit__live .dots .dot--mine {
+  box-shadow: 0 0 0 2px var(--color-green-500);
+}
+
+/* Stage: pay (per-person) */
+.split-pay { display: flex; flex-direction: column; gap: 14px; }
+.split-pay__amt {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 14px;
+  background: linear-gradient(135deg, var(--color-green-100), var(--bg-surface));
+  border: 1px solid var(--color-green-200);
+  border-radius: 14px;
+}
+[data-theme="dark"] .split-pay__amt {
+  background: linear-gradient(135deg, rgba(34,197,94,0.15), var(--bg-surface));
+  border-color: rgba(34,197,94,0.30);
+}
+.split-pay__amt .lab {
+  font-family: var(--font-body); font-size: 12px; font-weight: 600;
+  color: var(--color-green-800); text-transform: uppercase; letter-spacing: 0.08em;
+}
+[data-theme="dark"] .split-pay__amt .lab { color: var(--color-green-400); }
+.split-pay__amt .val {
+  font-family: var(--font-display); font-weight: 900; font-size: 28px;
+  color: var(--fg-primary); font-variant-numeric: tabular-nums;
+}
+
+/* Stage: done */
+.split-done {
+  display: flex; flex-direction: column; align-items: center; gap: 12px;
+  padding: 12px;
+}
+.split-done__ic {
+  width: 72px; height: 72px; border-radius: 50%;
+  background: var(--color-green-100);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 38px; color: var(--color-green-700);
+}
+[data-theme="dark"] .split-done__ic { background: rgba(34,197,94,0.18); color: var(--color-green-400); }
+.split-done__h1 {
+  font-family: var(--font-display); font-weight: 900; font-size: 20px;
+  color: var(--fg-primary); text-align: center; letter-spacing: -0.01em;
+}
+.split-done__p {
+  font-family: var(--font-body); font-size: 13px; color: var(--fg-muted);
+  text-align: center; line-height: 1.5;
+}
+.split-done__bar {
+  width: 100%; height: 10px; border-radius: 9999px;
+  background: var(--bg-chip); overflow: hidden;
+}
+.split-done__bar__fill {
+  height: 100%; border-radius: 9999px;
+  background: linear-gradient(90deg, var(--color-green-500), var(--color-green-600));
+  transition: width 520ms var(--ease-smooth);
+}
+.split-done__row {
+  display: flex; justify-content: space-between; align-items: baseline; width: 100%;
+  font-family: var(--font-body); font-size: 13px; color: var(--fg-secondary);
+}
+.split-done__row strong {
+  font-family: var(--font-display); font-weight: 900; font-size: 16px;
+  color: var(--fg-primary); font-variant-numeric: tabular-nums;
+}
+
+/* ---- 4) Cobro mixto ---- */
+.bill__methods--grid4 {
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+.carta[data-bp="desktop"] .bill__methods--grid4,
+.carta[data-bp="tablet"] .bill__methods--grid4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+.bill__method--mixed {
+  background: color-mix(in oklab, var(--color-amber-400) 5%, var(--bg-surface));
+  border-color: color-mix(in oklab, var(--color-amber-400) 24%, var(--border-subtle));
+}
+.bill__method--mixed:hover { border-color: var(--color-amber-400); }
+.bill__method--mixed .ic { background: var(--color-amber-100); color: var(--color-amber-800); }
+[data-theme="dark"] .bill__method--mixed { background: color-mix(in oklab, var(--color-amber-400) 9%, var(--bg-surface)); border-color: color-mix(in oklab, var(--color-amber-400) 30%, var(--border-subtle)); }
+[data-theme="dark"] .bill__method--mixed .ic { background: rgba(251,191,36,0.18); color: var(--color-amber-300); }
+
+.bill__method--split {
+  background: color-mix(in oklab, var(--color-blue-400) 5%, var(--bg-surface));
+  border-color: color-mix(in oklab, var(--color-blue-400) 24%, var(--border-subtle));
+}
+.bill__method--split:hover { border-color: var(--color-blue-400); }
+.bill__method--split .ic { background: rgba(46,80,176,0.10); color: var(--color-blue-400); }
+[data-theme="dark"] .bill__method--split { background: color-mix(in oklab, var(--color-blue-400) 12%, var(--bg-surface)); border-color: color-mix(in oklab, var(--color-blue-400) 35%, var(--border-subtle)); }
+[data-theme="dark"] .bill__method--split .ic { background: rgba(46,80,176,0.25); color: var(--color-blue-300); }
+
+.mixed-stage { display: flex; flex-direction: column; gap: 14px; }
+.mixed-stage__head { text-align: center; }
+.mixed-stage__title {
+  font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  color: var(--fg-primary); letter-spacing: -0.01em;
+}
+.mixed-stage__sub {
+  font-family: var(--font-body); font-size: 12.5px;
+  color: var(--fg-muted); margin-top: 4px; line-height: 1.5;
+  display: flex; gap: 8px; justify-content: center; flex-wrap: wrap;
+}
+.mixed-stage__sub strong { color: var(--fg-primary); font-weight: 700; }
+
+.mixed-tile {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px; border-radius: 9999px;
+  font-family: var(--font-body); font-weight: 700; font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+}
+.mixed-tile--cash { background: var(--color-green-100); color: var(--color-green-700); }
+.mixed-tile--card { background: rgba(34,211,238,0.16); color: #0E7490; }
+[data-theme="dark"] .mixed-tile--cash { background: rgba(34,197,94,0.18); color: var(--color-green-400); }
+[data-theme="dark"] .mixed-tile--card { background: rgba(34,211,238,0.22); color: var(--color-cyan-400); }
+
+/* Fader bar — visual split between cash and card */
+.fader { position: relative; padding: 8px 0; }
+.fader__bar {
+  display: flex; height: 84px; border-radius: 16px;
+  overflow: hidden; box-shadow: 0 4px 14px rgba(17,24,39,0.08);
+  border: 1px solid var(--border-subtle);
+}
+.fader__cash, .fader__card {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 2px;
+  transition: width 220ms var(--ease-smooth);
+  min-width: 0;
+}
+.fader__cash {
+  background: linear-gradient(135deg, var(--color-green-500), var(--color-green-700));
+  color: #fff;
+}
+.fader__card {
+  background: linear-gradient(135deg, #22D3EE, #0891B2);
+  color: #042F3C;
+}
+.fader__lab {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.10em; opacity: 0.85;
+  text-overflow: ellipsis; overflow: hidden; white-space: nowrap;
+}
+.fader__amt {
+  font-family: var(--font-display); font-weight: 900; font-size: 22px;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis; overflow: hidden; white-space: nowrap;
+}
+.fader__cash:empty, .fader__card:empty { display: none; }
+.fader__range {
+  width: 100%; appearance: none; background: transparent;
+  height: 28px; margin-top: -6px; position: relative; z-index: 2;
+  cursor: ew-resize;
+}
+.fader__range::-webkit-slider-runnable-track { height: 4px; background: transparent; }
+.fader__range::-webkit-slider-thumb {
+  appearance: none;
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--bg-base);
+  border: 3px solid var(--fg-primary);
+  cursor: grab;
+  margin-top: -12px;
+  box-shadow: 0 4px 12px rgba(17,24,39,0.30);
+}
+.fader__range::-moz-range-thumb {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: var(--bg-base);
+  border: 3px solid var(--fg-primary);
+  cursor: grab;
+  box-shadow: 0 4px 12px rgba(17,24,39,0.30);
+}
+
+.mixed-chips { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; }
+.mixed-chip {
+  padding: 8px 14px; border-radius: 9999px;
+  border: 1.5px solid var(--border-subtle);
+  background: var(--bg-surface);
+  font: inherit;
+  font-family: var(--font-body); font-weight: 600; font-size: 12.5px;
+  color: var(--fg-secondary); cursor: pointer;
+  font-variant-numeric: tabular-nums;
+  transition: border-color var(--duration-fast), background-color var(--duration-fast);
+}
+.mixed-chip:hover { border-color: var(--border-strong); color: var(--fg-primary); }
+.mixed-chip--active {
+  background: var(--fg-primary); color: var(--bg-base);
+  border-color: var(--fg-primary);
+}
+[data-theme="dark"] .mixed-chip--active { background: var(--color-blue-400); border-color: var(--color-blue-400); color: #fff; }
+
+.mixed-precise {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto auto;
+  align-items: center;
+  column-gap: 10px;
+  padding: 10px 14px;
+  background: var(--bg-chip);
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+}
+.mixed-precise .lab {
+  font-family: var(--font-body); font-size: 10.5px; font-weight: 700;
+  color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.10em;
+  white-space: nowrap;
+}
+/* The 1fr spacer between label and stepper */
+.mixed-precise .lab + .mixed-precise__b { grid-column: 3; }
+.mixed-precise__b {
+  height: 32px; min-width: 56px;
+  padding: 0 10px;
+  border-radius: 9px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  cursor: pointer;
+  font-family: var(--font-mono); font-weight: 700; font-size: 12px;
+  color: var(--fg-secondary);
+  font-variant-numeric: tabular-nums;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: background-color 150ms var(--ease-out, ease),
+              border-color 150ms var(--ease-out, ease),
+              color 150ms var(--ease-out, ease);
+}
+.mixed-precise__b:hover {
+  background: var(--bg-base);
+  border-color: color-mix(in oklab, var(--fg-primary) 16%, var(--border-subtle));
+  color: var(--fg-primary);
+}
+.mixed-precise__b:active { transform: translateY(0.5px); }
+.mixed-precise__num {
+  min-width: 84px; text-align: center;
+  font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  color: var(--fg-primary);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+
+/* Mobile: keep the row but allow stepper to wrap if very tight */
+.carta[data-bp="mobile"] .mixed-precise { column-gap: 8px; padding: 10px 12px; }
+.carta[data-bp="mobile"] .mixed-precise__b { min-width: 52px; font-size: 11.5px; padding: 0 8px; }
+.carta[data-bp="mobile"] .mixed-precise__num { min-width: 72px; font-size: 17px; }
+@media (max-width: 360px) {
+  .mixed-precise { grid-template-columns: 1fr; row-gap: 8px; justify-items: stretch; }
+  .mixed-precise .lab { text-align: center; }
+  .mixed-precise > :not(.lab) { justify-self: center; }
+  .mixed-precise__b, .mixed-precise__num { grid-column: auto !important; }
+  .mixed-precise { grid-auto-flow: column; grid-template-columns: auto auto auto; }
+  .mixed-precise .lab { grid-column: 1 / -1; }
+}
+
+.mixed-warn {
+  display: flex; align-items: start; gap: 10px;
+  padding: 12px 14px;
+  background: rgba(251,191,36,0.08);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(251,191,36,0.3);
+  border-radius: 12px;
+  color: var(--color-amber-800);
+}
+[data-theme="dark"] .mixed-warn {
+  background: rgba(251,191,36,0.10); border-color: rgba(251,191,36,0.40);
+  color: var(--color-amber-300);
+}
+.mixed-warn__ic {
+  flex-shrink: 0;
+  width: 22px; height: 22px; border-radius: 50%;
+  background: var(--color-amber-300); color: #5A2F00;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-display); font-weight: 900; font-size: 13px;
+}
+.mixed-warn strong {
+  display: block;
+  font-family: var(--font-body); font-weight: 700; font-size: 12.5px; line-height: 1.35;
+}
+.mixed-warn span {
+  display: block;
+  font-family: var(--font-body); font-size: 11.5px;
+  color: color-mix(in oklab, var(--color-amber-800) 80%, var(--fg-secondary));
+  margin-top: 2px;
+}
+[data-theme="dark"] .mixed-warn span { color: color-mix(in oklab, var(--color-amber-300) 80%, var(--fg-secondary)); }
+
+.mixed-note {
+  padding: 12px 14px;
+  background: rgba(34,197,94,0.08);
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(34,197,94,0.3);
+  border-radius: 12px;
+  font-family: var(--font-body); font-size: 12.5px;
+  color: var(--color-green-800);
+}
+[data-theme="dark"] .mixed-note {
+  background: rgba(34,197,94,0.12); border-color: rgba(34,197,94,0.30);
+  color: var(--color-green-400);
+}
+
+.mixed-stage--waiting { align-items: center; }
+.mixed-waiting {
+  display: flex; flex-direction: column; align-items: center; gap: 10px;
+  width: 100%;
+}
+.mixed-waiting__ic {
+  position: relative;
+  width: 80px; height: 80px; border-radius: 50%;
+  background: var(--color-amber-100); color: var(--color-amber-800);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 36px;
+}
+[data-theme="dark"] .mixed-waiting__ic { background: rgba(251,191,36,0.18); color: var(--color-amber-300); }
+.mixed-waiting__pulse {
+  position: absolute; inset: -6px; border-radius: 50%;
+  border: 2px solid var(--color-amber-300);
+  animation: waiterPulse 1.6s ease-in-out infinite;
+  opacity: 0.65;
+}
+@keyframes waiterPulse {
+  0%   { transform: scale(0.95); opacity: 0.7; }
+  60%  { transform: scale(1.15); opacity: 0; }
+  100% { transform: scale(0.95); opacity: 0; }
+}
+
+.mixed-receipt {
+  width: 100%;
+  background: var(--bg-base);
+  border: 1px dashed var(--border-strong);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.mixed-receipt__row {
+  display: flex; justify-content: space-between; align-items: baseline;
+  font-family: var(--font-body); font-size: 13px; color: var(--fg-secondary);
+}
+.mixed-receipt__row .b {
+  font-family: var(--font-display); font-weight: 800;
+  color: var(--fg-primary); font-variant-numeric: tabular-nums;
+}
+.mixed-receipt__row + .mixed-receipt__row { border-top: 1px dashed var(--border-subtle); padding-top: 6px; }
+.mixed-receipt__row--ok { color: var(--color-green-700); }
+[data-theme="dark"] .mixed-receipt__row--ok { color: var(--color-green-400); }
+.mixed-receipt__row--ok .b { color: var(--color-green-700); }
+[data-theme="dark"] .mixed-receipt__row--ok .b { color: var(--color-green-400); }
+.mixed-receipt__row--pending { color: var(--color-amber-800); }
+[data-theme="dark"] .mixed-receipt__row--pending { color: var(--color-amber-300); }
+.mixed-receipt__row--pending .b { color: var(--color-amber-800); }
+[data-theme="dark"] .mixed-receipt__row--pending .b { color: var(--color-amber-300); }
+
+/* Drawer wide override for desktop */
+.carta[data-bp="desktop"] .drawer--wide,
+.carta[data-bp="tablet"] .drawer--wide {
+  height: auto;
+  max-height: 86%;
+}
+.carta[data-bp="mobile"] .drawer--wide {
+  max-height: 92%;
+}
+
+/* Make tip-row breathing room consistent on mobile when grid4 */
+.carta[data-bp="mobile"] .bill__methods--grid4 .bill__method {
+  padding: 16px 10px;
+}
+.bill__methods--grid4 .bill__method .nm { font-size: 14px; }
+.bill__methods--grid4 .bill__method .ds { font-size: 10.5px; }
+.bill__methods--grid4 .bill__method .ic { width: 40px; height: 40px; }
+
+
+
+/* ============================================================
+   New-flows polish: heading layout, button no-wrap, list inset
+   ============================================================ */
+
+.drawer__heading { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1; }
+.drawer__heading .drawer__title { font-size: 18px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.drawer__subtitle {
+  font-family: var(--font-body); font-size: 12px;
+  color: var(--fg-muted); line-height: 1.35;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.drawer__head .drawer__total { flex-shrink: 0; margin-left: 12px; }
+
+/* Split items: keep slot avatars inside their row */
+.split-items__list { padding-right: 4px; padding-left: 4px; }
+.split-line { box-sizing: border-box; }
+.split-line__slots { padding-right: 2px; }
+
+/* Pay-button never wraps the price */
+.split-items__foot .btn-primary,
+.split-pay .btn-primary,
+.mixed-stage .btn-primary { white-space: nowrap; }
+
+/* Tighten the new bill drawer body so it doesn't feel cramped on mobile */
+.drawer--bill.drawer--wide .drawer__body { padding-left: 16px; padding-right: 16px; }
+.carta[data-bp="mobile"] .drawer--bill.drawer--wide .drawer__body { padding-left: 12px; padding-right: 12px; }
+
+/* Slot text should be readable — bump weight */
+.slot { font-size: 13px; line-height: 1; }
+
+/* Make the pie SVG never stretch — keep centered with explicit size */
+.split-equit__pie svg { display: block; }
+
+/* The mixed-stage waiting receipt prevents content from being too wide */
+.mixed-receipt { max-width: 100%; }
+
+
+/* ============================================================
+   FABs: drop down when there is no cart-bar, push up when there is.
+   Smooth transition tied to cart-bar presence.
+   ============================================================ */
+.fab--chat, .fab--bill, .fab-cluster {
+  transition: bottom 260ms var(--ease-smooth);
+}
+.carta:not(:has(.cart-bar)) .fab--chat,
+.carta:not(:has(.cart-bar)) .fab--bill,
+.carta:not(:has(.cart-bar)) .fab-cluster {
+  bottom: 16px;
+}
+
+
+/* ============================================================
+   FAB "Mi pedido" — versión vibrante con icono + badge
+   - Color: índigo/cobalt sólido (separa visualmente de la cuenta roja
+     y de la barra del carrito verde — pedidos en curso).
+   - Icono dedicado (ticket de cocina) en círculo blanco.
+   - Badge rojo con contador como notificación clásica.
+   ============================================================ */
+.fab--orders {
+  /* Sólido, llamativo, claramente distinto del verde del carrito y
+     del rojo de la cuenta. Cobalt/índigo profundo de la paleta. */
+  background: linear-gradient(135deg, #3B5BDB, #1E3A8A);
+  color: #FFFFFF;
+  border: 1px solid rgba(255,255,255,0.18);
+  padding: 0 16px 0 6px;
+  box-shadow: 0 10px 24px rgba(30,58,138,0.45), 0 0 0 0 rgba(59,91,219,0.55);
+  position: static;
+}
+.fab--orders:hover {
+  background: linear-gradient(135deg, #4C6BE5, #2945A0);
+  filter: brightness(1.05);
+}
+[data-theme="dark"] .fab--orders {
+  background: linear-gradient(135deg, #4C6BE5, #2945A0);
+  border-color: rgba(255,255,255,0.22);
+  box-shadow: 0 10px 24px rgba(0,0,0,0.55), inset 0 1px 0 rgba(255,255,255,0.12);
+}
+[data-theme="dark"] .fab--orders:hover {
+  background: linear-gradient(135deg, #5B79EC, #3B5BDB);
+  border-color: rgba(255,255,255,0.32);
+}
+
+/* Slot del icono — círculo blanco que contrasta sobre el azul */
+.fab--orders__ic {
+  position: relative;
+  flex-shrink: 0;
+  width: 34px; height: 34px;
+  border-radius: 9999px;
+  background: #FFFFFF;
+  color: #1E3A8A;
+  display: inline-flex; align-items: center; justify-content: center;
+  box-shadow: inset 0 0 0 1px rgba(30,58,138,0.18);
+}
+[data-theme="dark"] .fab--orders__ic { color: #0B1C46; background: #F4F6FF; }
+
+/* Badge de notificación — rojo, esquina superior derecha del icono */
+.fab--orders__badge {
+  position: absolute;
+  top: -4px; right: -6px;
+  min-width: 18px; height: 18px;
+  padding: 0 5px;
+  border-radius: 9999px;
+  background: linear-gradient(180deg, #F87171, #DC2626);
+  color: #FFFFFF;
+  border: 2px solid #FFFFFF;
+  box-shadow: 0 2px 6px rgba(220,38,38,0.45);
+  font-family: var(--font-display); font-weight: 900; font-size: 11px;
+  font-variant-numeric: tabular-nums; line-height: 1;
+  display: inline-flex; align-items: center; justify-content: center;
+  animation: order-badge-pulse 2.4s ease-in-out infinite;
+}
+[data-theme="dark"] .fab--orders__badge {
+  border-color: #1E3A8A;
+}
+@keyframes order-badge-pulse {
+  0%, 100% { box-shadow: 0 2px 6px rgba(220,38,38,0.45), 0 0 0 0 rgba(220,38,38,0.55); }
+  50%      { box-shadow: 0 2px 6px rgba(220,38,38,0.45), 0 0 0 6px rgba(220,38,38,0); }
+}
+
+.fab--orders__label {
+  font-family: var(--font-body); font-weight: 700; font-size: 13.5px;
+  letter-spacing: 0.01em; color: #FFFFFF;
+}
+
+
+/* ============================================================
+   Stepper de detalle de producto — color semántico
+   Verde para sumar (+), rojo para restar (-) en ambos temas.
+   ============================================================ */
+.pdetail__qtybtn--minus {
+  background: linear-gradient(180deg, #FCA5A5, #F87171);
+  color: #FFFFFF;
+  box-shadow: 0 2px 6px rgba(239, 68, 68, 0.35);
+}
+.pdetail__qtybtn--minus:hover { background: linear-gradient(180deg, #FB7185, #DC2626); }
+
+.pdetail__qtybtn--plus {
+  background: linear-gradient(180deg, #86EFAC, #22C55E);
+  color: #FFFFFF;
+  box-shadow: 0 2px 6px rgba(34, 197, 94, 0.40);
+}
+.pdetail__qtybtn--plus:hover { background: linear-gradient(180deg, #4ADE80, #16A34A); }
+
+[data-theme="dark"] .pdetail__qtybtn--minus {
+  background: linear-gradient(180deg, #EF4444, #B91C1C);
+  box-shadow: 0 2px 6px rgba(239, 68, 68, 0.50);
+}
+[data-theme="dark"] .pdetail__qtybtn--minus:hover { background: linear-gradient(180deg, #F87171, #DC2626); }
+
+[data-theme="dark"] .pdetail__qtybtn--plus {
+  background: linear-gradient(180deg, #22C55E, #15803D);
+  box-shadow: 0 2px 6px rgba(34, 197, 94, 0.55);
+}
+[data-theme="dark"] .pdetail__qtybtn--plus:hover { background: linear-gradient(180deg, #4ADE80, #16A34A); }
+
+/* Disabled state when minus would go below 1 */
+.pdetail__qtybtn:disabled {
+  filter: grayscale(0.6); opacity: 0.55; cursor: not-allowed;
+}
+
+
+/* ============================================================
+   Tu pedido — drawer rediseñado (cart-head, cart-drawer__body,
+   cart-sum, cart-empty, cart-foot)
+   Aesthetic: comanda artesanal — papel cálido, dorado para el
+   importe, tarjetas con foto del plato, mini-recibo.
+   ============================================================ */
+
+.drawer--cart {
+  /* Permite que el drawer crezca lo necesario sin romper el alto;
+     mantiene la animación bottom-sheet existente. */
+  max-height: 88%;
+}
+.carta[data-bp="mobile"] .drawer--cart { max-height: 92%; }
+.carta[data-bp="tablet"] .drawer--cart,
+.carta[data-bp="desktop"] .drawer--cart { max-height: 84%; }
+
+/* ── Header con kicker + título grande + chips ───────────── */
+.cart-head {
+  padding: 14px 18px 12px;
+  background:
+    radial-gradient(120% 100% at 0% 0%, color-mix(in oklab, var(--color-amber-100) 35%, var(--bg-surface)) 0%, var(--bg-surface) 60%);
+  border-bottom: 1px solid var(--border-subtle);
+  position: relative;
+}
+[data-theme="dark"] .cart-head {
+  background:
+    radial-gradient(120% 100% at 0% 0%, rgba(251,191,36,0.10) 0%, var(--bg-surface) 60%);
+}
+.cart-head--col { padding: 18px 16px 12px; border-bottom: 1px solid var(--border-subtle); }
+
+.cart-head__row {
+  display: flex; align-items: start; justify-content: space-between; gap: 12px;
+}
+.cart-head__heading { display: flex; flex-direction: column; gap: 4px; min-width: 0; flex: 1; }
+.cart-head__kicker {
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 700;
+  letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--price-gold); opacity: 0.85;
+}
+[data-theme="dark"] .cart-head__kicker { color: var(--color-amber-300); }
+.cart-head__title {
+  margin: 0;
+  font-family: var(--font-display); font-weight: 900; font-size: 28px;
+  line-height: 1; letter-spacing: -0.02em;
+  color: var(--fg-primary);
+  white-space: nowrap;
+}
+.carta[data-bp="mobile"] .cart-head__title { font-size: 26px; }
+
+.cart-head__close { flex-shrink: 0; }
+
+.cart-head__chips {
+  display: flex; align-items: center; flex-wrap: wrap; gap: 6px;
+  margin-top: 10px;
+}
+.cart-head__chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px;
+  background: var(--bg-base);
+  border: 1px solid var(--border-subtle);
+  border-radius: 9999px;
+  font-family: var(--font-body); font-size: 11.5px; font-weight: 600;
+  color: var(--fg-secondary);
+  line-height: 1.2;
+}
+.cart-head__chip--mesa {
+  color: var(--color-green-700);
+  border-color: color-mix(in oklab, var(--color-green-500) 32%, var(--border-subtle));
+  background: color-mix(in oklab, var(--color-green-100) 60%, var(--bg-surface));
+}
+[data-theme="dark"] .cart-head__chip--mesa {
+  color: var(--color-green-400);
+  background: rgba(34,197,94,0.12);
+  border-color: rgba(34,197,94,0.30);
+}
+.cart-head__chipDot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--color-green-500);
+  box-shadow: 0 0 0 2px rgba(34,197,94,0.20);
+  animation: chipDot-pulse 2.4s ease-in-out infinite;
+}
+@keyframes chipDot-pulse {
+  0%, 100% { box-shadow: 0 0 0 2px rgba(34,197,94,0.15); }
+  50%      { box-shadow: 0 0 0 5px rgba(34,197,94,0); }
+}
+
+/* ── Body / scroll area ──────────────────────────────────── */
+.cart-drawer__body {
+  flex: 1; min-height: 0; overflow-y: auto;
+  padding: 12px 14px 14px;
+  display: flex; flex-direction: column; gap: 12px;
+}
+.cart-drawer__list, .cart-drawer__list--col {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.cart-drawer__list--col { padding: 12px 14px; flex: 1; overflow-y: auto; }
+
+/* ── CartItem v2 (con foto, stepper rojo/verde, custom tags) ── */
+.citem {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  padding: 10px;
+  transition: border-color var(--duration-fast), transform var(--duration-fast);
+}
+.citem:hover { border-color: var(--border-strong); }
+
+.citem__top {
+  display: flex; align-items: stretch; gap: 12px;
+}
+.citem__photo {
+  width: 52px; height: 52px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, color-mix(in oklab, var(--color-amber-100) 45%, var(--bg-base)), var(--bg-chip));
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 28px;
+  flex-shrink: 0;
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,0.04);
+}
+[data-theme="dark"] .citem__photo {
+  background: linear-gradient(135deg, rgba(251,191,36,0.12), var(--bg-chip));
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.04);
+}
+
+.citem__main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; align-self: center; }
+.citem__name {
+  font-family: var(--font-display); font-weight: 800; font-size: 15px;
+  color: var(--fg-primary); line-height: 1.2;
+  letter-spacing: -0.005em;
+  overflow: hidden; text-overflow: ellipsis;
+  display: -webkit-box; -webkit-box-orient: vertical; -webkit-line-clamp: 1; line-clamp: 1;
+}
+.citem__unit {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-family: var(--font-body); font-size: 11.5px; font-weight: 500;
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+.citem__unitPrice { color: var(--fg-secondary); font-weight: 600; }
+.citem__unitDot { opacity: 0.6; }
+
+.citem__customTags {
+  display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px;
+}
+.citem__customTag {
+  display: inline-flex; align-items: center;
+  padding: 2px 7px; border-radius: 9999px;
+  background: rgba(245, 158, 11, 0.14);
+  color: var(--color-amber-800);
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.04em; text-transform: uppercase;
+}
+[data-theme="dark"] .citem__customTag {
+  background: rgba(251,191,36,0.18); color: var(--color-amber-300);
+}
+
+.citem__side {
+  display: flex; flex-direction: column; align-items: flex-end; gap: 6px;
+  flex-shrink: 0;
+  justify-content: space-between;
+  min-width: 78px;
+}
+.citem__price {
+  font-family: var(--font-display); font-weight: 900; font-size: 16px;
+  color: var(--price-gold); font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+}
+
+/* QtyControl pill — stepper rojo/verde compacto */
+.citem .qty {
+  display: inline-flex; align-items: center; gap: 0;
+  background: var(--bg-base);
+  border-radius: 9999px;
+  padding: 3px;
+  border: 1px solid var(--border-subtle);
+}
+.citem .qty button {
+  width: 26px; height: 26px; border-radius: 9999px;
+  border: none; cursor: pointer;
+  font-family: var(--font-display); font-weight: 900; font-size: 14px;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: transform 140ms var(--ease-bounce), filter var(--duration-fast);
+  color: #FFFFFF;
+}
+.citem .qty button:active { transform: scale(0.9); }
+.citem .qty button:first-child {
+  background: linear-gradient(180deg, #FCA5A5, #F87171);
+  box-shadow: 0 1px 3px rgba(239,68,68,0.35);
+}
+.citem .qty button:first-child:hover { background: linear-gradient(180deg, #FB7185, #DC2626); }
+.citem .qty button:last-child {
+  background: linear-gradient(180deg, #86EFAC, #22C55E);
+  box-shadow: 0 1px 3px rgba(34,197,94,0.40);
+}
+.citem .qty button:last-child:hover { background: linear-gradient(180deg, #4ADE80, #16A34A); }
+[data-theme="dark"] .citem .qty button:first-child { background: linear-gradient(180deg, #EF4444, #B91C1C); }
+[data-theme="dark"] .citem .qty button:last-child { background: linear-gradient(180deg, #22C55E, #15803D); }
+.citem .qty span {
+  min-width: 26px; padding: 0 4px; text-align: center;
+  font-family: var(--font-display); font-weight: 900; font-size: 14px;
+  color: var(--fg-primary); font-variant-numeric: tabular-nums;
+}
+
+.citem__quitar {
+  margin-top: 10px; padding-top: 10px;
+  border-top: 1px dashed var(--border-subtle);
+  display: flex; flex-direction: column; gap: 6px;
+}
+.citem__quitarLabel {
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-muted);
+}
+.citem__chips { display: flex; flex-wrap: wrap; gap: 6px; }
+
+/* ── Mini-recibo (CartSummary) ───────────────────────────── */
+.cart-sum {
+  background: var(--bg-base);
+  border: 1px dashed var(--border-strong);
+  border-radius: 14px;
+  padding: 12px 14px;
+  position: relative;
+}
+.cart-sum::before, .cart-sum::after {
+  /* Dos muescas estilo ticket en los laterales superiores */
+  content: ""; position: absolute; top: -7px;
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--bg-surface);
+  border: 1px dashed var(--border-strong);
+}
+.cart-sum::before { left: 14px; }
+.cart-sum::after  { right: 14px; }
+.carta[data-bp="desktop"] .cart-sum,
+.carta[data-bp="tablet"]  .cart-sum {
+  margin-top: 4px;
+}
+
+.cart-sum__head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  margin-bottom: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px dashed var(--border-subtle);
+}
+.cart-sum__lab {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-muted);
+}
+.cart-sum__ct {
+  font-family: var(--font-body); font-size: 12px; font-weight: 600;
+  color: var(--fg-secondary); font-variant-numeric: tabular-nums;
+}
+.cart-sum__rows { display: flex; flex-direction: column; gap: 6px; }
+.cart-sum__row {
+  display: flex; align-items: baseline; justify-content: space-between;
+  font-family: var(--font-body); font-size: 12.5px;
+  color: var(--fg-secondary);
+}
+.cart-sum__row .num {
+  font-family: var(--font-display); font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.cart-sum__row--muted { color: var(--fg-muted); font-size: 11.5px; }
+.cart-sum__row--time {
+  color: var(--color-green-700);
+  padding-top: 6px;
+  border-top: 1px dashed var(--border-subtle);
+  margin-top: 2px;
+}
+[data-theme="dark"] .cart-sum__row--time { color: var(--color-green-400); }
+.cart-sum__row--time .num { color: inherit; }
+
+/* ── Empty state ─────────────────────────────────────────── */
+.cart-empty {
+  padding: 36px 24px 28px;
+  text-align: center;
+  display: flex; flex-direction: column; align-items: center; gap: 10px;
+  flex: 1; justify-content: center;
+}
+.cart-empty__art {
+  position: relative; width: 96px; height: 96px;
+  margin-bottom: 6px;
+}
+.cart-empty__plate {
+  position: absolute; inset: 8px;
+  border-radius: 50%;
+  background: var(--bg-surface);
+  border: 2px dashed var(--border-strong);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.04);
+  animation: cartEmpty-spin 24s linear infinite;
+}
+@keyframes cartEmpty-spin {
+  to { transform: rotate(360deg); }
+}
+.cart-empty__fork, .cart-empty__knife {
+  position: absolute; top: 50%; width: 2px; height: 70px;
+  background: var(--fg-muted); opacity: 0.45;
+  transform-origin: 50% 50%; transform: translateY(-50%);
+}
+.cart-empty__fork  { left: 8px; transform: translateY(-50%) rotate(-22deg); }
+.cart-empty__knife { right: 8px; transform: translateY(-50%) rotate(22deg); }
+.cart-empty__emoji {
+  position: absolute; inset: 0;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 44px;
+  filter: grayscale(0.15);
+  animation: cartEmpty-bob 3.4s ease-in-out infinite;
+}
+@keyframes cartEmpty-bob {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-4px); }
+}
+.cart-empty__h {
+  font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  color: var(--fg-primary); letter-spacing: -0.01em;
+}
+.cart-empty__p {
+  font-family: var(--font-body); font-size: 13px; color: var(--fg-muted);
+  line-height: 1.45;
+}
+
+/* ── Footer total + CTA ──────────────────────────────────── */
+.cart-foot {
+  border-top: 1px solid var(--border-subtle);
+  padding: 12px 16px 14px;
+  background:
+    linear-gradient(180deg, var(--bg-surface), var(--bg-base));
+  display: flex; flex-direction: column; gap: 10px;
+  position: relative;
+}
+.cart-foot::before {
+  /* Línea decorativa dorada para separar */
+  content: ""; position: absolute; left: 16px; right: 16px; top: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--price-gold), transparent);
+  opacity: 0.35;
+}
+.cart-foot__totalRow {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 4px 0 2px;
+}
+.cart-foot__totalLab {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.cart-foot__totalVal {
+  font-family: var(--font-display); font-weight: 900; font-size: 30px;
+  color: var(--price-gold); font-variant-numeric: tabular-nums;
+  letter-spacing: -0.015em;
+  line-height: 1;
+}
+.cart-foot__cta {
+  display: flex; align-items: center; justify-content: center; gap: 10px;
+  padding: 13px 16px 13px 12px;
+  border-radius: 14px; border: none;
+  background: linear-gradient(135deg, #22C55E 0%, #15803D 100%);
+  color: #FFFFFF;
+  font-family: var(--font-display); font-weight: 800; font-size: 15px;
+  letter-spacing: 0.005em;
+  cursor: pointer;
+  box-shadow:
+    0 8px 22px rgba(21, 128, 61, 0.32),
+    inset 0 1px 0 rgba(255,255,255,0.18);
+  transition: transform 140ms var(--ease-bounce), filter var(--duration-fast);
+  position: relative; overflow: hidden;
+}
+.cart-foot__cta:hover { filter: brightness(1.06); transform: translateY(-1px); }
+.cart-foot__cta:active { transform: translateY(0); }
+.cart-foot__cta:disabled { opacity: 0.6; cursor: wait; transform: none; }
+.cart-foot__ctaIc {
+  width: 30px; height: 30px; border-radius: 9999px;
+  background: rgba(255,255,255,0.18);
+  display: inline-flex; align-items: center; justify-content: center;
+  color: #FFFFFF;
+  flex-shrink: 0;
+}
+.cart-foot__ctaLab { flex: 0 0 auto; text-align: center; }
+.cart-foot__ctaArrow {
+  position: absolute; right: 16px; top: 50%; transform: translateY(-50%);
+  font-family: var(--font-display); font-weight: 900; font-size: 22px;
+  line-height: 1;
+  transition: transform 200ms var(--ease-smooth);
+}
+.cart-foot__cta:hover .cart-foot__ctaArrow { transform: translateY(-50%) translateX(3px); }
+
+/* (las reglas por breakpoint ya no son necesarias: el centrado es global) */
+
+.cart-foot__secondary {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 11px 14px;
+  border-radius: 12px;
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  color: var(--fg-secondary);
+  cursor: pointer;
+  font-family: var(--font-body); font-weight: 700; font-size: 13px;
+  transition: border-color var(--duration-fast), color var(--duration-fast), background-color var(--duration-fast);
+}
+.cart-foot__secondary:hover {
+  color: var(--fg-primary);
+  border-color: var(--color-red-400);
+  background: color-mix(in oklab, var(--color-red-400) 6%, transparent);
+}
+[data-theme="dark"] .cart-foot__secondary:hover {
+  background: color-mix(in oklab, var(--color-red-400) 12%, transparent);
+}
+
+
+/* Aviso "Cocina cerrada" en la cabecera de cada categoría afectada */
+.category__closed {
+  display: inline-flex; align-items: center; gap: 6px;
+  margin-left: 4px;
+  padding: 3px 10px 3px 8px;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, var(--color-amber-100), color-mix(in oklab, var(--color-amber-200) 60%, var(--color-amber-100)));
+  border: 1px solid color-mix(in oklab, var(--color-amber-400) 45%, var(--border-subtle));
+  color: var(--color-amber-800);
+  font-family: var(--font-body); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  vertical-align: middle;
+  box-shadow: 0 1px 3px rgba(245,158,11,0.18);
+}
+[data-theme="dark"] .category__closed {
+  background: linear-gradient(135deg, rgba(251,191,36,0.18), rgba(251,191,36,0.08));
+  border-color: rgba(251,191,36,0.40);
+  color: var(--color-amber-300);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.30);
+}
+.category__closedDot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--color-amber-400);
+  box-shadow: 0 0 0 3px rgba(245,158,11,0.20);
+  animation: cat-closed-pulse 1.8s ease-in-out infinite;
+  flex-shrink: 0;
+}
+[data-theme="dark"] .category__closedDot {
+  background: var(--color-amber-300);
+  box-shadow: 0 0 0 3px rgba(251,191,36,0.20);
+}
+@keyframes cat-closed-pulse {
+  0%, 100% { transform: scale(1);   opacity: 1; }
+  50%      { transform: scale(0.85); opacity: 0.65; }
+}
+
+
+/* ============================================================
+   chip-quitar — refuerzo de la diferencia visible entre estados
+   off (ingrediente incluido) y on (ingrediente quitado).
+   - Off: pill neutra, texto + signo "−" tenue.
+   - On:  ámbar saturado, texto blanco, signo "✕" y tachado.
+   Funciona igual en claro y oscuro.
+   ============================================================ */
+.chip-quitar {
+  display: inline-flex; align-items: center; gap: 5px;
+  position: relative;
+}
+/* Glifo de estado al inicio del chip */
+.chip-quitar::before {
+  content: "+";
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 14px; height: 14px; border-radius: 50%;
+  font-family: var(--font-display); font-weight: 900;
+  font-size: 10px; line-height: 1;
+  background: var(--bg-chip);
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+.chip-quitar--on::before {
+  content: "✕";
+  background: #FFFFFF;
+  color: var(--color-amber-800);
+}
+
+/* On (ingrediente quitado) — saturado y con tachado */
+.chip-quitar--on {
+  background: linear-gradient(180deg, var(--color-amber-300), var(--color-amber-400));
+  color: #2A1B05;
+  border-color: var(--color-amber-400);
+  font-weight: 800;
+  box-shadow: 0 2px 8px rgba(245,158,11,0.30);
+  text-decoration: line-through;
+  text-decoration-color: rgba(42,27,5,0.55);
+  text-decoration-thickness: 1.5px;
+}
+
+/* Dark mode — mismo patrón pero ajustado al night-blue de fondo */
+[data-theme="dark"] .chip-quitar {
+  background: rgba(255,255,255,0.04);
+  border-color: rgba(255,255,255,0.10);
+  color: var(--color-blue-200);
+}
+[data-theme="dark"] .chip-quitar:hover {
+  border-color: rgba(255,255,255,0.30);
+  color: #FFFFFF;
+}
+[data-theme="dark"] .chip-quitar::before {
+  background: rgba(255,255,255,0.08);
+  color: var(--color-blue-200);
+}
+[data-theme="dark"] .chip-quitar--on {
+  background: linear-gradient(180deg, var(--color-amber-300), #C8860F);
+  color: #1A0F04;
+  border-color: var(--color-amber-300);
+  box-shadow: 0 2px 10px rgba(251,191,36,0.45);
+  text-decoration-color: rgba(26,15,4,0.65);
+}
+[data-theme="dark"] .chip-quitar--on::before {
+  background: #1A0F04;
+  color: var(--color-amber-300);
+}
+
+
+/* Diferenciar visualmente extras añadidos vs ingredientes quitados
+   en la fila del carrito */
+.citem__customTag--removed {
+  background: rgba(245, 158, 11, 0.14);
+  color: var(--color-amber-800);
+}
+[data-theme="dark"] .citem__customTag--removed {
+  background: rgba(251,191,36,0.18); color: var(--color-amber-300);
+}
+.citem__customTag--extra {
+  background: color-mix(in oklab, var(--color-green-500) 14%, var(--bg-base));
+  color: var(--color-green-700);
+}
+[data-theme="dark"] .citem__customTag--extra {
+  background: rgba(34,197,94,0.18); color: var(--color-green-400);
+}
+
+
+/* Toda la cart-bar es ahora un <button>: hereda interacción completa */
+.cart-bar {
+  appearance: none;
+  border: 1px solid var(--cart-bar-border);
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  width: auto;
+  transition: transform 140ms var(--ease-bounce), filter var(--duration-fast), box-shadow var(--duration-fast);
+}
+.cart-bar:hover {
+  filter: brightness(1.04);
+  transform: translateY(-1px);
+}
+.cart-bar:active { transform: translateY(0) scale(0.99); transition-duration: 80ms; }
+.cart-bar:focus-visible {
+  outline: 2px solid var(--color-green-500);
+  outline-offset: 3px;
+}
+/* El pill antes era <button>, ahora es <span>; mantén su estilo */
+.cart-bar__cta {
+  display: inline-flex; align-items: center; justify-content: center;
+  background: var(--cta-view-order);
+  color: white;
+  padding: 8px 16px;
+  border-radius: 9999px;
+  font-weight: 600; font-size: 13px;
+  font-family: var(--font-body);
+  pointer-events: none; /* el click ya lo maneja el botón padre */
+}
+.cart-bar:hover .cart-bar__cta { filter: brightness(1.1); }
+
+
+/* Tapas indicator: no se rompe con muchas tapas
+   - Texto en una línea con elipsis
+   - Tokens máx. 8 con overflow "+N" */
+.tapas-indicator__copy {
+  flex-shrink: 1; min-width: 0;
+  white-space: nowrap; overflow: hidden;
+}
+.tapas-indicator__copy span {
+  overflow: hidden; text-overflow: ellipsis;
+  max-width: 200px;
+}
+.tapas-indicator__tokens { flex-shrink: 0; max-width: 100%; }
+.tapas-indicator__tokensMore {
+  margin-left: 4px;
+  padding: 2px 6px;
+  border-radius: 9999px;
+  background: rgba(245,158,11,0.20);
+  color: var(--color-amber-800);
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 800;
+  letter-spacing: 0.02em; line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+[data-theme="dark"] .tapas-indicator__tokensMore {
+  background: rgba(251,191,36,0.22); color: var(--color-amber-300);
+}
+
+/* En mobile, ocultamos los tokens si no caben y dejamos solo el contador */
+.carta[data-bp="mobile"] .tapas-indicator__tokens .tk { width: 6px; height: 6px; }
+
+/* Restringe la pill al ancho del panel para que no genere scroll horizontal */
+.tapas-indicator {
+  max-width: calc(100% - 32px);
+}
+
+
+/* ============================================================
+   Tapas modal — REDISEÑO "tasca artesanal"
+   Paleta: ámbar/oro sobre crema cálida (claro) o navy con velo
+   dorado (oscuro). Tipografía display para títulos, mono para
+   kicker/etiquetas. Tapa cards como platos cerámicos.
+   ============================================================ */
+
+.tapas-modal {
+  max-width: 480px;
+  padding: 0;
+  overflow: hidden;
+  display: flex; flex-direction: column;
+  max-height: 92%;
+  background:
+    radial-gradient(120% 80% at 0% 0%, color-mix(in oklab, var(--color-amber-100) 55%, var(--bg-surface)) 0%, var(--bg-surface) 50%);
+  border: 1px solid color-mix(in oklab, var(--color-amber-400) 30%, var(--border-subtle));
+}
+[data-theme="dark"] .tapas-modal {
+  background:
+    radial-gradient(120% 80% at 0% 0%, rgba(251,191,36,0.12) 0%, transparent 60%),
+    var(--bg-surface);
+  border-color: rgba(251,191,36,0.30);
+}
+
+/* ── HEADER ──────────────────────────────────────────────── */
+.tapas-head--v2 {
+  position: relative;
+  padding: 22px 22px 16px;
+  background: none;
+  border-bottom: 1px dashed color-mix(in oklab, var(--color-amber-400) 35%, var(--border-subtle));
+}
+[data-theme="dark"] .tapas-head--v2 {
+  border-bottom-color: rgba(251,191,36,0.30);
+}
+.tapas-close {
+  position: absolute; top: 12px; right: 12px;
+  width: 32px; height: 32px; border-radius: 9999px;
+  background: rgba(0,0,0,0.04);
+  color: var(--fg-secondary);
+  border: none; cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: background var(--duration-fast), color var(--duration-fast);
+}
+.tapas-close:hover { background: rgba(0,0,0,0.10); color: var(--fg-primary); }
+[data-theme="dark"] .tapas-close { background: rgba(255,255,255,0.05); }
+[data-theme="dark"] .tapas-close:hover { background: rgba(255,255,255,0.12); color: #FFF; }
+
+.tapas-head__pre {
+  display: flex; flex-direction: column; align-items: center;
+  gap: 6px; margin-bottom: 4px;
+}
+.tapas-head__ornament {
+  font-family: var(--font-display);
+  font-size: 12px; color: var(--color-amber-800);
+  opacity: 0.65; letter-spacing: 0.3em;
+}
+[data-theme="dark"] .tapas-head__ornament { color: var(--color-amber-300); }
+.tapas-head__kicker {
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 700;
+  letter-spacing: 0.22em;
+  color: var(--color-amber-800);
+}
+[data-theme="dark"] .tapas-head__kicker { color: var(--color-amber-300); }
+
+.tapas-head__big {
+  margin: 6px 0 4px;
+  font-family: var(--font-display); font-weight: 900;
+  font-size: 30px; line-height: 1; letter-spacing: -0.025em;
+  color: var(--fg-primary);
+  text-align: center;
+}
+.tapas-head__lead {
+  margin: 0 auto 14px;
+  max-width: 320px;
+  font-family: var(--font-body); font-size: 13px;
+  color: var(--fg-secondary); line-height: 1.5;
+  text-align: center;
+}
+.tapas-head__lead strong {
+  color: var(--color-amber-800); font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+[data-theme="dark"] .tapas-head__lead strong { color: var(--color-amber-300); }
+
+/* Coins gilded */
+.tapas-coins {
+  display: flex; align-items: center; justify-content: center;
+  flex-wrap: wrap; gap: 6px;
+  margin: 14px auto 6px;
+  max-width: 100%;
+}
+.tapa-coin {
+  width: 30px; height: 30px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: linear-gradient(135deg, #F5DC92 0%, #B47B19 60%, #ECC25A 100%);
+  box-shadow:
+    0 2px 6px rgba(180,123,25,0.35),
+    inset 0 1px 0 rgba(255,255,255,0.45),
+    inset 0 -2px 4px rgba(0,0,0,0.10);
+  position: relative;
+  flex-shrink: 0;
+  transition: transform 200ms var(--ease-bounce);
+}
+.tapa-coin:hover { transform: rotate(8deg) scale(1.08); }
+.tapa-coin__face {
+  font-size: 14px;
+  filter: drop-shadow(0 1px 0 rgba(255,255,255,0.5));
+}
+.tapa-coin--used {
+  background: linear-gradient(135deg, #E5E5E5 0%, #999 100%);
+  box-shadow:
+    0 1px 3px rgba(0,0,0,0.10) inset,
+    0 0 0 1px rgba(0,0,0,0.05) inset;
+  opacity: 0.55;
+}
+.tapa-coin--used .tapa-coin__face { filter: grayscale(1); }
+[data-theme="dark"] .tapa-coin--used {
+  background: linear-gradient(135deg, #4B5563 0%, #1F2937 100%);
+}
+.tapa-coin--more {
+  background: rgba(180,123,25,0.18);
+  color: var(--color-amber-800);
+  font-family: var(--font-display); font-weight: 900; font-size: 12px;
+  width: auto; min-width: 30px; padding: 0 8px;
+  border-radius: 9999px;
+  box-shadow: none;
+  border: 1px dashed var(--color-amber-400);
+}
+[data-theme="dark"] .tapa-coin--more {
+  background: rgba(251,191,36,0.18); color: var(--color-amber-300);
+  border-color: rgba(251,191,36,0.55);
+}
+
+.tapas-rule {
+  display: flex; align-items: center; gap: 8px;
+  margin: 8px 0 4px;
+}
+.tapas-rule__line {
+  flex: 1; height: 1px;
+  background: linear-gradient(90deg, transparent, color-mix(in oklab, var(--color-amber-400) 50%, var(--border-strong)), transparent);
+}
+.tapas-rule__text {
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  color: var(--fg-muted); white-space: nowrap;
+}
+
+/* Variants v2 */
+.tapas-variants--v2 {
+  margin: 12px auto 0; max-width: 100%;
+  background: rgba(0,0,0,0.04);
+  padding: 8px 12px; border-radius: 10px;
+}
+[data-theme="dark"] .tapas-variants--v2 { background: rgba(255,255,255,0.04); }
+
+/* ── BODY ────────────────────────────────────────────────── */
+.tapas-body {
+  flex: 1; min-height: 0; overflow-y: auto;
+  padding: 14px 16px 16px;
+  display: flex; flex-direction: column; gap: 16px;
+}
+.tapas-listLabel {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  color: var(--fg-muted);
+  padding-left: 2px;
+}
+
+.tapas-list--v2 {
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 0;
+  flex-shrink: 0;
+}
+.tapas-list--v2[data-disabled="true"] { opacity: 0.55; pointer-events: none; }
+
+/* Tapa card como un platillo: aro dorado alrededor de la foto */
+.tapa-card--v2 {
+  display: flex; align-items: center; gap: 14px;
+  padding: 12px;
+  border: 1.5px solid var(--border-subtle);
+  border-radius: 16px;
+  background: var(--bg-surface);
+  cursor: pointer; text-align: left;
+  font: inherit; color: inherit;
+  flex-shrink: 0;
+  transition: border-color var(--duration-fast),
+              background-color var(--duration-fast),
+              transform 160ms var(--ease-bounce);
+  position: relative; overflow: hidden;
+  animation: tapaCard-in 380ms cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+  animation-delay: calc(var(--i, 0) * 50ms);
+}
+@keyframes tapaCard-in {
+  from { transform: translateY(8px); opacity: 0; }
+  to   { transform: translateY(0); opacity: 1; }
+}
+.tapa-card--v2:hover:not(:disabled) {
+  border-color: var(--color-amber-400);
+  transform: translateY(-1px);
+  background: color-mix(in oklab, var(--color-amber-100) 25%, var(--bg-surface));
+}
+[data-theme="dark"] .tapa-card--v2:hover:not(:disabled) {
+  background: rgba(251,191,36,0.06);
+}
+.tapa-card--v2:disabled { cursor: not-allowed; opacity: 0.5; }
+.tapa-card--v2.tapa-card--selected {
+  border-color: var(--color-amber-400);
+  background: linear-gradient(135deg, color-mix(in oklab, var(--color-amber-100) 55%, var(--bg-surface)), var(--bg-surface));
+  box-shadow:
+    0 0 0 3px rgba(251,191,36,0.20),
+    0 6px 18px rgba(180,123,25,0.15);
+}
+[data-theme="dark"] .tapa-card--v2.tapa-card--selected {
+  background: linear-gradient(135deg, rgba(251,191,36,0.18), var(--bg-surface));
+  box-shadow: 0 0 0 3px rgba(251,191,36,0.25);
+}
+
+/* Plato cerámico */
+.tapa-card__plate {
+  position: relative;
+  width: 56px; height: 56px;
+  flex-shrink: 0;
+}
+.tapa-card__plate::before {
+  content: ""; position: absolute; inset: 0;
+  border-radius: 50%;
+  background: var(--bg-base);
+  border: 2px solid color-mix(in oklab, var(--color-amber-400) 55%, var(--border-strong));
+  box-shadow:
+    inset 0 2px 4px rgba(0,0,0,0.05),
+    0 1px 3px rgba(180,123,25,0.18);
+}
+.tapa-card__plate::after {
+  content: ""; position: absolute; inset: 6px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, color-mix(in oklab, var(--color-amber-100) 60%, var(--bg-base)), var(--bg-base));
+  border: 1px dashed color-mix(in oklab, var(--color-amber-400) 40%, transparent);
+}
+[data-theme="dark"] .tapa-card__plate::before {
+  background: rgba(255,255,255,0.04);
+  border-color: rgba(251,191,36,0.45);
+}
+[data-theme="dark"] .tapa-card__plate::after {
+  background: linear-gradient(135deg, rgba(251,191,36,0.10), rgba(255,255,255,0.02));
+  border-color: rgba(251,191,36,0.25);
+}
+.tapa-card__plateInner {
+  position: absolute; inset: 0;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 30px; z-index: 2;
+  filter: drop-shadow(0 1px 1px rgba(0,0,0,0.10));
+}
+
+.tapa-card__main { flex: 1; min-width: 0; }
+.tapa-card__name {
+  font-family: var(--font-display); font-weight: 800;
+  font-size: 16px; color: var(--fg-primary);
+  letter-spacing: -0.01em; line-height: 1.2;
+  margin-bottom: 2px;
+}
+.tapa-card__hint {
+  font-family: var(--font-body); font-size: 11.5px;
+  color: var(--fg-muted); line-height: 1.35;
+}
+
+.tapa-card__meta {
+  display: flex; flex-direction: column; align-items: flex-end; gap: 6px;
+  flex-shrink: 0;
+}
+.tapa-card__radio {
+  width: 22px; height: 22px; border-radius: 50%;
+  background: transparent;
+  border: 1.5px solid var(--border-strong);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-display); font-weight: 900;
+  font-size: 12px; color: transparent;
+  transition: all var(--duration-fast);
+}
+.tapa-card__radio.is-on {
+  background: linear-gradient(135deg, var(--color-amber-300), #B47B19);
+  border-color: #B47B19;
+  color: #FFFFFF;
+  box-shadow: 0 2px 6px rgba(180,123,25,0.40);
+}
+[data-theme="dark"] .tapa-card__radio.is-on { color: #1A0F04; }
+
+.tapa-card__pill {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 3px 9px; border-radius: 9999px;
+  font-family: var(--font-mono); font-weight: 800; font-size: 10.5px;
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.tapa-card__pill--free {
+  background: linear-gradient(135deg, #F5DC92, #ECC25A);
+  color: #2A1B05;
+  box-shadow: 0 1px 3px rgba(180,123,25,0.30);
+}
+.tapa-card__pill--paid {
+  background: color-mix(in oklab, var(--color-amber-100) 80%, var(--bg-base));
+  color: var(--color-amber-800);
+  border: 1px solid var(--color-amber-300);
+}
+[data-theme="dark"] .tapa-card__pill--paid {
+  background: rgba(251,191,36,0.18);
+  color: var(--color-amber-300);
+  border-color: rgba(251,191,36,0.35);
+}
+
+/* ── CHEF EXTRA (sugerencia) ─────────────────────────────── */
+.chef-extra {
+  position: relative;
+  border-radius: 16px;
+  background:
+    linear-gradient(135deg, #2A6FDB, #1B4D9A);
+  color: #E0EBFF;
+  padding: 14px 14px 14px 16px;
+  overflow: hidden;
+  margin-top: 6px;
+  isolation: isolate;
+  flex-shrink: 0;
+}
+.chef-extra::before {
+  content: ""; position: absolute; inset: 0; z-index: 0;
+  background:
+    radial-gradient(60% 80% at 100% 0%, rgba(255,255,255,0.10), transparent 60%);
+}
+.chef-extra__kicker {
+  display: inline-flex; align-items: center;
+  align-self: flex-start;
+  padding: 3px 10px; border-radius: 999px;
+  background: var(--color-amber-300); color: #2A1B05;
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 800;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  white-space: nowrap;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.18);
+  margin-bottom: 7px;
+}
+.chef-extra__head {
+  display: flex; align-items: center; gap: 12px;
+  width: 100%;
+  background: transparent;
+  border: none; padding: 0;
+  font: inherit; color: inherit;
+  cursor: pointer;
+  position: relative; z-index: 1;
+}
+.chef-extra__photo {
+  width: 48px; height: 48px; border-radius: 50%;
+  background: rgba(255,255,255,0.10);
+  border: 2px solid rgba(255,255,255,0.18);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 26px; flex-shrink: 0;
+}
+.chef-extra__main { flex: 1; min-width: 0; text-align: left; }
+.chef-extra__name {
+  font-family: var(--font-display); font-weight: 900; font-size: 16px;
+  color: #FFFFFF; letter-spacing: -0.005em; line-height: 1.2;
+}
+.chef-extra__hint {
+  font-family: var(--font-body); font-size: 11.5px;
+  color: rgba(255,255,255,0.75);
+  margin-top: 2px;
+}
+.chef-extra__meta {
+  display: flex; flex-direction: column; align-items: flex-end; gap: 4px;
+  flex-shrink: 0;
+}
+.chef-extra__price {
+  font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  color: var(--color-amber-300); font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em; line-height: 1;
+}
+.chef-extra__chev {
+  width: 24px; height: 24px; border-radius: 50%;
+  background: rgba(255,255,255,0.16);
+  color: #FFFFFF;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-display); font-weight: 900; font-size: 16px;
+  line-height: 1;
+}
+.chef-extra__body {
+  position: relative; z-index: 1;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px dashed rgba(255,255,255,0.22);
+}
+.chef-extra__body p {
+  margin: 0 0 10px;
+  font-family: var(--font-body); font-size: 12px;
+  color: rgba(255,255,255,0.85); line-height: 1.45;
+}
+.chef-extra__cta {
+  width: 100%;
+  padding: 11px 14px;
+  border: none; border-radius: 10px;
+  background: linear-gradient(135deg, var(--color-amber-300), #B47B19);
+  color: #1A0F04;
+  font-family: var(--font-body); font-weight: 800; font-size: 13.5px;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(180,123,25,0.45), inset 0 1px 0 rgba(255,255,255,0.30);
+  transition: filter var(--duration-fast), transform 140ms var(--ease-bounce);
+}
+.chef-extra__cta:hover { filter: brightness(1.06); transform: translateY(-1px); }
+
+/* ── FOOTER ──────────────────────────────────────────────── */
+.tapas-foot--v2 {
+  display: flex; gap: 10px;
+  padding: 12px 14px;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-base);
+}
+.tapas-foot--v2 .tapas-foot__secondary {
+  flex: 0 0 auto;
+  padding: 12px 18px;
+  background: transparent;
+  border: 1px solid var(--border-strong);
+  border-radius: 12px;
+  color: var(--fg-secondary);
+  font-family: var(--font-body); font-weight: 600; font-size: 13.5px;
+  cursor: pointer;
+  transition: background var(--duration-fast), color var(--duration-fast);
+}
+.tapas-foot--v2 .tapas-foot__secondary:hover {
+  background: var(--bg-chip);
+  color: var(--fg-primary);
+}
+.tapas-foot--v2 .tapas-foot__primary {
+  flex: 1;
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  padding: 12px 16px;
+  border: none; border-radius: 12px;
+  background: linear-gradient(135deg, var(--color-amber-300), #B47B19);
+  color: #1A0F04;
+  font-family: var(--font-display); font-weight: 900; font-size: 14px;
+  letter-spacing: 0.005em;
+  cursor: pointer;
+  box-shadow:
+    0 6px 18px rgba(180,123,25,0.45),
+    inset 0 1px 0 rgba(255,255,255,0.30);
+  transition: filter var(--duration-fast), transform 140ms var(--ease-bounce);
+}
+.tapas-foot--v2 .tapas-foot__primary:hover:not(:disabled) {
+  filter: brightness(1.06); transform: translateY(-1px);
+}
+.tapas-foot--v2 .tapas-foot__primary:disabled {
+  background: var(--bg-chip);
+  color: var(--fg-muted);
+  cursor: not-allowed;
+  box-shadow: none;
+}
+.tapas-foot__arrow {
+  font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  line-height: 1; transition: transform 200ms var(--ease-smooth);
+}
+.tapas-foot--v2 .tapas-foot__primary:hover .tapas-foot__arrow { transform: translateX(3px); }
+
+/* ============================================================
+   COBRO MIXTO · paso de PROPINA (nuevo) — conserva el fader;
+   estilos aditivos, no modifican el flujo existente.
+   ============================================================ */
+.mixed-tipChips {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 7px;
+}
+.mixed-tipChip {
+  appearance: none;
+  display: flex; flex-direction: column; align-items: center; gap: 3px;
+  padding: 11px 4px 9px;
+  border-radius: 14px;
+  border: 1.5px solid var(--border-subtle);
+  background: var(--bg-surface);
+  cursor: pointer;
+  transition: border-color var(--duration-fast), background-color var(--duration-fast), transform var(--duration-fast);
+}
+.mixed-tipChip:hover { border-color: var(--border-strong); transform: translateY(-1px); }
+.mixed-tipChip .pct {
+  font-family: var(--font-display); font-weight: 900; font-size: 15px; line-height: 1;
+  color: var(--fg-primary); letter-spacing: -0.01em;
+}
+.mixed-tipChip .amt {
+  font-family: var(--font-mono); font-size: 9px; letter-spacing: 0.03em;
+  color: var(--fg-muted); font-variant-numeric: tabular-nums;
+}
+.mixed-tipChip--active {
+  background: linear-gradient(135deg, var(--color-green-500), var(--color-green-700));
+  border-color: var(--color-green-700);
+}
+.mixed-tipChip--active .pct { color: #fff; }
+.mixed-tipChip--active .amt { color: rgba(255,255,255,0.82); }
+[data-theme="dark"] .mixed-tipChip--active {
+  background: linear-gradient(135deg, var(--color-green-500), var(--color-green-800));
+  border-color: var(--color-green-500);
+}
+.carta[data-bp="mobile"] .mixed-tipChip .pct { font-size: 14px; }
+@media (max-width: 360px) {
+  .mixed-tipChips { grid-template-columns: repeat(3, 1fr); }
+}
+
+.mixed-tipInput {
+  display: grid; grid-template-columns: 1fr auto; align-items: stretch;
+  border: 1.5px solid var(--border-subtle);
+  border-radius: 14px; background: var(--bg-surface); overflow: hidden;
+  transition: border-color var(--duration-fast);
+}
+.mixed-tipInput:focus-within { border-color: var(--color-green-600); }
+[data-theme="dark"] .mixed-tipInput:focus-within { border-color: var(--color-cyan-400); }
+.mixed-tipInput input {
+  border: none; background: transparent; outline: none; width: 100%;
+  padding: 13px 14px 13px 16px;
+  font-family: var(--font-display); font-weight: 800; font-size: 17px;
+  color: var(--fg-primary); font-variant-numeric: tabular-nums;
+}
+.mixed-tipInput input::placeholder { color: var(--fg-muted); font-weight: 500; font-family: var(--font-body); font-size: 14px; }
+.mixed-tipInput__cur {
+  display: inline-flex; align-items: center; padding: 0 16px;
+  font-family: var(--font-display); font-weight: 800; font-size: 16px;
+  color: var(--fg-muted); border-left: 1.5px solid var(--border-subtle);
+}
+
+.mixed-tipSummary {
+  display: grid; gap: 6px;
+  padding: 14px 16px;
+  background: var(--bg-chip);
+  border-radius: 14px;
+  font-family: var(--font-body); font-size: 14px;
+}
+.mixed-tipSummary__row {
+  display: flex; align-items: baseline; justify-content: space-between;
+  color: var(--fg-secondary);
+}
+.mixed-tipSummary__row .v {
+  font-family: var(--font-display); font-weight: 800;
+  font-variant-numeric: tabular-nums; letter-spacing: -0.01em; color: var(--fg-primary);
+}
+.mixed-tipSummary__row--tip { color: var(--color-green-700); font-weight: 600; }
+[data-theme="dark"] .mixed-tipSummary__row--tip { color: var(--color-green-400); }
+.mixed-tipSummary__row--tip .v { color: inherit; }
+.mixed-tipSummary__row--total {
+  padding-top: 8px; margin-top: 2px;
+  border-top: 1px solid var(--border-subtle); color: var(--fg-primary);
+}
+.mixed-tipSummary__row--total .v { font-size: 18px; color: var(--price-gold); }
+
+
+/* ════════════════════════════════════════════════════════════════
+   TICKET DESCARGABLE
+   - Botón de descarga (aparece sólo con pago confirmado)
+   - Barra persistente "pago completado"
+   - Modal de vista previa + descarga (imprimir / guardar PDF)
+   - 3 plantillas de recibo: classic · minimal · modern
+   El recibo se imprime SIEMPRE como papel (claro), aun en modo oscuro.
+   ════════════════════════════════════════════════════════════════ */
+
+/* ── Botón de descarga ───────────────────────────────────── */
+.ticket-dl {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  font-family: var(--font-body); font-weight: 700; font-size: 14px;
+  border-radius: 12px; cursor: pointer;
+  transition: filter var(--duration-fast), background var(--duration-fast), transform var(--duration-fast);
+}
+.ticket-dl:active { transform: translateY(1px); }
+.ticket-dl--block {
+  width: 100%; padding: 12px 16px;
+  background: var(--bg-chip); color: var(--fg-primary);
+  border: 1.5px solid var(--border-strong);
+}
+.ticket-dl--block:hover { background: var(--bg-canvas); border-color: var(--brand-primary); }
+.ticket-dl--ghost {
+  padding: 9px 14px; background: transparent; color: var(--brand-primary);
+  border: 1.5px solid var(--border-subtle);
+}
+.ticket-dl--ghost:hover { border-color: var(--brand-primary); background: var(--color-green-50); }
+[data-theme="dark"] .ticket-dl--ghost:hover { background: rgba(46,80,176,0.12); }
+.bill__doneTicket { width: 100%; margin-top: 12px; }
+
+/* ── Barra persistente: pago completado + descargar ───────── */
+.ticket-ready {
+  position: absolute; left: 16px; right: 16px; bottom: 16px; z-index: 38;
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 12px 12px 14px;
+  background: var(--glass-bg-base); backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--border-subtle);
+  border-left: 4px solid var(--color-green-500);
+  border-radius: 16px; box-shadow: var(--shadow-pop);
+  animation: ticket-ready-in 320ms var(--ease-bounce) both;
+}
+@keyframes ticket-ready-in { from { opacity: 0; transform: translateY(14px); } to { opacity: 1; transform: none; } }
+.ticket-ready__ic {
+  display: inline-flex; flex: 0 0 auto;
+  width: 34px; height: 34px; border-radius: 10px;
+  align-items: center; justify-content: center;
+  background: var(--color-green-100); color: var(--color-green-700);
+}
+[data-theme="dark"] .ticket-ready__ic { background: rgba(34,197,94,0.15); color: var(--color-green-400); }
+.ticket-ready__copy { display: flex; flex-direction: column; min-width: 0; flex: 1 1 auto; }
+.ticket-ready__copy strong { font-family: var(--font-display); font-weight: 800; font-size: 14px; color: var(--fg-primary); }
+.ticket-ready__copy span { font-size: 12px; color: var(--fg-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ticket-ready__cta {
+  flex: 0 0 auto; display: inline-flex; align-items: center; gap: 6px;
+  padding: 9px 13px; border-radius: 11px; cursor: pointer;
+  background: var(--cta-view-order); color: #fff; border: none;
+  font-family: var(--font-body); font-weight: 700; font-size: 13px;
+}
+.ticket-ready__cta:hover { filter: brightness(1.06); }
+.ticket-ready__x {
+  flex: 0 0 auto; width: 28px; height: 28px; border-radius: 8px; cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: transparent; border: none; color: var(--fg-muted);
+}
+.ticket-ready__x:hover { background: var(--bg-chip); color: var(--fg-primary); }
+
+/* ── Modal de vista previa ────────────────────────────────── */
+.ticket-modal__panel {
+  width: 100%; max-width: 420px; padding: 0;
+  display: flex; flex-direction: column; max-height: 88%;
+  overflow: hidden;
+}
+.ticket-modal__head {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 12px;
+  padding: 18px 18px 12px;
+}
+.ticket-modal__titles { display: flex; flex-direction: column; gap: 2px; }
+.ticket-modal__kicker {
+  font-family: var(--font-body); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.1em; text-transform: uppercase; color: var(--fg-muted);
+}
+.ticket-modal__title { font-family: var(--font-display); font-weight: 900; font-size: 21px; line-height: 1.1; color: var(--fg-primary); }
+.ticket-modal__stage {
+  flex: 1 1 auto; overflow: auto;
+  display: flex; justify-content: center;
+  padding: 8px 18px 18px;
+  background:
+    repeating-linear-gradient(45deg, rgba(17,24,39,0.022) 0 10px, transparent 10px 20px),
+    var(--bg-canvas);
+}
+[data-theme="dark"] .ticket-modal__stage {
+  background:
+    repeating-linear-gradient(45deg, rgba(255,255,255,0.025) 0 10px, transparent 10px 20px),
+    var(--color-night-800);
+}
+.ticket-modal__route {
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 18px; border-top: 1px solid var(--border-subtle);
+}
+.ticket-modal__routeLab {
+  flex: 0 0 auto; display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--font-body); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.04em; text-transform: uppercase; color: var(--color-green-700);
+}
+.ticket-modal__routeLab::before { content: "🔒"; font-size: 11px; }
+[data-theme="dark"] .ticket-modal__routeLab { color: var(--color-green-400); }
+.ticket-modal__routeUrl {
+  flex: 1 1 auto; min-width: 0;
+  font-family: var(--font-mono); font-size: 11px; color: var(--fg-muted);
+  background: var(--bg-chip); padding: 5px 8px; border-radius: 7px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.ticket-modal__fmt {
+  flex: 0 0 auto; font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.04em; color: var(--fg-secondary);
+  background: var(--bg-chip); border: 1px solid var(--border-subtle);
+  padding: 4px 7px; border-radius: 7px;
+}
+.ticket-modal__foot {
+  display: flex; gap: 10px; padding: 14px 18px 18px;
+  border-top: 1px solid var(--border-subtle);
+}
+.ticket-modal__foot .btn-secondary { flex: 0 0 auto; width: auto; padding-left: 22px; padding-right: 22px; }
+.ticket-modal__foot .btn-primary { flex: 1 1 auto; width: auto; }
+.ticket-modal__dl { display: inline-flex; align-items: center; justify-content: center; gap: 8px; }
+
+/* ════ EL RECIBO — siempre papel claro ════ */
+.tk {
+  --paper:   #FFFFFF;
+  --ink:     #16130F;
+  --ink-2:   #5A554C;
+  --ink-3:   #908A7E;
+  --hair:    #E4DFD4;
+  --accent:  #16A34A;
+  width: 300px; max-width: 100%;
+  background: var(--paper); color: var(--ink);
+  box-shadow: 0 10px 30px rgba(17,24,39,0.18);
+  box-sizing: border-box;
+}
+.tk * { box-sizing: border-box; }
+
+/* Shared line list */
+.tk-lines { display: flex; flex-direction: column; }
+.tk-line {
+  display: grid; grid-template-columns: auto 1fr auto; gap: 8px;
+  align-items: baseline; padding: 5px 0;
+}
+.tk-line__qty { color: var(--ink-2); font-variant-numeric: tabular-nums; font-weight: 700; }
+.tk-line__name { color: var(--ink); font-weight: 600; line-height: 1.25; }
+.tk-line__mod { color: var(--ink-3); font-size: 0.85em; line-height: 1.3; }
+.tk-line__amt { color: var(--ink); font-weight: 700; font-variant-numeric: tabular-nums; white-space: nowrap; }
+
+/* Shared totals */
+.tk-totals { display: flex; flex-direction: column; gap: 3px; }
+.tk-tot__row { display: flex; justify-content: space-between; color: var(--ink-2); font-variant-numeric: tabular-nums; }
+.tk-tot__row span:last-child { font-weight: 700; color: var(--ink); }
+.tk-tot__row--grand { color: var(--ink); font-weight: 800; }
+.tk-tot__row--grand span { font-weight: 900 !important; }
+
+/* ─── CLASSIC — recibo térmico ─── */
+.tk--classic {
+  font-family: var(--font-mono); font-size: 12px; line-height: 1.5;
+  padding: 22px 20px 16px;
+  border-radius: 2px;
+  /* borde dentado superior/inferior tipo papel cortado */
+  -webkit-mask:
+    radial-gradient(5px at 5px 0, transparent 98%, #000) top left / 10px 6px repeat-x,
+    radial-gradient(5px at 5px 100%, transparent 98%, #000) bottom left / 10px 6px repeat-x,
+    linear-gradient(#000 0 0) center / 100% calc(100% - 10px) no-repeat;
+  mask:
+    radial-gradient(5px at 5px 0, transparent 98%, #000) top left / 10px 6px repeat-x,
+    radial-gradient(5px at 5px 100%, transparent 98%, #000) bottom left / 10px 6px repeat-x,
+    linear-gradient(#000 0 0) center / 100% calc(100% - 10px) no-repeat;
+}
+.tk-c__head { text-align: center; }
+.tk-c__logo {
+  width: 40px; height: 40px; margin: 0 auto 8px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  border: 2px solid var(--ink); font-family: var(--font-display);
+  font-weight: 900; font-size: 20px;
+}
+.tk-c__name { font-weight: 700; font-size: 15px; letter-spacing: 0.06em; text-transform: uppercase; }
+.tk-c__meta { color: var(--ink-2); font-size: 11px; }
+.tk-c__rule { border-top: 1.5px solid var(--ink); margin: 12px 0; }
+.tk-c__rule--dash { border-top: 1px dashed var(--ink-3); }
+.tk-c__info { display: grid; grid-template-columns: 1fr 1fr; gap: 4px 12px; }
+.tk-c__info > div { display: flex; justify-content: space-between; gap: 6px; }
+.tk-c__info span { color: var(--ink-3); }
+.tk-c__info b { font-weight: 700; }
+.tk--classic .tk-line__qty { min-width: 26px; }
+.tk--classic .tk-totals { gap: 4px; }
+.tk-c__pay { text-align: center; letter-spacing: 0.05em; color: var(--ink-2); font-size: 11px; }
+.tk-c__footer { white-space: pre-line; text-align: center; color: var(--ink-2); font-size: 10.5px; line-height: 1.5; margin-top: 12px; }
+.tk-c__star { text-align: center; color: var(--ink); margin-top: 12px; letter-spacing: 0.1em; }
+
+/* ─── MINIMAL — esencial, hairlines ─── */
+.tk--minimal {
+  font-family: var(--font-body); font-size: 13px; line-height: 1.5;
+  padding: 30px 26px; border-radius: 4px;
+}
+.tk-m__top { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; }
+.tk-m__name { font-family: var(--font-display); font-weight: 800; font-size: 19px; letter-spacing: -0.01em; }
+.tk-m__order { color: var(--ink-3); font-variant-numeric: tabular-nums; font-size: 13px; }
+.tk-m__sub { color: var(--ink-3); font-size: 11.5px; margin-top: 4px; }
+.tk--minimal .tk-lines { margin: 22px 0; border-top: 1px solid var(--hair); padding-top: 14px; }
+.tk--minimal .tk-line { padding: 6px 0; }
+.tk--minimal .tk-totals { border-top: 1px solid var(--hair); padding-top: 14px; gap: 5px; }
+.tk--minimal .tk-tot__row--grand { padding-top: 6px; font-size: 15px; }
+.tk-m__pay { margin-top: 18px; color: var(--ink-2); font-size: 12px; }
+.tk-m__footer { white-space: pre-line; color: var(--ink-3); font-size: 11px; line-height: 1.5; margin-top: 18px; padding-top: 14px; border-top: 1px solid var(--hair); }
+
+/* ─── MODERN — tarjeta con acento ─── */
+.tk--modern {
+  font-family: var(--font-body); font-size: 13px; line-height: 1.5;
+  padding: 20px; border-radius: 16px;
+  border: 1px solid var(--hair);
+}
+.tk-mo__head { display: flex; align-items: center; gap: 11px; }
+.tk-mo__logo {
+  width: 42px; height: 42px; flex: 0 0 auto; border-radius: 12px;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--accent); color: #fff;
+  font-family: var(--font-display); font-weight: 900; font-size: 20px;
+}
+.tk-mo__heading { flex: 1 1 auto; min-width: 0; }
+.tk-mo__name { font-family: var(--font-display); font-weight: 800; font-size: 17px; line-height: 1.1; }
+.tk-mo__meta { color: var(--ink-3); font-size: 11px; margin-top: 2px; }
+.tk-mo__badge {
+  flex: 0 0 auto; align-self: flex-start;
+  font-size: 11px; font-weight: 700; letter-spacing: 0.02em;
+  color: #0F7A37; background: #E8F8EE; border: 1px solid #BBEFCB;
+  padding: 4px 9px; border-radius: 999px;
+}
+.tk-mo__grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 8px 14px;
+  background: #FAF8F3; border-radius: 12px; padding: 12px 14px; margin: 16px 0;
+}
+.tk-mo__grid > div { display: flex; flex-direction: column; gap: 1px; }
+.tk-mo__grid span { color: var(--ink-3); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em; }
+.tk-mo__grid b { font-weight: 700; font-size: 13px; }
+.tk--modern .tk-lines { border-bottom: 1px solid var(--hair); padding-bottom: 12px; margin-bottom: 12px; }
+.tk--modern .tk-line { padding: 6px 0; }
+.tk--modern .tk-tot__row--grand {
+  margin-top: 8px; padding: 10px 12px; border-radius: 10px;
+  background: var(--accent); color: #fff; font-size: 15px;
+}
+.tk--modern .tk-tot__row--grand span { color: #fff !important; }
+.tk-mo__pay {
+  display: inline-flex; align-items: center; gap: 7px; margin-top: 14px;
+  color: var(--ink-2); font-size: 12.5px; font-weight: 600;
+}
+.tk-mo__payIc { display: inline-flex; color: var(--accent); }
+.tk-mo__footer { white-space: pre-line; color: var(--ink-3); font-size: 11px; line-height: 1.5; margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--hair); }
+
+/* Mobile: keep the modal comfy */
+.carta[data-bp="mobile"] .ticket-modal__panel { max-height: 90%; }
+.carta[data-bp="mobile"] .ticket-modal__foot .btn-secondary { padding-left: 16px; padding-right: 16px; }

--- a/public/js/allergen-pictograms.js
+++ b/public/js/allergen-pictograms.js
@@ -1,0 +1,271 @@
+/* Pictogramas oficiales de alérgenos — portados de allergens-oficiales.html.
+   Cada entrada devuelve el contenido interno de un <svg viewBox="0 0 100 100">.
+   Se inyecta en el badge con dangerouslySetInnerHTML.
+
+   Convención: círculo sólido del color del alérgeno + anillo blanco interior,
+   silueta blanca centrada. La variable CSS --c se usa para tintar sombras y
+   detalles secundarios que comparten el color del alérgeno. */
+
+(function () {
+  const RING = `<circle cx="50" cy="50" r="48" fill="var(--c)"></circle>
+                <circle cx="50" cy="50" r="43" fill="none" stroke="#fff" stroke-width="1.6" opacity="0.55"></circle>`;
+
+  const PICTOGRAMS = {
+    gluten: () => `${RING}
+      <g fill="#fff">
+        <rect x="48.2" y="32" width="3.6" height="42" rx="1.6"></rect>
+        <g>
+          <ellipse cx="40" cy="42" rx="4" ry="7" transform="rotate(-28 40 42)"></ellipse>
+          <ellipse cx="60" cy="42" rx="4" ry="7" transform="rotate(28 60 42)"></ellipse>
+          <ellipse cx="38" cy="52" rx="4" ry="7" transform="rotate(-28 38 52)"></ellipse>
+          <ellipse cx="62" cy="52" rx="4" ry="7" transform="rotate(28 62 52)"></ellipse>
+          <ellipse cx="36" cy="62" rx="4" ry="7" transform="rotate(-28 36 62)"></ellipse>
+          <ellipse cx="64" cy="62" rx="4" ry="7" transform="rotate(28 64 62)"></ellipse>
+        </g>
+        <ellipse cx="50" cy="30" rx="3.2" ry="6"></ellipse>
+      </g>`,
+
+    crustaceos: () => `${RING}
+      <g transform="translate(50 50) scale(0.86) translate(-50 -50)">
+        <g fill="#fff">
+          <ellipse cx="50" cy="58" rx="22" ry="13"></ellipse>
+          <rect x="43" y="40" width="2.6" height="7" rx="1.3"></rect>
+          <rect x="54.4" y="40" width="2.6" height="7" rx="1.3"></rect>
+          <circle cx="44.3" cy="38" r="2.6"></circle>
+          <circle cx="55.7" cy="38" r="2.6"></circle>
+        </g>
+        <g stroke="#fff" stroke-width="5" stroke-linecap="round" fill="none">
+          <path d="M 32,50 Q 24,44 22,34"></path>
+          <path d="M 68,50 Q 76,44 78,34"></path>
+        </g>
+        <g transform="translate(20 28) rotate(-30)">
+          <ellipse cx="0" cy="0" rx="10" ry="7" fill="#fff"></ellipse>
+          <path d="M 2,-2 L 11,-4 L 11,4 L 2,2 Z" fill="var(--c)"></path>
+        </g>
+        <g transform="translate(80 28) rotate(30)">
+          <ellipse cx="0" cy="0" rx="10" ry="7" fill="#fff"></ellipse>
+          <path d="M -2,-2 L -11,-4 L -11,4 L -2,2 Z" fill="var(--c)"></path>
+        </g>
+        <g stroke="#fff" stroke-width="3" stroke-linecap="round" fill="none">
+          <path d="M 30,58 Q 18,60 12,70"></path>
+          <path d="M 32,66 Q 20,72 16,82"></path>
+          <path d="M 40,72 Q 36,80 38,86"></path>
+          <path d="M 70,58 Q 82,60 88,70"></path>
+          <path d="M 68,66 Q 80,72 84,82"></path>
+          <path d="M 60,72 Q 64,80 62,86"></path>
+        </g>
+      </g>`,
+
+    huevos: () => `${RING}
+      <g>
+        <g>
+          <path d="M 30,39 C 20,40 19,49 19,55 C 19,65 23,71 30,71 C 37,71 41,65 41,55 C 41,49 40,40 30,39 Z" fill="#fff"></path>
+          <path d="M 41,55 C 41,65 37,71 30,71 C 36,69 38,62 38,55 C 38,49 36,42 33,40 C 36,42 41,49 41,55 Z" fill="var(--c)" opacity="0.24"></path>
+          <ellipse cx="24" cy="48" rx="2.4" ry="5" fill="#fff" transform="rotate(-28 24 48)"></ellipse>
+        </g>
+        <g>
+          <path d="M 50,39 C 40,40 39,49 39,55 C 39,65 43,71 50,71 C 57,71 61,65 61,55 C 61,49 60,40 50,39 Z" fill="#fff"></path>
+          <path d="M 61,55 C 61,65 57,71 50,71 C 56,69 58,62 58,55 C 58,49 56,42 53,40 C 56,42 61,49 61,55 Z" fill="var(--c)" opacity="0.24"></path>
+          <ellipse cx="44" cy="48" rx="2.4" ry="5" fill="#fff" transform="rotate(-28 44 48)"></ellipse>
+        </g>
+        <g>
+          <path d="M 70,39 C 60,40 59,49 59,55 C 59,65 63,71 70,71 C 77,71 81,65 81,55 C 81,49 80,40 70,39 Z" fill="#fff"></path>
+          <path d="M 81,55 C 81,65 77,71 70,71 C 76,69 78,62 78,55 C 78,49 76,42 73,40 C 76,42 81,49 81,55 Z" fill="var(--c)" opacity="0.24"></path>
+          <ellipse cx="64" cy="48" rx="2.4" ry="5" fill="#fff" transform="rotate(-28 64 48)"></ellipse>
+        </g>
+      </g>`,
+
+    pescado: () => `${RING}
+      <g fill="#fff">
+        <path d="M14,50 Q28,28 52,30 Q68,32 74,50 Q68,68 52,70 Q28,72 14,50 Z"></path>
+        <path d="M74,50 L86,38 L82,50 L86,62 Z"></path>
+        <path d="M44,30 L52,18 L56,32 Z" opacity="0.85"></path>
+        <path d="M28,38 Q24,50 28,62" fill="none" stroke="var(--c)" stroke-width="2" stroke-linecap="round"></path>
+        <circle cx="22" cy="46" r="2.6" fill="var(--c)"></circle>
+      </g>`,
+
+    cacahuetes: () => `${RING}
+      <g fill="#fff">
+        <path d="M50,18
+                 C 36,18 30,28 34,40
+                 C 36,46 36,48 34,52
+                 C 32,58 32,68 36,76
+                 C 40,82 44,82 50,82
+                 C 56,82 60,82 64,76
+                 C 68,68 68,58 66,52
+                 C 64,48 64,46 66,40
+                 C 70,28 64,18 50,18 Z"></path>
+      </g>
+      <path d="M 66,40 C 64,48 64,48 66,52 C 68,58 68,68 64,76 C 60,82 56,82 50,82 C 56,80 60,76 62,68 C 64,58 62,52 62,50 C 62,48 64,42 64,32 C 64,26 60,20 56,18 C 62,18 70,28 66,40 Z" fill="var(--c)" opacity="0.16"></path>
+      <g stroke="var(--c)" stroke-width="1.4" stroke-linecap="round" fill="none">
+        <path d="M40,28 Q50,30 60,28"></path>
+        <path d="M40,38 Q50,40 60,38"></path>
+        <path d="M38,50 Q50,52 62,50"></path>
+        <path d="M40,62 Q50,64 60,62"></path>
+        <path d="M40,72 Q50,74 60,72"></path>
+        <path d="M44,22 Q42,50 44,78"></path>
+        <path d="M50,20 Q48,50 50,80"></path>
+        <path d="M56,22 Q58,50 56,78"></path>
+      </g>
+      <ellipse cx="42" cy="30" rx="2.6" ry="5" fill="#fff" opacity="0.95" transform="rotate(-22 42 30)"></ellipse>`,
+
+    soja: () => `${RING}
+      <g fill="#fff">
+        <path d="M 20,62
+                 Q 20,50 32,50
+                 Q 38,46 44,50
+                 Q 50,54 56,50
+                 Q 62,46 68,50
+                 Q 80,50 80,62
+                 Q 80,74 68,74
+                 Q 62,78 56,74
+                 Q 50,70 44,74
+                 Q 38,78 32,74
+                 Q 20,74 20,62 Z"></path>
+        <path d="M 70,52 Q 62,44 54,36" stroke="#fff" stroke-width="2.4" fill="none" stroke-linecap="round"></path>
+        <g>
+          <ellipse cx="56" cy="30" rx="5" ry="2.8" transform="rotate(-30 56 30)"></ellipse>
+          <ellipse cx="48" cy="28" rx="5" ry="2.8" transform="rotate(-70 48 28)"></ellipse>
+          <ellipse cx="62" cy="24" rx="5" ry="2.8" transform="rotate(-10 62 24)"></ellipse>
+        </g>
+      </g>
+      <g fill="var(--c)">
+        <circle cx="38" cy="62" r="5.4"></circle>
+        <circle cx="50" cy="62" r="5.8"></circle>
+        <circle cx="62" cy="62" r="5.4"></circle>
+      </g>
+      <g fill="#fff" opacity="0.55">
+        <ellipse cx="36" cy="60" rx="1.4" ry="2.4" transform="rotate(-30 36 60)"></ellipse>
+        <ellipse cx="48" cy="60" rx="1.6" ry="2.6" transform="rotate(-30 48 60)"></ellipse>
+        <ellipse cx="60" cy="60" rx="1.4" ry="2.4" transform="rotate(-30 60 60)"></ellipse>
+      </g>`,
+
+    lacteos: () => `${RING}
+      <g fill="#fff">
+        <rect x="35" y="40" width="30" height="40" rx="1.5"></rect>
+        <path d="M 35,40 L 50,26 L 65,40 Z"></path>
+      </g>
+      <g stroke="var(--c)" stroke-width="1.2" fill="none" stroke-linecap="round" opacity="0.55">
+        <line x1="50" y1="26" x2="50" y2="40"></line>
+        <line x1="35" y1="40" x2="50" y2="33"></line>
+        <line x1="65" y1="40" x2="50" y2="33"></line>
+      </g>
+      <rect x="59" y="40" width="6" height="40" fill="var(--c)" opacity="0.18"></rect>
+      <path d="M 57,40 L 50,30 L 65,40 Z" fill="var(--c)" opacity="0.18"></path>
+      <rect x="35" y="52" width="30" height="11" fill="var(--c)" opacity="0.7"></rect>
+      <g fill="#fff">
+        <circle cx="42" cy="57.5" r="1.4"></circle>
+        <circle cx="50" cy="57.5" r="1.4"></circle>
+        <circle cx="58" cy="57.5" r="1.4"></circle>
+      </g>
+      <g fill="#fff">
+        <path d="M 76,52 C 72,56 72,62 76,66 C 80,62 80,56 76,52 Z"></path>
+        <path d="M 80,72 C 78,74 78,77 80,79 C 82,77 82,74 80,72 Z" opacity="0.8"></path>
+      </g>`,
+
+    "frutos-cascara": () => `${RING}
+      <g fill="#fff">
+        <ellipse cx="50" cy="50" rx="28" ry="32"></ellipse>
+      </g>
+      <line x1="50" y1="20" x2="50" y2="80" stroke="var(--c)" stroke-width="2.4"></line>
+      <g stroke="var(--c)" stroke-width="2" stroke-linecap="round" fill="none">
+        <path d="M40,30 Q32,40 38,50 Q32,60 40,70"></path>
+        <path d="M44,32 Q38,42 44,52 Q38,62 44,70"></path>
+        <path d="M60,30 Q68,40 62,50 Q68,60 60,70"></path>
+        <path d="M56,32 Q62,42 56,52 Q62,62 56,70"></path>
+      </g>`,
+
+    apio: () => `${RING}
+      <g fill="#fff">
+        <path d="M40,42 L36,82 L46,82 L46,42 Z"></path>
+        <path d="M50,38 L46,84 L56,84 L56,38 Z" opacity="0.85"></path>
+        <path d="M60,42 L56,82 L66,82 L62,42 Z"></path>
+        <path d="M44,42 Q34,28 30,18 Q44,22 46,38 Z"></path>
+        <path d="M52,38 Q50,22 56,12 Q62,24 56,38 Z"></path>
+        <path d="M58,40 Q70,28 76,20 Q72,36 62,42 Z"></path>
+      </g>`,
+
+    mostaza: () => `${RING}
+      <g fill="#fff">
+        <rect x="38" y="22" width="24" height="8" rx="1.5"></rect>
+        <rect x="42" y="30" width="16" height="6"></rect>
+        <rect x="32" y="36" width="36" height="44" rx="3"></rect>
+      </g>
+      <rect x="36" y="48" width="28" height="20" fill="var(--c)" opacity="0.7"></rect>
+      <text x="50" y="62" font-family="ui-sans-serif, system-ui, sans-serif" font-size="9" font-weight="900" fill="#fff" text-anchor="middle" letter-spacing="0.5">MUST</text>`,
+
+    sesamo: () => `${RING}
+      <g fill="#fff">
+        <path d="M50,18 Q70,28 66,46 Q50,42 50,18 Z" opacity="0.85"></path>
+        <path d="M50,18 Q30,28 34,46 Q50,42 50,18 Z" opacity="0.85"></path>
+        <ellipse cx="36" cy="56" rx="5" ry="3.4" transform="rotate(-20 36 56)"></ellipse>
+        <ellipse cx="50" cy="52" rx="5" ry="3.4"></ellipse>
+        <ellipse cx="64" cy="56" rx="5" ry="3.4" transform="rotate(20 64 56)"></ellipse>
+        <ellipse cx="42" cy="66" rx="5" ry="3.4" transform="rotate(15 42 66)"></ellipse>
+        <ellipse cx="58" cy="66" rx="5" ry="3.4" transform="rotate(-15 58 66)"></ellipse>
+        <ellipse cx="50" cy="76" rx="5" ry="3.4"></ellipse>
+      </g>`,
+
+    sulfitos: () => `${RING}
+      <g fill="none" stroke="#fff">
+        <polygon points="50,28 68,39 68,61 50,72 32,61 32,39" stroke-width="3.5" stroke-linejoin="round"></polygon>
+        <polygon points="50,35 62,42 62,58 50,65 38,58 38,42" stroke-width="1.5" stroke-linejoin="round" opacity="0.5"></polygon>
+      </g>
+      <text x="50" y="50" text-anchor="middle" dominant-baseline="central" fill="#fff"
+            font-family="ui-sans-serif, system-ui, sans-serif"
+            font-weight="900" font-size="16" letter-spacing="0.5">E-X</text>`,
+
+    moluscos: () => `${RING}
+      <g transform="translate(2 2)">
+        <path d="M48 72 L24 60 Q22 50 26 30 Q30 26 32 30 Q34 24 38 26 Q40 20 44 24 Q46 18 50 22 Q54 20 56 26 Q58 22 62 26 Q64 24 66 30 Q70 28 70 30 Q74 50 72 60 Z" fill="#fff"></path>
+        <g stroke="var(--c)" stroke-width="1.6" stroke-linecap="round" fill="none">
+          <path d="M48 70 L28 36"></path>
+          <path d="M48 70 L36 24"></path>
+          <path d="M48 70 L44 22"></path>
+          <path d="M48 70 L52 22"></path>
+          <path d="M48 70 L60 24"></path>
+          <path d="M48 70 L68 36"></path>
+        </g>
+        <ellipse cx="48" cy="72" rx="6" ry="2.5" fill="#fff"></ellipse>
+      </g>`,
+
+    altramuces: () => `${RING}
+      <g fill="#fff">
+        <rect x="48.5" y="46" width="3" height="36" rx="1"></rect>
+        <ellipse cx="50" cy="22" rx="6" ry="4"></ellipse>
+        <ellipse cx="46" cy="28" rx="8" ry="4"></ellipse>
+        <ellipse cx="54" cy="28" rx="8" ry="4"></ellipse>
+        <ellipse cx="44" cy="36" rx="9" ry="4.5"></ellipse>
+        <ellipse cx="56" cy="36" rx="9" ry="4.5"></ellipse>
+        <ellipse cx="42" cy="44" rx="10" ry="4.5"></ellipse>
+        <ellipse cx="58" cy="44" rx="10" ry="4.5"></ellipse>
+        <path d="M50,68 Q34,72 28,82 Q42,80 50,72 Z"></path>
+        <path d="M50,68 Q66,72 72,82 Q58,80 50,72 Z"></path>
+      </g>`,
+  };
+
+  const ALLERGEN_COLORS = {
+    gluten:           "#E27B2D",
+    crustaceos:       "#4FAFD4",
+    huevos:           "#F2D374",
+    pescado:          "#1E3F7D",
+    cacahuetes:       "#C97847",
+    soja:             "#6DBE5A",
+    lacteos:          "#6B3F2A",
+    "frutos-cascara": "#7A3A24",
+    apio:             "#95C93F",
+    mostaza:          "#C68A1F",
+    sesamo:           "#B5A082",
+    sulfitos:         "#6E2A4D",
+    moluscos:         "#6FB6D8",
+    altramuces:       "#F0D04A",
+  };
+
+  function pictogramSVG(id) {
+    const fn = PICTOGRAMS[id];
+    if (!fn) return "";
+    return fn();
+  }
+
+  window.ZAMPA_PICTOGRAMS = { PICTOGRAMS, ALLERGEN_COLORS, pictogramSVG };
+})();

--- a/resources/views/components/daily-menu-availability.blade.php
+++ b/resources/views/components/daily-menu-availability.blade.php
@@ -3,34 +3,20 @@
 {{-- Indicador de disponibilidad del menú del día.
      Se renderiza dentro del banner (sin x-data propio), hereda el scope Alpine del banner. --}}
 
-<div x-show="menuData?.menu?.max_per_day !== null" class="mt-1.5">
+<div x-show="menuData?.menu?.max_per_day !== null" style="margin-top:6px">
 
     <template x-if="menuData?.menu?.available_count === 0">
-        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full
-                     text-xs font-medium bg-red-500/20 text-red-300 border border-red-500/30"
-              role="status">
-            <span class="w-1.5 h-1.5 rounded-full bg-red-400" aria-hidden="true"></span>
-            Agotado
+        <span class="dm-banner__agotado" role="status">
+            <span class="dm-banner__agotadoDot" aria-hidden="true"></span>
+            Agotado por hoy
         </span>
     </template>
 
     <template x-if="menuData?.menu?.available_count > 0 && menuData?.menu?.available_count <= 3">
-        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full
-                     text-xs font-medium bg-amber-500/20 text-amber-300 border border-amber-500/30"
-              role="status"
-              :aria-label="`Últimos ${menuData.menu.available_count} menús disponibles`">
-            <span class="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" aria-hidden="true"></span>
-            <span x-text="`Últimos ${menuData.menu.available_count}`"></span>
-        </span>
-    </template>
-
-    <template x-if="menuData?.menu?.available_count > 3">
-        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full
-                     text-xs font-medium bg-green-500/20 text-green-300 border border-green-500/30"
-              role="status"
-              :aria-label="`Quedan ${menuData.menu.available_count} menús disponibles`">
-            <span class="w-1.5 h-1.5 rounded-full bg-green-400" aria-hidden="true"></span>
-            <span x-text="`Quedan ${menuData.menu.available_count}`"></span>
+        <span style="display:inline-flex;align-items:center;gap:6px;padding:4px 10px;border-radius:9999px;background:var(--color-amber-100);color:var(--color-amber-800);font-family:var(--font-body);font-size:11px;font-weight:700"
+              role="status">
+            <span style="width:6px;height:6px;border-radius:50%;background:currentColor;flex-shrink:0" aria-hidden="true"></span>
+            Quedan <span x-text="menuData?.menu?.available_count"></span>
         </span>
     </template>
 

--- a/resources/views/components/daily-menu-banner.blade.php
+++ b/resources/views/components/daily-menu-banner.blade.php
@@ -1,7 +1,7 @@
 {{-- @author SebastianBCF --}}
 {{-- @author Ayrtonalania --}}
-{{-- Banner del Menú del Día en la carta digital pública.
-     Se inserta al inicio del <main> de la carta, antes de las categorías. --}}
+{{-- Banner del Menú del Día — estructura idéntica al Design System (dm-banner).
+     Se inserta al inicio del carta__body. Gestiona el stepper vía Alpine. --}}
 @props(['hash'])
 
 @once
@@ -19,55 +19,60 @@ window.dailyMenuBanner = function (hash) {
 
     return {
         hash,
-
-        /* ── Banner ─────────────────────────────────────────────────── */
-        menuData: null,
-        loading:  true,
-        open:     false,
+        menuData:  null,
+        loading:   true,
+        open:      false,
+        exiting:   false,
+        stuck:     false,
         showExclusivityWarning: false,
 
-        /* ── Stepper ─────────────────────────────────────────────────── */
-        pasos:         [],
-        pasoActual:    0,
-        selections:    {},   // { [sectionId]: { product_id, product_name } }
-        timings:       {},   // { [roundNumber]: delayMinutes }
-        enviando:      false,
-        enviado:       false,
-        errorMsg:      null,
+        /* ── Stepper ─── */
+        pasos:          [],
+        pasoActual:     0,
+        selections:     {},
+        timings:        {},
+        timingRules:    [],
+        enviando:       false,
+        enviado:        false,
+        errorMsg:       null,
         intentoAvanzar: false,
-        timingRules:   [],
+        closingModal:   false,
 
-        /* ── Computed ───────────────────────────────────────────────── */
+        /* ── Computed ─── */
+        get agotado() {
+            return !this.menuData || this.menuData.menu?.available_count === 0;
+        },
         get pasoActualObj() {
             return this.pasos[this.pasoActual] ?? null;
         },
-
-        get puedeAvanzar() {
-            const paso = this.pasoActualObj;
-            if (!paso) return false;
-            if (paso.tipo === 'timing') return true;
-            if (paso.tipo === 'seleccion') {
-                return !paso.required || (this.selections[paso.sectionId]?.length ?? 0) > 0;
-            }
-            return true;
+        get pct() {
+            if (!this.pasos.length) return 0;
+            if (this.enviado) return 100;
+            return Math.round(this.pasoActual / Math.max(this.pasos.length - 1, 1) * 100);
+        },
+        get isLastStep() {
+            return this.pasoActualObj?.tipo === 'confirmacion';
+        },
+        get isFirstStep() {
+            return this.pasoActual === 0;
+        },
+        get canProceed() {
+            const p = this.pasoActualObj;
+            if (!p) return false;
+            if (p.tipo === 'timing' || p.tipo === 'confirmacion') return true;
+            const picks = this.selections[p.sectionId] ?? [];
+            if (p.optional) return true;
+            return picks.length >= 1;
+        },
+        get dateLabel() {
+            const d = new Date();
+            return d.toLocaleDateString('es-ES', { weekday:'long', day:'numeric', month:'long' });
         },
 
-        get horasEstimadas() {
-            const result = {};
-            const now = new Date();
-            Object.entries(this.timings).forEach(([round, delay]) => {
-                const d = new Date(now.getTime() + delay * 60000);
-                result[parseInt(round)] = d.toLocaleTimeString('es-ES', {
-                    hour: '2-digit', minute: '2-digit',
-                });
-            });
-            return result;
-        },
-
-        /* ── Inicialización ─────────────────────────────────────────── */
+        /* ── Init ─── */
         async init() {
             try {
-                const res  = await fetch(`/api/v1/menu/${hash}/daily-menu`);
+                const res  = await fetch('/api/v1/menu/' + this.hash + '/daily-menu');
                 const json = await res.json();
                 this.menuData = json.data ?? null;
                 if (this.menuData) this._buildFromData(this.menuData);
@@ -78,8 +83,14 @@ window.dailyMenuBanner = function (hash) {
             }
         },
 
-        /* ── Lógica del banner ──────────────────────────────────────── */
+        /* ── Banner ─── */
+        dismiss() {
+            if (this.exiting) return;
+            this.exiting = true;
+        },
+
         openStepper() {
+            if (this.agotado) return;
             if (Alpine.store('cart').items.length > 0) {
                 this.showExclusivityWarning = true;
             } else {
@@ -99,30 +110,31 @@ window.dailyMenuBanner = function (hash) {
         },
 
         _doOpen() {
-            this.open = true;
-            this.$nextTick(() => {
-                const stepper  = document.getElementById('daily-menu-stepper');
-                const focusable = stepper?.querySelector(
-                    'button:not([disabled]), input:not([disabled]), [href]'
-                );
-                if (focusable) focusable.focus();
-            });
+            this.showExclusivityWarning = false;
+            this.open      = true;
+            this.closingModal = false;
         },
 
-        close() {
-            this.open = false;
-            this.$nextTick(() => this.$refs.openButton?.focus());
+        requestClose() {
+            if (this.enviando && !this.enviado) return;
+            if (this.closingModal) return;
+            this.closingModal = true;
+            setTimeout(() => {
+                this.open = false;
+                this.closingModal = false;
+                if (this.enviado) {
+                    this.enviado = false;
+                    this.pasoActual = 0;
+                    this.selections = {};
+                }
+            }, 240);
         },
 
-        /* ── Construcción del stepper ───────────────────────────────── */
+        /* ── Stepper build ─── */
         _buildFromData(data) {
             const sections = data.sections ?? [];
-            const pasos    = [];
-            const timings  = {};
-
-            // Agrupar secciones por round_number de su timing_rule embebida.
-            // La API no devuelve un array timing_rules raíz; cada sección
-            // lleva su regla embebida como section.timing_rule.
+            const pasos = [];
+            const timings = {};
             const byRound = new Map();
             const noRound = [];
 
@@ -130,11 +142,7 @@ window.dailyMenuBanner = function (hash) {
                 const rn = section.timing_rule?.round_number ?? null;
                 if (rn !== null) {
                     if (!byRound.has(rn)) {
-                        byRound.set(rn, {
-                            round:    rn,
-                            minDelay: section.timing_rule.estimated_prep_minutes,
-                            sections: [],
-                        });
+                        byRound.set(rn, { round: rn, minDelay: section.timing_rule.estimated_prep_minutes, sections: [] });
                         timings[rn] = section.timing_rule.default_delay_minutes;
                     }
                     byRound.get(rn).sections.push(section);
@@ -145,43 +153,35 @@ window.dailyMenuBanner = function (hash) {
 
             const rounds = [...byRound.values()].sort((a, b) => a.round - b.round);
 
-            // Secciones sin regla de timing van primero
             noRound.forEach(section => {
                 pasos.push({
-                    tipo:      'seleccion',
+                    tipo: 'seleccion',
                     sectionId: section.id,
-                    label:     SECTION_LABELS[section.type] ?? section.type,
-                    required:  section.is_required,
-                    round:     null,
+                    label: SECTION_LABELS[section.type] ?? section.type,
+                    required: section.is_required,
+                    optional: !section.is_required,
+                    round: null,
                     section,
                 });
             });
 
-            // Secciones con timing, intercaladas con pasos de timing
             rounds.forEach((group, idx) => {
                 group.sections.forEach(section => {
                     pasos.push({
-                        tipo:      'seleccion',
+                        tipo: 'seleccion',
                         sectionId: section.id,
-                        label:     SECTION_LABELS[section.type] ?? section.type,
-                        required:  section.is_required,
-                        round:     group.round,
+                        label: SECTION_LABELS[section.type] ?? section.type,
+                        required: section.is_required,
+                        optional: !section.is_required,
+                        round: group.round,
                         section,
                     });
                 });
-
                 if (idx < rounds.length - 1) {
                     const nextGroup = rounds[idx + 1];
                     const nextSec   = nextGroup.sections[0];
-                    const nextName  = nextSec
-                        ? (SECTION_LABELS[nextSec.type] ?? nextSec.type).toLowerCase()
-                        : 'el siguiente plato';
-                    pasos.push({
-                        tipo:     'timing',
-                        round:    nextGroup.round,
-                        label:    `¿Cuándo quieres ${nextName}?`,
-                        minDelay: nextGroup.minDelay,
-                    });
+                    const nextName  = nextSec ? (SECTION_LABELS[nextSec.type] ?? nextSec.type).toLowerCase() : 'el siguiente plato';
+                    pasos.push({ tipo: 'timing', round: nextGroup.round, label: '¿Cuándo quieres ' + nextName + '?', minDelay: nextGroup.minDelay });
                 }
             });
 
@@ -191,34 +191,23 @@ window.dailyMenuBanner = function (hash) {
             this.timingRules = rounds;
         },
 
-        sectionLabel(type) {
-            return SECTION_LABELS[type] ?? type;
-        },
+        sectionLabel: (type) => ({ first_course:'Primer plato', second_course:'Segundo plato', dessert:'Postre', coffee:'Café', drink:'Bebida', bread:'Pan' })[type] ?? type,
 
-        /* ── Navegación del stepper ─────────────────────────────────── */
+        /* ── Navegación ─── */
         siguiente() {
-            const paso = this.pasoActualObj;
-            if (!paso) return;
-
-            if (paso.tipo === 'seleccion') {
+            const p = this.pasoActualObj;
+            if (!p) return;
+            if (p.tipo === 'seleccion' && p.required && !(this.selections[p.sectionId]?.length > 0)) {
                 this.intentoAvanzar = true;
-                if (paso.required && !this.selections[paso.sectionId]) return;
-                this.intentoAvanzar = false;
+                return;
             }
-
+            this.intentoAvanzar = false;
             this.pasoActual = Math.min(this.pasoActual + 1, this.pasos.length - 1);
-
-            setTimeout(() => {
-                const stepper = document.getElementById('daily-menu-stepper');
-                const el = stepper && stepper.querySelector(
-                    '[data-step-content] button:not([disabled]), [data-step-content] input:not([disabled])'
-                );
-                if (el) el.focus();
-            }, 50);
         },
 
         anterior() {
             this.intentoAvanzar = false;
+            if (this.isFirstStep) { this.requestClose(); return; }
             this.pasoActual = Math.max(0, this.pasoActual - 1);
         },
 
@@ -226,75 +215,59 @@ window.dailyMenuBanner = function (hash) {
             if (idx <= this.pasoActual) this.pasoActual = idx;
         },
 
-        /* ── Selecciones ────────────────────────────────────────────── */
+        /* ── Selecciones ─── */
         selectProduct(sectionId, productId, productName, maxQty) {
             const max     = maxQty ?? 1;
             const current = this.selections[sectionId] ?? [];
             const idx     = current.findIndex(s => s.product_id === productId);
-
             if (max === 1) {
-                // Comportamiento radio: reemplaza o deselecciona
-                this.selections = {
-                    ...this.selections,
-                    [sectionId]: idx !== -1 ? [] : [{ product_id: productId, product_name: productName }],
-                };
+                this.selections = { ...this.selections, [sectionId]: idx !== -1 ? [] : [{ product_id: productId, product_name: productName }] };
             } else {
-                // Comportamiento checkbox: toggle hasta el máximo
                 if (idx !== -1) {
-                    this.selections = {
-                        ...this.selections,
-                        [sectionId]: current.filter(s => s.product_id !== productId),
-                    };
+                    this.selections = { ...this.selections, [sectionId]: current.filter(s => s.product_id !== productId) };
                 } else if (current.length < max) {
-                    this.selections = {
-                        ...this.selections,
-                        [sectionId]: [...current, { product_id: productId, product_name: productName }],
-                    };
+                    this.selections = { ...this.selections, [sectionId]: [...current, { product_id: productId, product_name: productName }] };
                 }
             }
         },
 
+        isSelected(sectionId, productId) {
+            return (this.selections[sectionId] ?? []).some(s => s.product_id === productId);
+        },
+
         skipSection(sectionId) {
-            const copy = { ...this.selections };
-            delete copy[sectionId];
-            this.selections = copy;
+            this.selections = { ...this.selections, [sectionId]: [{ product_id: '__skipped__', product_name: '' }] };
             this.siguiente();
         },
 
-        /* ── Timing ─────────────────────────────────────────────────── */
-        decrementTiming(round, min) {
-            if (this.timings[round] > min) {
-                this.timings = {
-                    ...this.timings,
-                    [round]: Math.max(min, this.timings[round] - 5),
-                };
-            }
+        isSkipped(sectionId) {
+            const arr = this.selections[sectionId] ?? [];
+            return arr.length > 0 && arr[0].product_id === '__skipped__';
         },
 
-        incrementTiming(round) {
-            if (this.timings[round] < 120) {
-                this.timings = {
-                    ...this.timings,
-                    [round]: Math.min(120, this.timings[round] + 5),
-                };
-            }
+        /* ── Timing ─── */
+        setTiming(round, val) {
+            this.timings = { ...this.timings, [round]: val };
         },
 
-        /* ── Confirmación ───────────────────────────────────────────── */
+        /* ── Confirmación ─── */
         confirmationSelections() {
             if (!this.menuData) return [];
             const result = [];
             (this.menuData.sections ?? []).forEach(s => {
-                (this.selections[s.id] ?? []).forEach(sel => {
-                    result.push({
-                        section_label: SECTION_LABELS[s.type] ?? s.type,
-                        product_name:  sel.product_name,
-                    });
+                const arr = (this.selections[s.id] ?? []).filter(x => x.product_id !== '__skipped__');
+                const skipped = this.isSkipped(s.id);
+                result.push({
+                    section_label: this.sectionLabel(s.type),
+                    products: arr.map(x => x.product_name),
+                    skipped,
+                    empty: !skipped && arr.length === 0,
                 });
             });
             return result;
         },
 
+        /* ── Submit ─── */
         async submitOrder() {
             this.enviando = true;
             this.errorMsg = null;
@@ -303,7 +276,7 @@ window.dailyMenuBanner = function (hash) {
                     selections: Object.entries(this.selections)
                         .filter(([, v]) => v?.length > 0)
                         .flatMap(([sectionId, sels]) =>
-                            sels.map(sel => ({
+                            sels.filter(s => s.product_id !== '__skipped__').map(sel => ({
                                 section_id: parseInt(sectionId),
                                 product_id: sel.product_id,
                                 quantity:   1,
@@ -313,19 +286,15 @@ window.dailyMenuBanner = function (hash) {
                         const firstRound = this.timingRules.length > 0 ? this.timingRules[0].round : null;
                         return Object.entries(this.timings)
                             .filter(([round]) => parseInt(round) !== firstRound)
-                            .map(([round, delay]) => ({
-                                round:         parseInt(round),
-                                delay_minutes: delay,
-                            }));
+                            .map(([round, delay]) => ({ round: parseInt(round), delay_minutes: delay }));
                     })(),
                 };
-                const res = await fetch(`/api/v1/menu/${hash}/daily-menu/order`, {
+                const res = await fetch('/api/v1/menu/' + this.hash + '/daily-menu/order', {
                     method:  'POST',
                     headers: {
-                        'Content-Type':     'application/json',
-                        'X-CSRF-TOKEN':     document.querySelector('meta[name="csrf-token"]')?.content ?? '',
-                        'Accept':           'application/json',
-                        'X-Requested-With': 'XMLHttpRequest',
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content ?? '',
+                        'Accept':       'application/json',
                     },
                     body: JSON.stringify(body),
                 });
@@ -346,94 +315,79 @@ window.dailyMenuBanner = function (hash) {
 </script>
 @endonce
 
+{{-- ── Wrapper Alpine ──────────────────────────────────────────── --}}
 <div
     x-data="dailyMenuBanner('{{ $hash }}')"
     x-show="!loading && menuData !== null"
     x-cloak
-    class="mb-4"
 >
-    {{-- ── Card del banner ────────────────────────────────────────── --}}
-    <div class="rounded-xl border border-blue-600/40
-                bg-gradient-to-br from-[#2E50B0] to-[#1A3380]
-                dark:from-[#1A3380] dark:to-[#0E1A38]
-                p-4 shadow-lg shadow-blue-900/40">
-
-        <div class="flex items-start justify-between gap-3">
-            <div class="flex-1 min-w-0">
-
-                {{-- Etiqueta superior --}}
-                <div class="flex items-center gap-2 mb-1">
-                    <svg class="w-4 h-4 text-yellow-400 flex-shrink-0" fill="currentColor"
-                         viewBox="0 0 20 20" aria-hidden="true">
-                        <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
-                    </svg>
-                    <span class="text-xs font-semibold uppercase tracking-widest
-                                 text-blue-200">
-                        Menú del día
-                    </span>
-                </div>
-
-                {{-- Título y descripción --}}
-                <h2 class="text-white font-bold text-lg leading-snug"
-                    x-text="menuData?.menu?.title"></h2>
-                <p class="text-blue-200 text-sm mt-0.5 line-clamp-2"
-                   x-text="menuData?.menu?.description"
-                   x-show="menuData?.menu?.description"></p>
-
-                {{-- Secciones como pills --}}
-                <div class="flex flex-wrap gap-1.5 mt-2">
-                    <template x-for="section in menuData?.sections ?? []"
-                              :key="section.id">
-                        <span class="text-xs px-2 py-0.5 rounded-full
-                                     bg-white/10 text-blue-100">
-                            <span x-text="sectionLabel(section.type)"></span>
-                            <span x-show="section.is_free"
-                                  class="text-yellow-300"> · incluido</span>
-                        </span>
-                    </template>
-                </div>
-
-            </div>
-
-            {{-- Precio y disponibilidad --}}
-            <div class="flex-shrink-0 text-right">
-                <span class="text-2xl font-bold text-white"
-                      x-text="parseFloat(menuData?.menu?.price ?? 0).toFixed(2).replace('.', ',') + ' €'">
-                </span>
-                <x-daily-menu-availability />
-            </div>
+    {{-- ── Banner DS ────────────────────────────────────────────── --}}
+    <div
+        :class="'dm-banner' +
+            (exiting   ? ' dm-banner--exit'      : '') +
+            (stuck     ? ' dm-banner--stuck'     : '') +
+            (agotado   ? ''                       : ' dm-banner--clickable')"
+        :role="agotado ? 'status' : 'button'"
+        :tabindex="agotado ? undefined : 0"
+        :aria-label="agotado ? undefined : 'Abrir ' + (menuData?.menu?.title ?? 'Menú del día')"
+        aria-live="polite"
+        @click="!agotado && openStepper()"
+        @keydown.enter.prevent="!agotado && openStepper()"
+        @keydown.space.prevent="!agotado && openStepper()"
+    >
+        <div class="dm-banner__stamp" aria-hidden="true">
+            <span class="dm-banner__stampMark">◇</span>
+            <span class="dm-banner__stampLabel">MENÚ DEL DÍA</span>
         </div>
 
-        {{-- Botón de apertura --}}
-        <button
-            x-ref="openButton"
-            type="button"
-            @click="openStepper()"
-            :disabled="menuData?.menu?.available_count === 0"
-            aria-haspopup="dialog"
-            :aria-expanded="open.toString()"
-            aria-controls="daily-menu-stepper"
-            class="mt-4 w-full py-2.5 px-4 rounded-lg font-semibold text-sm min-h-[44px]
-                   bg-yellow-400 text-gray-900 hover:bg-yellow-300
-                   focus:outline-none focus:ring-2 focus:ring-yellow-400
-                   focus:ring-offset-2 focus:ring-offset-blue-900
-                   disabled:opacity-40 disabled:cursor-not-allowed
-                   transition-colors duration-150"
-        >
-            <span x-show="menuData?.menu?.available_count !== 0">
-                Ver el menú completo →
-            </span>
-            <span x-show="menuData?.menu?.available_count === 0">
-                Menú agotado
-            </span>
-        </button>
+        <div class="dm-banner__body">
+            <div class="dm-banner__date" x-text="dateLabel"></div>
+            <div class="dm-banner__title" x-text="menuData?.menu?.title"></div>
+            <div class="dm-banner__tagline"
+                 x-text="menuData?.menu?.description"
+                 x-show="menuData?.menu?.description"></div>
+        </div>
 
+        <div class="dm-banner__side">
+            <template x-if="agotado">
+                <span class="dm-banner__agotado" aria-label="Menú del día agotado por hoy">
+                    <span class="dm-banner__agotadoDot" aria-hidden="true"></span>
+                    Agotado por hoy
+                </span>
+            </template>
+            <template x-if="!agotado">
+                <span style="display:flex;flex-direction:column;align-items:flex-end;gap:6px">
+                    <span class="dm-banner__price"
+                          x-text="parseFloat(menuData?.menu?.price ?? 0).toFixed(2).replace('.', ',') + ' €'"
+                          :aria-label="'Precio ' + parseFloat(menuData?.menu?.price ?? 0).toFixed(2).replace('.', ',') + ' euros'">
+                    </span>
+                    <button type="button" class="dm-banner__cta"
+                            @click.stop="openStepper()">
+                        Ver menú
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                             stroke="currentColor" stroke-width="2.4"
+                             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M5 12h14M13 5l7 7-7 7"/>
+                        </svg>
+                    </button>
+                </span>
+            </template>
+        </div>
+
+        <button type="button" class="dm-banner__close"
+                @click.stop="dismiss()"
+                aria-label="Descartar anuncio del menú del día">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" stroke-width="2.5"
+                 stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M18 6L6 18M6 6l12 12"/>
+            </svg>
+        </button>
     </div>
 
-    {{-- Dialog de exclusividad --}}
+    {{-- ── Diálogo de exclusividad ────────────────────────────── --}}
     <x-daily-menu-exclusivity-dialog />
 
-    {{-- Stepper modal --}}
-    <x-daily-menu-stepper :hash="$hash" x-show="open" />
-
+    {{-- ── Stepper modal ──────────────────────────────────────── --}}
+    <x-daily-menu-stepper :hash="$hash" />
 </div>

--- a/resources/views/components/daily-menu-exclusivity-dialog.blade.php
+++ b/resources/views/components/daily-menu-exclusivity-dialog.blade.php
@@ -1,88 +1,51 @@
 {{-- @author SebastianBCF --}}
 {{-- @author Ayrtonalania --}}
-{{-- Dialog de exclusividad: se muestra cuando el usuario tiene ítems en el carrito
-     y quiere abrir el menú del día. Hereda el scope Alpine del banner (sin x-data propio). --}}
+{{-- Diálogo de exclusividad del menú del día — clases DS (modal + dm-excl).
+     Sin x-data propio: hereda el scope Alpine de dailyMenuBanner. --}}
 
 <div
-    role="alertdialog"
-    aria-modal="true"
-    aria-labelledby="exclusivity-title"
-    aria-describedby="exclusivity-desc"
+    class="scrim modal--center"
     x-show="showExclusivityWarning"
-    @keydown.escape.window="if (showExclusivityWarning) { showExclusivityWarning = false; $nextTick(() => $refs.openButton?.focus()); }"
+    @click="showExclusivityWarning = false; $nextTick(() => {})"
+    @keydown.escape.window="if (showExclusivityWarning) showExclusivityWarning = false"
     @keydown.tab.window="
         if (!showExclusivityWarning || !$el.contains(document.activeElement)) return;
         $event.preventDefault();
-        const focusable = [...$el.querySelectorAll('button:not([disabled]),[href],input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex=\'-1\'])')];
+        const focusable = [...$el.querySelectorAll('button:not([disabled]),[href],input:not([disabled])')];
         if (!focusable.length) return;
         const idx = focusable.indexOf(document.activeElement);
-        focusable[$event.shiftKey
-            ? (idx - 1 + focusable.length) % focusable.length
-            : (idx + 1) % focusable.length
-        ].focus();
+        focusable[$event.shiftKey ? (idx - 1 + focusable.length) % focusable.length : (idx + 1) % focusable.length].focus();
     "
-    x-transition:enter="transition ease-out duration-200"
-    x-transition:enter-start="opacity-0"
-    x-transition:enter-end="opacity-100"
-    x-transition:leave="transition ease-in duration-150"
-    x-transition:leave-start="opacity-100"
-    x-transition:leave-end="opacity-0"
-    class="fixed inset-0 z-[60] flex items-end sm:items-center justify-center p-4"
+    role="alertdialog"
+    aria-modal="true"
+    aria-labelledby="dm-excl-title"
+    aria-describedby="dm-excl-desc"
     x-cloak
 >
-    {{-- Overlay --}}
-    <div class="absolute inset-0 bg-black/70 backdrop-blur-sm"
-         @click="showExclusivityWarning = false"
-         aria-hidden="true"></div>
+    <div class="modal__panel modal__panel--narrow" @click.stop>
+        <div class="dm-excl">
+            <div class="dm-excl__ic" aria-hidden="true">!</div>
 
-    {{-- Panel --}}
-    <div class="relative w-full max-w-sm rounded-2xl
-                bg-[#0E1A38] border border-blue-600/40
-                shadow-2xl shadow-blue-900/50 p-5 z-10">
+            <div class="dm-excl__title" id="dm-excl-title">
+                El menú del día va aparte
+            </div>
 
-        <h3 id="exclusivity-title"
-            class="text-white font-bold text-base mb-2">
-            ¿Quieres pedir el Menú del Día?
-        </h3>
+            <div class="dm-excl__copy" id="dm-excl-desc">
+                Para pedir el menú del día tu carrito debe estar vacío. Tienes
+                <strong x-text="Alpine.store('cart').items.length + (Alpine.store('cart').items.length === 1 ? ' artículo' : ' artículos')"></strong>
+                añadidos à la carte.
+            </div>
 
-        <p id="exclusivity-desc" class="text-blue-200 text-sm leading-relaxed mb-4">
-            Tienes
-            <span class="font-semibold text-white"
-                  x-text="Alpine.store('cart').items.length"></span><span
-                  x-text="Alpine.store('cart').items.length === 1 ? ' producto' : ' productos'"></span>
-            en tu carrito à la carte. El Menú del Día y el pedido normal
-            no pueden combinarse en la misma comanda.
-            <br><br>
-            Si continúas, <strong class="text-white">tu carrito actual se vaciará.</strong>
-        </p>
-
-        <div class="flex flex-col gap-2">
-
-            {{-- Botón primario visual: camino seguro (cancelar) --}}
-            <button
-                @click="showExclusivityWarning = false"
-                class="w-full py-2.5 px-4 rounded-lg font-semibold text-sm
-                       bg-[#2E50B0] text-white hover:bg-[#3660CC]
-                       focus:outline-none focus:ring-2 focus:ring-blue-400
-                       focus:ring-offset-2 focus:ring-offset-[#0E1A38]
-                       transition-colors"
-            >
-                Volver a la carta
-            </button>
-
-            {{-- Botón destructivo: vaciar carrito y continuar --}}
-            <button
-                @click="clearCartAndOpen()"
-                class="w-full py-2.5 px-4 rounded-lg font-medium text-sm
-                       border border-red-500/60 text-red-400
-                       hover:bg-red-500/10 hover:text-red-300
-                       focus:outline-none focus:ring-2 focus:ring-red-500/50
-                       focus:ring-offset-2 focus:ring-offset-[#0E1A38]
-                       transition-colors"
-            >
-                Vaciar carrito y ver el menú
-            </button>
-
+            <div class="dm-excl__actions">
+                <button type="button" class="btn-secondary"
+                        @click="showExclusivityWarning = false">
+                    Cancelar
+                </button>
+                <button type="button" class="btn-primary dm-excl__btnPrimary"
+                        @click="clearCartAndOpen()">
+                    Vaciar carrito y continuar
+                </button>
+            </div>
         </div>
     </div>
 </div>

--- a/resources/views/components/daily-menu-stepper.blade.php
+++ b/resources/views/components/daily-menu-stepper.blade.php
@@ -1,367 +1,286 @@
 {{-- @author SebastianBCF --}}
 {{-- @author Ayrtonalania --}}
-{{-- Stepper modal del menú del día.
-     Sin x-data propio: hereda todo el scope Alpine del banner.
-     Se usa con: <x-daily-menu-stepper :hash="$hash" x-show="open" @close.window="close()" /> --}}
+{{-- Stepper modal del menú del día — estructura idéntica al DS (scrim + dm-modal).
+     Sin x-data propio: hereda el scope Alpine del banner (dailyMenuBanner). --}}
 @props(['hash'])
 
+{{-- ── Scrim + dm-modal ─────────────────────────────────────────── --}}
 <div
-    id="daily-menu-stepper"
+    class="scrim scrim--center scrim--dm"
+    x-show="open"
+    :class="closingModal ? 'is-closing' : ''"
+    @click="requestClose()"
+    @keydown.escape.window="if (open) requestClose()"
     role="dialog"
     aria-modal="true"
-    aria-labelledby="stepper-title"
-    @keydown.escape.window="if (open) close()"
-    @keydown.tab.window="
-        if (!open || !$el.contains(document.activeElement)) return;
-        $event.preventDefault();
-        const focusable = [...$el.querySelectorAll('button:not([disabled]),[href],input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex=\'-1\'])')].filter(el => el.offsetParent !== null);
-        if (!focusable.length) return;
-        const idx = focusable.indexOf(document.activeElement);
-        focusable[$event.shiftKey
-            ? (idx - 1 + focusable.length) % focusable.length
-            : (idx + 1) % focusable.length
-        ].focus();
-    "
-    class="fixed inset-0 z-50 flex flex-col
-           bg-[#050B1F]/95 backdrop-blur-sm
-           sm:items-center sm:justify-center"
-    x-transition:enter="transition ease-out duration-200"
-    x-transition:enter-start="opacity-0 translate-y-4"
-    x-transition:enter-end="opacity-100 translate-y-0"
-    x-transition:leave="transition ease-in duration-150"
-    x-transition:leave-start="opacity-100 translate-y-0"
-    x-transition:leave-end="opacity-0 translate-y-4"
+    aria-labelledby="dm-step-title"
     x-cloak
     {{ $attributes }}
 >
-
-    {{-- Panel interior --}}
-    <div class="relative flex flex-col w-full h-full
-                sm:h-auto sm:max-w-lg sm:max-h-[90vh]
-                sm:rounded-2xl sm:border sm:border-blue-600/40
-                bg-[#0E1A38] overflow-hidden">
-
-        {{-- ── Pantalla de éxito ─────────────────────────────────────── --}}
-        <div
-            x-show="enviado"
-            class="flex-1 flex flex-col items-center justify-center px-6 py-12 text-center"
-            role="status"
-            aria-live="polite"
-        >
-            <div class="w-16 h-16 rounded-full bg-green-500/20 border border-green-500/30
-                        flex items-center justify-center mb-5">
-                <svg class="w-8 h-8 text-green-400" fill="none" stroke="currentColor"
-                     viewBox="0 0 24 24" aria-hidden="true">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                          stroke-width="2" d="M5 13l4 4L19 7"/>
-                </svg>
+    {{-- ── Panel dm-modal ──────────────────────────────────────── --}}
+    <div
+        class="dm-modal"
+        :class="closingModal ? 'is-closing' : ''"
+        @click.stop
+    >
+        {{-- Cabecera --}}
+        <div class="dm-modal__head">
+            <div class="dm-modal__brandRow">
+                <span class="dm-modal__mark" aria-hidden="true">◇</span>
+                <span class="dm-modal__brand">MENÚ DEL DÍA</span>
+                <span class="dm-modal__date"
+                      x-text="new Date().toLocaleDateString('es-ES', {day:'numeric', month:'long'})">
+                </span>
             </div>
-            <h3 class="text-white font-bold text-xl mb-2">¡Pedido enviado!</h3>
-            <p class="text-blue-200 text-sm max-w-xs leading-relaxed">
-                Tu menú del día está en camino. Te lo serviremos en los tiempos acordados.
-            </p>
-            <button
-                @click="close()"
-                class="mt-8 px-6 py-2.5 rounded-lg font-semibold text-sm
-                       bg-[#2E50B0] text-white hover:bg-[#3660CC]
-                       focus:outline-none focus:ring-2 focus:ring-blue-400
-                       focus:ring-offset-2 focus:ring-offset-[#0E1A38]
-                       transition-colors"
-            >
-                Volver a la carta
+            <button type="button" class="icon-btn dm-modal__close"
+                    @click="requestClose()"
+                    aria-label="Cerrar menú del día">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+                     stroke="currentColor" stroke-width="2.5"
+                     stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M18 6L6 18M6 6l12 12"/>
+                </svg>
             </button>
         </div>
 
-        {{-- ── Flujo del stepper ─────────────────────────────────────── --}}
-        <div x-show="!enviado" class="flex flex-col flex-1 min-h-0">
-
-            {{-- Header --}}
-            <div class="flex items-center justify-between px-4 pt-4 pb-3
-                        border-b border-blue-800/40 flex-shrink-0 gap-3">
-
-                <h2 id="stepper-title"
-                    class="text-white font-bold text-base shrink-0">
-                    Menú del Día
-                </h2>
-
-                {{-- Indicador de pasos (dots) --}}
-                <nav aria-label="Pasos del menú del día"
-                     class="flex items-center gap-1.5 flex-1 justify-center flex-wrap">
-                    <template x-for="(paso, idx) in pasos" :key="idx">
-                        <button
-                            type="button"
-                            @click="irAPaso(idx)"
-                            :aria-current="pasoActual === idx ? 'step' : undefined"
-                            :aria-label="`Paso ${idx + 1} de ${pasos.length}: ${paso.label}`"
-                            :class="{
-                                'rounded-full transition-all duration-200': true,
-                                'w-3 h-3 bg-[#2E50B0] scale-125': pasoActual === idx,
-                                'w-2.5 h-2.5 bg-[#2E50B0]/50': pasoActual !== idx && idx < pasoActual,
-                                'w-2.5 h-2.5 bg-white/20': idx > pasoActual
-                            }"
-                        ></button>
-                    </template>
-                </nav>
-
-                {{-- Botón cerrar --}}
-                <button
-                    type="button"
-                    @click="close()"
-                    aria-label="Cerrar menú del día"
-                    class="shrink-0 p-2 rounded-lg text-blue-300 hover:text-white
-                           hover:bg-white/10 focus:outline-none
-                           focus:ring-2 focus:ring-blue-400 transition-colors"
-                >
-                    <svg class="w-5 h-5" fill="none" stroke="currentColor"
-                         viewBox="0 0 24 24" aria-hidden="true">
-                        <path stroke-linecap="round" stroke-linejoin="round"
-                              stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-                    </svg>
-                </button>
-            </div>
-
-            {{-- Barra de progreso --}}
-            <div class="h-0.5 bg-white/10 flex-shrink-0" aria-hidden="true">
-                <div class="h-full bg-[#2E50B0] transition-all duration-300"
-                     :style="`width: ${pasos.length ? ((pasoActual + 1) / pasos.length) * 100 : 0}%`">
+        {{-- Barra de progreso --}}
+        <div
+            class="dm-modal__progress"
+            x-show="!enviado"
+            role="progressbar"
+            :aria-valuemin="1"
+            :aria-valuemax="pasos.length"
+            :aria-valuenow="pasoActual + 1"
+            :aria-label="'Paso ' + (pasoActual + 1) + ' de ' + pasos.length"
+        >
+            <div class="dm-modal__progressBar">
+                <div class="dm-modal__progressFill"
+                     :style="'width: ' + pct + '%'">
                 </div>
             </div>
+            <div class="dm-modal__progressLabel"
+                 x-text="'Paso ' + (pasoActual + 1) + ' de ' + pasos.length">
+            </div>
+        </div>
 
-            {{-- ── Área de contenido scrollable ──────────────────────── --}}
-            <div class="flex-1 overflow-y-auto px-4 py-5 min-h-0" data-step-content>
+        {{-- ── Cuerpo scrollable ────────────────────────────────── --}}
+        <div class="dm-modal__body">
 
-                {{-- Paso de selección de producto --}}
-                <div x-show="pasoActualObj?.tipo === 'seleccion'">
+            {{-- Pantalla de éxito --}}
+            <div x-show="enviado" class="dm-step dm-step--done" role="status" aria-live="polite">
+                <div class="dm-step__doneIc" aria-hidden="true">
+                    <svg width="40" height="40" viewBox="0 0 24 24" fill="none"
+                         stroke="currentColor" stroke-width="3"
+                         stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M4 12l5 5L20 6"/>
+                    </svg>
+                </div>
+                <h3 class="dm-step__doneTitle">¡Pedido enviado a cocina!</h3>
+                <p class="dm-step__doneCopy">
+                    Tu menú del día está en camino. Te lo serviremos en los tiempos acordados.
+                </p>
+            </div>
 
-                    <div class="flex items-center justify-between mb-4">
-                        <h3 class="text-white font-bold text-lg"
+            {{-- Paso de selección --}}
+            <div x-show="!enviado && pasoActualObj?.tipo === 'seleccion'">
+                <div class="dm-step">
+                    <div class="dm-step__head">
+                        <h3 class="dm-step__title" id="dm-step-title"
                             x-text="pasoActualObj?.label"></h3>
-                        <template x-if="(pasoActualObj?.section?.max_quantity ?? 1) > 1">
-                            <span class="text-xs text-blue-300 bg-blue-900/40 border border-blue-700/50 px-2.5 py-1 rounded-full"
-                                  aria-live="polite">
-                                <span x-text="(selections[pasoActualObj?.sectionId] ?? []).length"></span>/<span x-text="pasoActualObj?.section?.max_quantity"></span> elegidos
-                            </span>
-                        </template>
+                        <p class="dm-step__hint"
+                           x-text="(pasoActualObj?.section?.max_quantity ?? 1) === 1
+                               ? (pasoActualObj?.optional ? 'Elige uno (opcional)' : 'Elige uno')
+                               : 'Elige hasta ' + pasoActualObj?.section?.max_quantity">
+                        </p>
                     </div>
 
-                    <div class="space-y-2" role="list">
+                    <div class="dm-step__options"
+                         :role="(pasoActualObj?.section?.max_quantity ?? 1) === 1 ? 'radiogroup' : 'group'"
+                         aria-labelledby="dm-step-title">
                         <template x-for="product in pasoActualObj?.section?.products ?? []"
                                   :key="product.id">
                             <button
                                 type="button"
-                                role="listitem"
-                                @click="selectProduct(pasoActualObj.sectionId, product.id, product.name, pasoActualObj.section?.max_quantity ?? 1)"
-                                :aria-pressed="(selections[pasoActualObj?.sectionId] ?? []).some(s => s.product_id === product.id)"
-                                :disabled="!(selections[pasoActualObj?.sectionId] ?? []).some(s => s.product_id === product.id) && (selections[pasoActualObj?.sectionId] ?? []).length >= (pasoActualObj?.section?.max_quantity ?? 1)"
-                                :class="{
-                                    'w-full text-left p-3 rounded-xl border-2 transition-all duration-150': true,
-                                    'border-[#2E50B0] bg-[#2E50B0]/20': (selections[pasoActualObj?.sectionId] ?? []).some(s => s.product_id === product.id),
-                                    'border-blue-800/40 bg-white/5 hover:border-blue-600/60 hover:bg-white/10': !(selections[pasoActualObj?.sectionId] ?? []).some(s => s.product_id === product.id),
-                                    'opacity-40 cursor-not-allowed': !(selections[pasoActualObj?.sectionId] ?? []).some(s => s.product_id === product.id) && (selections[pasoActualObj?.sectionId] ?? []).length >= (pasoActualObj?.section?.max_quantity ?? 1)
-                                }"
+                                :class="'dm-opt' +
+                                    (isSelected(pasoActualObj.sectionId, product.id) ? ' dm-opt--on' : '') +
+                                    (!product.is_active ? ' dm-opt--off' : '')"
+                                @click="product.is_active && selectProduct(pasoActualObj.sectionId, product.id, product.name, pasoActualObj.section?.max_quantity ?? 1)"
+                                :role="(pasoActualObj?.section?.max_quantity ?? 1) === 1 ? 'radio' : 'checkbox'"
+                                :aria-checked="isSelected(pasoActualObj.sectionId, product.id)"
+                                :disabled="!product.is_active"
                             >
-                                <div class="flex items-start justify-between gap-3">
-                                    <div class="flex-1 min-w-0">
-                                        <p class="text-white font-medium text-sm leading-snug"
-                                           x-text="product.name"></p>
-                                        <p class="text-blue-300 text-xs mt-0.5 line-clamp-2"
-                                           x-text="product.description"
-                                           x-show="product.description"></p>
-                                    </div>
-                                    <div class="flex items-center gap-2 flex-shrink-0">
-                                        <template x-if="!pasoActualObj?.section?.is_free">
-                                            <span class="text-blue-200 text-sm font-semibold"
-                                                  x-text="parseFloat(product.price).toFixed(2).replace('.', ',') + ' €'"></span>
+                                <span
+                                    :class="(pasoActualObj?.section?.max_quantity ?? 1) === 1
+                                        ? 'dm-opt__radio' + (isSelected(pasoActualObj.sectionId, product.id) ? ' is-on' : '')
+                                        : 'dm-opt__check' + (isSelected(pasoActualObj.sectionId, product.id) ? ' is-on' : '')"
+                                    aria-hidden="true">
+                                    <span x-show="(pasoActualObj?.section?.max_quantity ?? 1) > 1 && isSelected(pasoActualObj.sectionId, product.id)">
+                                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none"
+                                             stroke="currentColor" stroke-width="3.2"
+                                             stroke-linecap="round" stroke-linejoin="round">
+                                            <path d="M5 12l5 5L20 7"/>
+                                        </svg>
+                                    </span>
+                                </span>
+
+                                <div :class="'dm-opt__photo dm-opt__photo--food-' + ((product.id % 6) + 1)"
+                                     aria-hidden="true">
+                                    <template x-if="product.image">
+                                        <img :src="'/storage/' + product.image"
+                                             :alt="product.name"
+                                             style="width:100%;height:100%;object-fit:cover;border-radius:inherit">
+                                    </template>
+                                </div>
+
+                                <div class="dm-opt__body">
+                                    <div class="dm-opt__nameRow">
+                                        <span class="dm-opt__name" x-text="product.name"></span>
+                                        <template x-if="!product.is_active">
+                                            <span class="dm-opt__badge">Agotado</span>
                                         </template>
-                                        <template x-if="pasoActualObj?.section?.is_free">
-                                            <span class="text-green-400 text-xs font-medium px-1.5 py-0.5
-                                                         rounded bg-green-500/10 border border-green-500/20">
-                                                Incluido
-                                            </span>
-                                        </template>
-                                        <span
-                                            x-show="(selections[pasoActualObj?.sectionId] ?? []).some(s => s.product_id === product.id)"
-                                            class="w-5 h-5 rounded-full bg-[#2E50B0]
-                                                   flex items-center justify-center
-                                                   text-white text-xs font-bold flex-shrink-0"
-                                            aria-hidden="true"
-                                        >✓</span>
                                     </div>
+                                    <span class="dm-opt__desc"
+                                          x-text="product.description"
+                                          x-show="product.description"></span>
                                 </div>
                             </button>
                         </template>
                     </div>
 
-                    {{-- Alerta si obligatorio y no seleccionó --}}
-                    <div
-                        x-show="intentoAvanzar && pasoActualObj?.required && !((selections[pasoActualObj?.sectionId] ?? []).length > 0)"
-                        role="alert"
-                        class="mt-3 flex items-center gap-2 text-red-400 text-xs
-                               bg-red-500/10 border border-red-500/20 rounded-lg px-3 py-2"
-                    >
-                        <svg class="w-4 h-4 flex-shrink-0" fill="currentColor"
-                             viewBox="0 0 20 20" aria-hidden="true">
-                            <path fill-rule="evenodd"
-                                  d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
-                                  clip-rule="evenodd"/>
+                    {{-- Alerta obligatorio --}}
+                    <div x-show="intentoAvanzar && pasoActualObj?.required && !((selections[pasoActualObj?.sectionId] ?? []).filter(s => s.product_id !== '__skipped__').length > 0)"
+                         role="alert"
+                         style="margin-top:10px;padding:10px 14px;border-radius:10px;background:rgba(239,68,68,0.08);border:1px solid rgba(239,68,68,0.25);font-family:var(--font-body);font-size:13px;color:var(--color-red-400);display:flex;align-items:center;gap:8px">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"/>
                         </svg>
                         Por favor, selecciona una opción para continuar.
                     </div>
 
-                    {{-- Enlace para secciones opcionales --}}
-                    <button
-                        type="button"
-                        x-show="!pasoActualObj?.required"
-                        @click="skipSection(pasoActualObj.sectionId)"
-                        class="mt-3 text-sm text-blue-400 hover:text-blue-200
-                               underline underline-offset-2 transition-colors
-                               focus:outline-none focus:ring-1 focus:ring-blue-400 rounded"
-                    >
-                        Sin <span x-text="pasoActualObj?.label?.toLowerCase()"></span>, gracias →
-                    </button>
-
+                    {{-- Skip opcional --}}
+                    <template x-if="pasoActualObj?.optional">
+                        <button
+                            type="button"
+                            :class="'dm-skip' + (isSkipped(pasoActualObj.sectionId) ? ' dm-skip--on' : '')"
+                            @click="isSkipped(pasoActualObj.sectionId) ? selectProduct(pasoActualObj.sectionId, '__skipped__', '', 1) : skipSection(pasoActualObj.sectionId)"
+                        >
+                            <span :class="'dm-skip__check' + (isSkipped(pasoActualObj.sectionId) ? ' is-on' : '')" aria-hidden="true">
+                                <template x-if="isSkipped(pasoActualObj.sectionId)">
+                                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none"
+                                         stroke="currentColor" stroke-width="3.5"
+                                         stroke-linecap="round" stroke-linejoin="round">
+                                        <path d="M5 12l5 5L20 7"/>
+                                    </svg>
+                                </template>
+                            </span>
+                            <span x-text="isSkipped(pasoActualObj.sectionId)
+                                ? 'Sin ' + pasoActualObj.label.toLowerCase() + ' (cambiar)'
+                                : 'Sin ' + pasoActualObj.label.toLowerCase() + ', gracias'">
+                            </span>
+                        </button>
+                    </template>
                 </div>
-
-                {{-- Paso de timing --}}
-                <div x-show="pasoActualObj?.tipo === 'timing'">
-                    <x-daily-menu-timing-control />
-                </div>
-
-                {{-- Paso de confirmación --}}
-                <div x-show="pasoActualObj?.tipo === 'confirmacion'">
-
-                    <h3 class="text-white font-bold text-lg mb-5">Resumen de tu pedido</h3>
-
-                    <div id="confirmation-summary" class="space-y-3">
-                        <template x-for="sel in confirmationSelections()" :key="sel.section_label">
-                            <div class="flex items-start gap-3 text-sm
-                                        border-b border-blue-800/30 pb-3 last:border-0 last:pb-0">
-                                <span class="text-blue-400 w-28 flex-shrink-0 pt-0.5"
-                                      x-text="sel.section_label"></span>
-                                <span class="text-white font-medium leading-snug"
-                                      x-text="sel.product_name"></span>
-                            </div>
-                        </template>
-                    </div>
-
-                    {{-- Horarios estimados por ronda --}}
-                    <div class="mt-4 pt-4 border-t border-blue-800/40"
-                         x-show="timingRules.length > 1">
-                        <p class="text-blue-400 text-xs font-semibold uppercase tracking-wider mb-2">
-                            Horarios estimados
-                        </p>
-                        <template x-for="rule in timingRules" :key="rule.round">
-                            <div class="flex items-center justify-between text-xs text-blue-300 mb-1.5">
-                                <span x-text="`Ronda ${rule.round}`"></span>
-                                <span class="font-semibold text-blue-100"
-                                      x-text="horasEstimadas[rule.round] ?? '--:--'"></span>
-                            </div>
-                        </template>
-                    </div>
-
-                    {{-- Precio total del menú --}}
-                    <div class="mt-4 pt-4 border-t border-blue-800/40
-                                flex items-center justify-between">
-                        <span class="text-blue-300 text-sm">Total</span>
-                        <span class="text-white font-bold text-lg"
-                              x-text="parseFloat(menuData?.menu?.price ?? 0).toFixed(2).replace('.', ',') + ' €'"></span>
-                    </div>
-
-                    {{-- Mensaje de error --}}
-                    <div x-show="errorMsg"
-                         role="alert"
-                         class="mt-4 p-3 rounded-lg bg-red-500/10 border border-red-500/30
-                                text-red-400 text-sm flex items-start gap-2">
-                        <svg class="w-4 h-4 flex-shrink-0 mt-0.5" fill="currentColor"
-                             viewBox="0 0 20 20" aria-hidden="true">
-                            <path fill-rule="evenodd"
-                                  d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
-                                  clip-rule="evenodd"/>
-                        </svg>
-                        <span x-text="errorMsg"></span>
-                    </div>
-
-                </div>
-
-            </div>{{-- /data-step-content --}}
-
-            {{-- ── Footer de navegación ───────────────────────────────── --}}
-            <div class="flex items-center justify-between gap-3
-                        px-4 py-3 border-t border-blue-800/40 flex-shrink-0">
-
-                {{-- Anterior --}}
-                <button
-                    type="button"
-                    x-show="pasoActual > 0"
-                    @click="anterior()"
-                    class="px-4 py-2.5 rounded-lg text-sm font-medium min-h-[44px]
-                           text-blue-300 hover:text-white hover:bg-white/10
-                           focus:outline-none focus:ring-2 focus:ring-blue-400
-                           transition-colors"
-                >
-                    ← Anterior
-                </button>
-                <div x-show="pasoActual === 0" class="w-10" aria-hidden="true"></div>
-
-                {{-- Siguiente (pasos de selección y timing) --}}
-                <button
-                    type="button"
-                    x-show="pasos[pasoActual]?.tipo !== 'confirmacion'"
-                    @click="
-                        const _p = pasos[pasoActual];
-                        if (!_p) return;
-                        if (_p.tipo === 'seleccion' && _p.required && !((selections[_p.sectionId] ?? []).length > 0)) {
-                            intentoAvanzar = true;
-                            return;
-                        }
-                        intentoAvanzar = false;
-                        if (pasoActual + 1 < pasos.length) pasoActual = pasoActual + 1;
-                    "
-                    :disabled="pasos[pasoActual]?.tipo === 'seleccion' && pasos[pasoActual]?.required && !((selections[pasos[pasoActual]?.sectionId] ?? []).length > 0)"
-                    :aria-disabled="pasos[pasoActual]?.tipo === 'seleccion' && pasos[pasoActual]?.required && !((selections[pasos[pasoActual]?.sectionId] ?? []).length > 0)"
-                    :aria-label="`Ir al paso siguiente: ${pasos[pasoActual + 1]?.label ?? ''}`"
-                    :class="{
-                        'px-5 py-2.5 rounded-lg text-sm font-semibold transition-all min-h-[44px]': true,
-                        'bg-[#2E50B0] text-white hover:bg-[#3660CC] focus:outline-none focus:ring-2 focus:ring-blue-400': !(pasos[pasoActual]?.tipo === 'seleccion' && pasos[pasoActual]?.required && !((selections[pasos[pasoActual]?.sectionId] ?? []).length > 0)),
-                        'bg-white/10 text-white/40 cursor-not-allowed': pasos[pasoActual]?.tipo === 'seleccion' && pasos[pasoActual]?.required && !((selections[pasos[pasoActual]?.sectionId] ?? []).length > 0)
-                    }"
-                >
-                    Siguiente →
-                </button>
-
-                {{-- Confirmar (paso de confirmación) --}}
-                <button
-                    type="button"
-                    x-show="pasoActualObj?.tipo === 'confirmacion'"
-                    @click="submitOrder()"
-                    :disabled="enviando"
-                    :aria-busy="enviando"
-                    aria-describedby="confirmation-summary"
-                    class="flex-1 py-2.5 px-4 rounded-lg font-semibold text-sm min-h-[44px]
-                           bg-yellow-400 text-gray-900 hover:bg-yellow-300
-                           focus:outline-none focus:ring-2 focus:ring-yellow-400
-                           focus:ring-offset-2 focus:ring-offset-[#0E1A38]
-                           disabled:opacity-50 disabled:cursor-not-allowed
-                           transition-colors"
-                >
-                    <span x-show="!enviando">Confirmar menú y enviar pedido</span>
-                    <span x-show="enviando"
-                          class="flex items-center justify-center gap-2">
-                        <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24"
-                             aria-hidden="true">
-                            <circle class="opacity-25" cx="12" cy="12" r="10"
-                                    stroke="currentColor" stroke-width="4"/>
-                            <path class="opacity-75" fill="currentColor"
-                                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/>
-                        </svg>
-                        Enviando pedido...
-                    </span>
-                </button>
-
             </div>
 
-        </div>{{-- /!enviado --}}
+            {{-- Paso de timing --}}
+            <div x-show="!enviado && pasoActualObj?.tipo === 'timing'">
+                <x-daily-menu-timing-control />
+            </div>
 
-    </div>{{-- /panel interior --}}
+            {{-- Paso de confirmación --}}
+            <div x-show="!enviado && pasoActualObj?.tipo === 'confirmacion'">
+                <div class="dm-step">
+                    <div class="dm-step__head">
+                        <h3 class="dm-step__title" id="dm-step-title">Revisa tu selección</h3>
+                        <p class="dm-step__hint">Confirma y enviamos a cocina.</p>
+                    </div>
 
-</div>
+                    <div class="dm-summary">
+                        <template x-for="row in confirmationSelections()" :key="row.section_label">
+                            <div class="dm-summary__row">
+                                <div class="dm-summary__lab" x-text="row.section_label"></div>
+                                <div class="dm-summary__val">
+                                    <template x-if="row.skipped">
+                                        <span class="dm-summary__muted" x-text="'Sin ' + row.section_label.toLowerCase()"></span>
+                                    </template>
+                                    <template x-if="!row.skipped && row.empty">
+                                        <span class="dm-summary__muted">— sin elegir</span>
+                                    </template>
+                                    <template x-if="!row.skipped && !row.empty">
+                                        <span x-text="row.products.join(' · ')"></span>
+                                    </template>
+                                </div>
+                            </div>
+                        </template>
+
+                        {{-- Tiempos entre rondas --}}
+                        <template x-if="timingRules.length > 1">
+                            <div class="dm-summary__row dm-summary__row--inset">
+                                <div class="dm-summary__lab">Tiempos</div>
+                                <div class="dm-summary__val"
+                                     x-text="timingRules.map(r => timings[r.round] + ' min').join(' · ')">
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+
+                    <div class="dm-summary__total">
+                        <span class="dm-summary__totalLab">Total del menú</span>
+                        <span class="dm-summary__totalVal"
+                              x-text="parseFloat(menuData?.menu?.price ?? 0).toFixed(2).replace('.', ',') + ' €'">
+                        </span>
+                    </div>
+
+                    {{-- Error --}}
+                    <div x-show="errorMsg" role="alert"
+                         style="margin-top:12px;padding:10px 14px;border-radius:10px;background:rgba(239,68,68,0.08);border:1px solid rgba(239,68,68,0.25);font-family:var(--font-body);font-size:13px;color:var(--color-red-400)">
+                        <span x-text="errorMsg"></span>
+                    </div>
+                </div>
+            </div>
+
+        </div>{{-- /dm-modal__body --}}
+
+        {{-- ── Pie de navegación ───────────────────────────────── --}}
+        <div class="dm-modal__foot">
+
+            {{-- Éxito: solo botón cerrar --}}
+            <template x-if="enviado">
+                <button type="button" class="btn-primary" @click="requestClose()">Cerrar</button>
+            </template>
+
+            {{-- Confirmación: atrás + confirmar --}}
+            <template x-if="!enviado && isLastStep">
+                <span style="display:contents">
+                    <button type="button" class="btn-text" @click="anterior()" :disabled="enviando">
+                        Atrás
+                    </button>
+                    <button type="button" class="btn-primary dm-step__submit"
+                            @click="submitOrder()" :disabled="enviando">
+                        <span x-show="!enviando">
+                            Confirmar y enviar ·
+                            <span x-text="parseFloat(menuData?.menu?.price ?? 0).toFixed(2).replace('.', ',') + ' €'"></span>
+                        </span>
+                        <span x-show="enviando">Enviando…</span>
+                    </button>
+                </span>
+            </template>
+
+            {{-- Pasos intermedios: cancelar/atrás + siguiente --}}
+            <template x-if="!enviado && !isLastStep">
+                <span style="display:contents">
+                    <button type="button" class="btn-text" @click="anterior()">
+                        <span x-text="isFirstStep ? 'Cancelar' : 'Atrás'"></span>
+                    </button>
+                    <button type="button" class="btn-primary"
+                            @click="siguiente()"
+                            :disabled="!canProceed">
+                        Siguiente
+                    </button>
+                </span>
+            </template>
+
+        </div>
+
+    </div>{{-- /dm-modal --}}
+</div>{{-- /scrim --}}

--- a/resources/views/components/daily-menu-timing-control.blade.php
+++ b/resources/views/components/daily-menu-timing-control.blade.php
@@ -1,89 +1,49 @@
 {{-- @author SebastianBCF --}}
 {{-- @author Ayrtonalania --}}
-{{-- Control de timing [−] X min [+] para el stepper del menú del día.
-     Sin x-data propio: hereda el scope Alpine del banner (pasoActualObj, timings, horasEstimadas). --}}
+{{-- Control de tiempos entre rondas — clases DS (dm-timing + dm-timing__slider).
+     Sin x-data propio: hereda el scope Alpine de dailyMenuBanner. --}}
 
-<div class="py-2"
+<div class="dm-step"
      role="group"
-     :aria-labelledby="`timing-label-${pasoActualObj?.round}`">
+     :aria-labelledby="'dm-timing-title'">
 
-    <p :id="`timing-label-${pasoActualObj?.round}`"
-       class="text-white font-semibold mb-3 text-base"
-       x-text="pasoActualObj?.label">
-    </p>
-
-    <div class="flex items-center justify-center gap-6 my-6">
-
-        {{-- Botón menos --}}
-        <button
-            type="button"
-            @click="decrementTiming(pasoActualObj.round, pasoActualObj.minDelay)"
-            :disabled="timings[pasoActualObj?.round] <= pasoActualObj?.minDelay"
-            :aria-disabled="timings[pasoActualObj?.round] <= pasoActualObj?.minDelay"
-            :aria-label="`Reducir tiempo de la ronda ${pasoActualObj?.round}`"
-            :class="{
-                'w-12 h-12 rounded-full flex items-center justify-center border-2 border-blue-600/60 text-blue-300 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-[#0E1A38]': true,
-                'hover:bg-blue-800/50 hover:text-white': timings[pasoActualObj?.round] > pasoActualObj?.minDelay,
-                'opacity-35 cursor-not-allowed': timings[pasoActualObj?.round] <= pasoActualObj?.minDelay
-            }"
-        >
-            <svg class="w-5 h-5" fill="none" stroke="currentColor"
-                 viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round"
-                      stroke-width="2" d="M20 12H4"/>
-            </svg>
-        </button>
-
-        {{-- Valor actual — spinbutton con soporte de teclado (↑ ↓ Home End) --}}
-        <div class="text-center min-w-[80px]"
-             role="spinbutton"
-             tabindex="0"
-             :aria-valuemin="pasoActualObj?.minDelay"
-             :aria-valuemax="120"
-             :aria-valuenow="timings[pasoActualObj?.round]"
-             :aria-valuetext="timings[pasoActualObj?.round] + ' minutos'"
-             :aria-label="`Tiempo para la ronda ${pasoActualObj?.round}`"
-             @keydown.arrow-up.prevent="incrementTiming(pasoActualObj.round)"
-             @keydown.arrow-down.prevent="decrementTiming(pasoActualObj.round, pasoActualObj.minDelay)"
-             @keydown.home.prevent="timings = { ...timings, [pasoActualObj.round]: pasoActualObj.minDelay }"
-             @keydown.end.prevent="timings = { ...timings, [pasoActualObj.round]: 120 }"
-             class="focus:outline-none focus:ring-2 focus:ring-blue-400 rounded-lg">
-            <span class="text-5xl font-bold text-white"
-                  x-text="timings[pasoActualObj?.round]">
-            </span>
-            <span class="text-blue-300 text-sm ml-1">min</span>
-        </div>
-
-        {{-- Botón más --}}
-        <button
-            type="button"
-            @click="incrementTiming(pasoActualObj.round)"
-            :disabled="timings[pasoActualObj?.round] >= 120"
-            :aria-disabled="timings[pasoActualObj?.round] >= 120"
-            :aria-label="`Aumentar tiempo de la ronda ${pasoActualObj?.round}`"
-            :class="{
-                'w-12 h-12 rounded-full flex items-center justify-center border-2 border-blue-600/60 text-blue-300 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:ring-offset-[#0E1A38]': true,
-                'hover:bg-blue-800/50 hover:text-white': timings[pasoActualObj?.round] < 120,
-                'opacity-35 cursor-not-allowed': timings[pasoActualObj?.round] >= 120
-            }"
-        >
-            <svg class="w-5 h-5" fill="none" stroke="currentColor"
-                 viewBox="0 0 24 24" aria-hidden="true">
-                <path stroke-linecap="round" stroke-linejoin="round"
-                      stroke-width="2" d="M12 4v16m8-8H4"/>
-            </svg>
-        </button>
-
+    <div class="dm-step__head">
+        <h3 class="dm-step__title" id="dm-timing-title"
+            x-text="pasoActualObj?.label ?? 'Tiempos entre platos'"></h3>
+        <p class="dm-step__hint">
+            Marca cuánto quieres esperar entre rondas. Lo verá el equipo de cocina.
+        </p>
     </div>
 
-    {{-- Hora estimada de llegada --}}
-    <div aria-live="polite" aria-atomic="true"
-         class="text-center text-blue-200 text-sm">
-        <span x-text="`Tu plato llegará aprox. a las ${horasEstimadas[pasoActualObj?.round] ?? '--:--'}`"></span>
+    <div class="dm-timing">
+        <template x-for="rule in timingRules" :key="rule.round">
+            <div class="dm-timing__row">
+                <div class="dm-timing__top">
+                    <span class="dm-timing__label"
+                          x-text="'Ronda ' + rule.round"></span>
+                    <span class="dm-timing__val"
+                          x-text="(timings[rule.round] ?? rule.minDelay) + ' min'"></span>
+                </div>
+                <input
+                    type="range"
+                    :min="rule.minDelay"
+                    max="120"
+                    step="5"
+                    :value="timings[rule.round] ?? rule.minDelay"
+                    @input="setTiming(rule.round, Number($event.target.value))"
+                    class="dm-timing__slider"
+                    :aria-label="'Tiempo para ronda ' + rule.round"
+                    :aria-valuemin="rule.minDelay"
+                    aria-valuemax="120"
+                    :aria-valuenow="timings[rule.round] ?? rule.minDelay"
+                >
+                <div class="dm-timing__ticks">
+                    <span x-text="rule.minDelay + ' min'"></span>
+                    <span>—</span>
+                    <span>120 min</span>
+                </div>
+            </div>
+        </template>
     </div>
-
-    <p class="text-center text-blue-400/70 text-xs mt-1"
-       x-text="`Tiempo mínimo de preparación: ${pasoActualObj?.minDelay} min`">
-    </p>
 
 </div>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -223,6 +223,122 @@
             flex-direction: column;
             overflow: hidden;
         }
+
+        /* ── Carta DS — Layout crítico ──────────────────────────────── */
+        /* Garantiza que .carta llene el viewport independientemente de Tailwind */
+        html, body {
+            height: 100%;
+            margin: 0;
+            padding: 0;
+            overflow: hidden;
+        }
+        .carta {
+            height: 100dvh;
+            height: 100vh; /* fallback */
+            width: 100%;
+            max-width: 100%;
+        }
+        /* Animación spin para el spinner de envío */
+        @keyframes spin { to { transform: rotate(360deg); } }
+        /* Animación pulse para el banner de tapas y otros indicadores */
+        .banner-closed {
+            display: flex;
+            align-items: flex-start;
+            gap: 12px;
+            padding: 10px 16px;
+            background: var(--color-amber-100, #fef9c3);
+            color: var(--color-amber-800, #92400e);
+            border-bottom: 1px solid var(--color-amber-200, #fde68a);
+            flex-shrink: 0;
+        }
+        /* category__closed necesita definición de color */
+        .category__closed {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            font-family: var(--font-body);
+            font-size: 11px;
+            font-weight: 600;
+            color: var(--color-amber-700, #b45309);
+        }
+        .category__closedDot {
+            width: 6px; height: 6px;
+            border-radius: 50%;
+            background: currentColor;
+            flex-shrink: 0;
+        }
+        /* drawer--wide se usa para cobro partido/mixto */
+        .drawer--wide { max-height: 88dvh; max-height: 88vh; }
+        /* citem__customTags */
+        .citem__customTags {
+            display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px;
+        }
+        .citem__customTag {
+            padding: 2px 8px; border-radius: 9999px; font-size: 11px; font-weight: 500;
+            background: var(--bg-chip); color: var(--fg-muted);
+            border: 1px solid var(--border-subtle);
+        }
+        .citem__customTag--extra { color: var(--color-green-700); background: var(--color-green-50); border-color: var(--color-green-200); }
+        .citem__customTag--removed { color: var(--color-amber-700); background: var(--color-amber-50); border-color: var(--color-amber-200); }
+        /* cashTip clases adicionales */
+        .cashTip__spin {
+            display: inline-block; width: 14px; height: 14px;
+            border: 2px solid rgba(255,255,255,0.4); border-top-color: #fff;
+            border-radius: 50%; animation: spin 0.8s linear infinite;
+        }
+        .cashTip__ctaTag {
+            font-size: 11px; font-weight: 500; opacity: 0.75; margin-left: 4px;
+        }
+        /* tip clase (propina tarjeta) */
+        .tip {
+            flex: 1; padding: 14px 8px; border: 1px solid var(--glass-border);
+            border-radius: 12px; background: var(--glass-bg-surface);
+            display: flex; flex-direction: column; align-items: center; gap: 4px;
+            cursor: pointer; transition: border-color 150ms, background 150ms;
+        }
+        .tip:hover { border-color: var(--border-strong); }
+        .tip--selected { border-color: var(--brand-primary); background: var(--color-green-50); }
+        .tip .pct { font-family: var(--font-display); font-weight: 900; font-size: 18px; color: var(--fg-primary); }
+        .tip .amt { font-family: var(--font-body); font-size: 12px; color: var(--fg-muted); }
+        .tip-row { display: flex; gap: 8px; }
+        [data-theme="dark"] .tip--selected { background: rgba(34,197,94,0.1); }
+        /* bill footRow */
+        .bill__footRow { display: flex; gap: 8px; }
+        .bill__footRow--stack { flex-direction: column; }
+        /* cart-empty emojis */
+        .cart-empty__emoji { font-size: 48px; line-height: 1; margin-bottom: 12px; display: block; }
+        /* drawer__subtitle */
+        .drawer__subtitle {
+            font-family: var(--font-body); font-size: 12px; color: var(--fg-muted);
+            margin-top: 2px; line-height: 1.4;
+        }
+        /* method clases */
+        .method {
+            display: grid;
+            grid-template-columns: 44px 1fr auto;
+            align-items: center;
+            gap: 14px;
+            padding: 14px 16px;
+            border: 1px solid var(--glass-border);
+            border-radius: 14px;
+            background: var(--glass-bg-surface);
+            cursor: pointer;
+            text-align: left;
+            transition: border-color 150ms, transform 150ms;
+            width: 100%;
+        }
+        .method:hover { border-color: var(--brand-primary); transform: translateY(-1px); }
+        .method__ic {
+            width: 44px; height: 44px; border-radius: 50%;
+            background: var(--bg-chip);
+            display: inline-flex; align-items: center; justify-content: center;
+            flex-shrink: 0;
+        }
+        .method__txt { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+        .method__nm { font-family: var(--font-body); font-weight: 700; font-size: 15px; color: var(--fg-primary); }
+        .method__ds { font-family: var(--font-body); font-size: 12px; color: var(--fg-muted); }
+        .method__chev { color: var(--fg-muted); flex-shrink: 0; transition: transform 150ms, color 150ms; }
+        .method:hover .method__chev { transform: translateX(3px); color: var(--fg-primary); }
     </style>
 
     @php

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -13,21 +13,21 @@
     @else
     <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800;900&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
     @endif
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
     <link rel="stylesheet" href="{{ asset('css/carta/colors_and_type.css') }}">
     <link rel="stylesheet" href="{{ asset('css/carta/styles.css') }}">
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
     <meta name="stripe-key" content="{{ $stripePublicKey }}">
+    <script src="{{ asset('js/allergen-pictograms.js') }}"></script>
+    <script>window.ZAMPA_ALLERGEN_LABELS = @json(\App\Models\Ingredient::ALLERGEN_TYPES);</script>
     <script src="https://js.stripe.com/v3/" defer></script>
 
-    <!-- Dark mode: apply before paint to avoid flash -->
+    <!-- Dark mode: señal para que x-init de .carta la aplique antes del primer paint -->
     <script>
         (function () {
             const saved = localStorage.getItem('theme');
             const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-            const isDark = saved === 'dark' || (!saved && prefersDark);
-            if (isDark) {
-                document.documentElement.classList.add('dark');
-                document.getElementById('carta-root').setAttribute('data-theme', 'dark');
+            if (saved === 'dark' || (!saved && prefersDark)) {
+                document.documentElement.setAttribute('data-dark-pending', '1');
             }
         })();
     </script>
@@ -224,121 +224,10 @@
             overflow: hidden;
         }
 
-        /* ── Carta DS — Layout crítico ──────────────────────────────── */
-        /* Garantiza que .carta llene el viewport independientemente de Tailwind */
-        html, body {
-            height: 100%;
-            margin: 0;
-            padding: 0;
-            overflow: hidden;
-        }
-        .carta {
-            height: 100dvh;
-            height: 100vh; /* fallback */
-            width: 100%;
-            max-width: 100%;
-        }
-        /* Animación spin para el spinner de envío */
+        /* ── Layout crítico — garantiza que .carta llene el viewport ── */
+        html, body { height: 100%; margin: 0; padding: 0; overflow: hidden; }
+        .carta { height: 100dvh; height: 100vh; width: 100%; }
         @keyframes spin { to { transform: rotate(360deg); } }
-        /* Animación pulse para el banner de tapas y otros indicadores */
-        .banner-closed {
-            display: flex;
-            align-items: flex-start;
-            gap: 12px;
-            padding: 10px 16px;
-            background: var(--color-amber-100, #fef9c3);
-            color: var(--color-amber-800, #92400e);
-            border-bottom: 1px solid var(--color-amber-200, #fde68a);
-            flex-shrink: 0;
-        }
-        /* category__closed necesita definición de color */
-        .category__closed {
-            display: inline-flex;
-            align-items: center;
-            gap: 4px;
-            font-family: var(--font-body);
-            font-size: 11px;
-            font-weight: 600;
-            color: var(--color-amber-700, #b45309);
-        }
-        .category__closedDot {
-            width: 6px; height: 6px;
-            border-radius: 50%;
-            background: currentColor;
-            flex-shrink: 0;
-        }
-        /* drawer--wide se usa para cobro partido/mixto */
-        .drawer--wide { max-height: 88dvh; max-height: 88vh; }
-        /* citem__customTags */
-        .citem__customTags {
-            display: flex; flex-wrap: wrap; gap: 4px; margin-top: 4px;
-        }
-        .citem__customTag {
-            padding: 2px 8px; border-radius: 9999px; font-size: 11px; font-weight: 500;
-            background: var(--bg-chip); color: var(--fg-muted);
-            border: 1px solid var(--border-subtle);
-        }
-        .citem__customTag--extra { color: var(--color-green-700); background: var(--color-green-50); border-color: var(--color-green-200); }
-        .citem__customTag--removed { color: var(--color-amber-700); background: var(--color-amber-50); border-color: var(--color-amber-200); }
-        /* cashTip clases adicionales */
-        .cashTip__spin {
-            display: inline-block; width: 14px; height: 14px;
-            border: 2px solid rgba(255,255,255,0.4); border-top-color: #fff;
-            border-radius: 50%; animation: spin 0.8s linear infinite;
-        }
-        .cashTip__ctaTag {
-            font-size: 11px; font-weight: 500; opacity: 0.75; margin-left: 4px;
-        }
-        /* tip clase (propina tarjeta) */
-        .tip {
-            flex: 1; padding: 14px 8px; border: 1px solid var(--glass-border);
-            border-radius: 12px; background: var(--glass-bg-surface);
-            display: flex; flex-direction: column; align-items: center; gap: 4px;
-            cursor: pointer; transition: border-color 150ms, background 150ms;
-        }
-        .tip:hover { border-color: var(--border-strong); }
-        .tip--selected { border-color: var(--brand-primary); background: var(--color-green-50); }
-        .tip .pct { font-family: var(--font-display); font-weight: 900; font-size: 18px; color: var(--fg-primary); }
-        .tip .amt { font-family: var(--font-body); font-size: 12px; color: var(--fg-muted); }
-        .tip-row { display: flex; gap: 8px; }
-        [data-theme="dark"] .tip--selected { background: rgba(34,197,94,0.1); }
-        /* bill footRow */
-        .bill__footRow { display: flex; gap: 8px; }
-        .bill__footRow--stack { flex-direction: column; }
-        /* cart-empty emojis */
-        .cart-empty__emoji { font-size: 48px; line-height: 1; margin-bottom: 12px; display: block; }
-        /* drawer__subtitle */
-        .drawer__subtitle {
-            font-family: var(--font-body); font-size: 12px; color: var(--fg-muted);
-            margin-top: 2px; line-height: 1.4;
-        }
-        /* method clases */
-        .method {
-            display: grid;
-            grid-template-columns: 44px 1fr auto;
-            align-items: center;
-            gap: 14px;
-            padding: 14px 16px;
-            border: 1px solid var(--glass-border);
-            border-radius: 14px;
-            background: var(--glass-bg-surface);
-            cursor: pointer;
-            text-align: left;
-            transition: border-color 150ms, transform 150ms;
-            width: 100%;
-        }
-        .method:hover { border-color: var(--brand-primary); transform: translateY(-1px); }
-        .method__ic {
-            width: 44px; height: 44px; border-radius: 50%;
-            background: var(--bg-chip);
-            display: inline-flex; align-items: center; justify-content: center;
-            flex-shrink: 0;
-        }
-        .method__txt { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
-        .method__nm { font-family: var(--font-body); font-weight: 700; font-size: 15px; color: var(--fg-primary); }
-        .method__ds { font-family: var(--font-body); font-size: 12px; color: var(--fg-muted); }
-        .method__chev { color: var(--fg-muted); flex-shrink: 0; transition: transform 150ms, color 150ms; }
-        .method:hover .method__chev { transform: translateX(3px); color: var(--fg-primary); }
     </style>
 
     @php
@@ -411,14 +300,40 @@
     <script id="tapa-products" type="application/json">@json($tapaProductsForAlpine)</script>
     <script id="order-items" type="application/json">@json($activeOrderItemsForAlpine)</script>
     <script id="menu-context" type="application/json">@json($menuContext)</script>
+
+    {{-- Inicializa los badges de alérgenos con los pictogramas oficiales del DS --}}
+    <script>
+    (function initAllergenBadges() {
+        function fill() {
+            var p = window.ZAMPA_PICTOGRAMS;
+            var labels = window.ZAMPA_ALLERGEN_LABELS || {};
+            if (!p) return;
+            document.querySelectorAll('svg[data-al]').forEach(function (svg) {
+                var slug = svg.getAttribute('data-al');
+                var c = p.ALLERGEN_COLORS[slug] || '#888';
+                var inner = p.pictogramSVG(slug);
+                if (!inner) return;
+                svg.style.setProperty('--c', c);
+                svg.innerHTML = inner;
+            });
+        }
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', fill);
+        } else {
+            fill();
+        }
+        document.addEventListener('alpine:initialized', fill);
+    })();
+    </script>
 </head>
 
 <body>
 
     {{-- Skip to content --}}
-    <a href="#main-content"
-       class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4
-              bg-white text-indigo-700 px-4 py-2 rounded font-medium z-50 shadow">
+    <a href="#main-content" class="sr-only"
+       style="--skip-link:1"
+       onfocus="this.style.position='absolute';this.style.top='1rem';this.style.left='1rem';this.style.zIndex='9999';this.style.padding='8px 16px';this.style.background='var(--bg-base)';this.style.color='var(--brand-primary)';this.style.borderRadius='6px';this.style.boxShadow='var(--shadow-pop)';this.style.fontFamily='var(--font-body)';this.style.fontWeight='600';this.style.width='auto';this.style.height='auto';this.style.clip='auto';this.style.overflow='visible'"
+       onblur="this.removeAttribute('style')">
         Saltar al contenido principal
     </a>
 
@@ -427,6 +342,10 @@
          class="carta"
          data-theme="{{ $theme }}"
          x-init="
+            if (document.documentElement.getAttribute('data-dark-pending') === '1') {
+                $el.dataset.theme = 'dark';
+                document.documentElement.removeAttribute('data-dark-pending');
+            }
             $nextTick(() => {
                 const update = () => {
                     const w = window.innerWidth;
@@ -462,13 +381,12 @@
                 </span>
                 @endif
 
-                {{-- Toggle dark/light — sincroniza Tailwind + DS data-theme --}}
+                {{-- Toggle dark/light — data-theme en .carta, html conserva el tema base --}}
                 <button class="theme-toggle"
                         x-data="{
-                            dark: localStorage.getItem('theme') === 'dark' || (!localStorage.getItem('theme') && window.matchMedia('(prefers-color-scheme: dark)').matches),
+                            dark: document.querySelector('.carta')?.dataset.theme === 'dark',
                             toggle() {
                                 this.dark = !this.dark;
-                                document.documentElement.classList.toggle('dark', this.dark);
                                 document.querySelector('.carta').dataset.theme = this.dark ? 'dark' : '{{ $theme }}';
                                 localStorage.setItem('theme', this.dark ? 'dark' : 'light');
                             }
@@ -569,98 +487,7 @@
                 </symbol>
             </svg>
 
-            {{-- Sprite SVG: 14 alérgenos Reglamento UE 1169/2011 --}}
-            <svg aria-hidden="true" style="display:none;position:absolute;width:0;height:0;overflow:hidden;">
-                {{-- 1. Gluten (cereales con gluten) --}}
-                <symbol id="al-gluten" viewBox="0 0 24 24" fill="currentColor">
-                    <rect x="11.2" y="4" width="1.6" height="16" rx="0.8"/>
-                    <ellipse cx="12" cy="6.5" rx="2.8" ry="4"/>
-                    <ellipse cx="7" cy="11" rx="2.2" ry="3.2" transform="rotate(-30 7 11)"/>
-                    <ellipse cx="17" cy="11" rx="2.2" ry="3.2" transform="rotate(30 17 11)"/>
-                    <ellipse cx="7.5" cy="16.5" rx="2" ry="2.8" transform="rotate(-25 7.5 16.5)"/>
-                    <ellipse cx="16.5" cy="16.5" rx="2" ry="2.8" transform="rotate(25 16.5 16.5)"/>
-                </symbol>
-                {{-- 2. Crustáceos --}}
-                <symbol id="al-crustaceans" viewBox="0 0 24 24">
-                    <circle cx="18" cy="5" r="2.5" fill="currentColor"/>
-                    <path d="M18 3 L22 1.5 M18.8 2 L21.5 0" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-                    <path d="M18 5 C21 8 21 15 17 19 C14 22 9 22 6 19 C3 16 4 12 7 11 C10 10 12 12 11 15 C10.5 16.5 9.5 16.5 9 15.5"
-                          stroke="currentColor" stroke-width="3.5" fill="none" stroke-linecap="round"/>
-                </symbol>
-                {{-- 3. Huevo --}}
-                <symbol id="al-egg" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M12 2 C8 2 5 6 5 11 C5 16.5 8.1 22 12 22 C15.9 22 19 16.5 19 11 C19 6 16 2 12 2 Z"/>
-                </symbol>
-                {{-- 4. Pescado --}}
-                <symbol id="al-fish" viewBox="0 0 24 24" fill="currentColor">
-                    <ellipse cx="9.5" cy="12" rx="7.5" ry="5.5"/>
-                    <path d="M17 6.5 L24 4 L24 20 L17 17.5 Z"/>
-                    <circle cx="5" cy="11" r="1.4" fill="#050B1F"/>
-                </symbol>
-                {{-- 5. Cacahuetes --}}
-                <symbol id="al-peanuts" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M12 2 C7 2 4 4.5 4 7.5 C4 10.5 6.5 12 9.5 12.3 Q9 12.8 9 13.5 Q9 14 9.5 14.2 C6.5 14.8 4 16.5 4 19 C4 21.5 7.5 23 12 23 C16.5 23 20 21.5 20 19 C20 16.5 17.5 14.8 14.5 14.2 Q15 14 15 13.5 Q15 12.8 14.5 12.3 C17.5 12 20 10.5 20 7.5 C20 4.5 17 2 12 2 Z"/>
-                </symbol>
-                {{-- 6. Soja --}}
-                <symbol id="al-soy" viewBox="0 0 24 24" fill="currentColor">
-                    <circle cx="12" cy="6.5" r="4"/>
-                    <circle cx="7" cy="15.5" r="4"/>
-                    <circle cx="17" cy="15.5" r="4"/>
-                    <path d="M12 10 L7 12 M12 10 L17 12" stroke="currentColor" stroke-width="1.5" fill="none"/>
-                </symbol>
-                {{-- 7. Leche / Lácteos --}}
-                <symbol id="al-milk" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M12 2 L19 13 C19 18.5 15.9 22 12 22 C8.1 22 5 18.5 5 13 Z"/>
-                </symbol>
-                {{-- 8. Frutos secos (nueces, almendras…) --}}
-                <symbol id="al-nuts" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M12 2 C10 2 8.5 3.5 8 5 L6 8 C5 9 5 10 5 11 C5 15 8.1 20 12 20 C15.9 20 19 15 19 11 C19 10 19 9 18 8 L16 5 C15.5 3.5 14 2 12 2 Z"/>
-                    <path d="M12 20 L12 22 M10 21.5 L14 21.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" fill="none"/>
-                </symbol>
-                {{-- 9. Apio --}}
-                <symbol id="al-celery" viewBox="0 0 24 24" fill="currentColor">
-                    <rect x="4.5" y="11" width="3" height="10" rx="1.5"/>
-                    <rect x="10.5" y="8" width="3" height="13" rx="1.5"/>
-                    <rect x="16.5" y="11" width="3" height="10" rx="1.5"/>
-                    <path d="M6 11 C5 7 3.5 5 6 3 C8 4 8 8.5 6 11 Z"/>
-                    <path d="M12 8 C11 4 9.5 2 12 1 C14 2 14 5.5 12 8 Z"/>
-                    <path d="M18 11 C19 7 20.5 5 18 3 C16 4 16 8.5 18 11 Z"/>
-                </symbol>
-                {{-- 10. Mostaza --}}
-                <symbol id="al-mustard" viewBox="0 0 24 24" fill="currentColor">
-                    <rect x="8" y="11" width="8" height="10" rx="1.5"/>
-                    <rect x="9" y="8" width="6" height="3.5" rx="1"/>
-                    <rect x="9.5" y="5.5" width="5" height="3" rx="1.5"/>
-                    <circle cx="12" cy="4" r="1.2"/>
-                </symbol>
-                {{-- 11. Sésamo --}}
-                <symbol id="al-sesame" viewBox="0 0 24 24" fill="currentColor">
-                    <ellipse cx="12" cy="4.5" rx="2" ry="3.5"/>
-                    <ellipse cx="17.5" cy="7.5" rx="2" ry="3.5" transform="rotate(60 17.5 7.5)"/>
-                    <ellipse cx="19.5" cy="14" rx="2" ry="3.5" transform="rotate(120 19.5 14)"/>
-                    <ellipse cx="15" cy="19.5" rx="2" ry="3.5" transform="rotate(180 15 19.5)"/>
-                    <ellipse cx="9" cy="19.5" rx="2" ry="3.5" transform="rotate(240 9 19.5)"/>
-                    <ellipse cx="4.5" cy="14" rx="2" ry="3.5" transform="rotate(300 4.5 14)"/>
-                </symbol>
-                {{-- 12. Dióxido de azufre / Sulfitos --}}
-                <symbol id="al-sulphites" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M7 3 L17 3 C17 8.5 14.5 10.5 13 12 L13 17 L15 17 L15 20 L9 20 L9 17 L11 17 L11 12 C9.5 10.5 7 8.5 7 3 Z"/>
-                </symbol>
-                {{-- 13. Altramuces --}}
-                <symbol id="al-lupin" viewBox="0 0 24 24" fill="currentColor">
-                    <rect x="11.2" y="4" width="1.6" height="16" rx="0.8"/>
-                    <ellipse cx="12" cy="6" rx="3.5" ry="2.2"/>
-                    <ellipse cx="12" cy="10.5" rx="4" ry="2.5"/>
-                    <ellipse cx="12" cy="15" rx="3.5" ry="2.2"/>
-                    <ellipse cx="12" cy="18.5" rx="2.5" ry="1.8"/>
-                </symbol>
-                {{-- 14. Moluscos --}}
-                <symbol id="al-molluscs" viewBox="0 0 24 24" fill="currentColor">
-                    <path d="M12 22 L3 9 Q3 4 12 3 Q21 4 21 9 Z"/>
-                    <path d="M12 22 L4.5 8.5 M12 22 L7.5 4.5 M12 22 L12 3 M12 22 L16.5 4.5 M12 22 L19.5 8.5"
-                          stroke="#050B1F" stroke-width="0.9" fill="none"/>
-                </symbol>
-            </svg>
+            {{-- Los pictogramas de alérgenos se inyectan vía allergen-pictograms.js (ZAMPA_PICTOGRAMS) --}}
 
             {{-- Sprite SVG: categorías de tipo de alimento --}}
             <svg aria-hidden="true" style="display:none;position:absolute;width:0;height:0;overflow:hidden;">
@@ -1205,17 +1032,34 @@
         </div>
         @endif
 
-        {{-- ── Indicador de tapas ────────────────────────────────────────────── --}}
+        {{-- ── Indicador de tapas (DS: .tapas-indicator) ────────────────────── --}}
         @if($tapaConfig && $tapaConfig->tapas_enabled && $barItemsCount > 0)
-        <div style="display:flex;align-items:center;gap:10px;padding:10px 16px;background:linear-gradient(135deg,var(--color-amber-100),var(--color-amber-50));border-bottom:1px solid var(--color-amber-200);font-family:var(--font-body);font-size:13px;color:var(--color-amber-800);flex-shrink:0;"
-             role="status" aria-live="polite">
-            <span aria-hidden="true" style="font-size:20px">🍽️</span>
-            <div style="flex:1">
-                <strong>{{ $barItemsCount }} {{ Str::plural('tapa', $barItemsCount) }}</strong>
-                {{ $barItemsCount > 1 ? 'disponibles' : 'disponible' }}
-                @if($tapaConfig->tapas_free) · Gratuita@if($barItemsCount > 1)s@endif @else · {{ number_format($tapaConfig->tapa_price, 2, ',', '.') }} €@endif
-            </div>
-        </div>
+        @php
+            $tapasLeft     = max(0, $barItemsCount - $tapaVariantsUsed);
+            $maxTokens     = 8;
+            $shownTokens   = min($barItemsCount, $maxTokens);
+            $overflowTokens = max(0, $barItemsCount - $maxTokens);
+        @endphp
+        <button type="button"
+                class="tapas-indicator"
+                @click="$store.cart.showTapaModal = true"
+                :title="'Tienes ' + {{ $tapasLeft }} + ' tapa(s) por canjear'"
+                aria-label="{{ $tapasLeft }} {{ $tapasLeft === 1 ? 'tapa' : 'tapas' }} {{ $tapaConfig->tapas_free ? 'de cortesía' : 'incluidas' }} — Pedir">
+            <span class="tapas-indicator__glyph" aria-hidden="true">🍻</span>
+            <span class="tapas-indicator__copy">
+                <strong>{{ $tapasLeft }}</strong>
+                <span>{{ $tapasLeft === 1 ? 'tapa' : 'tapas' }} {{ $tapaConfig->tapas_free ? 'de cortesía' : 'incluidas' }}</span>
+            </span>
+            <span class="tapas-indicator__tokens" aria-hidden="true">
+                @for($t = 0; $t < $shownTokens; $t++)
+                    <span class="tk{{ $t < $tapaVariantsUsed ? ' tk--used' : '' }}"></span>
+                @endfor
+                @if($overflowTokens > 0)
+                    <span class="tapas-indicator__tokensMore">+{{ $overflowTokens }}</span>
+                @endif
+            </span>
+            <span class="tapas-indicator__cta">Pedir →</span>
+        </button>
         @endif
 
         {{-- ══════════════════════════════════════════════════════════════════════
@@ -1263,8 +1107,7 @@
                     </button>
                     @endforeach
                 </div>
-                {{-- Botón alérgenos fijo a la derecha --}}
-                @if($allergens->isNotEmpty())
+                {{-- Botón alérgenos fijo a la derecha (siempre visible) --}}
                 <button type="button"
                         class="filter-bar__pinned"
                         :class="activeAllergens.length > 0 ? 'filter-bar__pinned--on' : ''"
@@ -1281,11 +1124,9 @@
                           x-text="activeAllergens.length"
                           aria-hidden="true"></span>
                 </button>
-                @endif
             </nav>
 
             {{-- DS: .scrim > .drawer.drawer--allergens (sheet móvil) --}}
-            @if($allergens->isNotEmpty())
             <div class="scrim"
                  x-show="allergensOpen"
                  x-transition:enter="transition duration-200"
@@ -1313,18 +1154,20 @@
                     </div>
                     <div class="drawer__body">
                         <div class="allergens-grid">
-                            @foreach($allergens as $allergen)
+                            @foreach(\App\Models\Ingredient::ALLERGEN_TYPES as $slug => $name)
                             <button type="button"
                                     class="allergen-chip"
-                                    :class="activeAllergens.includes('{{ $allergen->slug }}') ? 'allergen-chip--active' : ''"
-                                    @click="toggleAllergen('{{ $allergen->slug }}')"
-                                    :aria-pressed="activeAllergens.includes('{{ $allergen->slug }}').toString()">
-                                <span class="allergen" aria-hidden="true">
-                                    <svg width="16" height="16" style="overflow:visible;display:block">
-                                        <use href="#al-{{ $allergen->slug }}"/>
-                                    </svg>
-                                </span>
-                                <span>{{ $allergen->name }}</span>
+                                    :class="activeAllergens.includes('{{ $slug }}') ? 'allergen-chip--active' : ''"
+                                    @click="toggleAllergen('{{ $slug }}')"
+                                    :aria-pressed="activeAllergens.includes('{{ $slug }}').toString()">
+                                <svg class="allergen-img"
+                                     data-al="{{ $slug }}"
+                                     viewBox="0 0 100 100"
+                                     width="22" height="22"
+                                     role="img"
+                                     aria-label="{{ $name }}">
+                                </svg>
+                                <span>{{ $name }}</span>
                             </button>
                             @endforeach
                         </div>
@@ -1336,7 +1179,6 @@
                     </div>
                 </div>
             </div>
-            @endif
         </div>{{-- /allergensOpen x-data --}}
         @endif
 
@@ -1348,9 +1190,6 @@
             {{-- DS: .carta__filters — sidebar (tablet + desktop, hidden on mobile via CSS) --}}
             @if($businessOpen && $categories->isNotEmpty())
             <div class="carta__filters" aria-label="Filtros">
-
-                {{-- Menú del día --}}
-                <x-daily-menu-availability />
 
                 {{-- Destino (cocina / barra / todo) --}}
                 <div class="filter-section">
@@ -1407,36 +1246,36 @@
                     </div>
                 </div>
 
-                {{-- Alérgenos --}}
-                @if($allergens->isNotEmpty())
+                {{-- Alérgenos — siempre los 14 del Reglamento UE 1169/2011 --}}
                 <div class="filter-section">
                     <div class="filter-section__label">Alérgenos</div>
                     <div class="filter-list filter-list--allergens" role="list">
-                        @foreach($allergens as $allergen)
+                        @foreach(\App\Models\Ingredient::ALLERGEN_TYPES as $slug => $name)
                         <div class="filter-list__item"
-                             :class="activeAllergens.includes('{{ $allergen->slug }}') ? 'filter-list__item--active' : ''"
-                             @click="toggleAllergen('{{ $allergen->slug }}')"
-                             @keydown.enter="toggleAllergen('{{ $allergen->slug }}')"
+                             :class="activeAllergens.includes('{{ $slug }}') ? 'filter-list__item--active' : ''"
+                             @click="toggleAllergen('{{ $slug }}')"
+                             @keydown.enter="toggleAllergen('{{ $slug }}')"
                              role="button" tabindex="0"
-                             :aria-pressed="activeAllergens.includes('{{ $allergen->slug }}').toString()">
+                             :aria-pressed="activeAllergens.includes('{{ $slug }}').toString()">
                             <span class="filter-list__check" aria-hidden="true">
-                                <svg x-show="activeAllergens.includes('{{ $allergen->slug }}')"
+                                <svg x-show="activeAllergens.includes('{{ $slug }}')"
                                      width="10" height="10" viewBox="0 0 24 24"
                                      fill="none" stroke="currentColor" stroke-width="3">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
                                 </svg>
                             </span>
-                            <span class="allergen" aria-hidden="true">
-                                <svg width="16" height="16" style="overflow:visible;display:block">
-                                    <use href="#al-{{ $allergen->slug }}"/>
-                                </svg>
-                            </span>
-                            <span style="font-size:13px">{{ $allergen->name }}</span>
+                            <svg class="allergen-img"
+                                 data-al="{{ $slug }}"
+                                 viewBox="0 0 100 100"
+                                 width="22" height="22"
+                                 role="img"
+                                 aria-label="{{ $name }}">
+                            </svg>
+                            <span style="font-size:13px">{{ $name }}</span>
                         </div>
                         @endforeach
                     </div>
                 </div>
-                @endif
 
                 {{-- Contador de visibles --}}
                 <div style="margin-top:auto;padding-top:16px;border-top:1px solid var(--border-subtle)">
@@ -1538,16 +1377,16 @@
                             {{-- Body --}}
                             <div class="pcard__body">
 
-                                {{-- Badges alérgenos --}}
+                                {{-- Badges alérgenos — pictogramas oficiales DS --}}
                                 <div class="pcard__badges">
                                     @foreach($allergenSlugs->take(5) as $slug)
-                                    <span class="allergen"
-                                          title="{{ \App\Models\Ingredient::ALLERGEN_TYPES[$slug] ?? $slug }}"
-                                          aria-label="{{ \App\Models\Ingredient::ALLERGEN_TYPES[$slug] ?? $slug }}">
-                                        <svg aria-hidden="true" width="12" height="12" style="overflow:visible;display:block">
-                                            <use href="#al-{{ $slug }}"/>
-                                        </svg>
-                                    </span>
+                                    <svg class="allergen-img"
+                                         data-al="{{ $slug }}"
+                                         viewBox="0 0 100 100"
+                                         width="22" height="22"
+                                         role="img"
+                                         aria-label="Contiene {{ \App\Models\Ingredient::ALLERGEN_TYPES[$slug] ?? $slug }}">
+                                    </svg>
                                     @endforeach
                                 </div>
 
@@ -1669,36 +1508,70 @@
         </button>
 
         {{-- ══════════════════════════════════════════════════════════════════════
-             FAB BILL — .fab.fab--bill position:absolute dentro de .carta
+             FAB CLUSTER — DS: .fab-cluster (Mis pedidos + Cuenta + Mi ticket)
              ══════════════════════════════════════════════════════════════════════ --}}
-        <button type="button"
-                class="fab fab--bill"
-                x-show="$store.bill.active && !$store.chat.open"
-                x-transition
-                @click="$store.bill.open()"
-                :disabled="$store.bill.requested && $store.bill.paymentDone"
-                :aria-label="$store.bill.paymentDone ? 'Pago completado' : ($store.bill.requested ? 'Cuenta solicitada' : 'Solicitar la cuenta')">
-            <svg aria-hidden="true" width="18" height="18" fill="none"
-                 stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round"
-                      d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z"/>
-            </svg>
-            <span x-text="$store.bill.paymentDone ? '¡Pagado!' : ($store.bill.requested ? 'Solicitado' : 'Cuenta')"></span>
-        </button>
+        <div class="fab-cluster"
+             x-show="$store.bill.active && !$store.chat.open"
+             x-transition:enter="transition duration-200"
+             x-transition:enter-start="opacity-0"
+             x-transition:enter-end="opacity-100"
+             x-transition:leave="transition duration-150"
+             x-transition:leave-start="opacity-100"
+             x-transition:leave-end="opacity-0">
 
-        {{-- Enlace descarga ticket post-pago --}}
-        <template x-if="$store.bill.paymentDone && $store.bill.paidOrderId">
-            <a :href="$store.bill.ticketDownloadBase + '/' + $store.bill.paidOrderId + '/download?hash=' + $store.bill.tableHash"
-               target="_blank" rel="noopener noreferrer"
-               class="delete-pill"
-               style="background:var(--cta-view-order);border-color:var(--color-green-400);color:#fff;text-decoration:none"
-               :aria-label="'Descargar ticket del pedido #' + $store.bill.paidOrderId">
-                <svg aria-hidden="true" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 16v-8m0 8l-3-3m3 3l3-3M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2"/>
-                </svg>
-                <strong>Descargar ticket</strong>
-            </a>
-        </template>
+            {{-- fab--orders: Mis pedidos (visible cuando hay pedido activo no pagado) --}}
+            <button type="button"
+                    class="fab fab--orders"
+                    x-show="$store.bill.active && !$store.bill.paymentDone"
+                    @click="$store.bill.open()"
+                    :aria-label="'Mi pedido activo — ver cuenta'">
+                <span class="fab--orders__ic" aria-hidden="true">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M5 3h14v18l-2-1.5-2 1.5-2-1.5-2 1.5-2-1.5-2 1.5-2-1.5L5 21V3z"/>
+                        <path d="M8 8h8M8 12h8M8 16h5" stroke-width="2.4"/>
+                    </svg>
+                    <span class="fab--orders__badge" aria-hidden="true">1</span>
+                </span>
+                <span class="fab--orders__label">Mi pedido</span>
+            </button>
+
+            {{-- fab--bill: Cuenta --}}
+            <button type="button"
+                    :class="'fab fab--bill' + ($store.bill.active && !$store.bill.paymentDone ? ' fab--in-cluster' : '')"
+                    x-show="!$store.bill.paymentDone"
+                    @click="$store.bill.open()"
+                    :disabled="$store.bill.requested && !$store.bill.paymentDone ? undefined : undefined"
+                    :aria-label="$store.bill.requested ? 'Cuenta solicitada' : 'Solicitar la cuenta'">
+                <span class="fab__ic" aria-hidden="true">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M4 2v20l3-2 3 2 3-2 3 2 3-2V2H4z"/>
+                        <path d="M8 7h8M8 11h8M8 15h6"/>
+                    </svg>
+                </span>
+                <span class="fab__label"
+                      x-text="$store.bill.requested ? 'Solicitada' : 'Cuenta'"></span>
+            </button>
+
+            {{-- fab--ticket: Mi ticket (visible tras pago completado) --}}
+            <template x-if="$store.bill.paymentDone && $store.bill.paidOrderId">
+                <a :href="$store.bill.ticketDownloadBase + '/' + $store.bill.paidOrderId + '/download?hash=' + $store.bill.tableHash"
+                   target="_blank" rel="noopener noreferrer"
+                   class="fab fab--ticket fab--in-cluster"
+                   :aria-label="'Descargar ticket #' + $store.bill.paidOrderId">
+                    <span class="fab__ic" aria-hidden="true">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M4 2v20l3-2 3 2 3-2 3 2 3-2V2H4z"/>
+                            <path d="M8 7h8M8 11h8M8 15h6"/>
+                        </svg>
+                    </span>
+                    <span class="fab__label">Mi ticket</span>
+                </a>
+            </template>
+
+        </div>
 
         {{-- ══════════════════════════════════════════════════════════════════════
              CART DRAWER — DS: .scrim > .drawer.drawer--cart
@@ -2342,12 +2215,8 @@
                         <legend class="sr-only">Selecciona los ítems que quieres pagar</legend>
                         <template x-for="item in $store.bill.splitItems" :key="item.id">
                             <label :for="'spi-' + item.id"
-                                   :class="item.claimed
-                                       ? 'opacity-50 cursor-not-allowed'
-                                       : $store.bill.isItemSelected(item.id)
-                                           ? 'ring-2'
-                                           : ''"
-                                   style="display:flex;align-items:center;gap:12px;padding:12px;border-radius:12px;border:2px solid var(--glass-border);cursor:pointer;background:var(--glass-bg-surface)">
+                                   :class="$store.bill.isItemSelected(item.id) ? 'slot--you' : ''"
+                                   :style="'display:flex;align-items:center;gap:12px;padding:12px;border-radius:12px;border:2px solid var(--glass-border);cursor:pointer;background:var(--glass-bg-surface);' + (item.claimed ? 'opacity:0.5;cursor:not-allowed;' : '')">
                                 <input type="checkbox"
                                        :id="'spi-' + item.id"
                                        :checked="$store.bill.isItemSelected(item.id)"
@@ -2577,11 +2446,6 @@
                 </div>
             </div>
         </div>
-
-        {{-- ── Daily menu dialogs (componentes Blade existentes) --}}
-        <x-daily-menu-stepper :hash="$table->unique_hash" />
-        <x-daily-menu-exclusivity-dialog />
-        <x-daily-menu-timing-control />
 
     </div>{{-- /carta (Alpine) --}}
 </body>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1070,2298 +1070,1403 @@
             </div>
         </div>{{-- /chatWidget --}}
 
-        {{-- ── FAB Solicitar cuenta ────────────────────────────────── --}}
-        <div class="fixed bottom-6 left-4 z-50"
-             x-show="$store.bill.active && !$store.chat.open"
-             x-transition:enter="transition ease-out duration-200"
-             x-transition:enter-start="opacity-0 scale-75"
-             x-transition:enter-end="opacity-100 scale-100"
-             x-transition:leave="transition ease-in duration-150"
-             x-transition:leave-start="opacity-100 scale-100"
-             x-transition:leave-end="opacity-0 scale-75">
-            <button type="button"
-                    @click="$store.bill.open()"
-                    :disabled="$store.bill.requested || $store.bill.sending"
-                    aria-label="Solicitar la cuenta"
-                    class="flex items-center gap-2 px-4 py-3 rounded-full shadow-xl font-bold text-sm
-                           transition-colors focus:outline-none focus:ring-4 focus:ring-indigo-400
-                           disabled:opacity-70 disabled:cursor-not-allowed"
-                    :class="$store.bill.requested
-                        ? 'bg-green-600 text-white'
-                        : 'bg-indigo-600 hover:bg-indigo-700 text-white'">
-                <template x-if="!$store.bill.requested && !$store.bill.sending">
-                    <span class="flex items-center gap-2">
-                        <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round"
-                                  d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z"/>
-                        </svg>
-                        Pedir la cuenta
-                    </span>
-                </template>
-                <template x-if="$store.bill.sending">
-                    <span class="flex items-center gap-2">
-                        <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
-                        </svg>
-                        Enviando...
-                    </span>
-                </template>
-                <template x-if="$store.bill.requested">
-                    <span class="flex items-center gap-2">
-                        <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
-                        </svg>
-                        <span x-text="$store.bill.paymentDone ? '¡Pago completado!' : ($store.bill.method === 'cash' ? 'Cuenta solicitada · Efectivo' : ($store.bill.method === 'mixed' ? 'Tarjeta pagada · Espera al camarero' : 'Cuenta solicitada · Tarjeta'))"></span>
-                    </span>
-                </template>
-            </button>
-            <template x-if="$store.bill.error">
-                <p class="mt-1 text-xs text-red-600 bg-white rounded px-2 py-1 shadow"
-                   role="alert"
-                   x-text="$store.bill.error"></p>
-            </template>
-            <template x-if="$store.bill.paymentDone && $store.bill.paidOrderId">
-                <a :href="$store.bill.ticketDownloadBase + '/' + $store.bill.paidOrderId + '/download?hash=' + $store.bill.tableHash"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   class="mt-2 w-full flex items-center justify-center gap-2 rounded-xl
-                          bg-white/20 hover:bg-white/30 text-white text-sm font-medium
-                          py-2.5 px-4 transition-colors focus:outline-none
-                          focus:ring-2 focus:ring-white/50"
-                   :aria-label="'Descargar ticket del pedido #' + $store.bill.paidOrderId">
-                    <svg aria-hidden="true" class="w-4 h-4 shrink-0" fill="none"
-                         stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round"
-                              d="M12 16v-8m0 8l-3-3m3 3l3-3M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2"/>
-                    </svg>
-                    Descargar ticket
-                </a>
-            </template>
-        </div>
-
-        {{-- ── Sheet: elección de método de pago ───────────────────── --}}
-        <div x-show="$store.bill.choosing"
-             x-transition:enter="transition ease-out duration-300"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="transition ease-in duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
-             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-             @click.self="$store.bill.close()"
-             @keydown.escape.window="$store.bill.close()"
-             aria-modal="true" role="dialog" aria-label="Elige cómo pagar">
-
-            <div x-show="$store.bill.choosing"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="translate-y-full"
-                 x-transition:enter-end="translate-y-0"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="translate-y-0"
-                 x-transition:leave-end="translate-y-full"
-                 class="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900
-                        rounded-t-2xl shadow-2xl px-5 pb-8 pt-4">
-
-                <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-5"></div>
-
-                <h2 class="text-lg font-bold text-gray-900 dark:text-white text-center mb-1">
-                    Solicitar la cuenta
-                </h2>
-                <p class="text-sm text-gray-500 dark:text-gray-400 text-center mb-6">
-                    ¿Cómo quieres pagar?
-                </p>
-
-                <div class="grid grid-cols-2 gap-3">
-                    <button type="button"
-                            @click="$store.bill.openCashTip()"
-                            class="flex flex-col items-center justify-center gap-2 py-5 rounded-2xl
-                                   bg-gray-50 dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700
-                                   hover:border-green-500 hover:bg-green-50 dark:hover:bg-green-900/20
-                                   transition-colors focus:outline-none focus:ring-2 focus:ring-green-500">
-                        <span class="text-3xl" aria-hidden="true">💵</span>
-                        <span class="font-semibold text-sm text-gray-800 dark:text-gray-200">Efectivo</span>
-                    </button>
-
-                    <button type="button"
-                            @click="$store.bill.openCardPayment()"
-                            class="flex flex-col items-center justify-center gap-2 py-5 rounded-2xl
-                                   bg-gray-50 dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700
-                                   hover:border-indigo-500 hover:bg-indigo-50 dark:hover:bg-indigo-900/20
-                                   transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                        <span class="text-3xl" aria-hidden="true">💳</span>
-                        <span class="font-semibold text-sm text-gray-800 dark:text-gray-200">Tarjeta</span>
-                    </button>
-                </div>
-
-                {{-- Cobro mixto (efectivo + tarjeta) --}}
-                <div class="mt-3">
-                    <button type="button"
-                            @click="$store.bill.openMixed()"
-                            class="w-full flex items-center justify-center gap-2 py-3.5 rounded-2xl
-                                   bg-gray-50 dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700
-                                   hover:border-amber-500 hover:bg-amber-50 dark:hover:bg-amber-900/20
-                                   transition-colors focus:outline-none focus:ring-2 focus:ring-amber-500">
-                        <span class="text-xl" aria-hidden="true">💵💳</span>
-                        <span class="font-semibold text-sm text-gray-800 dark:text-gray-200">Cobro mixto</span>
-                        <span class="text-xs text-gray-400 dark:text-gray-500">(efectivo + tarjeta)</span>
-                    </button>
-                </div>
-
-                {{-- Cobro partido (solo si está habilitado para este restaurante) --}}
-                <template x-if="$store.bill.splitEnabled">
-                    <div class="mt-3 space-y-2">
-                        <div class="flex items-center gap-2">
-                            <div class="flex-1 h-px bg-gray-200 dark:bg-gray-700"></div>
-                            <span class="text-xs font-medium text-gray-400 dark:text-gray-500 whitespace-nowrap px-2">o paga tu parte</span>
-                            <div class="flex-1 h-px bg-gray-200 dark:bg-gray-700"></div>
-                        </div>
-                        <button type="button"
-                                @click="$store.bill.openSplit()"
-                                class="w-full flex items-center justify-center gap-2 py-3.5 rounded-2xl
-                                       bg-gray-50 dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700
-                                       hover:border-violet-500 hover:bg-violet-50 dark:hover:bg-violet-900/20
-                                       transition-colors focus:outline-none focus:ring-2 focus:ring-violet-500">
-                            <span class="text-xl" aria-hidden="true">🤝</span>
-                            <span class="font-semibold text-sm text-gray-800 dark:text-gray-200">Cobro partido</span>
-                        </button>
-                    </div>
-                </template>
-
-                <button type="button"
-                        @click="$store.bill.close()"
-                        class="w-full mt-4 py-2.5 rounded-xl text-sm font-medium text-gray-500 dark:text-gray-400
-                               hover:text-gray-700 dark:hover:text-gray-200 focus:outline-none focus:underline transition-colors">
-                    Cancelar
-                </button>
-            </div>
-        </div>{{-- /sheet --}}
-
-        {{-- ── Sheet: propina (antes del pago con tarjeta) ───────── --}}
-        <div x-show="$store.bill.showingTip"
-             x-transition:enter="transition ease-out duration-300"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="transition ease-in duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
-             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-             @click.self="$store.bill.closeTip()"
-             @keydown.escape.window="$store.bill.closeTip()"
-             aria-modal="true" role="dialog" aria-label="Añadir propina">
-
-            <div x-show="$store.bill.showingTip"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="translate-y-full"
-                 x-transition:enter-end="translate-y-0"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="translate-y-0"
-                 x-transition:leave-end="translate-y-full"
-                 class="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900
-                        rounded-t-2xl shadow-2xl px-5 pb-8 pt-4">
-
-                <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-5"></div>
-
-                {{-- Cabecera --}}
-                <div class="flex items-center justify-between mb-5">
-                    <div>
-                        <h2 class="text-lg font-bold text-gray-900 dark:text-white">¿Quieres dejar propina?</h2>
-                        <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">La propina es completamente opcional</p>
-                    </div>
-                    <button type="button"
-                            @click="$store.bill.closeTip()"
-                            aria-label="Cancelar propina"
-                            class="p-1.5 rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100
-                                   dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-400">
-                        <svg aria-hidden="true" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                        </svg>
-                    </button>
-                </div>
-
-                {{-- Resumen del pedido --}}
-                <div class="bg-gray-50 dark:bg-gray-800 rounded-xl px-4 py-3 mb-5 flex justify-between items-center">
-                    <span class="text-sm text-gray-500 dark:text-gray-400">Total del pedido</span>
-                    <span class="text-lg font-bold text-gray-900 dark:text-white"
-                          x-text="$store.bill.orderTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                </div>
-
-                {{-- Botones de porcentaje --}}
-                <div class="grid grid-cols-4 gap-2 mb-4" role="group" aria-label="Porcentaje de propina">
-                    <template x-for="pct in [5, 10, 15, 20]" :key="pct">
-                        <button type="button"
-                                @click="$store.bill.setTipPercent(pct)"
-                                :aria-pressed="$store.bill.tipPercent === pct"
-                                :class="$store.bill.tipPercent === pct
-                                    ? 'ring-2 ring-indigo-500 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 border-indigo-400'
-                                    : 'bg-gray-50 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-700'"
-                                class="flex flex-col items-center py-3 rounded-xl border-2 font-semibold text-sm
-                                       transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                            <span x-text="pct + '%'"></span>
-                            <span class="text-xs font-normal mt-0.5 text-gray-500 dark:text-gray-400"
-                                  x-text="(Math.round($store.bill.orderTotal * pct) / 100).toFixed(2).replace('.', ',') + ' €'"></span>
-                        </button>
-                    </template>
-                </div>
-
-                {{-- Input de propina personalizada --}}
-                <div class="relative mb-5">
-                    <label for="custom-tip-input" class="sr-only">Propina personalizada en euros</label>
-                    <input type="number"
-                           id="custom-tip-input"
-                           min="0"
-                           step="0.50"
-                           placeholder="Otro importe"
-                           @input="$store.bill.updateCustomTip($event.target.value)"
-                           :value="$store.bill.tipPercent === null && $store.bill.tipAmount > 0 ? $store.bill.tipAmount : ''"
-                           aria-describedby="custom-tip-hint"
-                           class="w-full rounded-xl border border-gray-300 dark:border-gray-600
-                                  bg-white dark:bg-gray-800 text-gray-900 dark:text-white
-                                  px-4 py-3 pr-10 text-right placeholder-gray-400
-                                  focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500
-                                  [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none">
-                    <span class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 font-medium pointer-events-none"
-                          aria-hidden="true">€</span>
-                </div>
-                <p id="custom-tip-hint" class="sr-only">Escribe un importe personalizado en euros</p>
-
-                {{-- Desglose total + propina --}}
-                <div class="space-y-1 mb-5">
-                    <template x-if="$store.bill.tipAmount > 0">
-                        <div class="flex justify-between text-sm">
-                            <span class="text-gray-500 dark:text-gray-400">Propina</span>
-                            <span class="font-medium text-gray-700 dark:text-gray-300"
-                                  x-text="'+ ' + $store.bill.tipAmount.toFixed(2).replace('.', ',') + ' €'"></span>
-                        </div>
-                    </template>
-                    <div class="flex justify-between text-base font-bold border-t border-gray-200 dark:border-gray-700 pt-2">
-                        <span class="text-gray-900 dark:text-white">Total a pagar</span>
-                        <span class="text-indigo-600 dark:text-indigo-400"
-                              x-text="$store.bill.grandTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                    </div>
-                </div>
-
-                {{-- Botón continuar --}}
-                <button type="button"
-                        @click="$store.bill.proceedToStripe()"
-                        class="w-full py-3.5 rounded-xl bg-indigo-600 hover:bg-indigo-700
-                               text-white font-bold text-base shadow-sm transition-colors
-                               focus:outline-none focus:ring-4 focus:ring-indigo-400">
-                    <span x-show="$store.bill.tipAmount > 0">
-                        💳 Pagar <span x-text="$store.bill.grandTotal.toFixed(2).replace('.', ',') + ' €'"></span> con propina
-                    </span>
-                    <span x-show="$store.bill.tipAmount <= 0">
-                        💳 Pagar sin propina
-                    </span>
-                </button>
-
-                <button type="button"
-                        @click="$store.bill.closeTip()"
-                        class="w-full mt-3 py-2.5 rounded-xl text-sm font-medium text-gray-500 dark:text-gray-400
-                               hover:text-gray-700 dark:hover:text-gray-200 focus:outline-none focus:underline transition-colors">
-                    Cancelar
-                </button>
-            </div>
-        </div>{{-- /tip sheet --}}
-
-        {{-- ── Sheet: propina para efectivo ──────────────────────── --}}
-        <div x-show="$store.bill.showingCashTip"
-             x-transition:enter="transition ease-out duration-300"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="transition ease-in duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
-             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-             @click.self="$store.bill.closeCashTip()"
-             @keydown.escape.window="$store.bill.closeCashTip()"
-             aria-modal="true" role="dialog" aria-label="Añadir propina para pago en efectivo">
-
-            <div x-show="$store.bill.showingCashTip"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="translate-y-full"
-                 x-transition:enter-end="translate-y-0"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="translate-y-0"
-                 x-transition:leave-end="translate-y-full"
-                 class="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900
-                        rounded-t-2xl shadow-2xl px-5 pb-8 pt-4">
-
-                <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-5"></div>
-
-                <div class="flex items-center justify-between mb-5">
-                    <div>
-                        <h2 class="text-lg font-bold text-gray-900 dark:text-white">¿Quieres dejar propina?</h2>
-                        <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">La propina es completamente opcional</p>
-                    </div>
-                    <button type="button"
-                            @click="$store.bill.closeCashTip()"
-                            aria-label="Cancelar propina"
-                            class="p-1.5 rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100
-                                   dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-400">
-                        <svg aria-hidden="true" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                        </svg>
-                    </button>
-                </div>
-
-                <div class="bg-gray-50 dark:bg-gray-800 rounded-xl px-4 py-3 mb-5 flex justify-between items-center">
-                    <span class="text-sm text-gray-500 dark:text-gray-400">Total del pedido</span>
-                    <span class="text-lg font-bold text-gray-900 dark:text-white"
-                          x-text="$store.bill.orderTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                </div>
-
-                <div class="grid grid-cols-4 gap-2 mb-4" role="group" aria-label="Porcentaje de propina">
-                    <template x-for="pct in [5, 10, 15, 20]" :key="pct">
-                        <button type="button"
-                                @click="$store.bill.setCashTipPercent(pct)"
-                                :aria-pressed="$store.bill.cashTipPercent === pct"
-                                :class="$store.bill.cashTipPercent === pct
-                                    ? 'ring-2 ring-green-500 bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300 border-green-400'
-                                    : 'bg-gray-50 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-700'"
-                                class="flex flex-col items-center py-3 rounded-xl border-2 font-semibold text-sm
-                                       transition-colors focus:outline-none focus:ring-2 focus:ring-green-500">
-                            <span x-text="pct + '%'"></span>
-                            <span class="text-xs font-normal mt-0.5 text-gray-500 dark:text-gray-400"
-                                  x-text="(Math.round($store.bill.orderTotal * pct) / 100).toFixed(2).replace('.', ',') + ' €'"></span>
-                        </button>
-                    </template>
-                </div>
-
-                <div class="relative mb-5">
-                    <label for="cash-tip-input" class="sr-only">Propina personalizada en euros</label>
-                    <input type="number"
-                           id="cash-tip-input"
-                           min="0"
-                           step="0.50"
-                           placeholder="Otro importe"
-                           @input="$store.bill.updateCustomCashTip($event.target.value)"
-                           :value="$store.bill.cashTipPercent === null && $store.bill.cashTipAmount > 0 ? $store.bill.cashTipAmount : ''"
-                           class="w-full rounded-xl border border-gray-300 dark:border-gray-600
-                                  bg-white dark:bg-gray-800 text-gray-900 dark:text-white
-                                  px-4 py-3 pr-10 text-right placeholder-gray-400
-                                  focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-green-500
-                                  [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none">
-                    <span class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 font-medium pointer-events-none"
-                          aria-hidden="true">€</span>
-                </div>
-
-                <div class="space-y-1 mb-4">
-                    <template x-if="$store.bill.cashTipAmount > 0">
-                        <div class="flex justify-between text-sm">
-                            <span class="text-gray-500 dark:text-gray-400">Propina</span>
-                            <span class="font-medium text-gray-700 dark:text-gray-300"
-                                  x-text="'+ ' + $store.bill.cashTipAmount.toFixed(2).replace('.', ',') + ' €'"></span>
-                        </div>
-                    </template>
-                    <div class="flex justify-between text-base font-bold border-t border-gray-200 dark:border-gray-700 pt-2">
-                        <span class="text-gray-900 dark:text-white">Total a pagar</span>
-                        <span class="text-green-600 dark:text-green-400"
-                              x-text="$store.bill.cashGrandTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                    </div>
-                </div>
-
-                <div class="mb-5 bg-green-50 dark:bg-green-900/20 rounded-xl px-4 py-3 flex items-center gap-2 text-sm text-green-700 dark:text-green-300">
-                    <svg aria-hidden="true" class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                    </svg>
-                    <span>La propina se entrega directamente al camarero en efectivo</span>
-                </div>
-
-                <button type="button"
-                        @click="$store.bill.confirmCashPayment()"
-                        :disabled="$store.bill.sending"
-                        class="w-full py-3.5 rounded-xl bg-green-600 hover:bg-green-700 disabled:opacity-60
-                               text-white font-bold text-base shadow-sm transition-colors
-                               focus:outline-none focus:ring-4 focus:ring-green-400">
-                    <span x-show="!$store.bill.sending">
-                        <span x-show="$store.bill.cashTipAmount > 0">
-                            💵 Solicitar cuenta —
-                            <span x-text="$store.bill.cashGrandTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                            con propina
-                        </span>
-                        <span x-show="$store.bill.cashTipAmount <= 0">
-                            💵 Solicitar cuenta sin propina
-                        </span>
-                    </span>
-                    <span x-show="$store.bill.sending" class="flex items-center justify-center gap-2">
-                        <svg class="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
-                        </svg>
-                        Enviando solicitud...
-                    </span>
-                </button>
-
-                <button type="button"
-                        @click="$store.bill.closeCashTip()"
-                        class="w-full mt-3 py-2.5 rounded-xl text-sm font-medium text-gray-500 dark:text-gray-400
-                               hover:text-gray-700 dark:hover:text-gray-200 focus:outline-none focus:underline transition-colors">
-                    Cancelar
-                </button>
-            </div>
-        </div>{{-- /cash tip sheet --}}
-
-        {{-- ── Sheet: pago con tarjeta (Stripe Elements) ──────────── --}}
-        <div x-show="$store.bill.payingCard"
-             x-transition:enter="transition ease-out duration-300"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="transition ease-in duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
-             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-             @keydown.escape.window="$store.bill.closeCardPayment()"
-             aria-modal="true" role="dialog" aria-label="Pago con tarjeta">
-
-            <div x-show="$store.bill.payingCard"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="translate-y-full"
-                 x-transition:enter-end="translate-y-0"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="translate-y-0"
-                 x-transition:leave-end="translate-y-full"
-                 class="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900
-                        rounded-t-2xl shadow-2xl px-5 pb-8 pt-4 max-h-[92dvh] overflow-y-auto">
-
-                <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-5"></div>
-
-                {{-- Cabecera --}}
-                <div class="flex items-center justify-between mb-4">
-                    <div>
-                        <h2 class="text-lg font-bold text-gray-900 dark:text-white">Pago con tarjeta</h2>
-                        <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
-                            Total:
-                            <span class="font-semibold text-gray-900 dark:text-white"
-                                  x-text="$store.bill.stripeTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                        </p>
-                        <template x-if="$store.bill.tipAmount > 0">
-                            <p class="text-xs text-indigo-500 dark:text-indigo-400 mt-0.5">
-                                Incluye propina de
-                                <span x-text="$store.bill.tipAmount.toFixed(2).replace('.', ',') + ' €'"></span>
-                            </p>
-                        </template>
-                    </div>
-                    <button type="button"
-                            @click="$store.bill.closeCardPayment()"
-                            aria-label="Cerrar pago"
-                            class="p-1.5 rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100
-                                   dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-400">
-                        <svg aria-hidden="true" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                        </svg>
-                    </button>
-                </div>
-
-                {{-- Spinner mientras carga Stripe Elements --}}
-                <div x-show="!$store.bill.stripeReady && !$store.bill.stripeError"
-                     class="flex items-center justify-center py-10">
-                    <svg class="animate-spin w-8 h-8 text-indigo-500" fill="none" viewBox="0 0 24 24" aria-label="Cargando formulario de pago">
-                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
-                    </svg>
-                </div>
-
-                {{-- Formulario Stripe Elements --}}
-                <div id="stripe-payment-element" class="mb-4"></div>
-
-                {{-- Error de Stripe --}}
-                <template x-if="$store.bill.stripeError">
-                    <p class="mb-3 text-sm text-red-600 dark:text-red-400 font-medium text-center"
-                       role="alert"
-                       x-text="$store.bill.stripeError"></p>
-                </template>
-
-                {{-- Botón pagar --}}
-                <button type="button"
-                        x-show="$store.bill.stripeReady"
-                        @click="$store.bill.submitCardPayment()"
-                        :disabled="$store.bill.sending"
-                        class="w-full py-3.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 disabled:opacity-60
-                               text-white font-bold text-base shadow-sm transition-colors
-                               focus:outline-none focus:ring-4 focus:ring-indigo-400">
-                    <span x-show="!$store.bill.sending">
-                        💳 Pagar <span x-text="$store.bill.stripeTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                    </span>
-                    <span x-show="$store.bill.sending" class="flex items-center justify-center gap-2">
-                        <svg class="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
-                        </svg>
-                        Procesando...
-                    </span>
-                </button>
-
-                <p class="mt-3 text-center text-xs text-gray-400 dark:text-gray-500">
-                    Pago seguro procesado por
-                    <span class="font-semibold text-indigo-500">Stripe</span>
-                    &middot; Tarjeta de prueba: 4242 4242 4242 4242
-                </p>
-            </div>
-        </div>{{-- /stripe sheet --}}
-
-        {{-- ── Sheet: selector de modo de cobro partido ─────────────── --}}
-        <div x-show="$store.bill.showingSplit"
-             x-transition:enter="transition ease-out duration-300"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="transition ease-in duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
-             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-             @click.self="$store.bill.closeSplitSelector()"
-             @keydown.escape.window="$store.bill.closeSplitSelector()"
-             aria-modal="true" role="dialog" aria-label="Elige cómo pagar tu parte">
-
-            <div x-show="$store.bill.showingSplit"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="translate-y-full"
-                 x-transition:enter-end="translate-y-0"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="translate-y-0"
-                 x-transition:leave-end="translate-y-full"
-                 class="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900
-                        rounded-t-2xl shadow-2xl px-5 pb-8 pt-4">
-
-                <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-5"></div>
-
-                <h2 class="text-lg font-bold text-gray-900 dark:text-white text-center mb-1">
-                    Cobro partido
-                </h2>
-                <p class="text-sm text-gray-500 dark:text-gray-400 text-center mb-6">
-                    ¿Cómo quieres dividir la cuenta?
-                </p>
-
-                <div class="space-y-3">
-                    <button type="button"
-                            @click="!$store.bill.splitEquitativeLocked && $store.bill.openSplitItems()"
-                            :disabled="$store.bill.splitEquitativeLocked"
-                            :class="$store.bill.splitEquitativeLocked
-                                ? 'opacity-50 cursor-not-allowed bg-gray-50 dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700'
-                                : 'bg-gray-50 dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700 hover:border-violet-500 hover:bg-violet-50 dark:hover:bg-violet-900/20 focus:ring-2 focus:ring-violet-500'"
-                            class="w-full flex items-center gap-3 py-4 px-4 rounded-2xl
-                                   transition-colors focus:outline-none">
-                        <span class="text-2xl flex-shrink-0" aria-hidden="true">🧾</span>
-                        <div class="text-left">
-                            <p class="font-semibold text-sm text-gray-800 dark:text-gray-200">Pagar por ítems</p>
-                            <p class="text-xs mt-0.5"
-                               :class="$store.bill.splitEquitativeLocked
-                                   ? 'text-amber-600 dark:text-amber-400'
-                                   : 'text-gray-500 dark:text-gray-400'"
-                               x-text="$store.bill.splitEquitativeLocked
-                                   ? 'No disponible: ya hay pagos a partes iguales en curso'
-                                   : 'Elige exactamente qué platos pagas tú'">
-                            </p>
-                        </div>
-                    </button>
-
-                    <button type="button"
-                            @click="$store.bill.openSplitEq()"
-                            class="w-full flex items-center gap-3 py-4 px-4 rounded-2xl
-                                   bg-gray-50 dark:bg-gray-800 border-2 border-gray-200 dark:border-gray-700
-                                   hover:border-indigo-500 hover:bg-indigo-50 dark:hover:bg-indigo-900/20
-                                   transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500">
-                        <span class="text-2xl flex-shrink-0" aria-hidden="true">➗</span>
-                        <div class="text-left">
-                            <p class="font-semibold text-sm text-gray-800 dark:text-gray-200">Dividir a partes iguales</p>
-                            <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">El total se divide entre todos por igual</p>
-                        </div>
-                    </button>
-                </div>
-
-                <button type="button"
-                        @click="$store.bill.closeSplitSelector()"
-                        class="w-full mt-4 py-2.5 rounded-xl text-sm font-medium text-gray-500 dark:text-gray-400
-                               hover:text-gray-700 dark:hover:text-gray-200 focus:outline-none focus:underline transition-colors">
-                    Cancelar
-                </button>
-            </div>
-        </div>{{-- /split selector sheet --}}
-
-        {{-- ── Sheet: cobro partido por ítems (Modo A) ────────────────── --}}
-        <div x-show="$store.bill.splitShowItems"
-             x-transition:enter="transition ease-out duration-300"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="transition ease-in duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
-             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-             @click.self="$store.bill.closeSplitItems()"
-             @keydown.escape.window="$store.bill.closeSplitItems()"
-             aria-modal="true" role="dialog" aria-label="Selecciona qué ítems pagas">
-
-            <div x-show="$store.bill.splitShowItems"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="translate-y-full"
-                 x-transition:enter-end="translate-y-0"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="translate-y-0"
-                 x-transition:leave-end="translate-y-full"
-                 class="absolute bottom-0 left-0 right-0 max-h-[88dvh] flex flex-col
-                        bg-white dark:bg-gray-900 rounded-t-2xl shadow-2xl overflow-hidden">
-
-                {{-- Cabecera --}}
-                <div class="flex-shrink-0 px-5 pt-4 pb-3 border-b border-gray-200 dark:border-gray-700">
-                    <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-4"></div>
-                    <div class="flex items-center justify-between">
-                        <div>
-                            <h2 class="text-lg font-bold text-gray-900 dark:text-white">Pagar por ítems</h2>
-                            <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Marca los platos que quieres pagar tú</p>
-                        </div>
-                        <button type="button"
-                                @click="$store.bill.closeSplitItems()"
-                                aria-label="Cerrar selección de ítems"
-                                class="p-1.5 rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100
-                                       dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-400">
-                            <svg aria-hidden="true" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                            </svg>
-                        </button>
-                    </div>
-                </div>
-
-                {{-- Lista de ítems --}}
-                <div class="flex-1 overflow-y-auto px-5 py-3">
-                    <template x-if="$store.bill.splitItems.length === 0">
-                        <p class="text-center text-sm text-gray-400 dark:text-gray-500 py-8">
-                            No hay ítems en el pedido activo.
-                        </p>
-                    </template>
-                    <fieldset class="space-y-2">
-                        <legend class="sr-only">Selecciona los ítems que quieres pagar</legend>
-                        <template x-for="item in $store.bill.splitItems" :key="item.id">
-                            <label :for="'split-item-' + item.id"
-                                   :class="item.claimed
-                                       ? 'opacity-50 cursor-not-allowed bg-gray-50 dark:bg-gray-800/50 border-gray-200 dark:border-gray-700'
-                                       : $store.bill.isItemSelected(item.id)
-                                           ? 'ring-2 ring-violet-500 bg-violet-50 dark:bg-violet-900/20 border-violet-400 dark:border-violet-600 cursor-pointer'
-                                           : 'bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700 cursor-pointer hover:border-violet-400'"
-                                   class="flex items-center gap-3 p-3 rounded-xl border-2 transition-colors select-none">
-                                <input type="checkbox"
-                                       :id="'split-item-' + item.id"
-                                       :checked="$store.bill.isItemSelected(item.id)"
-                                       :disabled="item.claimed"
-                                       @change="$store.bill.toggleSplitItem(item.id, item.claimed)"
-                                       :aria-label="item.name + ' — ' + item.total.toFixed(2).replace('.', ',') + ' €'"
-                                       :aria-disabled="item.claimed"
-                                       class="w-5 h-5 rounded text-violet-600 border-gray-300
-                                              focus:ring-violet-500 flex-shrink-0">
-                                <div class="flex-1 min-w-0">
-                                    <p class="font-medium text-sm text-gray-900 dark:text-white leading-snug"
-                                       x-text="item.name"></p>
-                                    <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5"
-                                       x-text="item.quantity + ' × ' + item.price.toFixed(2).replace('.', ',') + ' €'"></p>
-                                </div>
-                                <div class="flex-shrink-0 text-right">
-                                    <template x-if="item.claimed">
-                                        <span class="inline-block text-xs font-medium text-amber-600 dark:text-amber-400
-                                                     bg-amber-100 dark:bg-amber-900/40 px-2 py-0.5 rounded-full"
-                                              aria-label="Ítem ya reclamado por otro comensal">
-                                            Ya reclamado
-                                        </span>
-                                    </template>
-                                    <template x-if="!item.claimed">
-                                        <span class="font-bold text-sm text-gray-700 dark:text-gray-300"
-                                              x-text="item.total.toFixed(2).replace('.', ',') + ' €'"></span>
-                                    </template>
-                                </div>
-                            </label>
-                        </template>
-                    </fieldset>
-                </div>
-
-                {{-- Footer con total reactivo y botón --}}
-                <div class="flex-shrink-0 px-5 py-4 border-t border-gray-200 dark:border-gray-700
-                            bg-white dark:bg-gray-900 space-y-3">
-                    <div role="status" aria-live="polite"
-                         class="flex items-center justify-between bg-gray-50 dark:bg-gray-800 rounded-xl px-4 py-3">
-                        <span class="text-sm font-medium text-gray-600 dark:text-gray-400">Tu total</span>
-                        <span class="text-xl font-bold text-violet-600 dark:text-violet-400"
-                              x-text="$store.bill.splitItemsTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                    </div>
-
-                    <button type="button"
-                            @click="$store.bill.openSplitTip(
-                                $store.bill.splitItemsTotal,
-                                'items',
-                                $store.bill.splitSelected
-                            )"
-                            :disabled="$store.bill.splitSelected.length === 0 || $store.bill.sending"
-                            class="w-full py-3.5 rounded-xl bg-violet-600 hover:bg-violet-700 disabled:opacity-50
-                                   text-white font-bold text-base shadow-sm transition-colors
-                                   focus:outline-none focus:ring-4 focus:ring-violet-400">
-                        <span x-show="!$store.bill.sending">
-                            💳 Pagar mi selección —
-                            <span x-text="$store.bill.splitItemsTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                        </span>
-                        <span x-show="$store.bill.sending" class="flex items-center justify-center gap-2">
-                            <svg class="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-                                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
-                            </svg>
-                            Procesando...
-                        </span>
-                    </button>
-
-                    <button type="button"
-                            @click="$store.bill.closeSplitItems()"
-                            class="w-full py-2.5 rounded-xl text-sm font-medium text-gray-500 dark:text-gray-400
-                                   hover:text-gray-700 dark:hover:text-gray-200 focus:outline-none focus:underline transition-colors">
-                        Cancelar
-                    </button>
-                </div>
-            </div>
-        </div>{{-- /split items sheet --}}
-
-        {{-- ── Sheet: cobro partido equitativo (Modo B) ───────────────── --}}
-        <div x-show="$store.bill.splitShowEq"
-             x-transition:enter="transition ease-out duration-300"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="transition ease-in duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
-             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-             @click.self="$store.bill.closeSplitEq()"
-             @keydown.escape.window="$store.bill.closeSplitEq()"
-             aria-modal="true" role="dialog" aria-label="Dividir la cuenta a partes iguales">
-
-            <div x-show="$store.bill.splitShowEq"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="translate-y-full"
-                 x-transition:enter-end="translate-y-0"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="translate-y-0"
-                 x-transition:leave-end="translate-y-full"
-                 class="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900
-                        rounded-t-2xl shadow-2xl px-5 pb-8 pt-4">
-
-                <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-5"></div>
-
-                <div class="flex items-center justify-between mb-5">
-                    <div>
-                        <h2 class="text-lg font-bold text-gray-900 dark:text-white">Dividir a partes iguales</h2>
-                        <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">¿Cuántas personas sois?</p>
-                    </div>
-                    <button type="button"
-                            @click="$store.bill.closeSplitEq()"
-                            aria-label="Cerrar cobro equitativo"
-                            class="p-1.5 rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100
-                                   dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-400">
-                        <svg aria-hidden="true" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                        </svg>
-                    </button>
-                </div>
-
-                {{-- Total del pedido --}}
-                <div class="bg-gray-50 dark:bg-gray-800 rounded-xl px-4 py-3 mb-5 flex justify-between items-center">
-                    <span class="text-sm text-gray-500 dark:text-gray-400">Total del pedido</span>
-                    <span class="text-lg font-bold text-gray-900 dark:text-white"
-                          x-text="$store.bill.orderTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                </div>
-
-                {{-- Selector de número de personas --}}
-                <div class="mb-5">
-                    <label for="split-people-input"
-                           class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                        Número de personas
-                    </label>
-                    <div class="flex items-center gap-3">
-                        <button type="button"
-                                @click="if ($store.bill.splitPeople > 2) $store.bill.splitPeople--"
-                                :disabled="$store.bill.splitPeople <= 2"
-                                aria-label="Reducir número de personas"
-                                class="w-10 h-10 flex items-center justify-center rounded-full border-2
-                                       border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400
-                                       hover:border-indigo-500 hover:text-indigo-600 dark:hover:text-indigo-400
-                                       disabled:opacity-40 disabled:cursor-not-allowed
-                                       focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-colors">
-                            <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M20 12H4"/>
-                            </svg>
-                        </button>
-                        <input type="number"
-                               id="split-people-input"
-                               x-model.number="$store.bill.splitPeople"
-                               min="2"
-                               :max="$store.bill.splitMaxParts || 20"
-                               aria-required="true"
-                               aria-describedby="split-people-hint"
-                               class="flex-1 text-center text-2xl font-bold text-gray-900 dark:text-white
-                                      bg-transparent border-0 focus:outline-none focus:ring-0">
-                        <button type="button"
-                                @click="if (!$store.bill.splitMaxParts || $store.bill.splitPeople < $store.bill.splitMaxParts) $store.bill.splitPeople++"
-                                :disabled="$store.bill.splitMaxParts && $store.bill.splitPeople >= $store.bill.splitMaxParts"
-                                aria-label="Aumentar número de personas"
-                                class="w-10 h-10 flex items-center justify-center rounded-full border-2
-                                       border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400
-                                       hover:border-indigo-500 hover:text-indigo-600 dark:hover:text-indigo-400
-                                       disabled:opacity-40 disabled:cursor-not-allowed
-                                       focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-colors">
-                            <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
-                            </svg>
-                        </button>
-                    </div>
-                    <p id="split-people-hint" class="sr-only">Mínimo 2 personas</p>
-                </div>
-
-                {{-- Resumen reactivo --}}
-                <div role="status" aria-live="polite"
-                     class="bg-indigo-50 dark:bg-indigo-900/20 rounded-xl px-4 py-4 mb-5 space-y-2">
-                    <div class="flex justify-between text-sm">
-                        <span class="text-gray-600 dark:text-gray-400">Total del pedido</span>
-                        <span class="font-medium text-gray-900 dark:text-white"
-                              x-text="$store.bill.orderTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                    </div>
-                    <div class="flex justify-between text-sm">
-                        <span class="text-gray-600 dark:text-gray-400">Personas</span>
-                        <span class="font-medium text-gray-900 dark:text-white"
-                              x-text="$store.bill.splitPeople"></span>
-                    </div>
-                    <div class="flex justify-between text-base font-bold border-t border-indigo-200 dark:border-indigo-700 pt-2">
-                        <span class="text-indigo-700 dark:text-indigo-300">Tu parte</span>
-                        <span class="text-indigo-600 dark:text-indigo-400 text-xl"
-                              x-text="$store.bill.splitMyPart.toFixed(2).replace('.', ',') + ' €'"></span>
-                    </div>
-                </div>
-
-                {{-- Botón pagar --}}
-                <button type="button"
-                        @click="$store.bill.openSplitTip($store.bill.splitMyPart, 'equitable', [])"
-                        :disabled="$store.bill.sending"
-                        class="w-full py-3.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 disabled:opacity-60
-                               text-white font-bold text-base shadow-sm transition-colors
-                               focus:outline-none focus:ring-4 focus:ring-indigo-400">
-                    <span x-show="!$store.bill.sending">
-                        💳 Pagar mi parte —
-                        <span x-text="$store.bill.splitMyPart.toFixed(2).replace('.', ',') + ' €'"></span>
-                    </span>
-                    <span x-show="$store.bill.sending" class="flex items-center justify-center gap-2">
-                        <svg class="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
-                        </svg>
-                        Procesando...
-                    </span>
-                </button>
-
-                <button type="button"
-                        @click="$store.bill.closeSplitEq()"
-                        class="w-full mt-3 py-2.5 rounded-xl text-sm font-medium text-gray-500 dark:text-gray-400
-                               hover:text-gray-700 dark:hover:text-gray-200 focus:outline-none focus:underline transition-colors">
-                    Cancelar
-                </button>
-            </div>
-        </div>{{-- /split equitable sheet --}}
-
-        {{-- ── Sheet: propina para cobro partido ──────────────────── --}}
-        <div x-show="$store.bill.showingSplitTip"
-             x-transition:enter="transition ease-out duration-300"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="transition ease-in duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
-             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-             @click.self="$store.bill.closeSplitTip()"
-             @keydown.escape.window="$store.bill.closeSplitTip()"
-             aria-modal="true" role="dialog" aria-label="Añadir propina al cobro partido">
-
-            <div x-show="$store.bill.showingSplitTip"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="translate-y-full"
-                 x-transition:enter-end="translate-y-0"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="translate-y-0"
-                 x-transition:leave-end="translate-y-full"
-                 class="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900
-                        rounded-t-2xl shadow-2xl px-5 pb-8 pt-4">
-
-                <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-5"></div>
-
-                <div class="flex items-center justify-between mb-5">
-                    <div>
-                        <h2 class="text-lg font-bold text-gray-900 dark:text-white">¿Quieres dejar propina?</h2>
-                        <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">La propina es completamente opcional</p>
-                    </div>
-                    <button type="button"
-                            @click="$store.bill.closeSplitTip()"
-                            aria-label="Cancelar propina"
-                            class="p-1.5 rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100
-                                   dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-400">
-                        <svg aria-hidden="true" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                        </svg>
-                    </button>
-                </div>
-
-                <div class="bg-gray-50 dark:bg-gray-800 rounded-xl px-4 py-3 mb-5 flex justify-between items-center">
-                    <span class="text-sm text-gray-500 dark:text-gray-400">Tu parte</span>
-                    <span class="text-lg font-bold text-gray-900 dark:text-white"
-                          x-text="$store.bill.splitTipBase.toFixed(2).replace('.', ',') + ' €'"></span>
-                </div>
-
-                <div class="grid grid-cols-4 gap-2 mb-4" role="group" aria-label="Porcentaje de propina">
-                    <template x-for="pct in [5, 10, 15, 20]" :key="pct">
-                        <button type="button"
-                                @click="$store.bill.setSplitTipPercent(pct)"
-                                :aria-pressed="$store.bill.splitTipPercent === pct"
-                                :class="$store.bill.splitTipPercent === pct
-                                    ? 'ring-2 ring-violet-500 bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300 border-violet-400'
-                                    : 'bg-gray-50 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-700'"
-                                class="flex flex-col items-center py-3 rounded-xl border-2 font-semibold text-sm
-                                       transition-colors focus:outline-none focus:ring-2 focus:ring-violet-500">
-                            <span x-text="pct + '%'"></span>
-                            <span class="text-xs font-normal mt-0.5 text-gray-500 dark:text-gray-400"
-                                  x-text="(Math.round($store.bill.splitTipBase * pct) / 100).toFixed(2).replace('.', ',') + ' €'"></span>
-                        </button>
-                    </template>
-                </div>
-
-                <div class="relative mb-5">
-                    <label for="split-tip-input" class="sr-only">Propina personalizada en euros</label>
-                    <input type="number"
-                           id="split-tip-input"
-                           min="0"
-                           step="0.50"
-                           placeholder="Otro importe"
-                           @input="$store.bill.updateCustomSplitTip($event.target.value)"
-                           :value="$store.bill.splitTipPercent === null && $store.bill.splitTipAmount > 0 ? $store.bill.splitTipAmount : ''"
-                           class="w-full rounded-xl border border-gray-300 dark:border-gray-600
-                                  bg-white dark:bg-gray-800 text-gray-900 dark:text-white
-                                  px-4 py-3 pr-10 text-right placeholder-gray-400
-                                  focus:outline-none focus:ring-2 focus:ring-violet-500 focus:border-violet-500
-                                  [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none">
-                    <span class="absolute right-4 top-1/2 -translate-y-1/2 text-gray-400 font-medium pointer-events-none"
-                          aria-hidden="true">€</span>
-                </div>
-
-                <div class="space-y-1 mb-5">
-                    <template x-if="$store.bill.splitTipAmount > 0">
-                        <div class="flex justify-between text-sm">
-                            <span class="text-gray-500 dark:text-gray-400">Propina</span>
-                            <span class="font-medium text-gray-700 dark:text-gray-300"
-                                  x-text="'+ ' + $store.bill.splitTipAmount.toFixed(2).replace('.', ',') + ' €'"></span>
-                        </div>
-                    </template>
-                    <div class="flex justify-between text-base font-bold border-t border-gray-200 dark:border-gray-700 pt-2">
-                        <span class="text-gray-900 dark:text-white">Total a pagar</span>
-                        <span class="text-violet-600 dark:text-violet-400"
-                              x-text="$store.bill.splitTipGrandTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                    </div>
-                </div>
-
-                <button type="button"
-                        @click="$store.bill.confirmSplitTip()"
-                        :disabled="$store.bill.sending"
-                        class="w-full py-3.5 rounded-xl bg-violet-600 hover:bg-violet-700 disabled:opacity-60
-                               text-white font-bold text-base shadow-sm transition-colors
-                               focus:outline-none focus:ring-4 focus:ring-violet-400">
-                    <span x-show="!$store.bill.sending">
-                        <span x-show="$store.bill.splitTipAmount > 0">
-                            💳 Pagar <span x-text="$store.bill.splitTipGrandTotal.toFixed(2).replace('.', ',') + ' €'"></span> con propina
-                        </span>
-                        <span x-show="$store.bill.splitTipAmount <= 0">
-                            💳 Pagar sin propina
-                        </span>
-                    </span>
-                    <span x-show="$store.bill.sending" class="flex items-center justify-center gap-2">
-                        <svg class="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
-                        </svg>
-                        Procesando...
-                    </span>
-                </button>
-
-                <button type="button"
-                        @click="$store.bill.closeSplitTip()"
-                        class="w-full mt-3 py-2.5 rounded-xl text-sm font-medium text-gray-500 dark:text-gray-400
-                               hover:text-gray-700 dark:hover:text-gray-200 focus:outline-none focus:underline transition-colors">
-                    Cancelar
-                </button>
-            </div>
-        </div>{{-- /split tip sheet --}}
-
-        {{-- ── Sheet: pago parcial con tarjeta (Stripe Elements) ──────── --}}
-        <div x-show="$store.bill.splitPayingCard"
-             x-transition:enter="transition ease-out duration-300"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="transition ease-in duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
-             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-             @keydown.escape.window="$store.bill.closeSplitPayment()"
-             aria-modal="true" role="dialog" aria-label="Pago parcial con tarjeta">
-
-            <div x-show="$store.bill.splitPayingCard"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="translate-y-full"
-                 x-transition:enter-end="translate-y-0"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="translate-y-0"
-                 x-transition:leave-end="translate-y-full"
-                 class="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900
-                        rounded-t-2xl shadow-2xl px-5 pb-8 pt-4 max-h-[92dvh] overflow-y-auto">
-
-                <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-5"></div>
-
-                <div class="flex items-center justify-between mb-4">
-                    <div>
-                        <h2 class="text-lg font-bold text-gray-900 dark:text-white">Pago parcial con tarjeta</h2>
-                        <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
-                            Tu parte:
-                            <span class="font-semibold text-gray-900 dark:text-white"
-                                  x-text="$store.bill.splitStripeTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                        </p>
-                    </div>
-                    <button type="button"
-                            @click="$store.bill.closeSplitPayment()"
-                            aria-label="Cerrar pago parcial"
-                            class="p-1.5 rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100
-                                   dark:hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-400">
-                        <svg aria-hidden="true" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                        </svg>
-                    </button>
-                </div>
-
-                {{-- Spinner mientras carga Stripe Elements --}}
-                <div x-show="!$store.bill.splitStripeReady && !$store.bill.splitStripeError"
-                     class="flex items-center justify-center py-10">
-                    <svg class="animate-spin w-8 h-8 text-indigo-500" fill="none" viewBox="0 0 24 24"
-                         aria-label="Cargando formulario de pago">
-                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
-                    </svg>
-                </div>
-
-                <div id="split-stripe-element" class="mb-4"></div>
-
-                <template x-if="$store.bill.splitStripeError">
-                    <p class="mb-3 text-sm text-red-600 dark:text-red-400 font-medium text-center"
-                       role="alert"
-                       x-text="$store.bill.splitStripeError"></p>
-                </template>
-
-                <button type="button"
-                        x-show="$store.bill.splitStripeReady"
-                        @click="$store.bill.submitSplitPayment()"
-                        :disabled="$store.bill.sending"
-                        class="w-full py-3.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 disabled:opacity-60
-                               text-white font-bold text-base shadow-sm transition-colors
-                               focus:outline-none focus:ring-4 focus:ring-indigo-400">
-                    <span x-show="!$store.bill.sending">
-                        💳 Pagar
-                        <span x-text="$store.bill.splitStripeTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                    </span>
-                    <span x-show="$store.bill.sending" class="flex items-center justify-center gap-2">
-                        <svg class="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
-                        </svg>
-                        Procesando...
-                    </span>
-                </button>
-
-                <p class="mt-3 text-center text-xs text-gray-400 dark:text-gray-500">
-                    Pago parcial seguro procesado por
-                    <span class="font-semibold text-indigo-500">Stripe</span>
-                    &middot; Tarjeta de prueba: 4242 4242 4242 4242
-                </p>
-            </div>
-        </div>{{-- /split stripe sheet --}}
-
-        {{-- ── Sheet: cobro mixto — selector de importe ───────────── --}}
-        <div x-show="$store.bill.showingMixed"
-             x-transition:enter="transition ease-out duration-300"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="transition ease-in duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
-             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-             @click.self="$store.bill.closeMixed()"
-             @keydown.escape.window="$store.bill.closeMixed()"
-             aria-modal="true" role="dialog" aria-label="Cobro mixto — elige importe en efectivo">
-
-            <div x-show="$store.bill.showingMixed"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="translate-y-full"
-                 x-transition:enter-end="translate-y-0"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="translate-y-0"
-                 x-transition:leave-end="translate-y-full"
-                 class="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900
-                        rounded-t-2xl shadow-2xl px-5 pb-8 pt-4">
-
-                <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-5"></div>
-
-                <div class="flex items-center justify-between mb-5">
-                    <button type="button" @click="$store.bill.closeMixed()"
-                            class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 focus:outline-none focus:underline"
-                            aria-label="Volver a métodos de pago">
-                        ← Volver
-                    </button>
-                    <h2 class="text-lg font-bold text-gray-900 dark:text-white">Cobro mixto</h2>
-                    <div class="w-14"></div>
-                </div>
-
-                <p class="text-sm text-gray-500 dark:text-gray-400 text-center mb-6">
-                    Elige cuánto pagas en efectivo. El resto se cobrará con tarjeta.
-                </p>
-
-                {{-- Total del pedido --}}
-                <div class="bg-gray-50 dark:bg-gray-800 rounded-xl px-4 py-3 mb-5 flex justify-between items-center">
-                    <span class="text-sm text-gray-500 dark:text-gray-400">Total del pedido</span>
-                    <span class="font-bold text-gray-900 dark:text-white"
-                          x-text="$store.bill.orderTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                </div>
-
-                {{-- Slider de importe en efectivo --}}
-                <div class="mb-5">
-                    <label for="mixed-cash-input" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                        Importe en efectivo
-                    </label>
-                    <div class="flex items-center gap-3">
-                        <input type="range"
-                               id="mixed-cash-slider"
-                               :min="0.01"
-                               :max="($store.bill.orderTotal - 0.50).toFixed(2)"
-                               step="0.01"
-                               x-model="$store.bill.mixedCashAmount"
-                               class="flex-1 accent-amber-500"
-                               aria-label="Importe en efectivo">
-                        <div class="relative w-28">
-                            <input type="number"
-                                   id="mixed-cash-input"
-                                   :min="0.01"
-                                   :max="($store.bill.orderTotal - 0.50).toFixed(2)"
-                                   step="0.01"
-                                   x-model="$store.bill.mixedCashAmount"
-                                   class="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 pr-7
-                                          text-sm text-right bg-white dark:bg-gray-800 dark:text-white
-                                          focus:ring-2 focus:ring-amber-500 focus:border-transparent"
-                                   aria-label="Importe exacto en efectivo">
-                            <span class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 text-sm">€</span>
-                        </div>
-                    </div>
-                </div>
-
-                {{-- Resumen del desglose --}}
-                <div class="rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 px-4 py-3 mb-6 space-y-2">
-                    <div class="flex justify-between text-sm">
-                        <span class="text-gray-600 dark:text-gray-300 flex items-center gap-1">
-                            <span aria-hidden="true">💵</span> Pagas en efectivo
-                        </span>
-                        <span class="font-semibold text-gray-900 dark:text-white"
-                              x-text="parseFloat($store.bill.mixedCashAmount || 0).toFixed(2).replace('.', ',') + ' €'"></span>
-                    </div>
-                    <div class="flex justify-between text-sm">
-                        <span class="text-gray-600 dark:text-gray-300 flex items-center gap-1">
-                            <span aria-hidden="true">💳</span> Pagas con tarjeta
-                        </span>
-                        <span class="font-semibold text-gray-900 dark:text-white"
-                              x-text="$store.bill.mixedCardAmount.toFixed(2).replace('.', ',') + ' €'"></span>
-                    </div>
-                </div>
-
-                <template x-if="!$store.bill.mixedCashValid">
-                    <p class="text-xs text-amber-600 dark:text-amber-400 text-center mb-3" role="alert">
-                        El importe con tarjeta debe ser al menos 0,50 €.
-                    </p>
-                </template>
-
-                <button type="button"
-                        @click="$store.bill.openMixedTip()"
-                        :disabled="!$store.bill.mixedCashValid || $store.bill.sending"
-                        class="w-full py-3.5 rounded-xl bg-amber-500 hover:bg-amber-600 disabled:opacity-50
-                               text-white font-bold text-base shadow-sm transition-colors
-                               focus:outline-none focus:ring-4 focus:ring-amber-300">
-                    Continuar → Añadir propina
-                </button>
-
-                <button type="button"
-                        @click="$store.bill.closeMixed()"
-                        class="w-full mt-3 py-2.5 rounded-xl text-sm font-medium text-gray-500 dark:text-gray-400
-                               hover:text-gray-700 dark:hover:text-gray-200 focus:outline-none focus:underline transition-colors">
-                    Cancelar
-                </button>
-            </div>
-        </div>{{-- /mixed selector sheet --}}
-
-        {{-- ── Sheet: cobro mixto — propina (sobre la parte de tarjeta) ── --}}
-        <div x-show="$store.bill.showingMixedTip"
-             x-transition:enter="transition ease-out duration-300"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="transition ease-in duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
-             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-             @click.self="$store.bill.closeMixedTip()"
-             @keydown.escape.window="$store.bill.closeMixedTip()"
-             aria-modal="true" role="dialog" aria-label="Añadir propina al pago con tarjeta">
-
-            <div x-show="$store.bill.showingMixedTip"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="translate-y-full"
-                 x-transition:enter-end="translate-y-0"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="translate-y-0"
-                 x-transition:leave-end="translate-y-full"
-                 class="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900
-                        rounded-t-2xl shadow-2xl px-5 pb-8 pt-4">
-
-                <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-5"></div>
-
-                <div class="flex items-center justify-between mb-5">
-                    <button type="button" @click="$store.bill.closeMixedTip()"
-                            class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 focus:outline-none focus:underline"
-                            aria-label="Volver a cobro mixto">
-                        ← Volver
-                    </button>
-                    <h2 class="text-lg font-bold text-gray-900 dark:text-white">Propina (tarjeta)</h2>
-                    <div class="w-14"></div>
-                </div>
-
-                <p class="text-sm text-gray-500 dark:text-gray-400 text-center mb-4">
-                    ¿Quieres añadir propina al pago con tarjeta?
-                </p>
-
-                <div class="grid grid-cols-4 gap-2 mb-4">
-                    <template x-for="pct in [5, 10, 15, 20]" :key="pct">
-                        <button type="button"
-                                @click="$store.bill.setMixedTipPercent(pct)"
-                                :class="$store.bill.mixedTipPercent === pct
-                                    ? 'bg-amber-500 text-white border-amber-500'
-                                    : 'bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:border-amber-400'"
-                                class="py-2.5 rounded-xl border-2 text-sm font-semibold transition-colors
-                                       focus:outline-none focus:ring-2 focus:ring-amber-400"
-                                :aria-pressed="$store.bill.mixedTipPercent === pct"
-                                :aria-label="'Propina ' + pct + '%'">
-                            <span x-text="pct + '%'"></span>
-                        </button>
-                    </template>
-                </div>
-
-                <div class="relative mb-5">
-                    <input type="number"
-                           min="0" max="500" step="0.01"
-                           placeholder="0,00"
-                           @input="$store.bill.updateCustomMixedTip($event.target.value)"
-                           class="w-full border border-gray-300 dark:border-gray-600 rounded-xl px-4 py-3 pr-10
-                                  text-sm bg-white dark:bg-gray-800 dark:text-white
-                                  focus:ring-2 focus:ring-amber-500 focus:border-transparent"
-                           aria-label="Importe personalizado de propina">
-                    <span class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400">€</span>
-                </div>
-
-                <div class="bg-gray-50 dark:bg-gray-800 rounded-xl px-4 py-3 mb-5 space-y-2">
-                    <div class="flex justify-between text-sm">
-                        <span class="text-gray-500 dark:text-gray-400">Pago con tarjeta</span>
-                        <span x-text="$store.bill.mixedTipBase.toFixed(2).replace('.', ',') + ' €'"
-                              class="font-medium text-gray-700 dark:text-gray-300"></span>
-                    </div>
-                    <template x-if="$store.bill.mixedTipAmount > 0">
-                        <div class="flex justify-between text-sm">
-                            <span class="text-gray-500 dark:text-gray-400">Propina</span>
-                            <span class="font-medium text-gray-700 dark:text-gray-300"
-                                  x-text="'+ ' + $store.bill.mixedTipAmount.toFixed(2).replace('.', ',') + ' €'"></span>
-                        </div>
-                    </template>
-                    <div class="flex justify-between text-base font-bold border-t border-gray-200 dark:border-gray-700 pt-2">
-                        <span class="text-gray-900 dark:text-white">Total con tarjeta</span>
-                        <span class="text-amber-600 dark:text-amber-400"
-                              x-text="$store.bill.mixedTipGrandTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                    </div>
-                </div>
-
-                <button type="button"
-                        @click="$store.bill.confirmMixedTip()"
-                        :disabled="$store.bill.sending"
-                        class="w-full py-3.5 rounded-xl bg-amber-500 hover:bg-amber-600 disabled:opacity-60
-                               text-white font-bold text-base shadow-sm transition-colors
-                               focus:outline-none focus:ring-4 focus:ring-amber-300">
-                    <span x-show="!$store.bill.sending">
-                        <span x-show="$store.bill.mixedTipAmount > 0"
-                              x-text="'💳 Pagar ' + $store.bill.mixedTipGrandTotal.toFixed(2).replace(\'.\', \',\') + ' € con tarjeta'"></span>
-                        <span x-show="$store.bill.mixedTipAmount <= 0">💳 Pagar sin propina</span>
-                    </span>
-                    <span x-show="$store.bill.sending" class="flex items-center justify-center gap-2">
-                        <svg class="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
-                        </svg>
-                        Procesando...
-                    </span>
-                </button>
-
-                <button type="button"
-                        @click="$store.bill.closeMixedTip()"
-                        class="w-full mt-3 py-2.5 rounded-xl text-sm font-medium text-gray-500 dark:text-gray-400
-                               hover:text-gray-700 dark:hover:text-gray-200 focus:outline-none focus:underline transition-colors">
-                    Cancelar
-                </button>
-            </div>
-        </div>{{-- /mixed tip sheet --}}
-
-        {{-- ── Sheet: cobro mixto — pago con tarjeta (Stripe) ─────── --}}
-        <div x-show="$store.bill.mixedPayingCard"
-             x-transition:enter="transition ease-out duration-300"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="transition ease-in duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
-             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-             @click.self="$store.bill.closeMixedPayment()"
-             @keydown.escape.window="$store.bill.closeMixedPayment()"
-             aria-modal="true" role="dialog" aria-label="Pago con tarjeta — cobro mixto">
-
-            <div x-show="$store.bill.mixedPayingCard"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="translate-y-full"
-                 x-transition:enter-end="translate-y-0"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="translate-y-0"
-                 x-transition:leave-end="translate-y-full"
-                 class="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900
-                        rounded-t-2xl shadow-2xl px-5 pb-8 pt-4">
-
-                <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-5"></div>
-
-                <div class="flex items-center justify-between mb-5">
-                    <button type="button" @click="$store.bill.closeMixedPayment()"
-                            class="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 focus:outline-none focus:underline"
-                            aria-label="Volver">← Volver</button>
-                    <h2 class="text-lg font-bold text-gray-900 dark:text-white">Pago con tarjeta</h2>
-                    <div class="w-14"></div>
-                </div>
-
-                {{-- Resumen antes de pagar --}}
-                <div class="bg-amber-50 dark:bg-amber-900/20 rounded-xl px-4 py-3 mb-5 space-y-1">
-                    <div class="flex justify-between text-sm">
-                        <span class="text-gray-500 dark:text-gray-400 flex items-center gap-1">
-                            <span aria-hidden="true">💵</span> Efectivo al camarero
-                        </span>
-                        <span class="font-semibold text-gray-800 dark:text-white"
-                              x-text="parseFloat($store.bill.mixedCashAmount || 0).toFixed(2).replace('.', ',') + ' €'"></span>
-                    </div>
-                    <div class="flex justify-between text-sm font-bold">
-                        <span class="text-gray-700 dark:text-gray-200 flex items-center gap-1">
-                            <span aria-hidden="true">💳</span> Cargo tarjeta ahora
-                        </span>
-                        <span class="text-amber-600 dark:text-amber-400"
-                              x-text="$store.bill.mixedStripeTotal.toFixed(2).replace('.', ',') + ' €'"></span>
-                    </div>
-                </div>
-
-                <template x-if="$store.bill.mixedStripeError">
-                    <p class="mb-3 text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20
-                               rounded-lg px-4 py-2"
-                       role="alert"
-                       x-text="$store.bill.mixedStripeError"></p>
-                </template>
-
-                <div id="mixed-stripe-element" class="mb-5 min-h-[120px]"></div>
-
-                <div x-show="!$store.bill.mixedStripeReady"
-                     class="flex items-center justify-center py-6 text-sm text-gray-400 gap-2">
-                    <svg class="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
-                    </svg>
-                    Cargando formulario...
-                </div>
-
-                <button type="button"
-                        @click="$store.bill.submitMixedPayment()"
-                        :disabled="!$store.bill.mixedStripeReady || $store.bill.sending"
-                        x-show="$store.bill.mixedStripeReady"
-                        class="w-full py-3.5 rounded-xl bg-amber-500 hover:bg-amber-600 disabled:opacity-60
-                               text-white font-bold text-base shadow-sm transition-colors
-                               focus:outline-none focus:ring-4 focus:ring-amber-300">
-                    <span x-show="!$store.bill.sending"
-                          x-text="'💳 Pagar ' + $store.bill.mixedStripeTotal.toFixed(2).replace(\'.\', \',\') + ' €'"></span>
-                    <span x-show="$store.bill.sending" class="flex items-center justify-center gap-2">
-                        <svg class="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24" aria-hidden="true">
-                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
-                        </svg>
-                        Procesando...
-                    </span>
-                </button>
-            </div>
-        </div>{{-- /mixed stripe sheet --}}
-
-        {{-- ── Cart Bar DS ─────────────────────────────────────────── --}}
-        <button type="button"
-                class="cart-bar"
-                x-show="$store.cart.count > 0 && !$store.chat.open"
-                x-transition:enter="transition ease-out duration-200"
-                x-transition:enter-start="opacity-0 translate-y-4"
-                x-transition:enter-end="opacity-100 translate-y-0"
-                x-transition:leave="transition ease-in duration-150"
-                x-transition:leave-start="opacity-100 translate-y-0"
-                x-transition:leave-end="opacity-0 translate-y-4"
-                @click="$store.cart.open = true"
-                aria-label="Ver pedido">
-            <div class="cart-bar__left">
-                <span class="cart-bar__icon">
-                    <svg aria-hidden="true" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round"
-                              d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"/>
-                    </svg>
-                    <span class="cart-bar__count" x-text="$store.cart.count" aria-hidden="true"></span>
-                </span>
-                <span x-text="$store.cart.count + ' ' + ($store.cart.count === 1 ? 'artículo' : 'artículos')"></span>
-            </div>
-            <span class="cart-bar__cta">Ver pedido</span>
-        </button>
-
-        {{-- ── Drawer del carrito ───────────────────────────────────── --}}
-        <div x-show="$store.cart.open"
-             x-transition:enter="transition ease-out duration-300"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="transition ease-in duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
-             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-             @click.self="$store.cart.open = false"
-             aria-modal="true" role="dialog" aria-label="Tu pedido">
-
-            <div x-show="$store.cart.open"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="translate-y-full"
-                 x-transition:enter-end="translate-y-0"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="translate-y-0"
-                 x-transition:leave-end="translate-y-full"
-                 class="absolute bottom-0 left-0 right-0 max-h-[90dvh] flex flex-col
-                        bg-white dark:bg-gray-900 rounded-t-2xl shadow-2xl overflow-hidden">
-
-                {{-- Handle + cabecera --}}
-                <div class="flex-shrink-0 px-4 pt-3 pb-3 border-b border-gray-200 dark:border-gray-700">
-                    <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-3"></div>
-                    <div class="flex items-center justify-between">
-                        <h2 class="text-lg font-bold text-gray-900 dark:text-white">
-                            Tu pedido
-                            <span class="ml-1 text-sm font-normal text-gray-400">
-                                (<span x-text="$store.cart.count"></span> <span x-text="$store.cart.count === 1 ? 'artículo' : 'artículos'"></span>)
-                            </span>
-                        </h2>
-                        <button type="button"
-                                @click="$store.cart.open = false"
-                                class="p-1.5 rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800
-                                       focus:outline-none focus:ring-2 focus:ring-gray-400">
-                            <svg aria-hidden="true" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
-                            </svg>
-                        </button>
-                    </div>
-                </div>
-
-                {{-- Lista de items --}}
-                <div class="flex-1 overflow-y-auto px-4 py-3 space-y-4">
-                    <template x-for="item in $store.cart.items" :key="item._key">
-                        <div class="bg-gray-50 dark:bg-gray-800 rounded-xl p-3 space-y-3">
-
-                            {{-- Fila producto --}}
-                            <div class="flex items-start gap-3">
-                                <div class="flex-1 min-w-0">
-                                    <p class="font-semibold text-gray-900 dark:text-white text-sm leading-snug" x-text="item.name"></p>
-                                    <p class="text-xs text-gray-400 mt-0.5" x-text="$store.cart.fmt(item.price) + ' / ud.'"></p>
-                                </div>
-
-                                {{-- Cantidad --}}
-                                <div class="flex items-center gap-2 flex-shrink-0">
-                                    <button type="button" @click="$store.cart.dec(item._key)"
-                                            class="w-7 h-7 rounded-full border-2 border-gray-300 dark:border-gray-600
-                                                   flex items-center justify-center text-gray-600 dark:text-gray-300
-                                                   hover:border-red-400 hover:text-red-500 transition-colors
-                                                   focus:outline-none focus:ring-2 focus:ring-red-400">
-                                        <svg aria-hidden="true" class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M20 12H4"/>
-                                        </svg>
-                                    </button>
-                                    <span class="w-5 text-center font-bold text-gray-900 dark:text-white text-sm" x-text="item.quantity"></span>
-                                    <button type="button" @click="$store.cart.inc(item._key)"
-                                            class="w-7 h-7 rounded-full border-2 border-gray-300 dark:border-gray-600
-                                                   flex items-center justify-center text-gray-600 dark:text-gray-300
-                                                   hover:border-green-500 hover:text-green-600 transition-colors
-                                                   focus:outline-none focus:ring-2 focus:ring-green-400">
-                                        <svg aria-hidden="true" class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
-                                        </svg>
-                                    </button>
-                                </div>
-
-                                {{-- Subtotal --}}
-                                <span class="flex-shrink-0 font-bold text-green-600 dark:text-green-400 text-sm"
-                                      x-text="$store.cart.fmt($store.cart.lineTotal(item))"></span>
-                            </div>
-
-                            {{-- Modificaciones --}}
-                            <template x-if="item.removable.length > 0 || item.extras.length > 0">
-                                <div class="border-t border-gray-200 dark:border-gray-700 pt-2 space-y-2">
-
-                                    <template x-if="item.removable.length > 0">
-                                        <div>
-                                            <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1.5">Quitar</p>
-                                            <div class="flex flex-wrap gap-1.5">
-                                                <template x-for="ing in item.removable" :key="ing.id">
-                                                    <button type="button"
-                                                            @click="$store.cart.toggleRemove(item._key, ing)"
-                                                            :class="$store.cart.hasMod(item._key, ing.id, 'remove')
-                                                                ? 'bg-red-100 dark:bg-red-900/40 border-red-400 text-red-700 dark:text-red-300'
-                                                                : 'bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300'"
-                                                            class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full border text-xs font-medium transition-colors
-                                                                   focus:outline-none focus:ring-2 focus:ring-red-400">
-                                                        <span x-text="'Sin ' + ing.name"></span>
-                                                    </button>
-                                                </template>
-                                            </div>
-                                        </div>
-                                    </template>
-
-                                    <template x-if="item.extras.length > 0">
-                                        <div>
-                                            <p class="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-1.5">Extra</p>
-                                            <div class="flex flex-wrap gap-1.5">
-                                                <template x-for="ing in item.extras" :key="ing.id">
-                                                    <button type="button"
-                                                            @click="$store.cart.toggleExtra(item._key, ing)"
-                                                            :class="$store.cart.hasMod(item._key, ing.id, 'add')
-                                                                ? 'bg-green-100 dark:bg-green-900/40 border-green-500 text-green-700 dark:text-green-300'
-                                                                : 'bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300'"
-                                                            class="inline-flex items-center gap-1 px-2.5 py-1 rounded-full border text-xs font-medium transition-colors
-                                                                   focus:outline-none focus:ring-2 focus:ring-green-400">
-                                                        <span x-text="'+ ' + ing.name + (ing.price > 0 ? ' (+' + ing.price.toFixed(2).replace(\'.\',\',\') + \' €)\' : \'\'  )"></span>
-                                                    </button>
-                                                </template>
-                                            </div>
-                                        </div>
-                                    </template>
-
-                                </div>
-                            </template>
-
-                        </div>
-                    </template>
-                </div>
-
-                {{-- Footer --}}
-                <div class="flex-shrink-0 px-4 py-4 border-t border-gray-200 dark:border-gray-700 space-y-3 bg-white dark:bg-gray-900">
-
-                    <template x-if="$store.cart.error">
-                        <p class="text-sm text-red-600 dark:text-red-400 text-center font-medium" x-text="$store.cart.error"></p>
-                    </template>
-
-                    <div class="flex items-center justify-between">
-                        <span class="text-base font-semibold text-gray-700 dark:text-gray-300">Total</span>
-                        <span class="text-xl font-bold text-gray-900 dark:text-white" x-text="$store.cart.fmt($store.cart.total)"></span>
-                    </div>
-
-                    <button type="button"
-                            @click="$store.cart.send()"
-                            :disabled="$store.cart.sending"
-                            class="w-full py-3.5 rounded-xl bg-green-600 hover:bg-green-700 disabled:opacity-60
-                                   text-white font-bold text-base shadow-sm transition-colors
-                                   focus:outline-none focus:ring-4 focus:ring-green-400">
-                        <span x-show="!$store.cart.sending" x-text="$store.cart.sendLabel"></span>
-                        <span x-show="$store.cart.sending" class="flex items-center justify-center gap-2">
-                            <svg class="animate-spin w-5 h-5" fill="none" viewBox="0 0 24 24">
-                                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-                                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
-                            </svg>
-                            Enviando...
-                        </span>
-                    </button>
+        {{-- ══════════════════════════════════════════════════════════════════════
+             RESTO DE LA CARTA — estructura HTML idéntica al Design System DS
+             Zampi chatbot preservado intacto en las líneas anteriores (1-1071)
+             ══════════════════════════════════════════════════════════════════════ --}}
+
+        {{-- ── Banner cocina cerrada (DS: banner-closed) ──────────────────────── --}}
+        @if(!$kitchenOpen)
+        <div class="banner-closed" role="status" aria-live="polite">
+            <span class="banner-closed__ic" aria-hidden="true">🌙</span>
+            <div>
+                <div class="banner-closed__title">La cocina está cerrada</div>
+                <div class="banner-closed__sub">
+                    @if($nextOpeningTime)Abre a las {{ $nextOpeningTime }}. @endif
+                    Mientras tanto puedes pedir de barra 🍺
                 </div>
             </div>
         </div>
+        @endif
 
-        {{-- ── Confirmación pedido enviado ─────────────────────────── --}}
-        <div x-show="$store.cart.sent"
-             x-transition:enter="transition ease-out duration-300"
-             x-transition:enter-start="opacity-0 scale-90"
-             x-transition:enter-end="opacity-100 scale-100"
-             x-transition:leave="transition ease-in duration-200"
-             x-transition:leave-start="opacity-100 scale-100"
-             x-transition:leave-end="opacity-0 scale-90"
-             class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-6">
-            <div class="bg-white dark:bg-gray-900 rounded-2xl shadow-2xl p-8 max-w-sm w-full text-center space-y-4">
-                <div class="mx-auto w-16 h-16 rounded-full bg-green-100 dark:bg-green-900/40 flex items-center justify-center">
-                    <svg class="w-9 h-9 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
-                    </svg>
-                </div>
-                <h3 class="text-xl font-bold text-gray-900 dark:text-white">¡Pedido enviado!</h3>
-                <p class="text-sm text-gray-500 dark:text-gray-400">Tu pedido está en camino a cocina. En breve lo tendrás listo.</p>
-                <button type="button"
-                        @click="$store.cart.sent = false"
-                        class="w-full py-2.5 rounded-xl bg-green-600 hover:bg-green-700 text-white font-bold transition-colors
-                               focus:outline-none focus:ring-4 focus:ring-green-400">
-                    Aceptar
-                </button>
+        {{-- ── Indicador de tapas ────────────────────────────────────────────── --}}
+        @if($tapaConfig && $tapaConfig->tapas_enabled && $barItemsCount > 0)
+        <div style="display:flex;align-items:center;gap:10px;padding:10px 16px;background:linear-gradient(135deg,var(--color-amber-100),var(--color-amber-50));border-bottom:1px solid var(--color-amber-200);font-family:var(--font-body);font-size:13px;color:var(--color-amber-800);flex-shrink:0;"
+             role="status" aria-live="polite">
+            <span aria-hidden="true" style="font-size:20px">🍽️</span>
+            <div style="flex:1">
+                <strong>{{ $barItemsCount }} {{ Str::plural('tapa', $barItemsCount) }}</strong>
+                {{ $barItemsCount > 1 ? 'disponibles' : 'disponible' }}
+                @if($tapaConfig->tapas_free) · Gratuita@if($barItemsCount > 1)s@endif @else · {{ number_format($tapaConfig->tapa_price, 2, ',', '.') }} €@endif
             </div>
         </div>
+        @endif
 
-        {{-- ── Barra de filtros ─────────────────────────────────────── --}}
-        @if($businessOpen)
-        <div class="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 shadow-sm"
-             role="region" aria-label="Filtros de la carta">
-            <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-3 space-y-2">
+        {{-- ══════════════════════════════════════════════════════════════════════
+             FILTER BAR (mobile) + ALLERGEN SHEET — x-data local para allergensOpen
+             ══════════════════════════════════════════════════════════════════════ --}}
+        @if($businessOpen && $categories->isNotEmpty())
+        <div x-data="{ allergensOpen: false }">
 
-                {{-- Grupo: Destino --}}
-                <div class="flex items-center gap-2 overflow-x-auto pb-1"
-                     role="group" aria-label="Filtrar por origen">
-                    <span class="flex-shrink-0 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                        Origen
-                    </span>
-
+            {{-- DS: .filter-bar > .filter-row --}}
+            <nav class="filter-bar" aria-label="Filtros de la carta">
+                <div class="filter-row">
+                    {{-- Destino: cocina / barra --}}
                     <button type="button"
+                            class="chip chip--small"
+                            :class="activeDestination === 'kitchen' ? 'chip--active' : ''"
                             @click="setDestination('kitchen')"
-                            :aria-pressed="activeDestination === 'kitchen'"
-                            :class="activeDestination === 'kitchen'
-                                ? 'bg-orange-500 dark:bg-orange-600 text-white border-orange-500 dark:border-orange-600'
-                                : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-orange-400 hover:text-orange-600 dark:hover:text-orange-400'"
-                            class="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full
-                                   text-sm font-medium border transition-colors duration-150
-                                   focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">
-                        <svg aria-hidden="true" class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
-                            <path fill-rule="evenodd"
-                                  d="M12.395 2.553a1 1 0 00-1.45-.385c-.345.23-.614.558-.822.88-.214.33-.403.713-.57 1.116-.334.804-.614 1.768-.84 2.734a31.365 31.365 0 00-.613 3.58 2.64 2.64 0 01-.945-1.067c-.328-.68-.398-1.534-.398-2.654A1 1 0 005.05 6.05 6.981 6.981 0 003 11a7 7 0 1011.95-4.95c-.592-.591-.98-.985-1.348-1.467-.363-.476-.724-1.063-1.207-2.03zM12.12 15.12A3 3 0 017 13s.879.5 2.5.5c0-1 .5-4 1.25-4.5.5 1 .786 1.293 1.371 1.879A2.99 2.99 0 0113 13a2.99 2.99 0 01-.879 2.121z"
-                                  clip-rule="evenodd"/>
-                        </svg>
-                        Cocina
+                            :aria-pressed="(activeDestination === 'kitchen').toString()">
+                        🍳 Cocina
                     </button>
-
                     <button type="button"
+                            class="chip chip--small"
+                            :class="activeDestination === 'bar' ? 'chip--active' : ''"
                             @click="setDestination('bar')"
-                            :aria-pressed="activeDestination === 'bar'"
-                            :class="activeDestination === 'bar'
-                                ? 'bg-amber-500 dark:bg-amber-600 text-white border-amber-500 dark:border-amber-600'
-                                : 'bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-amber-400 hover:text-amber-600 dark:hover:text-amber-400'"
-                            class="flex-shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full
-                                   text-sm font-medium border transition-colors duration-150
-                                   focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">
-                        <svg aria-hidden="true" class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20">
-                            <path d="M3 3a1 1 0 000 2h1.5l1.4 7H3a1 1 0 000 2h1.2l.4 2H3a1 1 0 100 2h14a1 1 0 100-2h-1.6l.4-2H17a1 1 0 000-2h-3.9L14.5 5H16a1 1 0 000-2H3z"/>
-                        </svg>
-                        Barra
+                            :aria-pressed="(activeDestination === 'bar').toString()">
+                        🍺 Barra
                     </button>
+                    {{-- Separador visual --}}
+                    <span style="width:1px;background:var(--border-subtle);margin:2px 4px;align-self:stretch;flex-shrink:0" aria-hidden="true"></span>
+                    {{-- Categorías --}}
+                    <button type="button"
+                            class="chip chip--small"
+                            :class="activeCategory === null ? 'chip--active' : ''"
+                            @click="setCategory(null)"
+                            :aria-pressed="(activeCategory === null).toString()">
+                        Todas
+                    </button>
+                    @foreach($categories as $cat)
+                    <button type="button"
+                            class="chip chip--small"
+                            x-show="isCategoryVisible({{ $cat->id }})"
+                            :class="activeCategory === {{ $cat->id }} ? 'chip--active' : ''"
+                            @click="setCategory({{ $cat->id }})"
+                            :aria-pressed="(activeCategory === {{ $cat->id }}).toString()">
+                        {{ $cat->name }}
+                    </button>
+                    @endforeach
+                </div>
+                {{-- Botón alérgenos fijo a la derecha --}}
+                @if($allergens->isNotEmpty())
+                <button type="button"
+                        class="filter-bar__pinned"
+                        :class="activeAllergens.length > 0 ? 'filter-bar__pinned--on' : ''"
+                        @click="allergensOpen = true"
+                        aria-label="Filtrar por alérgenos">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                         stroke="currentColor" stroke-width="2.2" stroke-linecap="round"
+                         stroke-linejoin="round" aria-hidden="true">
+                        <path d="M3 6h18M6 12h12M10 18h4"/>
+                    </svg>
+                    <span>Alérgenos</span>
+                    <span class="filter-bar__count"
+                          x-show="activeAllergens.length > 0"
+                          x-text="activeAllergens.length"
+                          aria-hidden="true"></span>
+                </button>
+                @endif
+            </nav>
+
+            {{-- DS: .scrim > .drawer.drawer--allergens (sheet móvil) --}}
+            @if($allergens->isNotEmpty())
+            <div class="scrim"
+                 x-show="allergensOpen"
+                 x-transition:enter="transition duration-200"
+                 x-transition:enter-start="opacity-0"
+                 x-transition:enter-end="opacity-100"
+                 x-transition:leave="transition duration-200"
+                 x-transition:leave-start="opacity-100"
+                 x-transition:leave-end="opacity-0"
+                 @click.self="allergensOpen = false"
+                 role="dialog" aria-modal="true" aria-label="Filtrar por alérgenos">
+                <div class="drawer drawer--allergens" @click.stop>
+                    <div class="drawer__grabber" aria-hidden="true"></div>
+                    <div class="drawer__head">
+                        <div>
+                            <div class="drawer__title">Filtrar por alérgenos</div>
+                            <div style="font-family:var(--font-body);font-size:12px;color:var(--fg-muted);margin-top:2px">
+                                Ocultamos los platos que los contengan.
+                            </div>
+                        </div>
+                        <button type="button" class="icon-btn" @click="allergensOpen = false" aria-label="Cerrar">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="drawer__body">
+                        <div class="allergens-grid">
+                            @foreach($allergens as $allergen)
+                            <button type="button"
+                                    class="allergen-chip"
+                                    :class="activeAllergens.includes('{{ $allergen->slug }}') ? 'allergen-chip--active' : ''"
+                                    @click="toggleAllergen('{{ $allergen->slug }}')"
+                                    :aria-pressed="activeAllergens.includes('{{ $allergen->slug }}').toString()">
+                                <span class="allergen" aria-hidden="true">
+                                    <svg width="16" height="16" style="overflow:visible;display:block">
+                                        <use href="#al-{{ $allergen->slug }}"/>
+                                    </svg>
+                                </span>
+                                <span>{{ $allergen->name }}</span>
+                            </button>
+                            @endforeach
+                        </div>
+                    </div>
+                    <div class="drawer__foot">
+                        <button type="button" class="btn-primary" @click="allergensOpen = false">
+                            Ver resultados
+                        </button>
+                    </div>
+                </div>
+            </div>
+            @endif
+        </div>{{-- /allergensOpen x-data --}}
+        @endif
+
+        {{-- ══════════════════════════════════════════════════════════════════════
+             CARTA MAIN — .carta__main > .carta__filters + .carta__body
+             ══════════════════════════════════════════════════════════════════════ --}}
+        <div class="carta__main">
+
+            {{-- DS: .carta__filters — sidebar (tablet + desktop, hidden on mobile via CSS) --}}
+            @if($businessOpen && $categories->isNotEmpty())
+            <div class="carta__filters" aria-label="Filtros">
+
+                {{-- Menú del día --}}
+                <x-daily-menu-availability />
+
+                {{-- Destino (cocina / barra / todo) --}}
+                <div class="filter-section">
+                    <div class="filter-section__label">Servicio</div>
+                    <div class="dest-toggle" role="group" aria-label="Filtrar por servicio">
+                        <button type="button"
+                                :class="activeDestination === null ? 'active' : ''"
+                                @click="setDestination(null)"
+                                :aria-pressed="(activeDestination === null).toString()">
+                            Todo
+                        </button>
+                        <button type="button"
+                                :class="activeDestination === 'kitchen' ? 'active' : ''"
+                                @click="setDestination('kitchen')"
+                                :aria-pressed="(activeDestination === 'kitchen').toString()"
+                                aria-label="Cocina">
+                            🍳
+                        </button>
+                        <button type="button"
+                                :class="activeDestination === 'bar' ? 'active' : ''"
+                                @click="setDestination('bar')"
+                                :aria-pressed="(activeDestination === 'bar').toString()"
+                                aria-label="Barra">
+                            🍺
+                        </button>
+                    </div>
                 </div>
 
-                {{-- Grupo: Alérgenos --}}
-                @if ($allergens->isNotEmpty())
-                    <div x-show="visibleAllergenKeys.length > 0"
-                         class="flex items-center flex-wrap gap-2 py-1"
-                         role="group" aria-label="Filtrar por alérgenos ausentes">
-                        <span class="flex-shrink-0 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
-                            Sin
-                        </span>
-
-                        @foreach ($allergens as $allergen)
-                            @php
-                                $allergenKey  = "'{$allergen->slug}'";
-                                $allergenName = $allergen->name;
-                            @endphp
-                            <div class="relative" x-data="{ tip: false }"
-                                 x-show="visibleAllergenKeys.includes({{ $allergenKey }})">
-                                <button type="button"
-                                        @click="toggleAllergen({{ $allergenKey }})"
-                                        @mouseenter="tip = true"
-                                        @mouseleave="tip = false"
-                                        @touchstart.passive="tip = true; setTimeout(() => tip = false, 1400)"
-                                        :aria-pressed="activeAllergens.includes({{ $allergenKey }})"
-                                        :class="activeAllergens.includes({{ $allergenKey }})
-                                            ? 'border-orange-500 opacity-100 ring-2 ring-orange-400 ring-offset-2 ring-offset-gray-900'
-                                            : 'border-transparent opacity-60 hover:opacity-100'"
-                                        class="p-1 rounded-full border-2 border-transparent transition-all duration-200 cursor-pointer
-                                               focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2
-                                               dark:focus:ring-offset-gray-900"
-                                        aria-label="{{ $allergenName }}">
-                                    <div class="h-12 w-12 rounded-full overflow-hidden">
-                                        <img src="{{ asset('images/allergens/' . $allergen->slug . '.svg') }}"
-                                             alt="{{ $allergenName }}"
-                                             class="h-full w-full object-contain">
-                                    </div>
-                                </button>
-
-                                <div x-show="tip"
-                                     x-transition:enter="transition ease-out duration-150"
-                                     x-transition:enter-start="opacity-0 -translate-y-1"
-                                     x-transition:enter-end="opacity-100 translate-y-0"
-                                     x-transition:leave="transition ease-in duration-100"
-                                     x-transition:leave-start="opacity-100"
-                                     x-transition:leave-end="opacity-0"
-                                     class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1
-                                            text-xs font-medium text-white bg-gray-900 dark:bg-gray-700
-                                            rounded-md whitespace-nowrap shadow-lg z-20 pointer-events-none"
-                                     role="tooltip">
-                                    {{ $allergenName }}
-                                </div>
-                            </div>
+                {{-- Categorías --}}
+                <div class="filter-section">
+                    <div class="filter-section__label">Categorías</div>
+                    <div class="filter-list" role="list">
+                        <div class="filter-list__item"
+                             :class="activeCategory === null ? 'filter-list__item--active' : ''"
+                             @click="setCategory(null)"
+                             @keydown.enter="setCategory(null)"
+                             role="button" tabindex="0"
+                             :aria-pressed="(activeCategory === null).toString()">
+                            <span>Todas</span>
+                            <span class="filter-list__count">{{ $categories->sum(fn($c) => $c->products->count()) }}</span>
+                        </div>
+                        @foreach($categories as $cat)
+                        <div class="filter-list__item"
+                             x-show="isCategoryVisible({{ $cat->id }})"
+                             :class="activeCategory === {{ $cat->id }} ? 'filter-list__item--active' : ''"
+                             @click="setCategory({{ $cat->id }})"
+                             @keydown.enter="setCategory({{ $cat->id }})"
+                             role="button" tabindex="0"
+                             :aria-pressed="(activeCategory === {{ $cat->id }}).toString()">
+                            <span>{{ $cat->name }}</span>
+                            <span class="filter-list__count">{{ $cat->products->count() }}</span>
+                        </div>
                         @endforeach
                     </div>
+                </div>
+
+                {{-- Alérgenos --}}
+                @if($allergens->isNotEmpty())
+                <div class="filter-section">
+                    <div class="filter-section__label">Alérgenos</div>
+                    <div class="filter-list filter-list--allergens" role="list">
+                        @foreach($allergens as $allergen)
+                        <div class="filter-list__item"
+                             :class="activeAllergens.includes('{{ $allergen->slug }}') ? 'filter-list__item--active' : ''"
+                             @click="toggleAllergen('{{ $allergen->slug }}')"
+                             @keydown.enter="toggleAllergen('{{ $allergen->slug }}')"
+                             role="button" tabindex="0"
+                             :aria-pressed="activeAllergens.includes('{{ $allergen->slug }}').toString()">
+                            <span class="filter-list__check" aria-hidden="true">
+                                <svg x-show="activeAllergens.includes('{{ $allergen->slug }}')"
+                                     width="10" height="10" viewBox="0 0 24 24"
+                                     fill="none" stroke="currentColor" stroke-width="3">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+                                </svg>
+                            </span>
+                            <span class="allergen" aria-hidden="true">
+                                <svg width="16" height="16" style="overflow:visible;display:block">
+                                    <use href="#al-{{ $allergen->slug }}"/>
+                                </svg>
+                            </span>
+                            <span style="font-size:13px">{{ $allergen->name }}</span>
+                        </div>
+                        @endforeach
+                    </div>
+                </div>
                 @endif
 
-                {{-- Contador + limpiar --}}
-                <div class="flex items-center justify-between min-h-[1.5rem]">
-                    <p class="text-xs text-gray-400 dark:text-gray-500"
+                {{-- Contador de visibles --}}
+                <div style="margin-top:auto;padding-top:16px;border-top:1px solid var(--border-subtle)">
+                    <p style="font-family:var(--font-body);font-size:11px;color:var(--fg-muted)"
                        role="status" aria-live="polite" aria-atomic="true">
-                        <span x-text="visibleCount"></span>&nbsp;<span x-text="visibleCount === 1 ? 'producto' : 'productos'"></span> visibles
+                        <span x-text="visibleCount"></span>&nbsp;<span x-text="visibleCount === 1 ? 'producto visible' : 'productos visibles'"></span>
                     </p>
                     <button type="button"
                             x-show="hasActiveFilters"
                             x-transition
                             @click="clearAll()"
-                            class="text-xs font-medium text-indigo-600 dark:text-indigo-400
-                                   hover:text-indigo-800 dark:hover:text-indigo-200
-                                   focus:outline-none focus:underline transition-colors">
+                            style="font-family:var(--font-body);font-size:12px;font-weight:600;color:var(--brand-primary);background:none;border:none;cursor:pointer;padding:4px 0;margin-top:6px">
                         Limpiar filtros
                     </button>
                 </div>
 
             </div>
-        </div>
-        @endif
+            @endif
 
-        {{-- ── Filtro de categorías DS (.filter-bar) ──────────────────── --}}
-        @if ($businessOpen && $categories->isNotEmpty())
-            <nav class="filter-bar" aria-label="Filtrar por categoría">
+            {{-- DS: .carta__body — área scrolleable con productos --}}
+            <div class="carta__body" id="main-content">
 
-                {{-- Chip "Todas" --}}
-                <button type="button"
-                        @click="setCategory(null)"
-                        :aria-pressed="activeCategory === null"
-                        :class="activeCategory === null ? 'chip chip--active' : 'chip'">
-                    Todas
-                </button>
+                {{-- Banner Menú del Día --}}
+                <x-daily-menu-banner :hash="$table->unique_hash" />
 
-                @foreach ($categories as $category)
+                @if(!$businessOpen)
+                {{-- ══ NEGOCIO CERRADO ══ --}}
+                <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;padding:64px 24px;text-align:center;gap:16px;min-height:60%"
+                     role="status" aria-live="polite">
+                    <div style="font-size:56px;line-height:1">🕐</div>
+                    <div style="font-family:var(--font-display);font-weight:900;font-size:24px;color:var(--fg-primary);line-height:1.2">
+                        {{ $table->user->business_name ?: $table->user->name }} está cerrado
+                    </div>
+                    <div style="font-family:var(--font-body);font-size:14px;color:var(--fg-muted);max-width:280px;line-height:1.5">
+                        Estamos fuera de nuestro horario de atención. Vuelve cuando estemos abiertos.
+                    </div>
+                    @if($businessNextOpening)
+                    <div style="background:var(--glass-bg-surface);border:1px solid var(--glass-border);border-radius:9999px;padding:8px 20px;font-family:var(--font-body);font-size:13px;font-weight:600;color:var(--fg-primary)">
+                        Próxima apertura a las {{ $businessNextOpening }}
+                    </div>
+                    @endif
+                    @if($hasActiveOrder)
                     <button type="button"
-                            x-show="isCategoryVisible({{ $category->id }})"
-                            @click="setCategory({{ $category->id }})"
-                            :aria-pressed="activeCategory === {{ $category->id }}"
-                            :class="activeCategory === {{ $category->id }} ? 'chip chip--active' : 'chip'">
-                        {{ $category->name }}
+                            @click="$store.bill.open()"
+                            style="margin-top:8px;padding:12px 24px;border-radius:9999px;background:var(--cta-view-order);color:#fff;border:none;cursor:pointer;font-family:var(--font-body);font-weight:700;font-size:14px;box-shadow:var(--shadow-fab)">
+                        💳 Solicitar la cuenta
                     </button>
-                @endforeach
-
-            </nav>
-        @endif
-
-        {{-- ════════════════════════════════════════════════════════════ --}}
-        {{-- NEGOCIO CERRADO: carta inaccesible + horarios del día      --}}
-        {{-- ════════════════════════════════════════════════════════════ --}}
-        <div class="carta__main">
-        <div class="carta__body" id="main-content">
-        @if(!$businessOpen)
-        <main class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-24">
-            <div class="text-center" role="status" aria-live="polite">
-                <div class="inline-flex items-center justify-center w-20 h-20 rounded-full bg-gray-100 dark:bg-gray-800 mb-6">
-                    <svg aria-hidden="true" class="w-10 h-10 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
-                              d="M12 6v6l4 2M12 2a10 10 0 100 20A10 10 0 0012 2z"/>
-                    </svg>
+                    @endif
                 </div>
-                <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
-                    {{ $table->user->business_name ?: $table->user->name }} {{ __('está cerrado ahora') }}
-                </h2>
-                <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
-                    {{ __('Estamos fuera de nuestro horario de atención. Vuelve cuando estemos abiertos.') }}
-                </p>
-                @if($businessNextOpening)
-                <p class="inline-block bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 text-sm font-semibold px-4 py-2 rounded-full">
-                    {{ __('Próxima apertura a las') }} {{ $businessNextOpening }}
-                </p>
-                @endif
-            </div>
 
-            @if($hasActiveOrder)
-            <div class="mt-8 rounded-2xl bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-700 p-5 text-center" role="alert">
-                <p class="text-sm font-semibold text-green-800 dark:text-green-300 mb-1">
-                    {{ __('Tienes un pedido activo') }}
-                </p>
-                <p class="text-xs text-green-700 dark:text-green-400 mb-4">
-                    {{ __('El negocio ha cerrado pero puedes solicitar la cuenta desde el botón de abajo.') }}
-                </p>
-                <button type="button"
-                        @click="$store.bill.open()"
-                        :disabled="$store.bill.requested || $store.bill.sending"
-                        class="inline-flex items-center gap-2 px-5 py-2.5 rounded-full bg-green-600 hover:bg-green-700
-                               text-white text-sm font-bold shadow transition-colors
-                               disabled:opacity-60 disabled:cursor-not-allowed
-                               focus:outline-none focus:ring-4 focus:ring-green-400">
-                    <template x-if="!$store.bill.requested">
-                        <span>💳 {{ __('Solicitar la cuenta') }}</span>
-                    </template>
-                    <template x-if="$store.bill.requested">
-                        <span>✅ {{ __('Cuenta solicitada') }}</span>
-                    </template>
-                </button>
-            </div>
-            @endif
-        </main>
-        @else
+                @else
+                {{-- ══ PRODUCTOS POR CATEGORÍA ══ --}}
+                @forelse($categories as $category)
+                @php $photoCycle = 0; @endphp
+                <div class="category"
+                     x-show="isCategoryVisible({{ $category->id }})"
+                     x-transition
+                     @if(!$kitchenOpen && $category->destination === 'kitchen')
+                     style="opacity:0.45;pointer-events:none"
+                     @endif>
 
-        {{-- ── Contenido principal ──────────────────────────────────── --}}
-        <main class="carta__products max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 space-y-10">
-
-            {{-- ── Menú del Día ──────────────────────────────────────── --}}
-            <x-daily-menu-banner :hash="$table->unique_hash" />
-
-            {{-- ── Banner cocina cerrada ──────────────────────────────── --}}
-            @if(!$kitchenOpen)
-            <div role="status"
-                 class="rounded-xl bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 p-4 sm:p-5 flex flex-col sm:flex-row items-start sm:items-center gap-3">
-                <span aria-hidden="true" class="text-2xl leading-none">🕐</span>
-                <div class="flex-1">
-                    <p class="text-sm font-semibold text-blue-800 dark:text-blue-300">
-                        {{ __('La cocina está cerrada en este momento') }}
-                    </p>
-                    <p class="text-xs text-blue-700 dark:text-blue-400 mt-0.5">
-                        {{ __('Ahora solo se sirven bebidas.') }}
-                        @if($nextOpeningTime)
-                            {{ __('La cocina abre a las') }}
-                            <span class="font-semibold">{{ $nextOpeningTime }}</span>.
-                        @endif
-                    </p>
-                </div>
-            </div>
-            @endif
-
-            {{-- ── Banner período de cierre de pedidos ──────────────── --}}
-            @if($businessOpen && !$orderingAllowed)
-            <div role="alert"
-                 class="rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 p-4 sm:p-5 flex flex-col sm:flex-row items-start sm:items-center gap-3">
-                <span aria-hidden="true" class="text-2xl leading-none">🛑</span>
-                <div class="flex-1">
-                    <p class="text-sm font-semibold text-amber-800 dark:text-amber-300">
-                        {{ __('La cocina ya no acepta pedidos') }}
-                    </p>
-                    <p class="text-xs text-amber-700 dark:text-amber-400 mt-0.5">
-                        {{ __('Estamos en el período de cierre. Puedes solicitar la cuenta desde el botón de abajo.') }}
-                    </p>
-                </div>
-            </div>
-            @endif
-
-            {{-- Estado vacío cuando los filtros excluyen todo --}}
-            <div x-show="hasActiveFilters && visibleCount === 0"
-                 x-transition
-                 class="text-center py-16"
-                 role="status" aria-live="polite">
-                <svg aria-hidden="true" class="mx-auto w-12 h-12 text-gray-300 dark:text-gray-600 mb-4"
-                     fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
-                          d="M21 21l-4.35-4.35M17 11A6 6 0 115 11a6 6 0 0112 0z"/>
-                </svg>
-                <p class="text-lg font-medium text-gray-400 dark:text-gray-500">
-                    Ningún producto coincide con los filtros seleccionados.
-                </p>
-                <button type="button"
-                        @click="clearAll()"
-                        class="mt-3 text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:underline
-                               focus:outline-none focus:underline">
-                    Ver todos los productos
-                </button>
-            </div>
-
-            @forelse ($categories as $category)
-                <section x-show="isCategoryVisible({{ $category->id }})"
-                         x-transition
-                         aria-labelledby="titulo-categoria-{{ $category->id }}"
-                         id="categoria-{{ $category->id }}">
-
-                    {{-- Encabezado de categoría --}}
-                    <div class="flex items-center gap-3 mb-4 px-3 py-2 rounded-lg
-                                bg-white dark:bg-gray-800
-                                border-l-4 border-indigo-500 dark:border-indigo-400
-                                shadow-sm">
-                        <h2 id="titulo-categoria-{{ $category->id }}"
-                            class="text-xl sm:text-2xl font-bold text-gray-900 dark:text-gray-100">
-                            {{ $category->name }}
-                        </h2>
-
-                        @if ($category->destination === 'bar')
-                            <span class="inline-flex items-center gap-1 text-xs font-medium
-                                         bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300
-                                         px-2 py-0.5 rounded-full border border-amber-200 dark:border-amber-700"
-                                  aria-label="Servida desde la barra">
-                                <svg aria-hidden="true" class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
-                                    <path d="M3 3a1 1 0 000 2h1.5l1.4 7H3a1 1 0 000 2h1.2l.4 2H3a1 1 0 100 2h14a1 1 0 100-2h-1.6l.4-2H17a1 1 0 000-2h-3.9L14.5 5H16a1 1 0 000-2H3z"/>
-                                </svg>
-                                Barra
-                            </span>
-                        @else
-                            <span class="inline-flex items-center gap-1 text-xs font-medium
-                                         bg-orange-100 dark:bg-orange-900/50 text-orange-700 dark:text-orange-300
-                                         px-2 py-0.5 rounded-full border border-orange-200 dark:border-orange-700"
-                                  aria-label="Preparada en cocina">
-                                <svg aria-hidden="true" class="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd"
-                                          d="M12.395 2.553a1 1 0 00-1.45-.385c-.345.23-.614.558-.822.88-.214.33-.403.713-.57 1.116-.334.804-.614 1.768-.84 2.734a31.365 31.365 0 00-.613 3.58 2.64 2.64 0 01-.945-1.067c-.328-.68-.398-1.534-.398-2.654A1 1 0 005.05 6.05 6.981 6.981 0 003 11a7 7 0 1011.95-4.95c-.592-.591-.98-.985-1.348-1.467-.363-.476-.724-1.063-1.207-2.03zM12.12 15.12A3 3 0 017 13s.879.5 2.5.5c0-1 .5-4 1.25-4.5.5 1 .786 1.293 1.371 1.879A2.99 2.99 0 0113 13a2.99 2.99 0 01-.879 2.121z"
-                                          clip-rule="evenodd"/>
-                                </svg>
-                                Cocina
-                            </span>
+                    <div class="category__head">
+                        <span class="category__name">{{ $category->name }}</span>
+                        <span class="category__count">{{ $category->products->count() }}</span>
+                        @if(!$kitchenOpen && $category->destination === 'kitchen')
+                        <span class="category__closed" role="status">
+                            <span class="category__closedDot" aria-hidden="true"></span>
+                            Cocina cerrada
+                        </span>
                         @endif
                     </div>
 
-                    {{-- Lista de productos --}}
-                    <ul class="space-y-3" role="list" aria-label="Productos de {{ $category->name }}">
-                        @foreach ($category->products as $product)
-                            <li x-show="isProductVisible({{ $product->id }})"
-                                x-transition:enter="transition ease-out duration-200"
-                                x-transition:enter-start="opacity-0 scale-95"
-                                x-transition:enter-end="opacity-100 scale-100"
-                                x-transition:leave="transition ease-in duration-150"
-                                x-transition:leave-start="opacity-100 scale-100"
-                                x-transition:leave-end="opacity-0 scale-95"
-                                class="pcard">
-                                    {{-- Foto --}}
-                                    @if ($product->image)
-                                        <div class="pcard__photo">
-                                            <img src="{{ Storage::url($product->image) }}"
-                                                 alt="Foto de {{ $product->name }}"
-                                                 loading="lazy"
-                                                 decoding="async"
-                                                 class="w-full h-full object-cover">
+                    <div class="product-grid">
+                        @foreach($category->products as $product)
+                        @php
+                            $photoCycle++;
+                            $photoStyle = (($photoCycle - 1) % 6) + 1;
+                            $allergenSlugs = $product->ingredients
+                                ->where('is_allergen', true)
+                                ->flatMap(fn($i) => $i->allergen_types ?? [])
+                                ->unique()->values();
+                        @endphp
+                        <div class="pcard"
+                             x-show="isProductVisible({{ $product->id }})"
+                             x-transition>
+
+                            {{-- Foto --}}
+                            @if($product->image)
+                            <div class="pcard__photo">
+                                <img src="{{ Storage::url($product->image) }}"
+                                     alt="Foto de {{ $product->name }}"
+                                     loading="lazy" decoding="async"
+                                     style="width:100%;height:100%;object-fit:cover">
+                            </div>
+                            @else
+                            <div class="pcard__photo pcard__photo--food-{{ $photoStyle }}" aria-hidden="true"></div>
+                            @endif
+
+                            {{-- Body --}}
+                            <div class="pcard__body">
+
+                                {{-- Badges alérgenos --}}
+                                <div class="pcard__badges">
+                                    @foreach($allergenSlugs->take(5) as $slug)
+                                    <span class="allergen"
+                                          title="{{ \App\Models\Ingredient::ALLERGEN_TYPES[$slug] ?? $slug }}"
+                                          aria-label="{{ \App\Models\Ingredient::ALLERGEN_TYPES[$slug] ?? $slug }}">
+                                        <svg aria-hidden="true" width="12" height="12" style="overflow:visible;display:block">
+                                            <use href="#al-{{ $slug }}"/>
+                                        </svg>
+                                    </span>
+                                    @endforeach
+                                </div>
+
+                                {{-- Nombre --}}
+                                <div class="pcard__name">{{ $product->name }}</div>
+
+                                {{-- Descripción --}}
+                                @if($product->description)
+                                <div class="pcard__desc">{{ $product->description }}</div>
+                                @endif
+
+                                {{-- Footer: precio + controles --}}
+                                <div class="pcard__foot" @click.stop>
+                                    @if($product->variants->isNotEmpty())
+                                    {{-- Producto CON variantes --}}
+                                    <div x-data="{
+                                             selectedVId: {{ $product->variants->first()->id }},
+                                             variants: {{ $product->variants->map(fn($v) => ['id' => $v->id, 'name' => $v->name, 'price' => (float)$v->price])->values()->toJson() }},
+                                             get sv() { return this.variants.find(v => v.id === this.selectedVId) || this.variants[0]; }
+                                         }"
+                                         style="width:100%;display:flex;flex-direction:column;gap:6px">
+                                        {{-- Selector de variante --}}
+                                        <div style="display:flex;flex-wrap:wrap;gap:4px">
+                                            @foreach($product->variants as $variant)
+                                            <button type="button"
+                                                    @click.stop="selectedVId = {{ $variant->id }}"
+                                                    :class="selectedVId === {{ $variant->id }} ? 'chip chip--small chip--active' : 'chip chip--small'"
+                                                    style="font-size:10px;padding:3px 8px"
+                                                    :aria-pressed="(selectedVId === {{ $variant->id }}).toString()">
+                                                {{ $variant->name }}
+                                                <span style="opacity:0.75">{{ number_format($variant->price, 2, ',', '.') }}&nbsp;€</span>
+                                            </button>
+                                            @endforeach
                                         </div>
-                                    @else
-                                        <div class="pcard__photo pcard__photo--food-1" aria-hidden="true"></div>
-                                    @endif
-
-                                    {{-- Info --}}
-                                    <div class="pcard__body">
-                                        @if($product->variants->isNotEmpty())
-                                        {{-- Producto con variantes --}}
-                                        <div x-data="{
-                                            selectedVariantId: {{ $product->variants->first()->id }},
-                                            variants: {{ $product->variants->map(fn($v) => ['id' => $v->id, 'name' => $v->name, 'price' => (float)$v->price])->values()->toJson() }},
-                                            get selectedVariant() { return this.variants.find(v => v.id === this.selectedVariantId); }
-                                        }">
-                                            <div class="flex items-start justify-between gap-2">
-                                                <h3 class="pcard__name">
-                                                    {{ $product->name }}
-                                                </h3>
-                                                <span class="pcard__price"
-                                                      x-text="'desde ' + Number(Math.min(...variants.map(v => v.price))).toFixed(2).replace('.',',') + ' €'"
-                                                      aria-label="Desde {{ number_format($product->variants->min('price'), 2, ',', '.') }} euros"></span>
-                                            </div>
-
-                                            @if ($product->description)
-                                                <p class="pcard__desc">
-                                                    {{ $product->description }}
-                                                </p>
-                                            @endif
-
-                                            {{-- Alérgenos --}}
-                                            @php
-                                                $productAllergenSlugs = $product->ingredients->where('is_allergen', true)
-                                                    ->flatMap(fn($i) => $i->allergen_types ?? [])
-                                                    ->unique()->values();
-                                            @endphp
-                                            @if ($productAllergenSlugs->isNotEmpty())
-                                                <div class="mt-2" aria-label="Alérgenos de {{ $product->name }}">
-                                                    <p class="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1">
-                                                        Alérgenos
-                                                    </p>
-                                                    <ul class="flex flex-wrap gap-3" role="list">
-                                                        @foreach ($productAllergenSlugs as $slug)
-                                                            <li><x-allergen-badge :slug="$slug" /></li>
-                                                        @endforeach
-                                                    </ul>
-                                                </div>
-                                            @endif
-
-                                            {{-- Chips de variante (server-rendered + Alpine para estado activo) --}}
-                                            <div class="mt-3 flex flex-wrap gap-2" role="group" aria-label="Elige tamaño de {{ $product->name }}">
-                                                @foreach($product->variants as $variant)
-                                                    <button type="button"
-                                                            @click="selectedVariantId = {{ $variant->id }}"
-                                                            :class="selectedVariantId === {{ $variant->id }}
-                                                                ? 'bg-indigo-600 text-white border-indigo-600'
-                                                                : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-600 hover:border-indigo-400'"
-                                                            :aria-pressed="(selectedVariantId === {{ $variant->id }}).toString()"
-                                                            class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-semibold
-                                                                   transition-colors duration-150
-                                                                   focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-1">
-                                                        {{ $variant->name }}
-                                                        <span class="opacity-75">{{ number_format($variant->price, 2, ',', '.') }}&nbsp;€</span>
-                                                    </button>
-                                                @endforeach
-                                            </div>
-
-                                            {{-- Botón añadir variante seleccionada --}}
-                                            <div class="mt-3 flex justify-end">
-                                                @if($orderingAllowed)
-                                                <button type="button"
-                                                        @click="$store.cart.addWithVariant(
-                                                            {{ $product->id }},
-                                                            selectedVariantId,
-                                                            selectedVariant.name,
-                                                            selectedVariant.price,
-                                                            products.find(p => p.id === {{ $product->id }})
-                                                        )"
-                                                        :aria-label="'Añadir ' + selectedVariant.name + ' de {{ $product->name }} al pedido'"
-                                                        class="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full
-                                                               bg-green-600 hover:bg-green-700 active:scale-95
-                                                               text-white text-sm font-semibold shadow-sm
-                                                               transition-all duration-150
-                                                               focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2">
-                                                    <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
-                                                    </svg>
-                                                    Añadir
-                                                </button>
-                                                @else
-                                                <span class="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full
-                                                             bg-gray-200 dark:bg-gray-700
-                                                             text-gray-400 dark:text-gray-500 text-sm font-semibold
-                                                             cursor-not-allowed select-none"
-                                                      aria-disabled="true" title="{{ __('Pedidos cerrados') }}">
-                                                    <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
-                                                    </svg>
-                                                    Añadir
-                                                </span>
-                                                @endif
-                                            </div>
-                                        </div>
-                                        @else
-                                        {{-- Producto sin variantes (comportamiento original) --}}
-                                        <div class="flex items-start justify-between gap-2">
-                                            <h3 class="pcard__name">
-                                                {{ $product->name }}
-                                            </h3>
-                                            <span class="flex-shrink-0 font-bold text-base sm:text-lg
-                                                         text-indigo-600 dark:text-indigo-400"
-                                                  aria-label="Precio: {{ number_format($product->price, 2, ',', '.') }} euros">
-                                                {{ number_format($product->price, 2, ',', '.') }}&nbsp;€
-                                            </span>
-                                        </div>
-
-                                        @if ($product->description)
-                                            <p class="pcard__desc">
-                                                {{ $product->description }}
-                                            </p>
-                                        @endif
-
-                                        {{-- Alérgenos --}}
-                                        @php
-                                            $productAllergenSlugs2 = $product->ingredients->where('is_allergen', true)
-                                                ->flatMap(fn($i) => $i->allergen_types ?? [])
-                                                ->unique()->values();
-                                        @endphp
-                                        @if ($productAllergenSlugs2->isNotEmpty())
-                                            <div class="mt-2" aria-label="Alérgenos de {{ $product->name }}">
-                                                <p class="text-xs font-semibold text-gray-400 dark:text-gray-500 uppercase tracking-wide mb-1">
-                                                    Alérgenos
-                                                </p>
-                                                <ul class="flex flex-wrap gap-3" role="list">
-                                                    @foreach ($productAllergenSlugs2 as $slug)
-                                                        <li><x-allergen-badge :slug="$slug" /></li>
-                                                    @endforeach
-                                                </ul>
-                                            </div>
-                                        @endif
-
-                                        {{-- Botón añadir al carrito --}}
-                                        <div class="mt-3 flex justify-end">
+                                        {{-- Precio + añadir variante --}}
+                                        <div style="display:flex;align-items:center;justify-content:space-between;gap:8px">
+                                            <span class="pcard__price" x-text="Number(sv.price).toFixed(2).replace('.',',') + ' €'"></span>
                                             @if($orderingAllowed)
                                             <button type="button"
-                                                    @click="$store.cart.add(products.find(p => p.id === {{ $product->id }}))"
-                                                    aria-label="Añadir {{ $product->name }} al pedido"
-                                                    class="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full
-                                                           bg-green-600 hover:bg-green-700 active:scale-95
-                                                           text-white text-sm font-semibold shadow-sm
-                                                           transition-all duration-150
-                                                           focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2">
-                                                <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
-                                                </svg>
-                                                Añadir
-                                            </button>
-                                            @else
-                                            <span class="inline-flex items-center gap-1.5 px-4 py-1.5 rounded-full
-                                                         bg-gray-200 dark:bg-gray-700
-                                                         text-gray-400 dark:text-gray-500 text-sm font-semibold
-                                                         cursor-not-allowed select-none"
-                                                  aria-disabled="true"
-                                                  title="{{ __('Pedidos cerrados') }}">
-                                                <svg aria-hidden="true" class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-                                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
-                                                </svg>
-                                                Añadir
-                                            </span>
+                                                    class="btn-add"
+                                                    @click.stop="$store.cart.addWithVariant({{ $product->id }}, selectedVId, sv.name, sv.price, products.find(p => p.id === {{ $product->id }}))"
+                                                    :aria-label="'Añadir ' + sv.name + ' de {{ $product->name }}'">+</button>
                                             @endif
                                         </div>
-                                        @endif
                                     </div>
-                                </div>
-                            </li>
-                        @endforeach
-                    </ul>
-                </section>
-            @empty
-                <div class="text-center py-20" role="status">
-                    <svg aria-hidden="true" class="mx-auto w-12 h-12 text-gray-300 dark:text-gray-600 mb-4"
-                         fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
-                              d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2
-                                 M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
-                    </svg>
-                    <p class="text-lg font-medium text-gray-400 dark:text-gray-500">
-                        La carta no está disponible en este momento.
-                    </p>
-                </div>
-            @endforelse
 
-        </main>
-        @endif{{-- /businessOpen --}}
-        </div>{{-- /carta__body --}}
+                                    @else
+                                    {{-- Producto SIN variantes --}}
+                                    <span class="pcard__price">{{ number_format((float)$product->price, 2, ',', '.') }}&nbsp;€</span>
+
+                                    @if($orderingAllowed)
+                                    {{-- btn-add cuando qty = 0 --}}
+                                    <button type="button"
+                                            class="btn-add"
+                                            x-show="!$store.cart.items.some(i => i.productId === {{ $product->id }} && !i.variantId)"
+                                            @click.stop="$store.cart.add(products.find(p => p.id === {{ $product->id }}))"
+                                            aria-label="Añadir {{ $product->name }}">+</button>
+                                    {{-- qty control cuando qty > 0 --}}
+                                    <div class="qty"
+                                         x-show="$store.cart.items.some(i => i.productId === {{ $product->id }} && !i.variantId)"
+                                         @click.stop>
+                                        <button class="qty-minus"
+                                                @click.stop="$store.cart.dec('{{ $product->id }}:none')"
+                                                aria-label="Quitar uno de {{ $product->name }}">−</button>
+                                        <span class="qty-n"
+                                              x-text="$store.cart.items.find(i => i.productId === {{ $product->id }} && !i.variantId)?.quantity || 0"></span>
+                                        <button class="qty-plus"
+                                                @click.stop="$store.cart.add(products.find(p => p.id === {{ $product->id }}))"
+                                                aria-label="Añadir otro de {{ $product->name }}">+</button>
+                                    </div>
+                                    @else
+                                    <span style="font-family:var(--font-body);font-size:11px;color:var(--fg-muted)">Cerrado</span>
+                                    @endif
+                                    @endif
+
+                                </div>{{-- /pcard__foot --}}
+                            </div>{{-- /pcard__body --}}
+                        </div>{{-- /pcard --}}
+                        @endforeach
+                    </div>{{-- /product-grid --}}
+                </div>{{-- /category --}}
+                @empty
+                <div style="text-align:center;color:var(--fg-muted);padding:32px 16px;font-family:var(--font-body);font-size:14px;line-height:1.5"
+                     role="status">
+                    <div style="font-size:40px;margin-bottom:10px">🔍</div>
+                    La carta no está disponible en este momento.
+                </div>
+                @endforelse
+                @endif
+
+            </div>{{-- /carta__body --}}
         </div>{{-- /carta__main --}}
 
-        {{-- ── Banner de Tapas disponibles ─────────────────────────── --}}
-        @if($tapaConfig && $barItemsCount > 0)
-        <section
-            aria-label="Tapas disponibles"
-            class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 mb-8"
-        >
-            <div class="rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 p-4 sm:p-5 flex flex-col sm:flex-row items-start sm:items-center gap-3">
-                <span aria-hidden="true" class="text-2xl leading-none">🍽️</span>
-                <div class="flex-1">
-                    <p class="text-sm font-semibold text-amber-800 dark:text-amber-300">
-                        {{ __('¡Tienes') }}
-                        <span class="font-bold text-base">{{ $barItemsCount }}</span>
-                        {{ Str::plural('tapa', $barItemsCount) }} {{ __('disponible') }}{{ $barItemsCount > 1 ? 's' : '' }}
-                    </p>
-                    <p class="text-xs text-amber-700 dark:text-amber-400 mt-0.5">
-                        @if($tapaConfig->tapas_free)
-                            {{ __('Las tapas son gratuitas. Al añadir una bebida te sugeriremos tu tapa.') }}
-                        @else
-                            {{ __('Precio por tapa:') }}
-                            <span class="font-semibold">{{ number_format($tapaConfig->tapa_price ?? 0, 2) }} €</span>
-                        @endif
-                        &bull; {{ __('Máximo') }} {{ $tapaConfig->max_tapa_variants }} {{ Str::plural('variante', $tapaConfig->max_tapa_variants) }} {{ __('distintas.') }}
-                        @if($tapaConfig->extra_tapa_enabled)
-                            &bull; {{ __('Tapa extra disponible por') }}
-                            <span class="font-semibold">{{ number_format($tapaConfig->extra_tapa_price ?? 0, 2) }} €</span>.
-                        @endif
-                    </p>
+        {{-- ══════════════════════════════════════════════════════════════════════
+             CART BAR — .cart-bar position:absolute dentro de .carta
+             ══════════════════════════════════════════════════════════════════════ --}}
+        <button type="button"
+                class="cart-bar"
+                x-show="$store.cart.count > 0 && !$store.chat.open"
+                x-transition
+                @click="$store.cart.open = true"
+                :aria-label="'Ver pedido — ' + $store.cart.count + ($store.cart.count === 1 ? ' artículo' : ' artículos') + ', total ' + Number($store.cart.total).toFixed(2).replace('.',',') + ' €'">
+            <div class="cart-bar__left">
+                <span class="cart-bar__icon">
+                    <svg aria-hidden="true" width="18" height="18" fill="none"
+                         stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                              d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"/>
+                    </svg>
+                    <span class="cart-bar__count" x-text="$store.cart.count" aria-hidden="true"></span>
+                </span>
+                <div style="display:flex;flex-direction:column;gap:2px;align-items:flex-start">
+                    <span x-text="$store.cart.count + ($store.cart.count === 1 ? ' artículo' : ' artículos')"></span>
+                    <span class="cart-bar__total"
+                          x-text="Number($store.cart.total).toFixed(2).replace('.',',') + ' €'"></span>
                 </div>
             </div>
-        </section>
-        @endif
+            <span class="cart-bar__cta">Ver pedido</span>
+        </button>
 
-        {{-- ── Modal sugerencia de tapa ────────────────────────────── --}}
-        <div x-show="$store.cart.showTapaModal"
-             x-transition:enter="transition ease-out duration-300"
+        {{-- ══════════════════════════════════════════════════════════════════════
+             FAB BILL — .fab.fab--bill position:absolute dentro de .carta
+             ══════════════════════════════════════════════════════════════════════ --}}
+        <button type="button"
+                class="fab fab--bill"
+                x-show="$store.bill.active && !$store.chat.open"
+                x-transition
+                @click="$store.bill.open()"
+                :disabled="$store.bill.requested && $store.bill.paymentDone"
+                :aria-label="$store.bill.paymentDone ? 'Pago completado' : ($store.bill.requested ? 'Cuenta solicitada' : 'Solicitar la cuenta')">
+            <svg aria-hidden="true" width="18" height="18" fill="none"
+                 stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round"
+                      d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z"/>
+            </svg>
+            <span x-text="$store.bill.paymentDone ? '¡Pagado!' : ($store.bill.requested ? 'Solicitado' : 'Cuenta')"></span>
+        </button>
+
+        {{-- Enlace descarga ticket post-pago --}}
+        <template x-if="$store.bill.paymentDone && $store.bill.paidOrderId">
+            <a :href="$store.bill.ticketDownloadBase + '/' + $store.bill.paidOrderId + '/download?hash=' + $store.bill.tableHash"
+               target="_blank" rel="noopener noreferrer"
+               class="delete-pill"
+               style="background:var(--cta-view-order);border-color:var(--color-green-400);color:#fff;text-decoration:none"
+               :aria-label="'Descargar ticket del pedido #' + $store.bill.paidOrderId">
+                <svg aria-hidden="true" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 16v-8m0 8l-3-3m3 3l3-3M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2"/>
+                </svg>
+                <strong>Descargar ticket</strong>
+            </a>
+        </template>
+
+        {{-- ══════════════════════════════════════════════════════════════════════
+             CART DRAWER — DS: .scrim > .drawer.drawer--cart
+             ══════════════════════════════════════════════════════════════════════ --}}
+        <div class="scrim"
+             x-show="$store.cart.open"
+             x-transition:enter="transition duration-200"
              x-transition:enter-start="opacity-0"
              x-transition:enter-end="opacity-100"
-             x-transition:leave="transition ease-in duration-200"
+             x-transition:leave="transition duration-200"
              x-transition:leave-start="opacity-100"
              x-transition:leave-end="opacity-0"
-             class="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-             @click.self="$store.cart.closeTapaModal()"
-             @keydown.escape.window="$store.cart.closeTapaModal()"
-             aria-modal="true"
-             role="dialog"
-             aria-label="Elige tu tapa"
-             style="display:none">
-
-            <div x-show="$store.cart.showTapaModal"
-                 x-transition:enter="transition ease-out duration-300"
-                 x-transition:enter-start="translate-y-full"
-                 x-transition:enter-end="translate-y-0"
-                 x-transition:leave="transition ease-in duration-200"
-                 x-transition:leave-start="translate-y-0"
-                 x-transition:leave-end="translate-y-full"
-                 class="absolute bottom-0 left-0 right-0 bg-white dark:bg-gray-900
-                        rounded-t-2xl shadow-2xl px-5 pb-8 pt-4 max-h-[85dvh] overflow-y-auto">
-
-                <div class="w-10 h-1 rounded-full bg-gray-300 dark:bg-gray-600 mx-auto mb-4"></div>
-
-                <h2 class="text-lg font-bold text-gray-900 dark:text-white mb-1">
-                    🍽️ {{ __('¿Quieres una tapa?') }}
-                </h2>
-                <p class="text-sm text-gray-500 dark:text-gray-400 mb-4"
-                   x-text="'Te quedan ' + ($store.cart.tapaConfig.maxVariants - $store.cart._variantsUsed) + ' variante(s) disponible(s).'">
-                </p>
-
-                <ul class="space-y-2 mb-4" aria-label="Tapas disponibles">
-                    <template x-for="tapa in $store.cart.tapaProducts" :key="tapa.id">
-                        <li>
-                            <button type="button"
-                                    @click="$store.cart.addTapa(tapa)"
-                                    class="w-full flex items-center justify-between px-4 py-3 rounded-xl
-                                           bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700
-                                           hover:bg-amber-100 dark:hover:bg-amber-800/30 transition-colors
-                                           focus:outline-none focus:ring-2 focus:ring-amber-500">
-                                <span class="font-medium text-gray-900 dark:text-white" x-text="tapa.name"></span>
-                                <span class="text-sm font-semibold text-amber-700 dark:text-amber-300"
-                                      x-text="$store.cart.tapaConfig.free ? 'Gratis' : ($store.cart.tapaConfig.tapaPrice.toFixed(2).replace('.', ',') + ' €')">
-                                </span>
-                            </button>
-                        </li>
+             @click.self="$store.cart.open = false"
+             role="dialog" aria-modal="true" aria-label="Tu pedido">
+            <div class="drawer drawer--cart" @click.stop>
+                <div class="drawer__grabber" aria-hidden="true"></div>
+                {{-- Cart head --}}
+                <div class="cart-head">
+                    <div class="cart-head__row">
+                        <div class="cart-head__heading">
+                            <span class="cart-head__kicker">Tu comanda</span>
+                            <h2 class="cart-head__title">Tu&nbsp;pedido</h2>
+                        </div>
+                        <button type="button" class="icon-btn cart-head__close"
+                                @click="$store.cart.open = false" aria-label="Cerrar">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                            </svg>
+                        </button>
+                    </div>
+                    <div class="cart-head__chips">
+                        <span class="cart-head__chip cart-head__chip--mesa">
+                            <span class="cart-head__chipDot" aria-hidden="true"></span>
+                            {{ $table->name }}
+                        </span>
+                        <span class="cart-head__chip"
+                              x-text="$store.cart.count === 0 ? 'Sin artículos' : $store.cart.count + ($store.cart.count === 1 ? ' artículo' : ' artículos')"></span>
+                    </div>
+                </div>
+                {{-- Cart body --}}
+                <div class="cart-drawer__body">
+                    {{-- Empty state --}}
+                    <template x-if="$store.cart.items.length === 0">
+                        <div class="cart-empty">
+                            <div class="cart-empty__art" aria-hidden="true">
+                                <span class="cart-empty__emoji">🍽️</span>
+                            </div>
+                            <div class="cart-empty__h">Tu pedido está vacío</div>
+                            <div class="cart-empty__p">Echa un ojo a la carta y añade tus platos.</div>
+                        </div>
                     </template>
-                </ul>
-
-                {{-- Tapa extra (si está habilitada) --}}
-                <template x-if="$store.cart.tapaConfig.extraEnabled">
-                    <div class="border-t border-gray-200 dark:border-gray-700 pt-4 mb-4">
-                        <p class="text-xs text-gray-500 dark:text-gray-400 mb-2">
-                            {{ __('Tapa extra (no consume variante)') }} —
-                            <span x-text="$store.cart.tapaConfig.extraPrice.toFixed(2).replace('.', ',') + ' €'"></span>
-                        </p>
-                        <template x-for="tapa in $store.cart.tapaProducts" :key="'extra-' + tapa.id">
+                    {{-- Items list --}}
+                    <template x-if="$store.cart.items.length > 0">
+                        <div>
+                            <div class="cart-drawer__list">
+                                <template x-for="item in $store.cart.items" :key="item._key">
+                                    <div class="citem">
+                                        <div class="citem__top">
+                                            <div class="citem__photo" aria-hidden="true">🍽️</div>
+                                            <div class="citem__main">
+                                                <div class="citem__name" x-text="item.name"></div>
+                                                <div class="citem__unit">
+                                                    <span class="citem__unitPrice"
+                                                          x-text="Number(item.price).toFixed(2).replace('.',',') + ' €'"></span>
+                                                    <span class="citem__unitDot">·</span>
+                                                    <span>por unidad</span>
+                                                </div>
+                                                {{-- Modificaciones --}}
+                                                <template x-if="item.mods && item.mods.length > 0">
+                                                    <div class="citem__customTags" aria-label="Personalizaciones">
+                                                        <template x-for="m in item.mods.filter(m => m.action === 'add')" :key="'e'+m.ingredientId">
+                                                            <span class="citem__customTag citem__customTag--extra"
+                                                                  x-text="'+ ' + m.name"></span>
+                                                        </template>
+                                                        <template x-for="m in item.mods.filter(m => m.action === 'remove')" :key="'r'+m.ingredientId">
+                                                            <span class="citem__customTag citem__customTag--removed"
+                                                                  x-text="'Sin ' + m.name"></span>
+                                                        </template>
+                                                    </div>
+                                                </template>
+                                            </div>
+                                            <div class="citem__side">
+                                                <div class="qty">
+                                                    <button class="qty-minus"
+                                                            @click="$store.cart.dec(item._key)"
+                                                            aria-label="Quitar uno">−</button>
+                                                    <span class="qty-n" x-text="item.quantity"></span>
+                                                    <button class="qty-plus"
+                                                            @click="$store.cart.inc(item._key)"
+                                                            aria-label="Añadir uno">+</button>
+                                                </div>
+                                                <span class="citem__price"
+                                                      x-text="Number(item.price * item.quantity).toFixed(2).replace('.',',') + ' €'"></span>
+                                            </div>
+                                        </div>
+                                        {{-- Quitar ingredientes --}}
+                                        <template x-if="item.removable && item.removable.length > 0">
+                                            <div class="citem__quitar">
+                                                <div class="citem__quitarLabel">Quitar</div>
+                                                <div class="citem__chips">
+                                                    <template x-for="ing in item.removable" :key="ing.id">
+                                                        <button type="button"
+                                                                class="chip-quitar"
+                                                                :class="$store.cart.hasMod(item._key, ing.id, 'remove') ? 'chip-quitar--on' : ''"
+                                                                @click="$store.cart.toggleRemove(item._key, ing)"
+                                                                :aria-pressed="$store.cart.hasMod(item._key, ing.id, 'remove').toString()"
+                                                                x-text="'Sin ' + ing.name"></button>
+                                                    </template>
+                                                </div>
+                                            </div>
+                                        </template>
+                                    </div>
+                                </template>
+                            </div>
+                            {{-- Cart summary --}}
+                            <div class="cart-sum" aria-label="Resumen del pedido">
+                                <div class="cart-sum__head">
+                                    <span class="cart-sum__lab">Resumen</span>
+                                    <span class="cart-sum__ct"
+                                          x-text="$store.cart.count + ($store.cart.count === 1 ? ' artículo' : ' artículos')"></span>
+                                </div>
+                                <div class="cart-sum__rows">
+                                    <div class="cart-sum__row">
+                                        <span>Subtotal (sin IVA)</span>
+                                        <span class="num"
+                                              x-text="Number($store.cart.total / 1.1).toFixed(2).replace('.',',') + ' €'"></span>
+                                    </div>
+                                    <div class="cart-sum__row cart-sum__row--muted">
+                                        <span>IVA 10% incluido</span>
+                                        <span class="num"
+                                              x-text="Number($store.cart.total - $store.cart.total / 1.1).toFixed(2).replace('.',',') + ' €'"></span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+                {{-- Cart foot --}}
+                <template x-if="$store.cart.items.length > 0">
+                    <div class="cart-foot">
+                        <div class="cart-foot__totalRow">
+                            <span class="cart-foot__totalLab">A pagar</span>
+                            <span class="cart-foot__totalVal"
+                                  x-text="Number($store.cart.total).toFixed(2).replace('.',',') + ' €'"></span>
+                        </div>
+                        <button type="button"
+                                class="cart-foot__cta"
+                                @click="$store.cart.send()"
+                                :disabled="$store.cart.sending || $store.cart.sent">
+                            <span class="cart-foot__ctaIc" aria-hidden="true">
+                                <template x-if="$store.cart.sent">✓</template>
+                                <template x-if="$store.cart.sending && !$store.cart.sent">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="animation:spin 1s linear infinite">
+                                        <circle cx="12" cy="12" r="10" stroke-dasharray="31.4" stroke-dashoffset="10"/>
+                                    </svg>
+                                </template>
+                                <template x-if="!$store.cart.sending && !$store.cart.sent">👨‍🍳</template>
+                            </span>
+                            <span class="cart-foot__ctaLab"
+                                  x-text="$store.cart.sending ? 'Enviando a cocina…' : ($store.cart.sent ? 'Pedido enviado' : $store.cart.sendLabel)"></span>
+                            <template x-if="!$store.cart.sending && !$store.cart.sent">
+                                <span class="cart-foot__ctaArrow" aria-hidden="true">→</span>
+                            </template>
+                        </button>
+                        <template x-if="$store.bill.active">
                             <button type="button"
-                                    @click="$store.cart.add({
-                                        id: tapa.id,
-                                        name: tapa.name + ' (extra)',
-                                        price: $store.cart.tapaConfig.extraPrice,
-                                        destination: 'kitchen',
-                                        removable: [],
-                                        extras: []
-                                    }); $store.cart.closeTapaModal()"
-                                    class="w-full mb-2 px-4 py-2.5 rounded-xl border border-gray-300 dark:border-gray-600
-                                           text-sm text-left text-gray-700 dark:text-gray-300
-                                           hover:border-indigo-400 hover:text-indigo-600 dark:hover:text-indigo-400
-                                           transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                                    x-text="tapa.name + ' (+' + $store.cart.tapaConfig.extraPrice.toFixed(2).replace('.', ',') + ' €)'">
+                                    class="cart-foot__secondary"
+                                    @click="$store.cart.open = false; $store.bill.open()">
+                                <svg aria-hidden="true" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z"/>
+                                </svg>
+                                Pedir cuenta
                             </button>
                         </template>
                     </div>
                 </template>
-
-                <button type="button"
-                        @click="$store.cart.closeTapaModal()"
-                        class="w-full py-2.5 rounded-xl text-sm font-medium text-gray-500 dark:text-gray-400
-                               hover:text-gray-700 dark:hover:text-gray-200
-                               focus:outline-none focus:underline transition-colors">
-                    {{ __('Ahora no') }}
-                </button>
+                {{-- Error de envío --}}
+                <template x-if="$store.cart.error">
+                    <p style="padding:8px 16px;font-family:var(--font-body);font-size:13px;color:var(--color-red-400);text-align:center"
+                       role="alert" x-text="$store.cart.error"></p>
+                </template>
             </div>
         </div>
 
-        {{-- ── Footer ──────────────────────────────────────────────── --}}
-        <footer class="mt-12 border-t border-gray-200 dark:border-gray-800 py-6 text-center">
-            <p class="text-xs text-gray-400 dark:text-gray-600">
-                Carta digital generada con
-                <span class="font-semibold text-indigo-500 dark:text-indigo-400">Zampa</span>
-            </p>
-        </footer>
+        {{-- ══════════════════════════════════════════════════════════════════════
+             BILL DRAWER — DS: .scrim > .drawer.drawer--bill (elección de método)
+             ══════════════════════════════════════════════════════════════════════ --}}
+        <div class="scrim"
+             x-show="$store.bill.choosing"
+             x-transition:enter="transition duration-200"
+             x-transition:enter-start="opacity-0"
+             x-transition:enter-end="opacity-100"
+             x-transition:leave="transition duration-200"
+             x-transition:leave-start="opacity-100"
+             x-transition:leave-end="opacity-0"
+             @click.self="$store.bill.close()"
+             role="dialog" aria-modal="true" aria-label="Solicitar la cuenta">
+            <div class="drawer drawer--bill" @click.stop>
+                <div class="drawer__grabber" aria-hidden="true"></div>
+                <div class="drawer__head">
+                    <div class="drawer__heading">
+                        <div class="drawer__title">Solicitar la cuenta</div>
+                        <div class="drawer__subtitle">¿Cómo quieres pagar?</div>
+                    </div>
+                    <div class="drawer__total" aria-label="Total a pagar">
+                        <div class="lab">Total</div>
+                        <div class="val" x-text="Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></div>
+                    </div>
+                    <button type="button" class="icon-btn" @click="$store.bill.close()" aria-label="Cerrar">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                        </svg>
+                    </button>
+                </div>
+                <div class="drawer__body">
+                    <div class="method-list">
+                        {{-- Efectivo --}}
+                        <button type="button" class="method method--cash" @click="$store.bill.openCashTip()">
+                            <span class="method__ic" aria-hidden="true">
+                                <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2">
+                                    <rect x="2" y="7" width="20" height="14" rx="2"/>
+                                    <path d="M16 3H8l-2 4h12l-2-4z"/>
+                                    <circle cx="12" cy="14" r="2"/>
+                                </svg>
+                            </span>
+                            <span class="method__txt">
+                                <span class="method__nm">Efectivo</span>
+                                <span class="method__ds">Pagas al camarero · puedes añadir propina</span>
+                            </span>
+                            <span class="method__chev" aria-hidden="true">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4">
+                                    <polyline points="9 6 15 12 9 18"/>
+                                </svg>
+                            </span>
+                        </button>
+                        {{-- Tarjeta --}}
+                        <button type="button" class="method method--card" @click="$store.bill.openCardPayment()">
+                            <span class="method__ic" aria-hidden="true">
+                                <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2">
+                                    <rect x="1" y="4" width="22" height="16" rx="2"/>
+                                    <line x1="1" y1="10" x2="23" y2="10"/>
+                                </svg>
+                            </span>
+                            <span class="method__txt">
+                                <span class="method__nm">Tarjeta</span>
+                                <span class="method__ds">Pago seguro · Stripe</span>
+                            </span>
+                            <span class="method__chev" aria-hidden="true">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4">
+                                    <polyline points="9 6 15 12 9 18"/>
+                                </svg>
+                            </span>
+                        </button>
+                        {{-- Cobro mixto --}}
+                        <button type="button" class="method method--mixed" @click="$store.bill.openMixed()">
+                            <span class="method__ic" aria-hidden="true">
+                                <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2">
+                                    <rect x="2" y="6" width="9" height="12" rx="2"/>
+                                    <rect x="13" y="5" width="9" height="14" rx="2"/>
+                                    <path d="M6.5 12h.01M17 12h.01"/>
+                                </svg>
+                            </span>
+                            <span class="method__txt">
+                                <span class="method__nm">Cobro mixto</span>
+                                <span class="method__ds">Una parte en efectivo, otra con tarjeta</span>
+                            </span>
+                            <span class="method__chev" aria-hidden="true">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4">
+                                    <polyline points="9 6 15 12 9 18"/>
+                                </svg>
+                            </span>
+                        </button>
+                        {{-- Cobro partido --}}
+                        <template x-if="$store.bill.splitEnabled">
+                            <button type="button" class="method method--split" @click="$store.bill.openSplit()">
+                                <span class="method__ic" aria-hidden="true">
+                                    <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2">
+                                        <circle cx="8" cy="9" r="3"/>
+                                        <circle cx="16" cy="9" r="3"/>
+                                        <path d="M3 20a5 5 0 0 1 10 0M11 20a5 5 0 0 1 10 0"/>
+                                    </svg>
+                                </span>
+                                <span class="method__txt">
+                                    <span class="method__nm">Cobro partido</span>
+                                    <span class="method__ds">Dividir entre comensales</span>
+                                </span>
+                                <span class="method__chev" aria-hidden="true">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4">
+                                        <polyline points="9 6 15 12 9 18"/>
+                                    </svg>
+                                </span>
+                            </button>
+                        </template>
+                    </div>
+                </div>
+                <div class="drawer__foot">
+                    <button type="button" class="btn-text" @click="$store.bill.close()">Cancelar</button>
+                </div>
+            </div>
+        </div>
 
-    </div>{{-- /x-data --}}
+        {{-- ══════════════════════════════════════════════════════════════════════
+             BILL SUB-SHEETS — propina efectivo, tarjeta, confirmaciones
+             Mantenemos la lógica Alpine pero con estructura DS drawer
+             ══════════════════════════════════════════════════════════════════════ --}}
+
+        {{-- Propina efectivo (cashTip) --}}
+        <div class="scrim"
+             x-show="$store.bill.showingTip"
+             x-transition
+             @click.self="$store.bill.closeTip()"
+             role="dialog" aria-modal="true" aria-label="¿Quieres dejar propina?">
+            <div class="drawer drawer--bill" @click.stop>
+                <div class="drawer__grabber" aria-hidden="true"></div>
+                <div class="drawer__head">
+                    <button type="button" class="icon-btn icon-btn--back" @click="$store.bill.close()" aria-label="Cambiar método">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4">
+                            <polyline points="15 18 9 12 15 6"/>
+                        </svg>
+                    </button>
+                    <div class="drawer__heading">
+                        <div class="drawer__title">¿Quieres dejar propina?</div>
+                        <div class="drawer__subtitle">Pago en efectivo · es opcional</div>
+                    </div>
+                    <div class="drawer__total" aria-label="Total a pagar">
+                        <div class="lab">Total a pagar</div>
+                        <div class="val" x-text="Number($store.bill.orderTotal + ($store.bill.tipAmount || 0)).toFixed(2).replace('.',',') + ' €'"></div>
+                    </div>
+                    <button type="button" class="icon-btn" @click="$store.bill.closeTip()" aria-label="Cerrar">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                        </svg>
+                    </button>
+                </div>
+                <div class="drawer__body">
+                    <div class="cashTip">
+                        <div class="cashTip__hero">
+                            <span class="lab">Total del pedido</span>
+                            <span class="val" x-text="Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></span>
+                        </div>
+                        <section class="cashTip__section">
+                            <div class="cashTip__label">
+                                <span>Propina sugerida</span>
+                                <span class="hint">Toca para elegir</span>
+                            </div>
+                            <div class="cashTip__grid">
+                                <template x-for="pct in [5, 10, 15, 20]" :key="pct">
+                                    <button type="button"
+                                            class="cashTip__chip"
+                                            :class="$store.bill.tipPercent === pct ? 'is-active' : ''"
+                                            :aria-pressed="($store.bill.tipPercent === pct).toString()"
+                                            @click="$store.bill.setTipPercent(pct)">
+                                        <span class="cashTip__pct" x-text="pct + '%'"></span>
+                                        <span class="cashTip__amt" x-text="Number(Math.round($store.bill.orderTotal * pct) / 100).toFixed(2).replace('.',',') + ' €'"></span>
+                                    </button>
+                                </template>
+                            </div>
+                            <div class="cashTip__input">
+                                <label for="cash-tip-input-ds" class="sr-only">Propina personalizada en euros</label>
+                                <input id="cash-tip-input-ds"
+                                       type="number" min="0" step="0.50" inputmode="decimal"
+                                       placeholder="Otra cantidad…"
+                                       @input="$store.bill.updateCustomTip($event.target.value)"
+                                       :value="$store.bill.tipPercent === null && $store.bill.tipAmount > 0 ? $store.bill.tipAmount : ''">
+                                <span class="cashTip__currency" aria-hidden="true">€</span>
+                            </div>
+                        </section>
+                        <section class="cashTip__summary" aria-live="polite">
+                            <div class="cashTip__row">
+                                <span>Pedido</span>
+                                <span class="v" x-text="Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></span>
+                            </div>
+                            <template x-if="($store.bill.tipAmount || 0) > 0">
+                                <div class="cashTip__row cashTip__row--tip">
+                                    <span>Propina</span>
+                                    <span class="v" x-text="'+ ' + Number($store.bill.tipAmount).toFixed(2).replace('.',',') + ' €'"></span>
+                                </div>
+                            </template>
+                            <div class="cashTip__row cashTip__row--total">
+                                <span>Total a pagar</span>
+                                <span class="v" x-text="Number($store.bill.orderTotal + ($store.bill.tipAmount || 0)).toFixed(2).replace('.',',') + ' €'"></span>
+                            </div>
+                        </section>
+                    </div>
+                </div>
+                <div class="drawer__foot">
+                    <div class="bill__footRow bill__footRow--stack">
+                        <button type="button"
+                                class="btn-primary cashTip__cta"
+                                :disabled="$store.bill.sending"
+                                @click="$store.bill.confirmCashPayment ? $store.bill.confirmCashPayment() : $store.bill.requestCash()">
+                            <template x-if="$store.bill.sending">
+                                <span><span class="cashTip__spin" aria-hidden="true"></span> Enviando solicitud…</span>
+                            </template>
+                            <template x-if="!$store.bill.sending">
+                                <span x-text="($store.bill.tipAmount || 0) > 0
+                                    ? 'Solicitar cuenta · ' + Number($store.bill.orderTotal + ($store.bill.tipAmount || 0)).toFixed(2).replace('.',',') + ' €'
+                                    : 'Solicitar cuenta · ' + Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></span>
+                            </template>
+                        </button>
+                        <button type="button" class="btn-secondary" @click="$store.bill.close()">← Cambiar método</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        {{-- Pago con tarjeta (tip %) --}}
+        <div class="scrim"
+             x-show="$store.bill.payingCard && !$store.bill.stripeReady"
+             x-transition
+             @click.self="$store.bill.close()"
+             role="dialog" aria-modal="true" aria-label="Elige tu propina">
+            <div class="drawer drawer--bill" @click.stop>
+                <div class="drawer__grabber" aria-hidden="true"></div>
+                <div class="drawer__head">
+                    <button type="button" class="icon-btn icon-btn--back" @click="$store.bill.close()" aria-label="Cambiar método">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><polyline points="15 18 9 12 15 6"/></svg>
+                    </button>
+                    <div class="drawer__heading">
+                        <div class="drawer__title">Elige tu propina</div>
+                        <div class="drawer__subtitle">Añade una propina al servicio</div>
+                    </div>
+                    <div class="drawer__total">
+                        <div class="lab">Total a pagar</div>
+                        <div class="val" x-text="Number($store.bill.grandTotal).toFixed(2).replace('.',',') + ' €'"></div>
+                    </div>
+                    <button type="button" class="icon-btn" @click="$store.bill.close()" aria-label="Cerrar">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                    </button>
+                </div>
+                <div class="drawer__body">
+                    <div class="tip-row" role="group" aria-label="Porcentaje de propina">
+                        <template x-for="p in [0, 10, 15, 20]" :key="p">
+                            <div class="tip"
+                                 :class="$store.bill.tipPercent === p ? 'tip--selected' : ''"
+                                 @click="$store.bill.setTipPercent(p)"
+                                 :aria-pressed="($store.bill.tipPercent === p).toString()"
+                                 role="button" tabindex="0">
+                                <div class="pct" x-text="p + '%'"></div>
+                                <div class="amt" x-text="p === 0 ? '—' : Number($store.bill.orderTotal * p / 100).toFixed(2).replace('.',',') + ' €'"></div>
+                            </div>
+                        </template>
+                    </div>
+                </div>
+                <div class="drawer__foot">
+                    <div class="bill__footRow bill__footRow--stack">
+                        <button type="button" class="btn-primary"
+                                @click="$store.bill.proceedToStripe()">
+                            Continuar — <span x-text="Number($store.bill.grandTotal).toFixed(2).replace('.',',') + ' €'"></span>
+                        </button>
+                        <button type="button" class="btn-secondary" @click="$store.bill.close()">← Cambiar método</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        {{-- Stripe payment --}}
+        <div class="scrim"
+             x-show="$store.bill.stripeReady"
+             x-transition
+             @click.self="$store.bill.close()"
+             role="dialog" aria-modal="true" aria-label="Pago con tarjeta">
+            <div class="drawer drawer--bill" @click.stop>
+                <div class="drawer__grabber" aria-hidden="true"></div>
+                <div class="drawer__head">
+                    <div class="drawer__heading">
+                        <div class="drawer__title">Pago con tarjeta</div>
+                        <div class="drawer__subtitle" x-text="$store.bill.tipPercent + '% de propina incluida'"></div>
+                    </div>
+                    <div class="drawer__total">
+                        <div class="lab">Total a pagar</div>
+                        <div class="val" x-text="Number($store.bill.grandTotal).toFixed(2).replace('.',',') + ' €'"></div>
+                    </div>
+                    <button type="button" class="icon-btn" @click="$store.bill.close()" aria-label="Cerrar">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                    </button>
+                </div>
+                <div class="drawer__body">
+                    <div style="display:flex;flex-direction:column;gap:16px">
+                        <div style="display:flex;align-items:center;gap:6px;font-family:var(--font-body);font-size:12px;font-weight:600;color:var(--fg-muted)">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                                <rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/>
+                            </svg>
+                            PAGO SEGURO · STRIPE
+                        </div>
+                        <div id="stripe-card-element" style="padding:16px;border:1px solid var(--glass-border);border-radius:12px;background:var(--glass-bg-surface)"></div>
+                        <template x-if="$store.bill.stripeError">
+                            <p style="color:var(--color-red-400);font-size:13px" role="alert" x-text="$store.bill.stripeError"></p>
+                        </template>
+                    </div>
+                </div>
+                <div class="drawer__foot">
+                    <div class="bill__footRow bill__footRow--stack">
+                        <button type="button" class="btn-primary"
+                                @click="$store.bill.payWithStripe()"
+                                :disabled="$store.bill.sending">
+                            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/>
+                            </svg>
+                            <span x-text="$store.bill.sending ? 'Procesando…' : 'Pagar ' + Number($store.bill.grandTotal).toFixed(2).replace('.',',') + ' €'"></span>
+                        </button>
+                        <button type="button" class="btn-secondary" @click="$store.bill.close()">← Cambiar método</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        {{-- Efectivo confirmado --}}
+        <div class="scrim"
+             x-show="$store.bill.requested && $store.bill.method === 'cash' && !$store.bill.paymentDone"
+             x-transition
+             @click.self="$store.bill.close()"
+             role="dialog" aria-modal="true" aria-label="Camarero avisado">
+            <div class="drawer drawer--bill" @click.stop>
+                <div class="drawer__grabber" aria-hidden="true"></div>
+                <div class="drawer__body">
+                    <div class="bill__done" style="text-align:center;padding:24px 0">
+                        <div style="font-size:56px;line-height:1;margin-bottom:12px">✅</div>
+                        <div style="font-family:var(--font-display);font-weight:900;font-size:22px;color:var(--fg-primary)">Camarero avisado</div>
+                        <div style="font-family:var(--font-body);font-size:13px;color:var(--fg-muted);margin-top:8px;line-height:1.5">
+                            Pasará a tu mesa en unos instantes.
+                        </div>
+                    </div>
+                </div>
+                <div class="drawer__foot">
+                    <button type="button" class="btn-text" @click="$store.bill.close()">Cerrar</button>
+                </div>
+            </div>
+        </div>
+
+        {{-- Tarjeta confirmada --}}
+        <div class="scrim"
+             x-show="$store.bill.paymentDone && $store.bill.method !== 'cash' && !$store.bill.showingSplit && !$store.bill.showingMixed"
+             x-transition
+             @click.self="$store.bill.close()"
+             role="dialog" aria-modal="true" aria-label="Pago confirmado">
+            <div class="drawer drawer--bill" @click.stop>
+                <div class="drawer__grabber" aria-hidden="true"></div>
+                <div class="drawer__body">
+                    <div class="bill__done" style="text-align:center;padding:24px 0">
+                        <div style="font-size:56px;line-height:1;margin-bottom:12px">🎉</div>
+                        <div style="font-family:var(--font-display);font-weight:900;font-size:22px;color:var(--fg-primary)">¡Pago confirmado!</div>
+                        <div style="font-family:var(--font-body);font-size:13px;color:var(--fg-muted);margin-top:8px;line-height:1.5">
+                            Gracias por tu visita. ¡Hasta pronto!
+                        </div>
+                        <template x-if="$store.bill.paidOrderId">
+                            <a :href="$store.bill.ticketDownloadBase + '/' + $store.bill.paidOrderId + '/download?hash=' + $store.bill.tableHash"
+                               target="_blank" rel="noopener noreferrer"
+                               style="display:inline-flex;align-items:center;gap:8px;margin-top:16px;padding:10px 20px;border-radius:9999px;background:var(--glass-bg-surface);border:1px solid var(--glass-border);color:var(--fg-primary);text-decoration:none;font-family:var(--font-body);font-weight:600;font-size:13px">
+                                <svg aria-hidden="true" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 16v-8m0 8l-3-3m3 3l3-3M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2"/>
+                                </svg>
+                                Descargar ticket
+                            </a>
+                        </template>
+                    </div>
+                </div>
+                <div class="drawer__foot">
+                    <button type="button" class="btn-text" @click="$store.bill.close()">Cerrar</button>
+                </div>
+            </div>
+        </div>
+
+        {{-- SPLIT PAYMENT --}}
+        <div class="scrim"
+             x-show="$store.bill.showingSplit"
+             x-transition
+             @click.self="$store.bill.closeSplitSelector()"
+             role="dialog" aria-modal="true" aria-label="Cobro partido">
+            <div class="drawer drawer--bill drawer--wide" @click.stop>
+                <div class="drawer__grabber" aria-hidden="true"></div>
+                <div class="drawer__head">
+                    <button type="button" class="icon-btn icon-btn--back" @click="$store.bill.close()" aria-label="Cambiar método">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><polyline points="15 18 9 12 15 6"/></svg>
+                    </button>
+                    <div class="drawer__heading">
+                        <div class="drawer__title">Cobro partido</div>
+                        <div class="drawer__subtitle">Dividís la cuenta en tiempo real</div>
+                    </div>
+                    <div class="drawer__total">
+                        <div class="lab">Total</div>
+                        <div class="val" x-text="Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></div>
+                    </div>
+                    <button type="button" class="icon-btn" @click="$store.bill.closeSplitSelector()" aria-label="Cerrar">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                    </button>
+                </div>
+                <div class="drawer__body">
+                    <div style="display:flex;flex-direction:column;gap:12px">
+                        {{-- Por ítems --}}
+                        <button type="button"
+                                @click="!$store.bill.splitEquitativeLocked && $store.bill.openSplitItems()"
+                                :disabled="$store.bill.splitEquitativeLocked"
+                                style="width:100%;display:flex;align-items:center;gap:12px;padding:14px;border-radius:14px;background:var(--glass-bg-surface);border:1px solid var(--glass-border);cursor:pointer;text-align:left"
+                                :style="$store.bill.splitEquitativeLocked ? 'opacity:0.5;cursor:not-allowed' : ''">
+                            <span style="font-size:24px;flex-shrink:0" aria-hidden="true">🧾</span>
+                            <div>
+                                <div style="font-family:var(--font-body);font-weight:700;font-size:14px;color:var(--fg-primary)">Pagar por ítems</div>
+                                <div style="font-family:var(--font-body);font-size:12px;color:var(--fg-muted);margin-top:2px"
+                                     x-text="$store.bill.splitEquitativeLocked ? 'No disponible: ya hay pagos a partes iguales' : 'Elige exactamente qué platos pagas tú'"></div>
+                            </div>
+                        </button>
+                        {{-- Equitativo --}}
+                        <button type="button"
+                                @click="$store.bill.openSplitEq()"
+                                style="width:100%;display:flex;align-items:center;gap:12px;padding:14px;border-radius:14px;background:var(--glass-bg-surface);border:1px solid var(--glass-border);cursor:pointer;text-align:left">
+                            <span style="font-size:24px;flex-shrink:0" aria-hidden="true">➗</span>
+                            <div>
+                                <div style="font-family:var(--font-body);font-weight:700;font-size:14px;color:var(--fg-primary)">Dividir a partes iguales</div>
+                                <div style="font-family:var(--font-body);font-size:12px;color:var(--fg-muted);margin-top:2px">El total se divide entre todos por igual</div>
+                            </div>
+                        </button>
+                    </div>
+                </div>
+                <div class="drawer__foot">
+                    <button type="button" class="btn-text" @click="$store.bill.closeSplitSelector()">Cancelar</button>
+                </div>
+            </div>
+        </div>
+
+        {{-- SPLIT POR ÍTEMS --}}
+        <div class="scrim"
+             x-show="$store.bill.splitShowItems"
+             x-transition
+             @click.self="$store.bill.closeSplitItems()"
+             role="dialog" aria-modal="true" aria-label="Pagar por ítems">
+            <div class="drawer drawer--bill drawer--wide" @click.stop
+                 style="max-height:88dvh;overflow:hidden;display:flex;flex-direction:column">
+                <div class="drawer__grabber" aria-hidden="true"></div>
+                <div class="drawer__head" style="flex-shrink:0">
+                    <div class="drawer__heading">
+                        <div class="drawer__title">Pagar por ítems</div>
+                        <div class="drawer__subtitle">Marca los platos que quieres pagar tú</div>
+                    </div>
+                    <button type="button" class="icon-btn" @click="$store.bill.closeSplitItems()" aria-label="Cerrar">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                    </button>
+                </div>
+                <div style="flex:1;overflow-y:auto;padding:14px 18px 0">
+                    <fieldset style="border:none;padding:0;display:flex;flex-direction:column;gap:8px">
+                        <legend class="sr-only">Selecciona los ítems que quieres pagar</legend>
+                        <template x-for="item in $store.bill.splitItems" :key="item.id">
+                            <label :for="'spi-' + item.id"
+                                   :class="item.claimed
+                                       ? 'opacity-50 cursor-not-allowed'
+                                       : $store.bill.isItemSelected(item.id)
+                                           ? 'ring-2'
+                                           : ''"
+                                   style="display:flex;align-items:center;gap:12px;padding:12px;border-radius:12px;border:2px solid var(--glass-border);cursor:pointer;background:var(--glass-bg-surface)">
+                                <input type="checkbox"
+                                       :id="'spi-' + item.id"
+                                       :checked="$store.bill.isItemSelected(item.id)"
+                                       :disabled="item.claimed"
+                                       @change="$store.bill.toggleSplitItem(item.id, item.claimed)"
+                                       style="width:18px;height:18px;flex-shrink:0">
+                                <div style="flex:1;min-width:0">
+                                    <div style="font-family:var(--font-body);font-weight:600;font-size:13px;color:var(--fg-primary)" x-text="item.name"></div>
+                                    <div style="font-family:var(--font-body);font-size:11px;color:var(--fg-muted);margin-top:2px"
+                                         x-text="item.quantity + ' × ' + Number(item.price).toFixed(2).replace('.',',') + ' €'"></div>
+                                </div>
+                                <template x-if="item.claimed">
+                                    <span style="font-size:11px;font-weight:600;color:var(--color-amber-600);background:var(--color-amber-100);border-radius:9999px;padding:3px 8px">Ya reclamado</span>
+                                </template>
+                                <template x-if="!item.claimed">
+                                    <span style="font-family:var(--font-display);font-weight:700;font-size:14px;color:var(--price-gold)"
+                                          x-text="Number(item.total).toFixed(2).replace('.',',') + ' €'"></span>
+                                </template>
+                            </label>
+                        </template>
+                    </fieldset>
+                </div>
+                <div class="drawer__foot" style="flex-shrink:0">
+                    <div style="display:flex;justify-content:space-between;margin-bottom:10px;font-family:var(--font-body);font-size:13px">
+                        <span style="color:var(--fg-muted)">Mi parte</span>
+                        <span style="font-weight:700;color:var(--price-gold)"
+                              x-text="Number($store.bill.splitSelectedTotal || 0).toFixed(2).replace('.',',') + ' €'"></span>
+                    </div>
+                    <button type="button" class="btn-primary"
+                            :disabled="!$store.bill.splitSelected || $store.bill.splitSelected.length === 0"
+                            @click="$store.bill.paySelectedItems()">
+                        Pagar mi parte
+                    </button>
+                    <button type="button" class="btn-text" @click="$store.bill.closeSplitItems()">Cancelar</button>
+                </div>
+            </div>
+        </div>
+
+        {{-- SPLIT EQUITATIVO --}}
+        <div class="scrim"
+             x-show="$store.bill.splitShowEq"
+             x-transition
+             @click.self="$store.bill.closeSplitEq()"
+             role="dialog" aria-modal="true" aria-label="Dividir a partes iguales">
+            <div class="drawer drawer--bill" @click.stop>
+                <div class="drawer__grabber" aria-hidden="true"></div>
+                <div class="drawer__head">
+                    <div class="drawer__heading">
+                        <div class="drawer__title">Dividir a partes iguales</div>
+                        <div class="drawer__subtitle">El total se divide entre todos</div>
+                    </div>
+                    <div class="drawer__total">
+                        <div class="lab">Total</div>
+                        <div class="val" x-text="Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></div>
+                    </div>
+                    <button type="button" class="icon-btn" @click="$store.bill.closeSplitEq()" aria-label="Cerrar">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                    </button>
+                </div>
+                <div class="drawer__body">
+                    <div style="display:flex;flex-direction:column;gap:16px">
+                        <label style="font-family:var(--font-body);font-size:13px;font-weight:600;color:var(--fg-secondary)">
+                            ¿Entre cuántas personas?
+                        </label>
+                        <input type="number"
+                               min="2"
+                               :max="$store.bill.splitMaxParts || 20"
+                               :value="$store.bill.splitPeople || 2"
+                               @input="$store.bill.splitPeople = parseInt($event.target.value) || 2"
+                               style="padding:12px;border-radius:12px;border:1px solid var(--glass-border);background:var(--glass-bg-surface);color:var(--fg-primary);font-family:var(--font-display);font-size:24px;font-weight:900;text-align:center;width:100%">
+                        <div style="text-align:center">
+                            <div style="font-family:var(--font-body);font-size:12px;color:var(--fg-muted)">Tu parte</div>
+                            <div style="font-family:var(--font-display);font-weight:900;font-size:32px;color:var(--price-gold)"
+                                 x-text="Number($store.bill.orderTotal / ($store.bill.splitPeople || 2)).toFixed(2).replace('.',',') + ' €'"></div>
+                        </div>
+                    </div>
+                </div>
+                <div class="drawer__foot">
+                    <button type="button" class="btn-primary" @click="$store.bill.payEquitative()">
+                        Pagar mi parte con tarjeta
+                    </button>
+                    <button type="button" class="btn-text" @click="$store.bill.closeSplitEq()">Cancelar</button>
+                </div>
+            </div>
+        </div>
+
+        {{-- MIXED PAYMENT --}}
+        <div class="scrim"
+             x-show="$store.bill.showingMixed"
+             x-transition
+             @click.self="$store.bill.closeMixed()"
+             role="dialog" aria-modal="true" aria-label="Cobro mixto">
+            <div class="drawer drawer--bill drawer--wide" @click.stop>
+                <div class="drawer__grabber" aria-hidden="true"></div>
+                <div class="drawer__head">
+                    <button type="button" class="icon-btn icon-btn--back" @click="$store.bill.close()" aria-label="Cambiar método">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4"><polyline points="15 18 9 12 15 6"/></svg>
+                    </button>
+                    <div class="drawer__heading">
+                        <div class="drawer__title">Pago mixto</div>
+                        <div class="drawer__subtitle">Efectivo + tarjeta</div>
+                    </div>
+                    <div class="drawer__total">
+                        <div class="lab">Total</div>
+                        <div class="val" x-text="Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></div>
+                    </div>
+                    <button type="button" class="icon-btn" @click="$store.bill.closeMixed()" aria-label="Cerrar">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                    </button>
+                </div>
+                <div class="drawer__body">
+                    <div style="display:flex;flex-direction:column;gap:16px">
+                        <div style="font-family:var(--font-body);font-size:13px;color:var(--fg-muted);line-height:1.5">
+                            Indica cuánto pagas en efectivo. El resto se cobará con tarjeta.
+                        </div>
+                        <div style="display:flex;align-items:center;gap:8px">
+                            <label for="mixed-cash-input" style="font-family:var(--font-body);font-size:13px;font-weight:600;color:var(--fg-secondary);white-space:nowrap">Efectivo (€)</label>
+                            <input id="mixed-cash-input"
+                                   type="number" min="0" step="0.01"
+                                   :max="$store.bill.orderTotal"
+                                   :value="$store.bill.mixedCashAmount || ''"
+                                   @input="$store.bill.mixedCashAmount = parseFloat($event.target.value) || 0"
+                                   style="flex:1;padding:10px 12px;border-radius:10px;border:1px solid var(--glass-border);background:var(--glass-bg-surface);color:var(--fg-primary);font-family:var(--font-body);font-size:16px">
+                        </div>
+                        <div style="display:flex;justify-content:space-between;padding:12px;border-radius:10px;background:var(--glass-bg-surface);border:1px solid var(--glass-border)">
+                            <span style="font-family:var(--font-body);font-size:13px;color:var(--fg-muted)">Parte con tarjeta</span>
+                            <span style="font-family:var(--font-display);font-weight:700;font-size:16px;color:var(--price-gold)"
+                                  x-text="Number(Math.max(0, $store.bill.orderTotal - ($store.bill.mixedCashAmount || 0))).toFixed(2).replace('.',',') + ' €'"></span>
+                        </div>
+                    </div>
+                </div>
+                <div class="drawer__foot">
+                    <button type="button" class="btn-primary"
+                            :disabled="!$store.bill.mixedCashAmount || $store.bill.mixedCashAmount >= $store.bill.orderTotal"
+                            @click="$store.bill.processMixed()">
+                        Continuar con tarjeta
+                    </button>
+                    <button type="button" class="btn-text" @click="$store.bill.closeMixed()">Cancelar</button>
+                </div>
+            </div>
+        </div>
+
+        {{-- Mixed: Stripe de la parte tarjeta --}}
+        <div class="scrim"
+             x-show="$store.bill.showingMixedStripe"
+             x-transition
+             @click.self="$store.bill.close()"
+             role="dialog" aria-modal="true" aria-label="Pago parte tarjeta">
+            <div class="drawer drawer--bill" @click.stop>
+                <div class="drawer__grabber" aria-hidden="true"></div>
+                <div class="drawer__head">
+                    <div class="drawer__heading">
+                        <div class="drawer__title">Parte con tarjeta</div>
+                        <div class="drawer__subtitle">Pago seguro · Stripe</div>
+                    </div>
+                    <div class="drawer__total">
+                        <div class="lab">A pagar</div>
+                        <div class="val" x-text="Number(Math.max(0, $store.bill.orderTotal - ($store.bill.mixedCashAmount || 0))).toFixed(2).replace('.',',') + ' €'"></div>
+                    </div>
+                    <button type="button" class="icon-btn" @click="$store.bill.close()" aria-label="Cerrar">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                    </button>
+                </div>
+                <div class="drawer__body">
+                    <div id="stripe-card-element-mixed" style="padding:16px;border:1px solid var(--glass-border);border-radius:12px;background:var(--glass-bg-surface)"></div>
+                    <template x-if="$store.bill.stripeError">
+                        <p style="color:var(--color-red-400);font-size:13px;margin-top:8px" role="alert" x-text="$store.bill.stripeError"></p>
+                    </template>
+                </div>
+                <div class="drawer__foot">
+                    <button type="button" class="btn-primary"
+                            @click="$store.bill.payMixedCard()"
+                            :disabled="$store.bill.sending">
+                        <span x-text="$store.bill.sending ? 'Procesando…' : 'Pagar con tarjeta'"></span>
+                    </button>
+                </div>
+            </div>
+        </div>
+
+        {{-- ══════════════════════════════════════════════════════════════════════
+             TAPA MODAL — DS: .modal > .modal__panel
+             ══════════════════════════════════════════════════════════════════════ --}}
+        <div class="modal"
+             x-show="$store.cart.showTapaModal"
+             x-transition:enter="transition duration-200"
+             x-transition:enter-start="opacity-0"
+             x-transition:enter-end="opacity-100"
+             x-transition:leave="transition duration-200"
+             x-transition:leave-start="opacity-100"
+             x-transition:leave-end="opacity-0"
+             @click.self="$store.cart.closeTapaModal()"
+             role="dialog" aria-modal="true" aria-label="Tapas disponibles">
+            <div class="modal__panel" @click.stop>
+                <div class="modal__head">
+                    <div>
+                        <div class="modal__title">¿Te llevas una tapa?</div>
+                        <div class="modal__sub">
+                            @if($tapaConfig && $tapaConfig->tapas_free)
+                            La primera tapa es invitación de la casa 🍻
+                            @else
+                            Con cada bebida puedes añadir una tapa
+                            @endif
+                        </div>
+                    </div>
+                    <button type="button" class="icon-btn" @click="$store.cart.closeTapaModal()" aria-label="Cerrar">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                        </svg>
+                    </button>
+                </div>
+                <div style="display:flex;flex-direction:column;gap:8px">
+                    <template x-for="tapa in $store.cart.tapaProducts" :key="tapa.id">
+                        <div class="tapa"
+                             @click="$store.cart.addTapa(tapa)">
+                            <div class="tapa__photo" aria-hidden="true">🍽️</div>
+                            <div class="tapa__main">
+                                <div class="tapa__name" x-text="tapa.name"></div>
+                                <div class="tapa__price"
+                                     :class="tapa.price === 0 ? 'tapa__price--free' : ''"
+                                     x-text="tapa.price === 0 ? 'Gratis' : '+ ' + Number(tapa.price).toFixed(2).replace('.',',') + ' €'"></div>
+                            </div>
+                        </div>
+                    </template>
+                </div>
+                <div style="display:flex;gap:8px;margin-top:4px">
+                    <button type="button" class="btn-secondary" style="flex:1" @click="$store.cart.closeTapaModal()">Ahora no</button>
+                </div>
+            </div>
+        </div>
+
+        {{-- ── Daily menu dialogs (componentes Blade existentes) --}}
+        <x-daily-menu-stepper :hash="$table->unique_hash" />
+        <x-daily-menu-exclusivity-dialog />
+        <x-daily-menu-timing-control />
+
+    </div>{{-- /carta (Alpine) --}}
 </body>
 </html>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1,14 +1,20 @@
 ﻿<!DOCTYPE html>
-<html lang="es" class="scroll-smooth">
+<html lang="es" data-theme="{{ $theme }}" id="carta-root">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>Carta — {{ $table->user->name }}</title>
-    <link rel="preconnect" href="https://fonts.bunny.net">
-    <link href="https://fonts.bunny.net/css?family=figtree:400,500,600,700&display=swap" rel="stylesheet" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
+    @if($theme === 'classic')
+    <link href="https://fonts.googleapis.com/css2?family=Marcellus&family=Spectral:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+    @elseif($theme === 'minimal')
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Archivo:wght@400;500;600&display=swap" rel="stylesheet">
+    @else
     <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800;900&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+    @endif
+    <link rel="stylesheet" href="{{ asset('css/carta/colors_and_type.css') }}">
+    <link rel="stylesheet" href="{{ asset('css/carta/styles.css') }}">
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     <meta name="stripe-key" content="{{ $stripePublicKey }}">
     <script src="https://js.stripe.com/v3/" defer></script>
@@ -18,8 +24,10 @@
         (function () {
             const saved = localStorage.getItem('theme');
             const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-            if (saved === 'dark' || (!saved && prefersDark)) {
+            const isDark = saved === 'dark' || (!saved && prefersDark);
+            if (isDark) {
                 document.documentElement.classList.add('dark');
+                document.getElementById('carta-root').setAttribute('data-theme', 'dark');
             }
         })();
     </script>
@@ -289,74 +297,80 @@
     <script id="menu-context" type="application/json">@json($menuContext)</script>
 </head>
 
-<body class="font-sans antialiased bg-gray-200 dark:bg-gray-900 text-gray-900 dark:text-gray-100 min-h-screen">
+<body>
 
     {{-- Skip to content --}}
     <a href="#main-content"
        class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4
-              bg-white dark:bg-gray-800 text-indigo-700 dark:text-indigo-300
-              px-4 py-2 rounded font-medium z-50 shadow">
+              bg-white text-indigo-700 px-4 py-2 rounded font-medium z-50 shadow">
         Saltar al contenido principal
     </a>
 
-    {{-- ── Componente Alpine raíz ──────────────────────────────────── --}}
-    <div x-data="menuFilters()">
+    {{-- ── Componente Alpine raíz + wrapper DS ───────────────────── --}}
+    <div x-data="menuFilters()"
+         class="carta"
+         data-theme="{{ $theme }}"
+         x-init="
+            $nextTick(() => {
+                const update = () => {
+                    const w = window.innerWidth;
+                    $el.dataset.bp = w < 640 ? 'mobile' : w < 1024 ? 'tablet' : 'desktop';
+                };
+                update();
+                window.addEventListener('resize', update);
+            });
+         ">
 
-        {{-- ── Header ──────────────────────────────────────────────── --}}
-        <header class="sticky top-0 z-40 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 shadow-sm">
-            <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
+        {{-- ── Header DS ────────────────────────────────────────────── --}}
+        <header class="header" role="banner">
+            <div class="header__brand">
+                <div class="header__logo" aria-hidden="true">
+                    {{ mb_strtoupper(mb_substr($table->user->business_name ?: $table->user->name, 0, 2)) }}
+                </div>
                 <div>
-                    <p class="text-xs font-medium text-indigo-600 dark:text-indigo-400 uppercase tracking-widest">
-                        Carta digital
-                    </p>
-                    <h1 class="text-lg sm:text-xl font-bold leading-tight text-gray-900 dark:text-white">
-                        {{ $table->user->name }}
-                    </h1>
+                    <div class="header__bizname">
+                        {{ $table->user->business_name ?: $table->user->name }}
+                    </div>
+                    <div class="header__table">{{ $table->name }}</div>
                 </div>
-                <div class="flex items-center gap-2">
-                    {{-- Badge de mesa --}}
-                    <span class="inline-flex items-center gap-1 text-xs font-medium
-                                 bg-indigo-100 dark:bg-indigo-900 text-indigo-700 dark:text-indigo-300
-                                 px-2.5 py-1 rounded-full">
-                        <svg aria-hidden="true" class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                  d="M3 10h11M9 21V3M19 14l2 2-2 2m2-2H13"/>
-                        </svg>
-                        {{ $table->name }}
+            </div>
+            <div class="header__actions">
+                {{-- Estado cocina --}}
+                @if(!$kitchenOpen && $nextOpeningTime)
+                <span class="kitchen-pill kitchen-pill--closed" aria-label="Cocina cerrada">
+                    <span class="kitchen-pill__dot"></span>
+                    <span class="kitchen-pill__stack">
+                        <span class="kitchen-pill__l1">Cocina cerrada</span>
+                        <span class="kitchen-pill__l2">abre {{ $nextOpeningTime }}</span>
                     </span>
+                </span>
+                @endif
 
-                    {{-- Toggle dark/light --}}
-                    <button x-data="{
-                                dark: localStorage.getItem('theme') === 'dark' || (!localStorage.getItem('theme') && window.matchMedia('(prefers-color-scheme: dark)').matches),
-                                toggle() {
-                                    this.dark = !this.dark;
-                                    document.documentElement.classList.toggle('dark', this.dark);
-                                    localStorage.setItem('theme', this.dark ? 'dark' : 'light');
-                                }
-                            }"
-                            @click="toggle()"
-                            :aria-label="dark ? 'Cambiar a modo claro' : 'Cambiar a modo oscuro'"
-                            :aria-pressed="dark.toString()"
-                            class="p-1.5 rounded-full
-                                   bg-gray-100 dark:bg-gray-700
-                                   text-gray-500 dark:text-gray-300
-                                   hover:bg-gray-200 dark:hover:bg-gray-600
-                                   focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1
-                                   transition-colors duration-150">
-                        {{-- Sol: en dark mode --}}
-                        <svg x-show="dark" aria-hidden="true" class="h-4 w-4 text-amber-400"
-                             fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-                            <path stroke-linecap="round" stroke-linejoin="round"
-                                  d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
-                        </svg>
-                        {{-- Luna: en light mode --}}
-                        <svg x-show="!dark" aria-hidden="true" class="h-4 w-4"
-                             fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-                            <path stroke-linecap="round" stroke-linejoin="round"
-                                  d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
-                        </svg>
-                    </button>
-                </div>
+                {{-- Toggle dark/light — sincroniza Tailwind + DS data-theme --}}
+                <button class="theme-toggle"
+                        x-data="{
+                            dark: localStorage.getItem('theme') === 'dark' || (!localStorage.getItem('theme') && window.matchMedia('(prefers-color-scheme: dark)').matches),
+                            toggle() {
+                                this.dark = !this.dark;
+                                document.documentElement.classList.toggle('dark', this.dark);
+                                document.querySelector('.carta').dataset.theme = this.dark ? 'dark' : '{{ $theme }}';
+                                localStorage.setItem('theme', this.dark ? 'dark' : 'light');
+                            }
+                        }"
+                        @click="toggle()"
+                        :aria-label="dark ? 'Cambiar a modo claro' : 'Cambiar a modo oscuro'"
+                        :aria-pressed="dark.toString()">
+                    <svg x-show="dark" aria-hidden="true" width="18" height="18"
+                         fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                              d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
+                    </svg>
+                    <svg x-show="!dark" aria-hidden="true" width="18" height="18"
+                         fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                              d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
+                    </svg>
+                </button>
             </div>
         </header>
 
@@ -2485,29 +2499,30 @@
             </div>
         </div>{{-- /mixed stripe sheet --}}
 
-        {{-- ── FAB Carrito ─────────────────────────────────────────── --}}
-        <div class="fixed bottom-6 right-4 z-50"
-             x-show="$store.cart.count > 0 && !$store.chat.open"
-             x-transition:enter="transition ease-out duration-200"
-             x-transition:enter-start="opacity-0 scale-75"
-             x-transition:enter-end="opacity-100 scale-100"
-             x-transition:leave="transition ease-in duration-150"
-             x-transition:leave-start="opacity-100 scale-100"
-             x-transition:leave-end="opacity-0 scale-75">
-            <button type="button"
-                    @click="$store.cart.open = true"
-                    class="relative flex items-center gap-2 px-5 py-3 rounded-full
-                           bg-green-600 hover:bg-green-700 text-white font-bold shadow-xl
-                           transition-colors focus:outline-none focus:ring-4 focus:ring-green-400">
-                <svg aria-hidden="true" class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round"
-                          d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"/>
-                </svg>
-                Ver pedido
-                <span class="absolute -top-2 -right-2 w-6 h-6 rounded-full bg-red-500 text-white text-xs font-bold flex items-center justify-center"
-                      x-text="$store.cart.count"></span>
-            </button>
-        </div>
+        {{-- ── Cart Bar DS ─────────────────────────────────────────── --}}
+        <button type="button"
+                class="cart-bar"
+                x-show="$store.cart.count > 0 && !$store.chat.open"
+                x-transition:enter="transition ease-out duration-200"
+                x-transition:enter-start="opacity-0 translate-y-4"
+                x-transition:enter-end="opacity-100 translate-y-0"
+                x-transition:leave="transition ease-in duration-150"
+                x-transition:leave-start="opacity-100 translate-y-0"
+                x-transition:leave-end="opacity-0 translate-y-4"
+                @click="$store.cart.open = true"
+                aria-label="Ver pedido">
+            <div class="cart-bar__left">
+                <span class="cart-bar__icon">
+                    <svg aria-hidden="true" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                              d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"/>
+                    </svg>
+                    <span class="cart-bar__count" x-text="$store.cart.count" aria-hidden="true"></span>
+                </span>
+                <span x-text="$store.cart.count + ' ' + ($store.cart.count === 1 ? 'artículo' : 'artículos')"></span>
+            </div>
+            <span class="cart-bar__cta">Ver pedido</span>
+        </button>
 
         {{-- ── Drawer del carrito ───────────────────────────────────── --}}
         <div x-show="$store.cart.open"
@@ -2819,54 +2834,38 @@
         </div>
         @endif
 
-        {{-- ── Filtro de categorías ────────────────────────────────────── --}}
+        {{-- ── Filtro de categorías DS (.filter-bar) ──────────────────── --}}
         @if ($businessOpen && $categories->isNotEmpty())
-            <nav aria-label="Filtrar por categoría"
-                 class="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700 overflow-x-auto">
-                <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
-                    <ul class="flex gap-1 py-2" role="list">
+            <nav class="filter-bar" aria-label="Filtrar por categoría">
 
-                        {{-- Chip "Todas" --}}
-                        <li>
-                            <button type="button"
-                                    @click="setCategory(null)"
-                                    :aria-pressed="activeCategory === null"
-                                    :class="activeCategory === null
-                                        ? 'bg-indigo-600 text-white'
-                                        : 'text-gray-600 dark:text-gray-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/40 hover:text-indigo-700 dark:hover:text-indigo-300'"
-                                    class="inline-block whitespace-nowrap px-3 py-1.5 rounded-full text-sm font-medium
-                                           transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500
-                                           focus:ring-offset-2 dark:focus:ring-offset-gray-900">
-                                Todas
-                            </button>
-                        </li>
+                {{-- Chip "Todas" --}}
+                <button type="button"
+                        @click="setCategory(null)"
+                        :aria-pressed="activeCategory === null"
+                        :class="activeCategory === null ? 'chip chip--active' : 'chip'">
+                    Todas
+                </button>
 
-                        @foreach ($categories as $category)
-                            <li x-show="isCategoryVisible({{ $category->id }})">
-                                <button type="button"
-                                        @click="setCategory({{ $category->id }})"
-                                        :aria-pressed="activeCategory === {{ $category->id }}"
-                                        :class="activeCategory === {{ $category->id }}
-                                            ? 'bg-indigo-600 text-white'
-                                            : 'text-gray-600 dark:text-gray-300 hover:bg-indigo-50 dark:hover:bg-indigo-900/40 hover:text-indigo-700 dark:hover:text-indigo-300'"
-                                        class="inline-block whitespace-nowrap px-3 py-1.5 rounded-full text-sm font-medium
-                                               transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500
-                                               focus:ring-offset-2 dark:focus:ring-offset-gray-900">
-                                    {{ $category->name }}
-                                </button>
-                            </li>
-                        @endforeach
+                @foreach ($categories as $category)
+                    <button type="button"
+                            x-show="isCategoryVisible({{ $category->id }})"
+                            @click="setCategory({{ $category->id }})"
+                            :aria-pressed="activeCategory === {{ $category->id }}"
+                            :class="activeCategory === {{ $category->id }} ? 'chip chip--active' : 'chip'">
+                        {{ $category->name }}
+                    </button>
+                @endforeach
 
-                    </ul>
-                </div>
             </nav>
         @endif
 
         {{-- ════════════════════════════════════════════════════════════ --}}
         {{-- NEGOCIO CERRADO: carta inaccesible + horarios del día      --}}
         {{-- ════════════════════════════════════════════════════════════ --}}
+        <div class="carta__main">
+        <div class="carta__body" id="main-content">
         @if(!$businessOpen)
-        <main id="main-content" class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-24">
+        <main class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-24">
             <div class="text-center" role="status" aria-live="polite">
                 <div class="inline-flex items-center justify-center w-20 h-20 rounded-full bg-gray-100 dark:bg-gray-800 mb-6">
                     <svg aria-hidden="true" class="w-10 h-10 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -2915,7 +2914,7 @@
         @else
 
         {{-- ── Contenido principal ──────────────────────────────────── --}}
-        <main id="main-content" class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 space-y-10">
+        <main class="carta__products max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-8 space-y-10">
 
             {{-- ── Menú del Día ──────────────────────────────────────── --}}
             <x-daily-menu-banner :hash="$table->unique_hash" />
@@ -3028,23 +3027,22 @@
                                 x-transition:leave="transition ease-in duration-150"
                                 x-transition:leave-start="opacity-100 scale-100"
                                 x-transition:leave-end="opacity-0 scale-95"
-                                class="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700
-                                       shadow-sm hover:shadow-md transition-shadow duration-200 overflow-hidden">
-                                <div class="flex gap-3 sm:gap-4 p-3 sm:p-4">
-
-                                    {{-- Imagen --}}
+                                class="pcard">
+                                    {{-- Foto --}}
                                     @if ($product->image)
-                                        <div class="flex-shrink-0">
+                                        <div class="pcard__photo">
                                             <img src="{{ Storage::url($product->image) }}"
                                                  alt="Foto de {{ $product->name }}"
                                                  loading="lazy"
                                                  decoding="async"
-                                                 class="h-20 w-20 sm:h-24 sm:w-24 object-cover rounded-lg">
+                                                 class="w-full h-full object-cover">
                                         </div>
+                                    @else
+                                        <div class="pcard__photo pcard__photo--food-1" aria-hidden="true"></div>
                                     @endif
 
                                     {{-- Info --}}
-                                    <div class="flex-1 min-w-0">
+                                    <div class="pcard__body">
                                         @if($product->variants->isNotEmpty())
                                         {{-- Producto con variantes --}}
                                         <div x-data="{
@@ -3053,16 +3051,16 @@
                                             get selectedVariant() { return this.variants.find(v => v.id === this.selectedVariantId); }
                                         }">
                                             <div class="flex items-start justify-between gap-2">
-                                                <h3 class="font-semibold text-base sm:text-lg leading-snug text-gray-900 dark:text-gray-100">
+                                                <h3 class="pcard__name">
                                                     {{ $product->name }}
                                                 </h3>
-                                                <span class="flex-shrink-0 font-bold text-base sm:text-lg text-indigo-600 dark:text-indigo-400"
+                                                <span class="pcard__price"
                                                       x-text="'desde ' + Number(Math.min(...variants.map(v => v.price))).toFixed(2).replace('.',',') + ' €'"
                                                       aria-label="Desde {{ number_format($product->variants->min('price'), 2, ',', '.') }} euros"></span>
                                             </div>
 
                                             @if ($product->description)
-                                                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
+                                                <p class="pcard__desc">
                                                     {{ $product->description }}
                                                 </p>
                                             @endif
@@ -3143,7 +3141,7 @@
                                         @else
                                         {{-- Producto sin variantes (comportamiento original) --}}
                                         <div class="flex items-start justify-between gap-2">
-                                            <h3 class="font-semibold text-base sm:text-lg leading-snug text-gray-900 dark:text-gray-100">
+                                            <h3 class="pcard__name">
                                                 {{ $product->name }}
                                             </h3>
                                             <span class="flex-shrink-0 font-bold text-base sm:text-lg
@@ -3154,7 +3152,7 @@
                                         </div>
 
                                         @if ($product->description)
-                                            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400 leading-relaxed">
+                                            <p class="pcard__desc">
                                                 {{ $product->description }}
                                             </p>
                                         @endif
@@ -3231,6 +3229,8 @@
 
         </main>
         @endif{{-- /businessOpen --}}
+        </div>{{-- /carta__body --}}
+        </div>{{-- /carta__main --}}
 
         {{-- ── Banner de Tapas disponibles ─────────────────────────── --}}
         @if($tapaConfig && $barItemsCount > 0)


### PR DESCRIPTION
## Resumen

Reescritura completa de la carta digital pública para que sea idéntica al Design System de Zampa. Sin clases Tailwind fuera del widget Zampi.

## Cambios principales

- **Design System CSS**: `colors_and_type.css` ampliado con tokens de los temas Clásico y Minimalista (colores, tipografía, modos oscuros por tema, skins visuales)
- **Orden de carga CSS**: Vite carga antes que el DS → los tokens del DS sobreescriben Tailwind's preflight
- **Dark mode**: toglea `data-theme` en `.carta` preservando el tema base en `<html>`; sin conflicto con scoping `[data-theme="classic"] .carta[data-theme="dark"]`
- **Tema por defecto**: `modern` hardcodeado en `MenuController` hasta que se mergee `feat/bloque11-1-menu-style-selector`
- **Menú del día (5 componentes)**: banner → `.dm-banner`, stepper → `.scrim + .dm-modal + .dm-step + .dm-opt`, dialog → `.dm-excl`, timing → `.dm-timing__slider`, availability simplificado
- **Bug fix**: eliminados componentes duplicados del menú del día fuera del scope Alpine (causa de línea azul y errores en consola)
- **Alérgenos**: `allergen-pictograms.js` copiado del DS a `public/js/`; badges renderizados como `<svg class="allergen-img" data-al="{slug}">` con pictogramas EU oficiales coloreados; los 14 alérgenos siempre visibles en sidebar y drawer móvil
- **Tapas indicator**: `.tapas-indicator` con tokens, glyph 🍻, número grande, tokens visuales y CTA "Pedir →"
- **FAB cluster**: `.fab-cluster` con `.fab--orders` (animación `orders-in`), `.fab--bill` (animación `fab-attention`), `.fab--ticket` post-pago

## Test plan

- [ ] Abrir carta con QR de mesa → tema moderno, modo claro
- [ ] Toggle dark mode → `.carta[data-theme="dark"]` activo, `<html>` mantiene el tema base
- [ ] Ver badges de alérgenos en tarjetas → círculos de colores EU (no badges ámbar)
- [ ] Abrir drawer de alérgenos en móvil → 14 alérgenos siempre visibles
- [ ] Sidebar desktop → 14 alérgenos siempre visibles
- [ ] Indicador de tapas → píldora ámbar con tokens visuales (si hay tapas activas)
- [ ] FAB Cuenta → aparece con animación `fab-attention` (pulse)
- [ ] FAB cluster → animación `cluster-in` al aparecer
- [ ] Banner menú del día → `.dm-banner` con sello y precio (si hay menú del día configurado)
- [ ] Stepper menú del día → `.dm-modal` con progreso, opciones `.dm-opt`, confirmación
- [ ] Sin errores de Alpine en consola