### PR TITLE
fix: restaurar menu_style dinámico en MenuController

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -153,7 +153,7 @@ class MenuController extends Controller
                 ->toArray()
             : [];
 
-        $theme = 'modern';
+        $theme = $table->user->menu_style ?: 'modern';
 
         return view('menu.show', compact(
             'theme', 'table', 'categories', 'allergens',


### PR DESCRIPTION
## Problema

El PR #251 hardcodeó `\$theme = 'modern'` temporalmente porque la migración `menu_style` aún no estaba en main. Tras mergear el PR #252, la columna ya existe.

## Cambio

```php
// Antes (hardcodeado)
$theme = 'modern';

// Ahora (dinámico)
$theme = $table->user->menu_style ?: 'modern';
```

El operador `?:` cubre tanto `null` como cadena vacía `''`, devolviendo siempre `'modern'` como fallback.