### PR TITLE
feat: accessibility fixes + filters for categories, ingredients and products

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -35,6 +35,7 @@ class CategoryController extends Controller
         $ownerId    = Auth::user()->ownerUserId();
         $categories = Category::where('user_id', $ownerId)
             ->when($request->filled('search'), fn ($q) => $q->where('name', 'like', '%' . $request->search . '%'))
+            ->when($request->filled('destination'), fn ($q) => $q->where('destination', $request->destination))
             ->paginate(15)
             ->withQueryString();
 

--- a/app/Http/Controllers/IngredientController.php
+++ b/app/Http/Controllers/IngredientController.php
@@ -31,13 +31,15 @@ class IngredientController extends Controller
      */
     public function index(Request $request): \Illuminate\View\View
     {
-        $ownerId     = Auth::user()->ownerUserId();
-        $ingredients = Ingredient::where('user_id', $ownerId)
+        $ownerId      = Auth::user()->ownerUserId();
+        $allergenTypes = Ingredient::ALLERGEN_TYPES;
+        $ingredients  = Ingredient::where('user_id', $ownerId)
             ->when($request->filled('search'), fn ($q) => $q->where('name', 'like', '%' . $request->search . '%'))
+            ->when($request->filled('allergen'), fn ($q) => $q->whereJsonContains('allergen_types', $request->allergen))
             ->paginate(15)
             ->withQueryString();
 
-        return view('ingredients.index', compact('ingredients'));
+        return view('ingredients.index', compact('ingredients', 'allergenTypes'));
     }
 
     /**

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -35,17 +35,19 @@ class ProductController extends Controller
    */
   public function index(Request $request): View
   {
-    $ownerId    = Auth::user()->ownerUserId();
-    $categories = Category::where('user_id', $ownerId)->orderBy('name')->get();
+    $ownerId      = Auth::user()->ownerUserId();
+    $categories   = Category::where('user_id', $ownerId)->orderBy('name')->get();
+    $allergenTypes = Ingredient::ALLERGEN_TYPES;
 
     $products = Product::where('user_id', $ownerId)
       ->with(['allergens', 'variants', 'categories'])
       ->when($request->filled('search'), fn ($q) => $q->where('name', 'like', '%' . $request->search . '%'))
       ->when($request->filled('category'), fn ($q) => $q->whereHas('categories', fn ($q2) => $q2->where('categories.id', $request->category)))
+      ->when($request->filled('allergen'), fn ($q) => $q->whereHas('ingredients', fn ($q2) => $q2->whereJsonContains('allergen_types', $request->allergen)))
       ->paginate(15)
       ->withQueryString();
 
-    return view('products.index', compact('products', 'categories'));
+    return view('products.index', compact('products', 'categories', 'allergenTypes'));
   }
 
   /**

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -7,6 +7,35 @@
 @tailwind utilities;
 
 @layer base {
+    /* Custom scrollbar — thin, rounded, Zampa palette */
+    ::-webkit-scrollbar {
+        width: 6px;
+        height: 6px;
+    }
+    ::-webkit-scrollbar-track {
+        background: transparent;
+    }
+    ::-webkit-scrollbar-thumb {
+        background: #D1D5DB; /* gray-300 */
+        border-radius: 9999px;
+    }
+    ::-webkit-scrollbar-thumb:hover {
+        background: #9CA3AF; /* gray-400 */
+    }
+    .dark ::-webkit-scrollbar-thumb {
+        background: #4B5563; /* gray-600 */
+    }
+    .dark ::-webkit-scrollbar-thumb:hover {
+        background: #6B7280; /* gray-500 */
+    }
+    * {
+        scrollbar-width: thin;
+        scrollbar-color: #D1D5DB transparent;
+    }
+    .dark * {
+        scrollbar-color: #4B5563 transparent;
+    }
+
     :root {
         --zampa-50:  #FDF6EC;
         --zampa-100: #FAE8CA;

--- a/resources/views/categories/create.blade.php
+++ b/resources/views/categories/create.blade.php
@@ -85,7 +85,7 @@
 
           <div class="grid grid-cols-2 gap-3" x-data="{ dest: '{{ old('destination', 'kitchen') }}' }">
 
-            <label class="cursor-pointer">
+            <label class="cursor-pointer block rounded-xl focus-within:ring-2 focus-within:ring-indigo-500 focus-within:ring-offset-2 dark:focus-within:ring-offset-gray-800">
               <input type="radio" name="destination" value="kitchen" x-model="dest" class="sr-only">
               <div class="flex flex-col items-center gap-2 p-4 rounded-xl border bg-white dark:bg-gray-700 transition-all"
                    :class="dest === 'kitchen'
@@ -102,7 +102,7 @@
               </div>
             </label>
 
-            <label class="cursor-pointer">
+            <label class="cursor-pointer block rounded-xl focus-within:ring-2 focus-within:ring-indigo-500 focus-within:ring-offset-2 dark:focus-within:ring-offset-gray-800">
               <input type="radio" name="destination" value="bar" x-model="dest" class="sr-only">
               <div class="flex flex-col items-center gap-2 p-4 rounded-xl border bg-white dark:bg-gray-700 transition-all"
                    :class="dest === 'bar'

--- a/resources/views/categories/edit.blade.php
+++ b/resources/views/categories/edit.blade.php
@@ -89,7 +89,7 @@
 
           <div class="grid grid-cols-2 gap-3" x-data="{ dest: '{{ old('destination', $category->destination) }}' }">
 
-            <label class="cursor-pointer">
+            <label class="cursor-pointer block rounded-xl focus-within:ring-2 focus-within:ring-indigo-500 focus-within:ring-offset-2 dark:focus-within:ring-offset-gray-800">
               <input type="radio" name="destination" value="kitchen" x-model="dest" class="sr-only">
               <div class="flex flex-col items-center gap-2 p-4 rounded-xl border bg-white dark:bg-gray-700 transition-all"
                    :class="dest === 'kitchen'
@@ -106,7 +106,7 @@
               </div>
             </label>
 
-            <label class="cursor-pointer">
+            <label class="cursor-pointer block rounded-xl focus-within:ring-2 focus-within:ring-indigo-500 focus-within:ring-offset-2 dark:focus-within:ring-offset-gray-800">
               <input type="radio" name="destination" value="bar" x-model="dest" class="sr-only">
               <div class="flex flex-col items-center gap-2 p-4 rounded-xl border bg-white dark:bg-gray-700 transition-all"
                    :class="dest === 'bar'

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -140,12 +140,12 @@
             </a>
             <form action="{{ route('categories.destroy', $category) }}" method="POST"
                   onsubmit="return confirm('¿Eliminar la categoría «{{ addslashes($category->name) }}»?');"
-                  class="flex">
+                  class="flex flex-1">
               @csrf
               @method('DELETE')
               <button type="submit"
                       aria-label="Eliminar categoría {{ $category->name }}"
-                      class="inline-flex items-center justify-center gap-1.5 text-sm font-semibold
+                      class="flex-1 inline-flex items-center justify-center gap-1.5 text-sm font-semibold
                              bg-white dark:bg-gray-700 text-red-600 dark:text-red-400
                              border border-red-200 dark:border-red-700
                              hover:bg-red-50 dark:hover:bg-red-900/20 shadow-sm hover:shadow

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -29,10 +29,10 @@
       </a>
     </div>
 
-    {{-- Búsqueda --}}
+    {{-- Búsqueda y filtros --}}
     <form method="GET" action="{{ route('categories.index') }}"
           class="mb-6 flex flex-col sm:flex-row gap-3 items-stretch sm:items-center"
-          role="search" aria-label="Buscar categorías">
+          role="search" aria-label="Buscar y filtrar categorías">
       <div class="relative flex-1">
         <svg class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 105 11a6 6 0 0012 0z"/>
@@ -42,17 +42,28 @@
                aria-label="Buscar categoría por nombre"
                class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 py-2 pl-9 pr-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
       </div>
+      <div class="relative">
+        <select name="destination" id="destination" aria-label="Filtrar por destino"
+                class="w-full sm:w-44 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 py-2 pl-3 pr-8 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 appearance-none">
+          <option value="">Cocina y barra</option>
+          <option value="kitchen" {{ request('destination') === 'kitchen' ? 'selected' : '' }}>Solo cocina</option>
+          <option value="bar" {{ request('destination') === 'bar' ? 'selected' : '' }}>Solo barra</option>
+        </select>
+        <svg class="absolute right-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+        </svg>
+      </div>
       <button type="submit"
               class="inline-flex items-center justify-center gap-1.5 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-sm py-2.5 px-4 rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors">
         <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 105 11a6 6 0 0012 0z"/>
         </svg>
-        Buscar
+        Filtrar
       </button>
-      @if(request()->filled('search'))
+      @if(request()->hasAny(['search', 'destination']))
         <a href="{{ route('categories.index') }}"
            class="inline-flex items-center justify-center gap-1.5 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-semibold text-sm py-2.5 px-4 rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors"
-           aria-label="Limpiar búsqueda">
+           aria-label="Limpiar filtros">
           <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
           </svg>

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -139,7 +139,8 @@
               Editar
             </a>
             <form action="{{ route('categories.destroy', $category) }}" method="POST"
-                  onsubmit="return confirm('¿Eliminar la categoría «{{ addslashes($category->name) }}»?');">
+                  onsubmit="return confirm('¿Eliminar la categoría «{{ addslashes($category->name) }}»?');"
+                  class="flex">
               @csrf
               @method('DELETE')
               <button type="submit"
@@ -148,7 +149,7 @@
                              bg-white dark:bg-gray-700 text-red-600 dark:text-red-400
                              border border-red-200 dark:border-red-700
                              hover:bg-red-50 dark:hover:bg-red-900/20 shadow-sm hover:shadow
-                             py-1.5 px-3 rounded-lg
+                             py-2 px-3 min-h-[44px] rounded-lg
                              focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 transition-all">
                 <svg class="h-3.5 w-3.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -124,13 +124,13 @@
           </div>
 
           {{-- Botones --}}
-          <div class="mt-auto flex gap-2 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <div class="mt-auto grid grid-cols-2 gap-2 pt-4 border-t border-gray-200 dark:border-gray-700">
             <a href="{{ route('categories.edit', $category) }}"
                aria-label="Editar categoría {{ $category->name }}"
-               class="flex-1 inline-flex items-center justify-center gap-1.5 text-sm font-semibold
-                      bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-200
-                      border border-gray-300 dark:border-gray-500
-                      hover:bg-gray-50 dark:hover:bg-gray-600 shadow-sm hover:shadow
+               class="flex items-center justify-center gap-1.5 text-sm font-semibold
+                      bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400
+                      border border-indigo-200 dark:border-indigo-700
+                      hover:bg-indigo-100 dark:hover:bg-indigo-900/50 shadow-sm
                       py-2 px-3 min-h-[44px] rounded-lg
                       focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 transition-all">
               <svg class="h-3.5 w-3.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -140,15 +140,15 @@
             </a>
             <form action="{{ route('categories.destroy', $category) }}" method="POST"
                   onsubmit="return confirm('¿Eliminar la categoría «{{ addslashes($category->name) }}»?');"
-                  class="flex flex-1">
+                  class="flex">
               @csrf
               @method('DELETE')
               <button type="submit"
                       aria-label="Eliminar categoría {{ $category->name }}"
-                      class="flex-1 inline-flex items-center justify-center gap-1.5 text-sm font-semibold
-                             bg-white dark:bg-gray-700 text-red-600 dark:text-red-400
+                      class="w-full flex items-center justify-center gap-1.5 text-sm font-semibold
+                             bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400
                              border border-red-200 dark:border-red-700
-                             hover:bg-red-50 dark:hover:bg-red-900/20 shadow-sm hover:shadow
+                             hover:bg-red-100 dark:hover:bg-red-900/20 shadow-sm
                              py-2 px-3 min-h-[44px] rounded-lg
                              focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 transition-all">
                 <svg class="h-3.5 w-3.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/resources/views/ingredients/index.blade.php
+++ b/resources/views/ingredients/index.blade.php
@@ -1,106 +1,189 @@
+{{-- @author SebastianBCF --}}
 <x-app-layout>
-  <x-slot name="header">
-    <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
-      {{ __('Despensa de Ingredientes') }}
-    </h2>
-  </x-slot>
+  <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
 
-  <div class="py-12">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <div class="p-6 text-gray-900 dark:text-gray-100">
-
-        {{-- Flash de éxito — triple redundancia: icono + color + texto --}}
-        @if(session('success'))
-        <div role="alert" aria-live="polite"
-             class="rounded-md bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-700 p-4 mb-6 flex items-start gap-3">
-          <svg class="h-5 w-5 text-emerald-600 dark:text-emerald-400 shrink-0 mt-0.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+    {{-- Cabecera --}}
+    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
+      <div class="flex items-center gap-3">
+        <span class="p-2.5 bg-green-100 dark:bg-green-900/50 rounded-xl shadow-sm" aria-hidden="true">
+          <svg class="h-6 w-6 text-green-700 dark:text-green-300" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"/>
           </svg>
-          <p class="text-sm text-emerald-800 dark:text-emerald-300">{{ session('success') }}</p>
+        </span>
+        <div>
+          <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 leading-tight">Ingredientes</h1>
+          <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+            {{ $ingredients->total() }} {{ $ingredients->total() === 1 ? 'ingrediente' : 'ingredientes' }} en tu despensa
+          </p>
         </div>
-        @endif
+      </div>
+      <a href="{{ route('ingredients.create') }}"
+         class="inline-flex items-center gap-2 bg-green-600 hover:bg-green-700 text-white
+                font-semibold text-sm py-2.5 px-4 rounded-lg shadow-md
+                focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2
+                dark:focus:ring-offset-gray-900 transition-colors">
+        <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
+        </svg>
+        Nuevo ingrediente
+      </a>
+    </div>
 
-        <div class="flex flex-col sm:flex-row justify-between gap-3 mb-4">
-          {{-- Búsqueda --}}
-          <form method="GET" action="{{ route('ingredients.index') }}"
-                class="flex flex-1 gap-3 items-center"
-                role="search" aria-label="Buscar ingredientes">
-            <div class="relative flex-1 max-w-sm">
-              <svg class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 105 11a6 6 0 0012 0z"/>
-              </svg>
-              <input type="text" name="search" id="search" value="{{ request('search') }}"
-                     placeholder="Buscar ingrediente..."
-                     aria-label="Buscar ingrediente por nombre"
-                     class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 py-2 pl-9 pr-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
-            </div>
-            <button type="submit"
-                    class="inline-flex items-center gap-1.5 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-sm py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition">
-              Buscar
-            </button>
-            @if(request()->filled('search'))
-              <a href="{{ route('ingredients.index') }}"
-                 class="inline-flex items-center gap-1.5 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-semibold text-sm py-2 px-3 rounded focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 transition"
-                 aria-label="Limpiar búsqueda">
-                <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-                </svg>
-              </a>
-            @endif
-          </form>
-          <a href="{{ route('ingredients.create') }}" class="inline-flex items-center gap-1.5 bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition">
-            + Nuevo Ingrediente
-          </a>
-        </div>
-        <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
-          @foreach ($ingredients as $ingredient)
-          <div class="p-4 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800 shadow-sm flex flex-col justify-between">
-            <div class="text-center">
-              <div class="text-2xl mb-2">{{ $ingredient->ingredientEmoji() }}</div>
-              <h3 class="font-bold text-gray-700 dark:text-gray-300">{{ $ingredient->name }}</h3>
+    {{-- Búsqueda y filtros --}}
+    <form method="GET" action="{{ route('ingredients.index') }}"
+          class="mb-6 flex flex-col sm:flex-row gap-3 items-stretch sm:items-center"
+          role="search" aria-label="Buscar y filtrar ingredientes">
+      <div class="relative flex-1">
+        <svg class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 105 11a6 6 0 0012 0z"/>
+        </svg>
+        <input type="text" name="search" id="search" value="{{ request('search') }}"
+               placeholder="Buscar ingrediente..."
+               aria-label="Buscar ingrediente por nombre"
+               class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 py-2 pl-9 pr-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+      </div>
+      <div class="relative">
+        <select name="allergen" id="allergen" aria-label="Filtrar por alérgeno"
+                class="w-full sm:w-52 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 py-2 pl-3 pr-8 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 appearance-none">
+          <option value="">Todos los alérgenos</option>
+          @foreach($allergenTypes as $slug => $label)
+            <option value="{{ $slug }}" {{ request('allergen') === $slug ? 'selected' : '' }}>
+              {{ $label }}
+            </option>
+          @endforeach
+        </select>
+        <svg class="absolute right-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+        </svg>
+      </div>
+      <button type="submit"
+              class="inline-flex items-center justify-center gap-1.5 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-sm py-2.5 px-4 rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors">
+        <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 105 11a6 6 0 0012 0z"/>
+        </svg>
+        Filtrar
+      </button>
+      @if(request()->hasAny(['search', 'allergen']))
+        <a href="{{ route('ingredients.index') }}"
+           class="inline-flex items-center justify-center gap-1.5 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-semibold text-sm py-2.5 px-4 rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors"
+           aria-label="Limpiar filtros">
+          <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+          </svg>
+          Limpiar
+        </a>
+      @endif
+    </form>
+
+    {{-- Flash de éxito --}}
+    @if(session('success'))
+    <div role="alert" aria-live="polite"
+         class="rounded-lg bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-700 p-4 mb-6 flex items-start gap-3 shadow-sm">
+      <svg class="h-5 w-5 text-emerald-600 dark:text-emerald-400 shrink-0 mt-0.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      </svg>
+      <p class="text-sm font-medium text-emerald-800 dark:text-emerald-300">{{ session('success') }}</p>
+    </div>
+    @endif
+
+    {{-- Grid de tarjetas --}}
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+      @forelse ($ingredients as $ingredient)
+
+      <article class="flex flex-col bg-white dark:bg-gray-800
+                       border border-gray-200 dark:border-gray-700
+                       rounded-xl shadow-md hover:shadow-xl
+                       transition-shadow duration-200 overflow-hidden"
+               aria-label="Ingrediente {{ $ingredient->name }}">
+
+        <div class="flex flex-col flex-1 p-5">
+          {{-- Emoji + nombre --}}
+          <div class="flex items-start gap-3 mb-4">
+            <span class="text-3xl mt-0.5" role="img" aria-hidden="true">{{ $ingredient->ingredientEmoji() }}</span>
+            <div class="flex-1 min-w-0">
+              <h2 class="text-base font-bold text-gray-900 dark:text-gray-100 leading-snug">
+                {{ $ingredient->name }}
+              </h2>
               @if($ingredient->is_allergen && !empty($ingredient->allergen_types))
-                <div class="mt-2 flex flex-wrap justify-center gap-1">
+                <div class="mt-2 flex flex-wrap gap-1" role="list" aria-label="Alérgenos de {{ $ingredient->name }}">
                   @foreach($ingredient->allergen_types as $allergenSlug)
                     <x-allergen-badge :slug="$allergenSlug" />
                   @endforeach
                 </div>
+              @else
+                <span class="inline-flex items-center gap-1 mt-1 text-xs text-gray-400 dark:text-gray-500">
+                  Sin alérgenos
+                </span>
               @endif
             </div>
-
-            {{-- Botones de Acción --}}
-            <div class="mt-4 flex flex-col sm:flex-row justify-end gap-2 border-t pt-3 dark:border-gray-600">
-              <a
-                href="{{ route('ingredients.edit', $ingredient) }}"
-                class="text-sm text-center bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400 hover:bg-indigo-100 dark:hover:bg-indigo-900/50 border border-indigo-200 dark:border-indigo-700 py-2 px-3 rounded focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2"
-              >
-                Editar
-              </a>
-              <form
-                action="{{ route('ingredients.destroy', $ingredient) }}"
-                method="POST"
-                onsubmit="return confirm('¿Seguro que quieres borrar el ingrediente {{ $ingredient->name }}?');"
-              >
-                @csrf
-                @method('DELETE')
-                <button
-                  type="submit"
-                  aria-label="Borrar ingrediente {{ $ingredient->name }}"
-                  class="w-full text-sm bg-red-50 text-red-600 hover:bg-red-100 border border-red-200 py-2 px-3 rounded focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2"
-                >
-                  Borrar
-                </button>
-              </form>
-            </div>
           </div>
-          @endforeach
-        </div>
 
-        @if($ingredients->hasPages())
-        <nav aria-label="Paginación de ingredientes" class="mt-4">
-          {{ $ingredients->links() }}
-        </nav>
-        @endif
+          {{-- Botones --}}
+          <div class="mt-auto flex gap-2 pt-4 border-t border-gray-200 dark:border-gray-700">
+            <a href="{{ route('ingredients.edit', $ingredient) }}"
+               aria-label="Editar ingrediente {{ $ingredient->name }}"
+               class="flex-1 inline-flex items-center justify-center gap-1.5 text-sm font-semibold
+                      bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-200
+                      border border-gray-300 dark:border-gray-500
+                      hover:bg-gray-50 dark:hover:bg-gray-600 shadow-sm hover:shadow
+                      py-2 px-3 min-h-[44px] rounded-lg
+                      focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 transition-all">
+              <svg class="h-3.5 w-3.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
+              </svg>
+              Editar
+            </a>
+            <form action="{{ route('ingredients.destroy', $ingredient) }}" method="POST"
+                  onsubmit="return confirm('¿Eliminar el ingrediente «{{ addslashes($ingredient->name) }}»?');">
+              @csrf
+              @method('DELETE')
+              <button type="submit"
+                      aria-label="Eliminar ingrediente {{ $ingredient->name }}"
+                      class="inline-flex items-center justify-center gap-1.5 text-sm font-semibold
+                             bg-white dark:bg-gray-700 text-red-600 dark:text-red-400
+                             border border-red-200 dark:border-red-700
+                             hover:bg-red-50 dark:hover:bg-red-900/20 shadow-sm hover:shadow
+                             py-1.5 px-3 rounded-lg
+                             focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 transition-all">
+                <svg class="h-3.5 w-3.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>
+                </svg>
+                Eliminar
+              </button>
+            </form>
+          </div>
+        </div>
+      </article>
+
+      @empty
+      <div class="col-span-3 py-16 flex flex-col items-center justify-center
+                  border border-dashed border-gray-300 dark:border-gray-600 rounded-xl"
+           role="status">
+        <span class="p-4 bg-gray-100 dark:bg-gray-700 rounded-full mb-4 shadow-sm" aria-hidden="true">
+          <svg class="h-8 w-8 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"/>
+          </svg>
+        </span>
+        <p class="text-base font-semibold text-gray-700 dark:text-gray-300 mb-1">Sin ingredientes todavía</p>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">Añade tu primer ingrediente a la despensa.</p>
+        <a href="{{ route('ingredients.create') }}"
+           class="inline-flex items-center gap-2 bg-green-600 hover:bg-green-700 text-white
+                  font-semibold text-sm py-2 px-4 rounded-lg shadow-md
+                  focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors">
+          <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
+          </svg>
+          Crear primer ingrediente
+        </a>
       </div>
+      @endforelse
     </div>
+
+    @if($ingredients->hasPages())
+    <nav aria-label="Paginación de ingredientes" class="mt-8">
+      {{ $ingredients->links() }}
+    </nav>
+    @endif
+
   </div>
 </x-app-layout>

--- a/resources/views/ingredients/index.blade.php
+++ b/resources/views/ingredients/index.blade.php
@@ -134,7 +134,8 @@
               Editar
             </a>
             <form action="{{ route('ingredients.destroy', $ingredient) }}" method="POST"
-                  onsubmit="return confirm('¿Eliminar el ingrediente «{{ addslashes($ingredient->name) }}»?');">
+                  onsubmit="return confirm('¿Eliminar el ingrediente «{{ addslashes($ingredient->name) }}»?');"
+                  class="flex">
               @csrf
               @method('DELETE')
               <button type="submit"
@@ -143,7 +144,7 @@
                              bg-white dark:bg-gray-700 text-red-600 dark:text-red-400
                              border border-red-200 dark:border-red-700
                              hover:bg-red-50 dark:hover:bg-red-900/20 shadow-sm hover:shadow
-                             py-1.5 px-3 rounded-lg
+                             py-2 px-3 min-h-[44px] rounded-lg
                              focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 transition-all">
                 <svg class="h-3.5 w-3.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/>

--- a/resources/views/ingredients/index.blade.php
+++ b/resources/views/ingredients/index.blade.php
@@ -135,12 +135,12 @@
             </a>
             <form action="{{ route('ingredients.destroy', $ingredient) }}" method="POST"
                   onsubmit="return confirm('¿Eliminar el ingrediente «{{ addslashes($ingredient->name) }}»?');"
-                  class="flex">
+                  class="flex flex-1">
               @csrf
               @method('DELETE')
               <button type="submit"
                       aria-label="Eliminar ingrediente {{ $ingredient->name }}"
-                      class="inline-flex items-center justify-center gap-1.5 text-sm font-semibold
+                      class="flex-1 inline-flex items-center justify-center gap-1.5 text-sm font-semibold
                              bg-white dark:bg-gray-700 text-red-600 dark:text-red-400
                              border border-red-200 dark:border-red-700
                              hover:bg-red-50 dark:hover:bg-red-900/20 shadow-sm hover:shadow

--- a/resources/views/ingredients/index.blade.php
+++ b/resources/views/ingredients/index.blade.php
@@ -119,13 +119,13 @@
           </div>
 
           {{-- Botones --}}
-          <div class="mt-auto flex gap-2 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <div class="mt-auto grid grid-cols-2 gap-2 pt-4 border-t border-gray-200 dark:border-gray-700">
             <a href="{{ route('ingredients.edit', $ingredient) }}"
                aria-label="Editar ingrediente {{ $ingredient->name }}"
-               class="flex-1 inline-flex items-center justify-center gap-1.5 text-sm font-semibold
-                      bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-200
-                      border border-gray-300 dark:border-gray-500
-                      hover:bg-gray-50 dark:hover:bg-gray-600 shadow-sm hover:shadow
+               class="flex items-center justify-center gap-1.5 text-sm font-semibold
+                      bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400
+                      border border-indigo-200 dark:border-indigo-700
+                      hover:bg-indigo-100 dark:hover:bg-indigo-900/50 shadow-sm
                       py-2 px-3 min-h-[44px] rounded-lg
                       focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 transition-all">
               <svg class="h-3.5 w-3.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -135,15 +135,15 @@
             </a>
             <form action="{{ route('ingredients.destroy', $ingredient) }}" method="POST"
                   onsubmit="return confirm('¿Eliminar el ingrediente «{{ addslashes($ingredient->name) }}»?');"
-                  class="flex flex-1">
+                  class="flex">
               @csrf
               @method('DELETE')
               <button type="submit"
                       aria-label="Eliminar ingrediente {{ $ingredient->name }}"
-                      class="flex-1 inline-flex items-center justify-center gap-1.5 text-sm font-semibold
-                             bg-white dark:bg-gray-700 text-red-600 dark:text-red-400
+                      class="w-full flex items-center justify-center gap-1.5 text-sm font-semibold
+                             bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-400
                              border border-red-200 dark:border-red-700
-                             hover:bg-red-50 dark:hover:bg-red-900/20 shadow-sm hover:shadow
+                             hover:bg-red-100 dark:hover:bg-red-900/20 shadow-sm
                              py-2 px-3 min-h-[44px] rounded-lg
                              focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 transition-all">
                 <svg class="h-3.5 w-3.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/resources/views/ingredients/index.blade.php
+++ b/resources/views/ingredients/index.blade.php
@@ -98,24 +98,24 @@
 
         <div class="flex flex-col flex-1 p-5">
           {{-- Emoji + nombre --}}
-          <div class="flex items-start gap-3 mb-4">
-            <span class="text-3xl mt-0.5" role="img" aria-hidden="true">{{ $ingredient->ingredientEmoji() }}</span>
-            <div class="flex-1 min-w-0">
-              <h2 class="text-base font-bold text-gray-900 dark:text-gray-100 leading-snug">
-                {{ $ingredient->name }}
-              </h2>
-              @if($ingredient->is_allergen && !empty($ingredient->allergen_types))
-                <div class="mt-2 flex flex-wrap gap-1" role="list" aria-label="Alérgenos de {{ $ingredient->name }}">
-                  @foreach($ingredient->allergen_types as $allergenSlug)
-                    <x-allergen-badge :slug="$allergenSlug" />
-                  @endforeach
-                </div>
-              @else
-                <span class="inline-flex items-center gap-1 mt-1 text-xs text-gray-400 dark:text-gray-500">
-                  Sin alérgenos
-                </span>
-              @endif
-            </div>
+          <div class="flex items-center gap-3 mb-3">
+            <span class="text-2xl shrink-0 leading-none" role="img" aria-hidden="true">{{ $ingredient->ingredientEmoji() }}</span>
+            <h2 class="text-base font-bold text-gray-900 dark:text-gray-100 leading-snug min-w-0 break-words">
+              {{ $ingredient->name }}
+            </h2>
+          </div>
+
+          {{-- Badges — flex-1 so buttons always align to bottom --}}
+          <div class="flex-1 mb-3">
+            @if($ingredient->is_allergen && !empty($ingredient->allergen_types))
+              <div class="flex flex-wrap gap-1" role="list" aria-label="Alérgenos de {{ $ingredient->name }}">
+                @foreach($ingredient->allergen_types as $allergenSlug)
+                  <x-allergen-badge :slug="$allergenSlug" />
+                @endforeach
+              </div>
+            @else
+              <span class="text-xs text-gray-400 dark:text-gray-500">Sin alérgenos</span>
+            @endif
           </div>
 
           {{-- Botones --}}

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -23,22 +23,22 @@
       </a>
     </div>
 
-    {{-- Filtros: búsqueda y categoría --}}
+    {{-- Filtros: búsqueda, categoría y alérgeno --}}
     <form method="GET" action="{{ route('products.index') }}"
-          class="mb-4 flex flex-col sm:flex-row gap-3 items-stretch sm:items-center"
+          class="mb-4 flex flex-col sm:flex-row gap-3 items-stretch sm:items-center flex-wrap"
           role="search" aria-label="Filtrar productos">
-      <div class="relative flex-1">
+      <div class="relative flex-1 min-w-48">
         <svg class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 105 11a6 6 0 0012 0z"/>
         </svg>
         <input type="text" name="search" id="search" value="{{ request('search') }}"
                placeholder="Buscar producto..."
                aria-label="Buscar producto por nombre"
-               class="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 py-2 pl-9 pr-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+               class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 py-2 pl-9 pr-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
       </div>
       <div class="relative">
         <select name="category" id="category" aria-label="Filtrar por categoría"
-                class="w-full sm:w-48 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 py-2 pl-3 pr-8 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 appearance-none">
+                class="w-full sm:w-48 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 py-2 pl-3 pr-8 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 appearance-none">
           <option value="">Todas las categorías</option>
           @foreach($categories as $cat)
             <option value="{{ $cat->id }}" {{ request('category') == $cat->id ? 'selected' : '' }}>
@@ -50,16 +50,30 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
         </svg>
       </div>
+      <div class="relative">
+        <select name="allergen" id="allergen" aria-label="Filtrar por alérgeno"
+                class="w-full sm:w-52 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 py-2 pl-3 pr-8 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 appearance-none">
+          <option value="">Todos los alérgenos</option>
+          @foreach($allergenTypes as $slug => $label)
+            <option value="{{ $slug }}" {{ request('allergen') === $slug ? 'selected' : '' }}>
+              {{ $label }}
+            </option>
+          @endforeach
+        </select>
+        <svg class="absolute right-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+        </svg>
+      </div>
       <button type="submit"
-              class="inline-flex items-center justify-center gap-1.5 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-sm py-2 px-4 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition">
+              class="inline-flex items-center justify-center gap-1.5 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-sm py-2 px-4 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors">
         <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 105 11a6 6 0 0012 0z"/>
         </svg>
         Filtrar
       </button>
-      @if(request()->hasAny(['search', 'category']))
+      @if(request()->hasAny(['search', 'category', 'allergen']))
         <a href="{{ route('products.index') }}"
-           class="inline-flex items-center justify-center gap-1.5 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-semibold text-sm py-2 px-4 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition"
+           class="inline-flex items-center justify-center gap-1.5 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-semibold text-sm py-2 px-4 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors"
            aria-label="Limpiar filtros">
           <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>


### PR DESCRIPTION
## Summary

- **Categories index**: added Cocina/Barra destination filter select; clear button triggers on `search` OR `destination`
- **Ingredients index**: full visual redesign to match categories style (self-contained header, card grid, unified filter bar); added allergen type filter select
- **Products index**: added allergen type filter select (combinable with existing category filter); unified filter bar styling
- **Category forms (create/edit)**: fixed keyboard accessibility — radio card labels now show a visible `focus-within:ring` when navigating via Tab (hidden radio was focusable but had no visible indicator on the card)
- **Ingredient index cards**: added `aria-label` to edit/delete buttons, `role="status"` on empty state, `role="list"` + `aria-label` on allergen badge groups

## Test plan

- [ ] Tab through category create/edit form — Cocina and Barra cards show indigo focus ring when focused via keyboard
- [ ] Categories index: filter by "Solo cocina" → only kitchen categories shown; combine with search text
- [ ] Ingredients index: filter by a specific allergen (e.g. Gluten) → only ingredients with that allergen_type appear
- [ ] Products index: filter by category AND allergen simultaneously → results respect both filters
- [ ] Limpiar button appears only when at least one filter is active; clears all params
- [ ] `php artisan test` → 100% pass
