### PR TITLE
fix: resolve FOUC ghost notifications and sidebar flash on page reload

### DIFF
--- a/resources/js/alpine/bar-panel.js
+++ b/resources/js/alpine/bar-panel.js
@@ -150,16 +150,63 @@ export function billRequestPolling(urls) {
 /**
  * Alpine component for showing notifications when kitchen marks orders ready.
  *
+ * Uses sessionStorage to track acknowledged order IDs so that a page refresh
+ * does not re-surface notifications the waiter already saw. Only genuinely new
+ * notifications (order IDs not previously acknowledged in this browser session)
+ * are shown. Explicit dismiss clears both the server flag and the local record
+ * so a future re-trigger for the same order will show again correctly.
+ *
  * @param {Array<Object>} initialOrders - Pre-loaded ready orders from PHP.
  * @param {Object}        urls          - API endpoint URL map.
  * @returns {Object} Alpine component definition.
  */
 export function notificationPolling(initialOrders, urls) {
+    const STORAGE_KEY = 'zampa:bar:ack-notifications';
+
+    /** @returns {Set<number>} Order IDs already acknowledged in this session. */
+    function getAcknowledged() {
+        try {
+            return new Set(JSON.parse(sessionStorage.getItem(STORAGE_KEY) || '[]'));
+        } catch {
+            return new Set();
+        }
+    }
+
+    /** @param {number} id */
+    function addAcknowledged(id) {
+        try {
+            const set = getAcknowledged();
+            set.add(id);
+            sessionStorage.setItem(STORAGE_KEY, JSON.stringify([...set]));
+        } catch {
+            // sessionStorage unavailable — degrade silently
+        }
+    }
+
+    /** @param {number} id */
+    function removeAcknowledged(id) {
+        try {
+            const set = getAcknowledged();
+            set.delete(id);
+            sessionStorage.setItem(STORAGE_KEY, JSON.stringify([...set]));
+        } catch {
+            // silent
+        }
+    }
+
     return {
-        /** @type {Array<Object>} Orders ready to be served. */
-        readyOrders: initialOrders,
+        /**
+         * Orders ready to be served, pre-filtered so previously-acknowledged
+         * orders do not reappear as ghost notifications after a page refresh.
+         *
+         * @type {Array<Object>}
+         */
+        readyOrders: initialOrders.filter(o => !getAcknowledged().has(o.id)),
 
         init() {
+            // Mark currently-visible orders as acknowledged so a page refresh
+            // does not re-surface them before the waiter takes action.
+            this.readyOrders.forEach(o => addAcknowledged(o.id));
             this.poll();
             setInterval(() => this.poll(), 20000);
         },
@@ -170,8 +217,22 @@ export function notificationPolling(initialOrders, urls) {
                     headers: { 'X-Requested-With': 'XMLHttpRequest' },
                 });
                 if (!res.ok) return;
-                const data   = await res.json();
-                this.readyOrders = data.orders;
+                const data      = await res.json();
+                const acked     = getAcknowledged();
+                const serverIds = new Set(data.orders.map(o => o.id));
+
+                // Genuinely new orders: server reports ready, never shown before.
+                const newOrders = data.orders.filter(o => !acked.has(o.id));
+                newOrders.forEach(o => addAcknowledged(o.id));
+
+                const visibleIds = new Set(this.readyOrders.map(o => o.id));
+
+                this.readyOrders = [
+                    // Keep currently-visible orders that the server still reports as ready.
+                    ...this.readyOrders.filter(o => serverIds.has(o.id)),
+                    // Append new orders not yet in the visible list.
+                    ...newOrders.filter(o => !visibleIds.has(o.id)),
+                ];
             } catch {
                 // silent
             }
@@ -189,6 +250,8 @@ export function notificationPolling(initialOrders, urls) {
                     },
                 });
                 if (!res.ok) return;
+                // Remove acknowledgement so a future re-trigger shows the notification again.
+                removeAcknowledged(id);
                 this.readyOrders = this.readyOrders.filter(o => o.id !== id);
             } catch {
                 // keep item — next poll will reflect DB

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -74,7 +74,7 @@
                     <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
                 </svg>
             </button>
-            <div id="nav-carta" x-show="cartaOpen" class="mt-0.5 ml-7 pl-3 border-l border-gray-200 dark:border-gray-700 space-y-0.5">
+            <div id="nav-carta" x-show="cartaOpen" x-cloak class="mt-0.5 ml-7 pl-3 border-l border-gray-200 dark:border-gray-700 space-y-0.5">
                 <a href="{{ route('categories.index') }}"
                    aria-current="{{ request()->routeIs('categories.*') ? 'page' : 'false' }}"
                    class="flex items-center px-3 py-1.5 rounded-md text-sm transition-colors
@@ -131,7 +131,7 @@
                     <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
                 </svg>
             </button>
-            <div id="nav-local" x-show="localOpen" class="mt-0.5 ml-7 pl-3 border-l border-gray-200 dark:border-gray-700 space-y-0.5">
+            <div id="nav-local" x-show="localOpen" x-cloak class="mt-0.5 ml-7 pl-3 border-l border-gray-200 dark:border-gray-700 space-y-0.5">
                 <a href="{{ route('tables.map') }}"
                    aria-current="{{ request()->routeIs('tables.*', 'zones.*') ? 'page' : 'false' }}"
                    class="flex items-center px-3 py-1.5 rounded-md text-sm transition-colors
@@ -172,7 +172,7 @@
                     <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
                 </svg>
             </button>
-            <div id="nav-negocio" x-show="negocioOpen" class="mt-0.5 ml-7 pl-3 border-l border-gray-200 dark:border-gray-700 space-y-0.5">
+            <div id="nav-negocio" x-show="negocioOpen" x-cloak class="mt-0.5 ml-7 pl-3 border-l border-gray-200 dark:border-gray-700 space-y-0.5">
                 <a href="{{ route('negocio.config.edit') }}"
                    aria-current="{{ request()->routeIs('negocio.*', 'tapas.*') ? 'page' : 'false' }}"
                    class="flex items-center px-3 py-1.5 rounded-md text-sm transition-colors

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -232,6 +232,7 @@
                     </svg>
                     Cocina
                     <span x-show="count > 0"
+                          x-cloak
                           x-text="count"
                           class="ml-auto inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-bold text-white bg-red-500 rounded-full"
                           :aria-label="count + ' pedidos nuevos sin atender'">
@@ -254,6 +255,7 @@
                     </svg>
                     Barra
                     <span x-show="count > 0"
+                          x-cloak
                           x-text="count"
                           class="ml-auto inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-bold text-white bg-amber-500 rounded-full"
                           :aria-label="count + ' bebidas pendientes en barra'">

--- a/resources/views/layouts/topbar.blade.php
+++ b/resources/views/layouts/topbar.blade.php
@@ -50,7 +50,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364-6.364l-.707.707M6.343 17.657l-.707.707M17.657 17.657l-.707-.707M6.343 6.343l-.707-.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
             </svg>
             {{-- Moon (shown in light mode) --}}
-            <svg x-show="!isDark" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <svg x-show="!isDark" x-cloak class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
             </svg>
         </button>

--- a/resources/views/layouts/topbar.blade.php
+++ b/resources/views/layouts/topbar.blade.php
@@ -45,12 +45,13 @@
                 class="p-2.5 min-h-[44px] min-w-[44px] rounded-md text-gray-500 dark:text-gray-400
                        hover:bg-gray-100 dark:hover:bg-gray-800 flex items-center justify-center
                        focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-colors">
-            {{-- Sun (shown in dark mode) --}}
-            <svg x-show="isDark" x-cloak class="h-5 w-5 text-amber-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            {{-- Sun (dark mode) / Moon (light mode): CSS-driven so the correct icon
+                 appears before Alpine runs, since app.blade.php already sets the
+                 `dark` class on <html> via a pre-render inline script. --}}
+            <svg class="h-5 w-5 text-amber-400 hidden dark:block" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364-6.364l-.707.707M6.343 17.657l-.707.707M17.657 17.657l-.707-.707M6.343 6.343l-.707-.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
             </svg>
-            {{-- Moon (shown in light mode) --}}
-            <svg x-show="!isDark" x-cloak class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <svg class="h-5 w-5 block dark:hidden" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
             </svg>
         </button>

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -2130,6 +2130,7 @@
 ══════════════════════════════════════════════════════ --}}
 <div x-data
      x-show="$store.helpModal.show"
+     x-cloak
      x-transition:enter="transition ease-out duration-200"
      x-transition:enter-start="opacity-0"
      x-transition:enter-end="opacity-100"

--- a/tests/Feature/Bloque6/NotificationTest.php
+++ b/tests/Feature/Bloque6/NotificationTest.php
@@ -3,6 +3,7 @@
 /**
  * @author AyrtonAlania
  * @author SebastianBCF
+ * @author BenjaminDTS
  */
 
 use App\Models\Order;
@@ -131,6 +132,50 @@ it('bar panel initial html has no ready orders when notification_ready is false'
 
     $response->assertOk();
     $response->assertSee('<script id="bar-ready-orders" type="application/json">[]</script>', false);
+});
+
+// ─── Regresión: carga de vista no borra notification_ready (ghost fix) ───────
+
+it('loading bar index does not clear notification_ready', function () {
+    $waiter = User::factory()->create(['role' => 'waiter']);
+    $table  = Table::factory()->create(['user_id' => $waiter->id]);
+
+    $order = Order::factory()->create([
+        'table_id'           => $table->id,
+        'status'             => 'ready',
+        'notification_ready' => true,
+    ]);
+
+    // Simula varias recargas de página: el flag debe mantenerse true en BD.
+    $this->actingAs($waiter)->get(route('bar.index'))->assertOk();
+    $this->actingAs($waiter)->get(route('bar.index'))->assertOk();
+    $this->actingAs($waiter)->get(route('bar.index'))->assertOk();
+
+    expect($order->fresh()->notification_ready)->toBeTrue();
+});
+
+it('notification_ready is cleared when all bar items are marked served', function () {
+    $waiter  = User::factory()->create(['role' => 'waiter']);
+    $table   = Table::factory()->create(['user_id' => $waiter->id]);
+    $product = \App\Models\Product::factory()->create(['user_id' => $waiter->id]);
+
+    $order = Order::factory()->create([
+        'table_id'           => $table->id,
+        'status'             => 'ready',
+        'notification_ready' => true,
+    ]);
+    $item = \App\Models\OrderItem::factory()->create([
+        'order_id'    => $order->id,
+        'product_id'  => $product->id,
+        'status'      => 'ready',
+        'destination' => 'bar',
+    ]);
+
+    $this->actingAs($waiter)
+        ->patchJson(route('bar.items.served', $item))
+        ->assertOk();
+
+    expect($order->fresh()->notification_ready)->toBeFalse();
 });
 
 // ─── Endpoint GET /notifications/bill-requests ────────────────────────────────


### PR DESCRIPTION
## Summary

- **Ghost notifications (bar panel):** `notificationPolling` now uses `sessionStorage` to track acknowledged order IDs. Notifications already seen in this browser session are filtered on page reload; only genuinely new notifications appear. Explicit dismiss still clears both the server flag and the session record.
- **Sidebar nav sections flash expanded:** Added `x-cloak` to `nav-carta`, `nav-local`, and `nav-negocio` — sections were visible before Alpine read their localStorage state.
- **Sidebar badge flash (red/orange):** Added `x-cloak` to the kitchen and bar badge `<span>` elements that had `x-show="count > 0"` without cloaking.
- **Dark mode icon flash:** Replaced `x-show`/`x-cloak` on sun/moon SVGs with Tailwind `hidden dark:block` / `block dark:hidden`. The pre-render inline script in `app.blade.php` already sets the `dark` class before first paint, so CSS responds instantly without waiting for Alpine.
- **Keyboard shortcuts modal flash (table map):** Added `x-cloak` to the help modal — its `fixed inset-0` overlay was covering the entire viewport before Alpine initialized the `helpModal` store.

## Root cause

All bugs share the same pattern: `x-show` without `x-cloak`. The `[x-cloak]{display:none!important}` rule exists in `app.blade.php` but the affected elements were not opted in, so they rendered visible before Alpine initialized.

## Test plan

- [ ] `php artisan test` — 1029 tests passing
- [ ] Reload bar panel with a pending ready notification — notification does not reappear after first dismiss or after being seen once
- [ ] Reload any admin page — sidebar sections stay in their last collapsed/expanded state with no flash
- [ ] Reload any admin page — kitchen (red) and bar (orange) badges do not flash an empty circle before showing the count
- [ ] Toggle dark mode, reload — correct sun/moon icon shown immediately with no flash
- [ ] Open table map — keyboard shortcuts modal does not appear for a second on entry
