### PR TITLE
feat(bloque11): Orders panel DS + tapas UX + carta entry animation

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -88,11 +88,12 @@ class MenuController extends Controller
             ->sortBy('name')
             ->values();
 
-        $tapaConfig        = null;
-        $barItemsCount     = 0;
-        $tapaVariantsUsed  = 0;
-        $tapaProducts      = collect();
-        $shouldSuggest     = false;
+        $tapaConfig          = null;
+        $barItemsCount       = 0;
+        $tapaVariantsUsed    = 0;
+        $tapasQuantityUsed   = 0;
+        $tapaProducts        = collect();
+        $shouldSuggest       = false;
 
         if ($config && $config->tapas_enabled) {
             $tapaConfig    = $config;
@@ -112,6 +113,13 @@ class MenuController extends Controller
                 )->whereHas('product.categories', fn ($q) =>
                     $q->where('categories.id', $tapaCategory->id)
                 )->distinct('product_id')->count('product_id');
+
+                $tapasQuantityUsed = OrderItem::whereHas('order', fn ($q) =>
+                    $q->where('table_id', $table->id)
+                      ->where('status', '!=', 'closed')
+                )->whereHas('product.categories', fn ($q) =>
+                    $q->where('categories.id', $tapaCategory->id)
+                )->sum('quantity');
 
                 $tapaProducts = $tapaCategory->products()
                                              ->where('is_active', true)
@@ -179,7 +187,7 @@ class MenuController extends Controller
         return view('menu.show', compact(
             'theme', 'table', 'categories', 'allergens',
             'tapaConfig', 'barItemsCount', 'kitchenOpen', 'nextOpeningTime',
-            'tapaVariantsUsed', 'tapaProducts', 'shouldSuggest',
+            'tapaVariantsUsed', 'tapasQuantityUsed', 'tapaProducts', 'shouldSuggest',
             'hasActiveOrder', 'activeOrderTotal', 'originalOrderTotal', 'billRequested', 'stripePublicKey',
             'splitPaymentEnabled', 'splitPaymentMaxParts', 'activeOrderItemsForAlpine', 'allOrdersForAlpine',
             'businessOpen', 'orderingAllowed', 'businessNextOpening', 'minutesUntilClose'

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -1163,47 +1163,78 @@
 .carta[data-chat="open"] .fab-cluster { display: none; }
 
 .fab--orders {
+  background: linear-gradient(135deg, #3B5BDB, #1E3A8A);
+  color: #FFFFFF;
+  border: 1px solid rgba(255,255,255,0.18);
+  padding: 0 16px 0 6px;
+  box-shadow: 0 10px 24px rgba(30,58,138,0.45);
   position: static;
   width: auto; height: 44px;
-  padding: 0 14px 0 6px;
   border-radius: 9999px;
   display: inline-flex; align-items: center; gap: 8px;
-  background: var(--bg-base);
-  color: var(--fg-primary);
-  border: 1px solid var(--border-subtle);
-  box-shadow: var(--shadow-fab);
   font-family: var(--font-body); font-size: 13.5px; font-weight: 700;
   letter-spacing: 0.005em;
   cursor: pointer;
   animation: orders-in 360ms var(--ease-smooth);
 }
 .fab--orders:hover {
-  background: var(--bg-surface);
-  border-color: var(--border-strong);
+  background: linear-gradient(135deg, #4C6BE5, #2945A0);
+  filter: brightness(1.05);
 }
-/* Dark: --bg-chip is semi-transparent blue, which made the pill see-through.
-   Force a solid night-blue surface for the hover state. */
+[data-theme="dark"] .fab--orders {
+  background: linear-gradient(135deg, #4C6BE5, #2945A0);
+  border-color: rgba(255,255,255,0.22);
+  box-shadow: 0 10px 24px rgba(0,0,0,0.55), inset 0 1px 0 rgba(255,255,255,0.12);
+}
 [data-theme="dark"] .fab--orders:hover {
-  background: var(--color-night-700);
-  border-color: rgba(46, 80, 176, 0.55);
+  background: linear-gradient(135deg, #5B79EC, #3B5BDB);
+  border-color: rgba(255,255,255,0.32);
 }
 @keyframes orders-in {
   from { transform: translateX(-6px) scale(0.96); opacity: 0; }
   to   { transform: translateX(0) scale(1); opacity: 1; }
 }
-.fab--orders__count {
+
+/* Círculo blanco que envuelve el icono y sirve de base al badge */
+.fab--orders__ic {
+  position: relative;
   flex-shrink: 0;
-  min-width: 32px; height: 32px;
-  padding: 0 8px;
+  width: 34px; height: 34px;
   border-radius: 9999px;
-  background: var(--brand-primary); color: var(--fg-on-accent);
-  font-family: var(--font-display); font-weight: 900; font-size: 14px;
-  font-variant-numeric: tabular-nums;
+  background: #FFFFFF;
+  color: #1E3A8A;
   display: inline-flex; align-items: center; justify-content: center;
-  line-height: 1;
+  box-shadow: inset 0 0 0 1px rgba(30,58,138,0.18);
 }
-[data-theme="dark"] .fab--orders__count { background: var(--color-green-500); color: #0A1430; }
-.fab--orders__label { white-space: nowrap; }
+[data-theme="dark"] .fab--orders__ic { color: #0B1C46; background: #F4F6FF; }
+
+/* Badge rojo de notificación — esquina superior derecha del icono */
+.fab--orders__badge {
+  position: absolute;
+  top: -4px; right: -6px;
+  min-width: 18px; height: 18px;
+  padding: 0 5px;
+  border-radius: 9999px;
+  background: linear-gradient(180deg, #F87171, #DC2626);
+  color: #FFFFFF;
+  border: 2px solid #FFFFFF;
+  box-shadow: 0 2px 6px rgba(220,38,38,0.45);
+  font-family: var(--font-display); font-weight: 900; font-size: 11px;
+  font-variant-numeric: tabular-nums; line-height: 1;
+  display: inline-flex; align-items: center; justify-content: center;
+  animation: order-badge-pulse 2.4s ease-in-out infinite;
+}
+[data-theme="dark"] .fab--orders__badge { border-color: #1E3A8A; }
+@keyframes order-badge-pulse {
+  0%, 100% { box-shadow: 0 2px 6px rgba(220,38,38,0.45), 0 0 0 0 rgba(220,38,38,0.55); }
+  50%      { box-shadow: 0 2px 6px rgba(220,38,38,0.45), 0 0 0 6px rgba(220,38,38,0); }
+}
+
+.fab--orders__label {
+  font-family: var(--font-body); font-weight: 700; font-size: 13.5px;
+  letter-spacing: 0.01em; color: #FFFFFF;
+  white-space: nowrap;
+}
 
 /* â”€â”€ "Mi ticket" pill â€” green, sits to the right of "Cuenta" â”€â”€ */
 .fab__ic { display: inline-flex; align-items: center; }

--- a/public/css/carta/flows/features.css
+++ b/public/css/carta/flows/features.css
@@ -229,6 +229,60 @@
   .tapas-indicator { animation: none; }
 }
 
+/* ── Overrides de tema para el indicador de tapas ────────────────────────── */
+
+/* Classic light — marrón cálido de la marca */
+[data-theme="classic"] .tapas-indicator {
+  --ti-bg:           linear-gradient(135deg, #7C5326, #4E3018);
+  --ti-border:       rgba(255,255,255,0.18);
+  --ti-shadow-base:  0 8px 22px rgba(46,32,19,0.45), 0 0 0 0 rgba(124,83,38,0.5);
+  --ti-shadow-peak:  0 18px 34px rgba(46,32,19,0.55), 0 0 0 9px rgba(124,83,38,0.22);
+  --ti-shadow-ring:  0 8px 22px rgba(46,32,19,0.45), 0 0 0 16px rgba(124,83,38,0);
+  --ti-token-color:  #F4ECDA;
+  --ti-token-border: rgba(244,236,218,0.38);
+}
+
+/* Classic dark — oro cálido sobre fondo oscuro sepia */
+[data-theme="classic"] .carta[data-theme="dark"] .tapas-indicator {
+  --ti-bg:           linear-gradient(135deg, #C79A4A, #9A7028);
+  --ti-border:       rgba(255,255,255,0.15);
+  --ti-shadow-base:  0 8px 28px rgba(0,0,0,0.65), 0 0 0 0 rgba(199,154,74,0.5);
+  --ti-shadow-peak:  0 20px 40px rgba(0,0,0,0.75), 0 0 0 10px rgba(199,154,74,0.25);
+  --ti-shadow-ring:  0 8px 28px rgba(0,0,0,0.65), 0 0 0 18px rgba(199,154,74,0);
+  --ti-glyph-bg:     rgba(26,19,13,0.22);
+  --ti-token-color:  #1A130D;
+  --ti-token-border: rgba(26,19,13,0.32);
+  --ti-text:         #1A130D;
+  --ti-text-muted:   rgba(26,19,13,0.68);
+  --ti-pill-bg:      rgba(26,19,13,0.18);
+  --ti-pill-border:  rgba(26,19,13,0.22);
+}
+
+/* Minimal light — negro puro, monocromo */
+[data-theme="minimal"] .tapas-indicator {
+  --ti-bg:           linear-gradient(135deg, #18181B, #09090B);
+  --ti-border:       rgba(255,255,255,0.1);
+  --ti-shadow-base:  0 8px 22px rgba(9,9,11,0.5), 0 0 0 0 rgba(24,24,27,0.55);
+  --ti-shadow-peak:  0 18px 34px rgba(9,9,11,0.65), 0 0 0 9px rgba(24,24,27,0.2);
+  --ti-shadow-ring:  0 8px 22px rgba(9,9,11,0.5), 0 0 0 16px rgba(24,24,27,0);
+}
+
+/* Minimal dark — blanco puro sobre negro, máximo contraste monocromo */
+[data-theme="minimal"] .carta[data-theme="dark"] .tapas-indicator {
+  --ti-bg:           linear-gradient(135deg, #FAFAFA, #D4D4D8);
+  --ti-border:       rgba(0,0,0,0.08);
+  --ti-shadow-base:  0 8px 28px rgba(0,0,0,0.7), 0 0 0 0 rgba(250,250,250,0.3);
+  --ti-shadow-peak:  0 20px 40px rgba(0,0,0,0.8), 0 0 0 10px rgba(250,250,250,0.12);
+  --ti-shadow-ring:  0 8px 28px rgba(0,0,0,0.7), 0 0 0 18px rgba(250,250,250,0);
+  --ti-glyph-bg:     rgba(9,9,11,0.12);
+  --ti-token-color:  #09090B;
+  --ti-token-border: rgba(9,9,11,0.3);
+  --ti-text:         #09090B;
+  --ti-text-muted:   rgba(9,9,11,0.65);
+  --ti-pill-bg:      rgba(9,9,11,0.1);
+  --ti-pill-border:  rgba(9,9,11,0.15);
+}
+
 .tapas-indicator__glyph {
   flex-shrink: 0;
   width: 38px; height: 38px; border-radius: 50%;

--- a/public/css/carta/flows/features.css
+++ b/public/css/carta/flows/features.css
@@ -158,65 +158,119 @@
 .biz-closed__btn:hover { background: var(--color-amber-400); }
 .biz-closed__btn:active { transform: scale(0.97); }
 
-/* ---- 2) Tapas indicator pill ---- */
+/* ---- 2) Tapas indicator ---- */
+/* Custom props permiten que @keyframes adapte sombra a cada tema */
 .tapas-indicator {
-  display: inline-flex; align-items: center; gap: 12px;
-  align-self: flex-start;
-  margin: 10px 16px 12px;
-  padding: 6px 14px 6px 6px;
-  background: linear-gradient(135deg, var(--color-amber-100), color-mix(in oklab, var(--color-amber-200) 70%, var(--color-amber-100)));
-  border: 1px solid color-mix(in oklab, var(--color-amber-400) 35%, var(--border-subtle));
-  border-radius: 9999px;
+  --ti-bg:           linear-gradient(135deg, #F59E0B, #C05B05);
+  --ti-border:       rgba(255,255,255,0.22);
+  --ti-shadow-base:  0 8px 22px rgba(180,83,9,0.42), 0 0 0 0 rgba(245,158,11,0.5);
+  --ti-shadow-peak:  0 18px 34px rgba(180,83,9,0.55), 0 0 0 9px rgba(245,158,11,0.22);
+  --ti-shadow-ring:  0 8px 22px rgba(180,83,9,0.42), 0 0 0 16px rgba(245,158,11,0);
+  --ti-glyph-bg:     rgba(255,255,255,0.22);
+  --ti-token-color:  #FFFFFF;
+  --ti-token-border: rgba(255,255,255,0.35);
+  --ti-text:         #FFFFFF;
+  --ti-text-muted:   rgba(255,255,255,0.88);
+  --ti-pill-bg:      rgba(255,255,255,0.22);
+  --ti-pill-border:  rgba(255,255,255,0.32);
+
+  display: flex; align-items: center; gap: 12px;
+  margin: 8px 12px 12px;
+  padding: 10px 16px 10px 10px;
+  background: var(--ti-bg);
+  border: 1.5px solid var(--ti-border);
+  border-radius: 18px;
   font-family: var(--font-body);
-  color: var(--color-amber-800);
+  color: var(--ti-text);
   cursor: pointer;
-  flex-shrink: 0;
-  width: auto; max-width: 100%;
-  transition: transform 120ms var(--ease-bounce), box-shadow var(--duration-fast);
-  box-shadow: 0 2px 8px rgba(245,158,11,0.12);
+  width: auto;
+  box-shadow: var(--ti-shadow-base);
+  animation: tapas-indicator-attention 5s var(--ease-smooth) 1.2s infinite;
+  transition: filter var(--duration-fast), transform 140ms var(--ease-bounce);
 }
+.tapas-indicator:hover {
+  filter: brightness(1.08);
+}
+.tapas-indicator:active { transform: translateY(0); }
+
+/* Dark mode — fondo más brillante para contrastar con bg oscuro */
 [data-theme="dark"] .tapas-indicator {
-  background: linear-gradient(135deg, rgba(251,191,36,0.12), rgba(251,191,36,0.04));
-  border-color: rgba(251,191,36,0.35);
-  color: var(--color-amber-300);
+  --ti-bg:           linear-gradient(135deg, #FBBF24, #D97706);
+  --ti-border:       rgba(255,255,255,0.18);
+  --ti-shadow-base:  0 8px 28px rgba(0,0,0,0.65), 0 0 0 0 rgba(251,191,36,0.55);
+  --ti-shadow-peak:  0 20px 40px rgba(0,0,0,0.75), 0 0 0 10px rgba(251,191,36,0.28);
+  --ti-shadow-ring:  0 8px 28px rgba(0,0,0,0.65), 0 0 0 18px rgba(251,191,36,0);
+  --ti-glyph-bg:     rgba(0,0,0,0.18);
+  --ti-token-color:  #1A0D00;
+  --ti-token-border: rgba(0,0,0,0.3);
+  --ti-text:         #1A0D00;
+  --ti-text-muted:   rgba(0,0,0,0.72);
+  --ti-pill-bg:      rgba(0,0,0,0.18);
+  --ti-pill-border:  rgba(0,0,0,0.22);
 }
-.tapas-indicator:hover { transform: translateY(-1px); box-shadow: 0 4px 14px rgba(245,158,11,0.20); }
+
+@keyframes tapas-indicator-attention {
+  0%, 62%, 100% {
+    transform: translateY(0) scale(1);
+    box-shadow: var(--ti-shadow-base);
+  }
+  70% {
+    transform: translateY(-8px) scale(1.03);
+    box-shadow: var(--ti-shadow-peak);
+  }
+  78% {
+    transform: translateY(0) scale(1);
+    box-shadow: var(--ti-shadow-ring);
+  }
+  85% { transform: translateY(-3px) scale(1.015); }
+  92% { transform: translateY(0) scale(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .tapas-indicator { animation: none; }
+}
+
 .tapas-indicator__glyph {
-  width: 32px; height: 32px; border-radius: 50%;
-  background: var(--color-amber-300); color: #5A2F00;
+  flex-shrink: 0;
+  width: 38px; height: 38px; border-radius: 50%;
+  background: var(--ti-glyph-bg);
   display: inline-flex; align-items: center; justify-content: center;
-  font-size: 16px; flex-shrink: 0;
+  font-size: 20px;
 }
-.tapas-indicator__copy { display: inline-flex; align-items: baseline; gap: 6px; line-height: 1; min-width: 0; }
+.tapas-indicator__body { display: flex; flex-direction: column; gap: 3px; flex: 1; min-width: 0; }
+.tapas-indicator__copy { display: inline-flex; align-items: baseline; gap: 5px; line-height: 1; }
 .tapas-indicator__copy strong {
-  font-family: var(--font-display); font-weight: 900; font-size: 18px;
-  color: var(--color-amber-800); letter-spacing: -0.02em;
+  font-family: var(--font-display); font-weight: 900; font-size: 22px;
+  color: var(--ti-text); letter-spacing: -0.02em;
   font-variant-numeric: tabular-nums; line-height: 1;
 }
 .tapas-indicator__copy span {
-  font-size: 12.5px; font-weight: 600; line-height: 1;
-  color: color-mix(in oklab, var(--color-amber-800) 80%, var(--fg-secondary));
+  font-size: 13px; font-weight: 700;
+  color: var(--ti-text-muted); line-height: 1;
 }
-[data-theme="dark"] .tapas-indicator__copy strong { color: var(--color-amber-300); }
-[data-theme="dark"] .tapas-indicator__copy span { color: color-mix(in oklab, var(--color-amber-300) 80%, var(--fg-secondary)); }
-.tapas-indicator__tokens { display: inline-flex; gap: 3px; padding: 0 4px; align-items: center; flex-shrink: 0; }
+.tapas-indicator__tokens { display: inline-flex; gap: 4px; align-items: center; }
 .tapas-indicator__tokens .tk {
-  width: 7px; height: 7px; border-radius: 50%;
-  background: var(--color-amber-300);
-  box-shadow: 0 0 0 1px rgba(0,0,0,0.05) inset;
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--ti-token-color);
 }
 .tapas-indicator__tokens .tk--used {
   background: transparent;
-  border: 1px dashed color-mix(in oklab, var(--color-amber-400) 60%, transparent);
-  box-shadow: none;
+  border: 1.5px dashed var(--ti-token-border);
+}
+.tapas-indicator__tokensMore {
+  font-family: var(--font-display); font-weight: 900; font-size: 11px;
+  color: var(--ti-text-muted);
 }
 .tapas-indicator__cta {
-  font-family: var(--font-body); font-size: 11.5px; font-weight: 700;
-  padding: 4px 10px; border-radius: 9999px;
-  background: var(--color-amber-300); color: #5A2F00;
-  white-space: nowrap;
+  flex-shrink: 0;
+  font-family: var(--font-body); font-size: 12px; font-weight: 800;
+  padding: 6px 12px; border-radius: 9999px;
+  background: var(--ti-pill-bg);
+  color: var(--ti-text);
+  border: 1px solid var(--ti-pill-border);
+  white-space: nowrap; letter-spacing: 0.01em;
+  transition: background-color var(--duration-fast);
 }
-[data-theme="dark"] .tapas-indicator__cta { background: var(--color-amber-300); color: #2A1B05; }
+.tapas-indicator:hover .tapas-indicator__cta { filter: brightness(1.12); }
 
 /* ---- 2b) Tapas modal v2 ---- */
 .modal__panel--tapas {

--- a/public/css/carta/layout/layout.css
+++ b/public/css/carta/layout/layout.css
@@ -345,3 +345,29 @@ html, body {
 .carta[data-bp="desktop"] .product-grid { grid-template-columns: repeat(3, 1fr); gap: 16px; }
 .carta[data-bp="desktop"][data-chat="open"] .carta__cartCol { display: none; }
 
+
+/* ── Animación de entrada en carga / recarga de página ─────────────────────
+   Fade + rise en bloques con stagger: header → filtros → contenido → cart bar.
+   animation-fill-mode: both mantiene opacity:0 antes de que arranque cada bloque.
+   ────────────────────────────────────────────────────────────────────────── */
+@keyframes carta-rise {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.header {
+  animation: carta-rise 380ms cubic-bezier(0.25, 0, 0.25, 1) 0ms both;
+}
+.filter-row {
+  animation: carta-rise 380ms cubic-bezier(0.25, 0, 0.25, 1) 60ms both;
+}
+.carta__main {
+  animation: carta-rise 400ms cubic-bezier(0.25, 0, 0.25, 1) 120ms both;
+}
+.cart-bar {
+  animation: carta-rise 360ms cubic-bezier(0.25, 0, 0.25, 1) 200ms both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header, .filter-row, .carta__main, .cart-bar { animation: none; }
+}

--- a/public/css/carta/themes/themes.css
+++ b/public/css/carta/themes/themes.css
@@ -584,8 +584,6 @@
 }
 .cart-foot__tapaPending:hover {
   filter: brightness(1.07);
-  transform: translateY(-1px);
-  animation-play-state: paused;
 }
 .cart-foot__tapaPending:active { transform: translateY(0); }
 [data-theme="dark"] .cart-foot__tapaPending {

--- a/public/css/carta/themes/themes.css
+++ b/public/css/carta/themes/themes.css
@@ -567,35 +567,85 @@
 }
 
 
-/* Aviso de tapas pendientes — mismo patrón que fab-attention (lift + ring pulse)
-   en ámbar cálido para distinguirse del verde del CTA y del rojo de la cuenta. */
+/* Aviso de tapas pendientes — mismo patrón que fab-attention (lift + ring pulse).
+   CSS vars permiten adaptar colores a cada tema sin duplicar la animación. */
 .cart-foot__tapaPending {
+  --ctp-bg:           linear-gradient(135deg, #F59E0B, #B45309);
+  --ctp-color:        #FFFFFF;
+  --ctp-shadow-base:  0 8px 20px rgba(180,83,9,0.38), 0 0 0 0 rgba(245,158,11,0.5);
+  --ctp-shadow-peak:  0 14px 28px rgba(180,83,9,0.48), 0 0 0 7px rgba(245,158,11,0.18);
+  --ctp-shadow-ring:  0 8px 20px rgba(180,83,9,0.38), 0 0 0 13px rgba(245,158,11,0);
+  --ctp-ic-bg:        rgba(255,255,255,0.22);
+
   display: flex; align-items: center; justify-content: center; gap: 10px;
   padding: 11px 16px;
   border-radius: 14px; border: none;
-  background: linear-gradient(135deg, #F59E0B, #B45309);
-  color: #FFFFFF;
+  background: var(--ctp-bg);
+  color: var(--ctp-color);
   font-family: var(--font-body); font-weight: 700; font-size: 13.5px;
-  text-align: center;
-  cursor: pointer;
-  box-shadow: 0 8px 20px rgba(180,83,9,0.38), 0 0 0 0 rgba(245,158,11,0.5);
+  text-align: center; cursor: pointer;
+  box-shadow: var(--ctp-shadow-base);
   animation: tapa-attention 5s var(--ease-smooth) 0.8s infinite;
-  transition: filter var(--duration-fast), transform 140ms var(--ease-bounce);
+  transition: filter var(--duration-fast);
 }
-.cart-foot__tapaPending:hover {
-  filter: brightness(1.07);
-}
+.cart-foot__tapaPending:hover { filter: brightness(1.07); }
 .cart-foot__tapaPending:active { transform: translateY(0); }
+
+/* ── Tema modern dark ── */
 [data-theme="dark"] .cart-foot__tapaPending {
-  background: linear-gradient(135deg, #FBBF24, #D97706);
-  box-shadow: 0 8px 20px rgba(0,0,0,0.45), 0 0 0 0 rgba(251,191,36,0.45);
+  --ctp-bg:          linear-gradient(135deg, #FBBF24, #D97706);
+  --ctp-color:       #1A0D00;
+  --ctp-ic-bg:       rgba(0,0,0,0.18);
+  --ctp-shadow-base: 0 8px 20px rgba(0,0,0,0.45), 0 0 0 0 rgba(251,191,36,0.45);
+  --ctp-shadow-peak: 0 14px 28px rgba(0,0,0,0.55), 0 0 0 7px rgba(251,191,36,0.22);
+  --ctp-shadow-ring: 0 8px 20px rgba(0,0,0,0.45), 0 0 0 13px rgba(251,191,36,0);
 }
 
-/* Icono emoji en círculo blanco translúcido — igual que fab--orders__ic */
+/* ── Tema classic light ── */
+[data-theme="classic"] .cart-foot__tapaPending {
+  --ctp-bg:          linear-gradient(135deg, #7C5326, #4E3018);
+  --ctp-color:       #FFFDF6;
+  --ctp-ic-bg:       rgba(255,253,246,0.2);
+  --ctp-shadow-base: 0 8px 20px rgba(46,32,19,0.45), 0 0 0 0 rgba(124,83,38,0.5);
+  --ctp-shadow-peak: 0 14px 28px rgba(46,32,19,0.55), 0 0 0 7px rgba(124,83,38,0.2);
+  --ctp-shadow-ring: 0 8px 20px rgba(46,32,19,0.45), 0 0 0 13px rgba(124,83,38,0);
+}
+
+/* ── Tema classic dark ── */
+[data-theme="classic"] .carta[data-theme="dark"] .cart-foot__tapaPending {
+  --ctp-bg:          linear-gradient(135deg, #C79A4A, #9A7028);
+  --ctp-color:       #1A130D;
+  --ctp-ic-bg:       rgba(26,19,13,0.2);
+  --ctp-shadow-base: 0 8px 20px rgba(0,0,0,0.55), 0 0 0 0 rgba(199,154,74,0.5);
+  --ctp-shadow-peak: 0 14px 28px rgba(0,0,0,0.65), 0 0 0 7px rgba(199,154,74,0.22);
+  --ctp-shadow-ring: 0 8px 20px rgba(0,0,0,0.55), 0 0 0 13px rgba(199,154,74,0);
+}
+
+/* ── Tema minimal light ── */
+[data-theme="minimal"] .cart-foot__tapaPending {
+  --ctp-bg:          linear-gradient(135deg, #18181B, #09090B);
+  --ctp-color:       #FFFFFF;
+  --ctp-ic-bg:       rgba(255,255,255,0.12);
+  --ctp-shadow-base: 0 8px 20px rgba(9,9,11,0.5), 0 0 0 0 rgba(24,24,27,0.55);
+  --ctp-shadow-peak: 0 14px 28px rgba(9,9,11,0.65), 0 0 0 7px rgba(24,24,27,0.2);
+  --ctp-shadow-ring: 0 8px 20px rgba(9,9,11,0.5), 0 0 0 13px rgba(24,24,27,0);
+}
+
+/* ── Tema minimal dark ── */
+[data-theme="minimal"] .carta[data-theme="dark"] .cart-foot__tapaPending {
+  --ctp-bg:          linear-gradient(135deg, #FAFAFA, #D4D4D8);
+  --ctp-color:       #09090B;
+  --ctp-ic-bg:       rgba(9,9,11,0.12);
+  --ctp-shadow-base: 0 8px 20px rgba(0,0,0,0.65), 0 0 0 0 rgba(250,250,250,0.3);
+  --ctp-shadow-peak: 0 14px 28px rgba(0,0,0,0.75), 0 0 0 7px rgba(250,250,250,0.12);
+  --ctp-shadow-ring: 0 8px 20px rgba(0,0,0,0.65), 0 0 0 13px rgba(250,250,250,0);
+}
+
+/* Icono emoji en círculo translúcido */
 .cart-foot__tapaPending__ic {
   flex-shrink: 0;
   width: 32px; height: 32px; border-radius: 9999px;
-  background: rgba(255,255,255,0.22);
+  background: var(--ctp-ic-bg);
   display: inline-flex; align-items: center; justify-content: center;
   font-size: 16px; line-height: 1;
 }
@@ -611,19 +661,19 @@
 }
 .cart-foot__tapaPending:hover .cart-foot__tapaPending__arrow { transform: translateX(3px); }
 
-/* Rebote + ring pulse — mismo patrón que fab-attention de la DS */
+/* Rebote + ring pulse usando CSS vars — se adapta a cada tema */
 @keyframes tapa-attention {
   0%, 65%, 100% {
     transform: translateY(0) scale(1);
-    box-shadow: 0 8px 20px rgba(180,83,9,0.38), 0 0 0 0 rgba(245,158,11,0.5);
+    box-shadow: var(--ctp-shadow-base);
   }
   73% {
     transform: translateY(-7px) scale(1.03);
-    box-shadow: 0 14px 28px rgba(180,83,9,0.48), 0 0 0 7px rgba(245,158,11,0.18);
+    box-shadow: var(--ctp-shadow-peak);
   }
   81% {
     transform: translateY(0) scale(1);
-    box-shadow: 0 8px 20px rgba(180,83,9,0.38), 0 0 0 13px rgba(245,158,11,0);
+    box-shadow: var(--ctp-shadow-ring);
   }
   88% { transform: translateY(-3px) scale(1.015); }
   95% { transform: translateY(0) scale(1); }

--- a/public/css/carta/themes/themes.css
+++ b/public/css/carta/themes/themes.css
@@ -567,6 +567,73 @@
 }
 
 
+/* Aviso de tapas pendientes — mismo patrón que fab-attention (lift + ring pulse)
+   en ámbar cálido para distinguirse del verde del CTA y del rojo de la cuenta. */
+.cart-foot__tapaPending {
+  display: flex; align-items: center; justify-content: center; gap: 10px;
+  padding: 11px 16px;
+  border-radius: 14px; border: none;
+  background: linear-gradient(135deg, #F59E0B, #B45309);
+  color: #FFFFFF;
+  font-family: var(--font-body); font-weight: 700; font-size: 13.5px;
+  text-align: center;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(180,83,9,0.38), 0 0 0 0 rgba(245,158,11,0.5);
+  animation: tapa-attention 5s var(--ease-smooth) 0.8s infinite;
+  transition: filter var(--duration-fast), transform 140ms var(--ease-bounce);
+}
+.cart-foot__tapaPending:hover {
+  filter: brightness(1.07);
+  transform: translateY(-1px);
+  animation-play-state: paused;
+}
+.cart-foot__tapaPending:active { transform: translateY(0); }
+[data-theme="dark"] .cart-foot__tapaPending {
+  background: linear-gradient(135deg, #FBBF24, #D97706);
+  box-shadow: 0 8px 20px rgba(0,0,0,0.45), 0 0 0 0 rgba(251,191,36,0.45);
+}
+
+/* Icono emoji en círculo blanco translúcido — igual que fab--orders__ic */
+.cart-foot__tapaPending__ic {
+  flex-shrink: 0;
+  width: 32px; height: 32px; border-radius: 9999px;
+  background: rgba(255,255,255,0.22);
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 16px; line-height: 1;
+}
+.cart-foot__tapaPending__txt { line-height: 1.3; }
+.cart-foot__tapaPending__txt strong {
+  font-family: var(--font-display); font-weight: 900; font-size: 15px;
+}
+.cart-foot__tapaPending__arrow {
+  flex-shrink: 0;
+  font-family: var(--font-display); font-weight: 900; font-size: 18px;
+  opacity: 0.85;
+  transition: transform 200ms var(--ease-smooth);
+}
+.cart-foot__tapaPending:hover .cart-foot__tapaPending__arrow { transform: translateX(3px); }
+
+/* Rebote + ring pulse — mismo patrón que fab-attention de la DS */
+@keyframes tapa-attention {
+  0%, 65%, 100% {
+    transform: translateY(0) scale(1);
+    box-shadow: 0 8px 20px rgba(180,83,9,0.38), 0 0 0 0 rgba(245,158,11,0.5);
+  }
+  73% {
+    transform: translateY(-7px) scale(1.03);
+    box-shadow: 0 14px 28px rgba(180,83,9,0.48), 0 0 0 7px rgba(245,158,11,0.18);
+  }
+  81% {
+    transform: translateY(0) scale(1);
+    box-shadow: 0 8px 20px rgba(180,83,9,0.38), 0 0 0 13px rgba(245,158,11,0);
+  }
+  88% { transform: translateY(-3px) scale(1.015); }
+  95% { transform: translateY(0) scale(1); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .cart-foot__tapaPending { animation: none; }
+}
+
 /* Aviso "Cocina cerrada" en la cabecera de cada categorÃ­a afectada */
 .category__closed {
   display: inline-flex; align-items: center; gap: 6px;

--- a/resources/js/alpine/cart.js
+++ b/resources/js/alpine/cart.js
@@ -38,12 +38,12 @@ export function calculateCartTotal(items) {
  * @param {Array}  tapaProducts   - Available tapa products.
  * @returns {boolean}
  */
-export function shouldShowTapaModal(cfg, barItemsCount, variantsUsed, tapaProducts) {
-    if (!cfg.enabled)                                           return false;
-    if (!cfg.kitchenOpen)                                       return false;
-    if (barItemsCount <= 0)                                     return false;
-    if (tapaProducts.length === 0)                              return false;
-    if (cfg.maxVariants > 0 && variantsUsed >= cfg.maxVariants) return false;
+export function shouldShowTapaModal(cfg, barItemsCount, tapasTotal, tapaProducts) {
+    if (!cfg.enabled)              return false;
+    if (!cfg.kitchenOpen)          return false;
+    if (barItemsCount <= 0)        return false;
+    if (tapaProducts.length === 0) return false;
+    if (tapasTotal >= barItemsCount) return false;
     return true;
 }
 
@@ -117,6 +117,7 @@ export function registerCart() {
         /** Server-side base counts (submitted orders before this session). */
         _initBarCount:     tapaConfig.barItemsCount ?? 0,
         _initVariantsUsed: tapaConfig.variantsUsed  ?? 0,
+        _initTapasTotal:   tapaConfig.tapasTotal    ?? 0,
 
         /** Reactive: bar items in current cart + server-side base. */
         get _barItemsCount() {
@@ -126,10 +127,16 @@ export function registerCart() {
             return this._initBarCount + cart;
         },
 
-        /** Reactive: distinct tapa product IDs in cart + server-side base. */
+        /** Reactive: distinct tapa product IDs in cart + server-side base (for variant-limit UI). */
         get _variantsUsed() {
             const ids = new Set(this.items.filter(i => i.isTapa).map(i => i.productId));
             return this._initVariantsUsed + ids.size;
+        },
+
+        /** Reactive: total tapa quantity in cart + server-side base (for entitlement counting). */
+        get _tapasTotal() {
+            const cartTotal = this.items.filter(i => i.isTapa).reduce((s, i) => s + i.quantity, 0);
+            return this._initTapasTotal + cartTotal;
         },
 
         /** Reactive: true when tapas are available but not yet chosen in the current cart. */
@@ -137,7 +144,7 @@ export function registerCart() {
             return shouldShowTapaModal(
                 this.tapaConfig,
                 this._barItemsCount,
-                this._variantsUsed,
+                this._tapasTotal,
                 this.tapaProducts,
             );
         },
@@ -153,10 +160,10 @@ export function registerCart() {
             const newBarItems = this.items
                 .filter(i => i.destination === 'bar' && !i.isTapa)
                 .reduce((s, i) => s + i.quantity, 0);
-            const newTapaVariants = new Set(
-                this.items.filter(i => i.isTapa).map(i => i.productId)
-            ).size;
-            return newBarItems > newTapaVariants;
+            const newTapasTotal = this.items
+                .filter(i => i.isTapa)
+                .reduce((s, i) => s + i.quantity, 0);
+            return newBarItems > newTapasTotal;
         },
 
         close() {
@@ -222,7 +229,7 @@ export function registerCart() {
             this.showTapaModal = shouldShowTapaModal(
                 this.tapaConfig,
                 this._barItemsCount,
-                this._variantsUsed,
+                this._tapasTotal,
                 this.tapaProducts,
             );
         },
@@ -235,8 +242,12 @@ export function registerCart() {
             const key      = tapaProduct.id + ':none';
             const existing = this.items.find(i => i._key === key);
             if (existing) {
-                // already in cart — just mark as tapa if not already
-                existing.isTapa = true;
+                if (!existing.isTapa) {
+                    existing.isTapa = true;
+                } else {
+                    existing.quantity++;
+                }
+                return;
             } else {
                 this.items.push({
                     _key:        key,
@@ -339,7 +350,7 @@ export function registerCart() {
         },
 
         async send() {
-            if (!this.items.length || this.sending || this._tapaSendBlocked) return;
+            if (!this.items.length || this.sending) return;
             this.sending = true;
             this.error   = null;
             try {

--- a/resources/js/alpine/cart.js
+++ b/resources/js/alpine/cart.js
@@ -39,11 +39,12 @@ export function calculateCartTotal(items) {
  * @returns {boolean}
  */
 export function shouldShowTapaModal(cfg, barItemsCount, variantsUsed, tapaProducts) {
-    if (!cfg.enabled)                       return false;
-    if (!cfg.kitchenOpen)                   return false;
-    if (barItemsCount <= 0)                 return false;
-    if (variantsUsed >= cfg.maxVariants)    return false;
-    if (tapaProducts.length === 0)          return false;
+    if (!cfg.enabled)                        return false;
+    if (!cfg.kitchenOpen)                    return false;
+    if (barItemsCount <= 0)                  return false;
+    if (variantsUsed >= barItemsCount)       return false;
+    if (variantsUsed >= cfg.maxVariants)     return false;
+    if (tapaProducts.length === 0)           return false;
     if (variantsUsed >= tapaProducts.length) return false;
     return true;
 }

--- a/resources/js/alpine/cart.js
+++ b/resources/js/alpine/cart.js
@@ -39,13 +39,11 @@ export function calculateCartTotal(items) {
  * @returns {boolean}
  */
 export function shouldShowTapaModal(cfg, barItemsCount, variantsUsed, tapaProducts) {
-    if (!cfg.enabled)                        return false;
-    if (!cfg.kitchenOpen)                    return false;
-    if (barItemsCount <= 0)                  return false;
-    if (variantsUsed >= barItemsCount)       return false;
-    if (variantsUsed >= cfg.maxVariants)     return false;
-    if (tapaProducts.length === 0)           return false;
-    if (variantsUsed >= tapaProducts.length) return false;
+    if (!cfg.enabled)                                           return false;
+    if (!cfg.kitchenOpen)                                       return false;
+    if (barItemsCount <= 0)                                     return false;
+    if (tapaProducts.length === 0)                              return false;
+    if (cfg.maxVariants > 0 && variantsUsed >= cfg.maxVariants) return false;
     return true;
 }
 
@@ -142,6 +140,23 @@ export function registerCart() {
                 this._variantsUsed,
                 this.tapaProducts,
             );
+        },
+
+        /**
+         * Reactive: true only when there are tapas pending AND the user still
+         * has unclaimed tapas from the current cart (new bar items not yet covered).
+         * Used to block the send button — avoids blocking when all tapas were
+         * already claimed in previously submitted orders.
+         */
+        get _tapaSendBlocked() {
+            if (!this._tapaPending) return false;
+            const newBarItems = this.items
+                .filter(i => i.destination === 'bar' && !i.isTapa)
+                .reduce((s, i) => s + i.quantity, 0);
+            const newTapaVariants = new Set(
+                this.items.filter(i => i.isTapa).map(i => i.productId)
+            ).size;
+            return newBarItems > newTapaVariants;
         },
 
         close() {
@@ -324,7 +339,7 @@ export function registerCart() {
         },
 
         async send() {
-            if (!this.items.length || this.sending || this._tapaPending) return;
+            if (!this.items.length || this.sending || this._tapaSendBlocked) return;
             this.sending = true;
             this.error   = null;
             try {

--- a/resources/js/alpine/orders.js
+++ b/resources/js/alpine/orders.js
@@ -27,6 +27,9 @@ export function registerOrders() {
         /** @type {Array<Object>} All orders for this table session. */
         list,
 
+        /** @type {Object|null} Order to show in the confirmed popup, null = hidden. */
+        confirmedOrder: null,
+
         /** @returns {Object|null} The currently selected order, or null. */
         get selected() {
             return this.list.find(o => o.id === this.selectedId) ?? null;
@@ -65,12 +68,24 @@ export function registerOrders() {
         },
 
         /**
-         * Appends a newly submitted order to the list.
+         * Appends a newly submitted order to the list and shows the
+         * order-confirmed popup automatically.
          *
          * @param {Object} order - { id, number, itemCount, total, sentAt, items[] }
          */
         push(order) {
             this.list.push(order);
+            this.confirmedOrder = order;
+        },
+
+        /** Shows the confirmed popup for a given order. */
+        showConfirmed(order) {
+            this.confirmedOrder = order;
+        },
+
+        /** Dismisses the order-confirmed popup. */
+        dismissConfirmed() {
+            this.confirmedOrder = null;
         },
 
         /**

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -3048,7 +3048,7 @@
 
 
                 {{-- ======================================================================
-             ORDERS PANEL — Mis pedidos (lista + detalle)
+             ORDERS PANEL — DS: OrdersWindow (lista + detalle)
              ====================================================================== --}}
         <div class="scrim"
              x-show="$store.orders.open"
@@ -3067,14 +3067,14 @@
 
                 {{-- Header — cambia entre vista lista y detalle --}}
                 <div class="drawer__head">
-                    <div class="drawer__heading">
+                    <div>
                         <div class="drawer__title"
                              x-text="$store.orders.selectedId === null ? 'Mis pedidos' : 'Pedido #' + $store.orders.selected?.number">
                         </div>
-                        <div class="drawer__subtitle"
+                        <div style="font-family:var(--font-body);font-size:12px;color:var(--fg-muted);margin-top:2px"
                              x-text="$store.orders.selectedId === null
-                                 ? ($store.orders.count + ' pedido' + ($store.orders.count !== 1 ? 's' : '') + ' enviado' + ($store.orders.count !== 1 ? 's' : ''))
-                                 : (($store.orders.selected?.itemCount ?? 0) + ' artículo' + (($store.orders.selected?.itemCount ?? 0) !== 1 ? 's' : '') + ' · ' + $store.orders.fmt($store.orders.selected?.total ?? 0))">
+                                 ? ($store.orders.count + ' ' + ($store.orders.count === 1 ? 'pedido enviado' : 'pedidos enviados'))
+                                 : (($store.orders.selected?.itemCount ?? 0) + ' ' + (($store.orders.selected?.itemCount ?? 0) === 1 ? 'artículo' : 'artículos') + ' · ' + $store.orders.fmt($store.orders.selected?.total ?? 0))">
                         </div>
                     </div>
                     <button type="button" class="icon-btn" @click="$store.orders.close()" aria-label="Cerrar">
@@ -3084,96 +3084,174 @@
                     </button>
                 </div>
 
-                {{-- Body lista --}}
+                {{-- Body — lista --}}
                 <template x-if="$store.orders.selectedId === null">
-                    <div class="drawer__body">
-                        <template x-for="order in $store.orders.list" :key="order.id">
-                            <button type="button" class="order-card" @click="$store.orders.openDetail(order.id)">
-                                <span class="order-badge" x-text="'#' + order.number"></span>
-                                <div class="order-card__info">
-                                    <div class="order-card__name" x-text="'Pedido #' + order.number"></div>
-                                    <div class="order-card__meta"
-                                         x-text="order.itemCount + ' artículo' + (order.itemCount !== 1 ? 's' : '') + ' · ' + order.sentAt">
+                    <div class="orders-body">
+                        <div class="orders-list">
+                            <template x-for="order in $store.orders.list" :key="order.id">
+                                <button type="button" class="order-row" @click="$store.orders.openDetail(order.id)">
+                                    <div class="order-row__num" x-text="'#' + order.number" aria-hidden="true"></div>
+                                    <div class="order-row__main">
+                                        <div class="order-row__title" x-text="'Pedido #' + order.number"></div>
+                                        <div class="order-row__meta">
+                                            <span x-text="order.itemCount + ' ' + (order.itemCount === 1 ? 'artículo' : 'artículos')"></span>
+                                            <template x-if="order.sentAt">
+                                                <span class="order-row__dot" aria-hidden="true">·</span>
+                                            </template>
+                                            <template x-if="order.sentAt">
+                                                <span x-text="order.sentAt"></span>
+                                            </template>
+                                        </div>
                                     </div>
-                                </div>
-                                <span class="order-card__price" x-text="$store.orders.fmt(order.total)"></span>
-                                <svg class="order-card__chevron" width="14" height="14" viewBox="0 0 24 24"
-                                     fill="none" stroke="currentColor" stroke-width="2.5"
-                                     stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                    <path d="M9 18l6-6-6-6"/>
-                                </svg>
-                            </button>
-                        </template>
-                    </div>
-                </template>
-
-                {{-- Body detalle --}}
-                <template x-if="$store.orders.selectedId !== null">
-                    <div class="drawer__body">
-                        <button type="button" class="orders-back" @click="$store.orders.backToList()">
-                            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                                 stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                                <path d="M15 18l-6-6 6-6"/>
-                            </svg>
-                            Volver a mis pedidos
-                        </button>
-
-                        <div class="order-detail-card">
-                            <div class="order-detail-card__head">
-                                <span class="order-badge order-badge--active"
-                                      x-text="'#' + $store.orders.selected?.number"></span>
-                                <div class="order-card__info">
-                                    <div class="order-card__name"
-                                         x-text="'Pedido #' + $store.orders.selected?.number"></div>
-                                    <div class="order-card__meta"
-                                         x-text="($store.orders.selected?.itemCount ?? 0) + ' artículo' + (($store.orders.selected?.itemCount ?? 0) !== 1 ? 's' : '') + ' · Enviado a las ' + $store.orders.selected?.sentAt">
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="order-detail-card__divider"></div>
-                            <template x-for="item in ($store.orders.selected?.items ?? [])" :key="item.name + item.price">
-                                <div class="order-item">
-                                    <span class="order-item__qty" x-text="item.quantity + '×'"></span>
-                                    <span class="order-item__name" x-text="item.name"></span>
-                                    <span class="order-item__price"
-                                          x-text="$store.orders.fmt(item.price * item.quantity)"></span>
-                                </div>
+                                    <div class="order-row__price" x-text="$store.orders.fmt(order.total)"></div>
+                                    <span class="order-row__chev" aria-hidden="true">
+                                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+                                             stroke="currentColor" stroke-width="2.5"
+                                             stroke-linecap="round" stroke-linejoin="round">
+                                            <path d="M9 18l6-6-6-6"/>
+                                        </svg>
+                                    </span>
+                                </button>
                             </template>
                         </div>
                     </div>
                 </template>
 
-                {{-- Footer lista --}}
+                {{-- Body — detalle --}}
+                <template x-if="$store.orders.selectedId !== null">
+                    <div class="orders-body">
+                        <div class="orders-detail">
+                            <button type="button" class="orders-back" @click="$store.orders.backToList()"
+                                    aria-label="Volver a la lista">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                     stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+                                     style="transform:rotate(180deg)" aria-hidden="true">
+                                    <path d="M9 18l6-6-6-6"/>
+                                </svg>
+                                <span>Volver a mis pedidos</span>
+                            </button>
+
+                            <div class="orders-detail__head">
+                                <div class="orders-detail__num"
+                                     x-text="'#' + $store.orders.selected?.number" aria-hidden="true"></div>
+                                <div>
+                                    <div class="orders-detail__title"
+                                         x-text="'Pedido #' + $store.orders.selected?.number"></div>
+                                    <div class="orders-detail__meta"
+                                         x-text="($store.orders.selected?.itemCount ?? 0) + ' ' + (($store.orders.selected?.itemCount ?? 0) === 1 ? 'artículo' : 'artículos') + ($store.orders.selected?.sentAt ? ' · Enviado a las ' + $store.orders.selected.sentAt : '')">
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="orders-detail__items">
+                                <template x-for="item in ($store.orders.selected?.items ?? [])"
+                                          :key="item.name + item.price">
+                                    <div class="orders-line">
+                                        <div class="orders-line__qty" x-text="item.quantity + '×'"></div>
+                                        <div class="orders-line__body">
+                                            <div class="orders-line__name" x-text="item.name"></div>
+                                        </div>
+                                        <div class="orders-line__price"
+                                             x-text="$store.orders.fmt(item.price * item.quantity)"></div>
+                                    </div>
+                                </template>
+                            </div>
+
+                            <div class="orders-detail__sub">
+                                <span class="lab">Subtotal del pedido</span>
+                                <span class="val"
+                                      x-text="$store.orders.fmt($store.orders.selected?.total ?? 0)"></span>
+                            </div>
+                        </div>
+                    </div>
+                </template>
+
+                {{-- Footer — solo en vista lista --}}
                 <template x-if="$store.orders.selectedId === null">
-                    <div class="drawer__foot">
-                        <div class="orders-total">
-                            <span class="orders-total__label">TOTAL CUENTA</span>
-                            <span class="orders-total__val"
-                                  x-text="$store.orders.fmt($store.orders.grandTotal)"></span>
+                    <div class="orders-foot">
+                        <div class="orders-foot__total">
+                            <span class="lab">Total cuenta</span>
+                            <span class="val" x-text="$store.orders.fmt($store.orders.grandTotal)"></span>
                         </div>
                         <button type="button" class="btn-primary"
                                 @click="$store.orders.close(); $store.bill.open()">
                             <svg aria-hidden="true" width="14" height="14" fill="none" stroke="currentColor"
-                                 stroke-width="2" viewBox="0 0 24 24">
+                                 stroke-width="2" viewBox="0 0 24 24" style="margin-right:6px;vertical-align:-3px">
                                 <path stroke-linecap="round" stroke-linejoin="round"
-                                      d="M9 14l6-6m-5.5.5h.01m4.99 5h.01M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16l3.5-2 3.5 2 3.5-2 3.5 2z"/>
+                                      d="M4 2v20l3-2 3 2 3-2 3 2 3-2V2H4z"/>
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M8 7h8M8 11h8M8 15h6"/>
                             </svg>
                             Solicitar cuenta
                         </button>
                     </div>
                 </template>
 
-                {{-- Footer detalle --}}
-                <template x-if="$store.orders.selectedId !== null">
-                    <div class="drawer__foot">
-                        <div class="orders-total">
-                            <span class="orders-total__label">SUBTOTAL DEL PEDIDO</span>
-                            <span class="orders-total__val"
-                                  x-text="$store.orders.fmt($store.orders.selected?.total ?? 0)"></span>
-                        </div>
-                    </div>
-                </template>
+            </div>
+        </div>
 
+        {{-- ======================================================================
+             ORDER CONFIRMED POPUP — DS: OrderConfirmedPopup
+             Aparece automáticamente al enviar un pedido a cocina/barra.
+             ====================================================================== --}}
+        <div class="scrim scrim--center order-confirmed"
+             x-show="$store.orders.confirmedOrder !== null"
+             style="display:none"
+             x-transition:enter="transition duration-200"
+             x-transition:enter-start="opacity-0"
+             x-transition:enter-end="opacity-100"
+             x-transition:leave="transition duration-200"
+             x-transition:leave-start="opacity-100"
+             x-transition:leave-end="opacity-0"
+             @click.self="$store.orders.dismissConfirmed()"
+             role="dialog" aria-modal="true" aria-label="Pedido enviado">
+
+            <div class="order-confirmed__panel" @click.stop>
+                <button type="button" class="icon-btn order-confirmed__x"
+                        @click="$store.orders.dismissConfirmed()" aria-label="Cerrar">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
+                         stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                    </svg>
+                </button>
+
+                <div class="order-confirmed__badge" aria-hidden="true">
+                    <svg viewBox="0 0 32 32" width="34" height="34" fill="none">
+                        <path d="M7 16.5l6 6 12-13" stroke="currentColor" stroke-width="3"
+                              stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                </div>
+
+                <div class="order-confirmed__num"
+                     x-text="'Pedido #' + $store.orders.confirmedOrder?.number"></div>
+                <div class="order-confirmed__title">Pedido enviado</div>
+                <div class="order-confirmed__sub">Lo llevamos en unos minutos 🍽</div>
+
+                <div class="order-confirmed__items">
+                    <template x-for="item in ($store.orders.confirmedOrder?.items.slice(0, 5) ?? [])"
+                              :key="item.name + item.price">
+                        <div class="order-confirmed__row">
+                            <span class="qty" x-text="item.quantity + '×'"></span>
+                            <span class="name" x-text="item.name"></span>
+                            <span class="price"
+                                  x-text="$store.orders.fmt(item.price * item.quantity)"></span>
+                        </div>
+                    </template>
+                    <template x-if="($store.orders.confirmedOrder?.items.length ?? 0) > 5">
+                        <div class="order-confirmed__more"
+                             x-text="'+ ' + ($store.orders.confirmedOrder.items.length - 5) + ' más…'"></div>
+                    </template>
+                </div>
+
+                <div class="order-confirmed__sub-total">
+                    <span class="lab">Subtotal</span>
+                    <span class="val"
+                          x-text="$store.orders.fmt($store.orders.confirmedOrder?.total ?? 0)"></span>
+                </div>
+
+                <button type="button" class="btn-primary"
+                        @click="$store.orders.dismissConfirmed()">
+                    Entendido
+                </button>
             </div>
         </div>
 

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -381,6 +381,7 @@
             'maxVariants'   => $tapaConfig?->max_tapa_variants ?? 0,
             'shouldSuggest' => $shouldSuggest,
             'variantsUsed'  => $tapaVariantsUsed,
+            'tapasTotal'    => (int) ($tapasQuantityUsed ?? 0),
             'barItemsCount' => (int) $barItemsCount,
             'kitchenOpen'   => $kitchenOpen,
         ];
@@ -1143,7 +1144,7 @@
         @if($tapaConfig && $tapaConfig->tapas_enabled)
         <button type="button"
                 class="tapas-indicator"
-                x-show="$store.cart.tapaConfig.enabled && $store.cart._barItemsCount > 0"
+                x-show="$store.cart.tapaConfig.enabled && $store.cart._barItemsCount > 0 && $store.cart._tapasTotal < $store.cart._barItemsCount"
                 x-transition:enter="transition ease-out duration-200"
                 x-transition:enter-start="opacity-0 translate-y-1"
                 x-transition:enter-end="opacity-100 translate-y-0"
@@ -1152,21 +1153,23 @@
                 x-transition:leave-end="opacity-0"
                 style="display:none"
                 @click="$store.cart.showTapaModal = true"
-                :aria-label="Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed) + ' ' + (Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed) === 1 ? 'tapa' : 'tapas') + ' ' + ($store.cart.tapaConfig.free ? 'de cortesía' : 'incluidas') + ' — Pedir'">
-            <span class="tapas-indicator__glyph" aria-hidden="true">🍻</span>
-            <span class="tapas-indicator__copy">
-                <strong x-text="Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed)"></strong>
-                <span x-text="(Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed) === 1 ? 'tapa' : 'tapas') + ' ' + ($store.cart.tapaConfig.free ? 'de cortesía' : 'incluidas')"></span>
+                :aria-label="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) + ' ' + (Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) === 1 ? 'tapa' : 'tapas') + ' ' + ($store.cart.tapaConfig.free ? 'de cortesía' : 'incluidas') + ' — Pedir'">
+            <span class="tapas-indicator__glyph" aria-hidden="true">🫕</span>
+            <span class="tapas-indicator__body">
+                <span class="tapas-indicator__copy">
+                    <strong x-text="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal)"></strong>
+                    <span x-text="(Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) === 1 ? 'tapa' : 'tapas') + ' ' + ($store.cart.tapaConfig.free ? 'de cortesía' : 'incluidas')"></span>
+                </span>
+                <span class="tapas-indicator__tokens" aria-hidden="true">
+                    <template x-for="i in Array.from({length: Math.min($store.cart._barItemsCount, 8)}, (_, idx) => idx)" :key="i">
+                        <span :class="'tk' + (i < $store.cart._tapasTotal ? ' tk--used' : '')"></span>
+                    </template>
+                    <span class="tapas-indicator__tokensMore"
+                          x-show="$store.cart._barItemsCount > 8"
+                          x-text="'+' + ($store.cart._barItemsCount - 8)"></span>
+                </span>
             </span>
-            <span class="tapas-indicator__tokens" aria-hidden="true">
-                <template x-for="i in Array.from({length: Math.min($store.cart._barItemsCount, 8)}, (_, idx) => idx)" :key="i">
-                    <span :class="'tk' + (i < $store.cart._variantsUsed ? ' tk--used' : '')"></span>
-                </template>
-                <span class="tapas-indicator__tokensMore"
-                      x-show="$store.cart._barItemsCount > 8"
-                      x-text="'+' + ($store.cart._barItemsCount - 8)"></span>
-            </span>
-            <span class="tapas-indicator__cta">Pedir →</span>
+            <span class="tapas-indicator__cta" aria-hidden="true">Elegir →</span>
         </button>
         @endif
 
@@ -1874,12 +1877,12 @@
                                     class="cart-foot__tapaPending"
                                     @click="$store.cart.showTapaModal = true"
                                     aria-live="polite"
-                                    :aria-label="'Tienes ' + Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed) + ' tapa' + (Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed) !== 1 ? 's' : '') + ' disponibles — Elegir'">
+                                    :aria-label="'Tienes ' + Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) + ' tapa' + (Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) !== 1 ? 's' : '') + ' disponibles — Elegir'">
                                 <span class="cart-foot__tapaPending__ic" aria-hidden="true">🫕</span>
                                 <span class="cart-foot__tapaPending__txt">
-                                    Tienes <strong x-text="Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed)"></strong>
-                                    tapa<template x-if="Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed) !== 1"><span>s</span></template>
-                                    disponible<template x-if="Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed) !== 1"><span>s</span></template>
+                                    Tienes <strong x-text="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal)"></strong>
+                                    tapa<template x-if="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) !== 1"><span>s</span></template>
+                                    disponible<template x-if="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) !== 1"><span>s</span></template>
                                     — Elegir
                                 </span>
                                 <span class="cart-foot__tapaPending__arrow" aria-hidden="true">→</span>
@@ -1889,8 +1892,7 @@
                                 class="cart-foot__cta"
                                 :class="{ 'cart-foot__cta--sending': $store.cart.sending }"
                                 @click="$store.cart.send()"
-                                :disabled="$store.cart.sending || $store.cart._tapaSendBlocked"
-                                :title="$store.cart._tapaSendBlocked ? 'Elige tus tapas antes de enviar' : ''">
+                                :disabled="$store.cart.sending">
                             <span class="cart-foot__ctaIc" aria-hidden="true">
                                 <template x-if="$store.cart.sent">✓</template>
                                 <template x-if="$store.cart.sending && !$store.cart.sent">
@@ -3281,7 +3283,7 @@
                  x-data="{
                      selectedTapaId: null,
                      showChefExtra: false,
-                     get left()         { return Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed); },
+                     get left()         { return Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal); },
                      get limitReached() { return $store.cart._variantsUsed >= $store.cart.tapaConfig.maxVariants && $store.cart.tapaConfig.maxVariants > 0; },
                      get tokensShown()  { return Math.min(Math.max($store.cart._barItemsCount, 1), 12); },
                      get tokensOver()   { return Math.max(0, $store.cart._barItemsCount - 12); },
@@ -3319,7 +3321,7 @@
                     </p>
                     <div class="tapas-coins" aria-hidden="true">
                         <template x-for="i in Array.from({length: tokensShown}, (_, idx) => idx)" :key="i">
-                            <span :class="'tapa-coin' + (i < $store.cart._variantsUsed ? ' tapa-coin--used' : '')">
+                            <span :class="'tapa-coin' + (i < $store.cart._tapasTotal ? ' tapa-coin--used' : '')">
                                 <span class="tapa-coin__face">🥟</span>
                             </span>
                         </template>
@@ -3350,11 +3352,11 @@
                 <div class="tapas-body">
                     <div class="tapas-listLabel">Elige tu tapa</div>
                     <div class="tapas-list tapas-list--v2"
-                         :data-disabled="(limitReached || left === 0).toString()">
+                         :data-disabled="(left === 0).toString()">
                         <template x-for="(tapa, idx) in $store.cart.tapaProducts" :key="tapa.id">
                             <button type="button"
                                     :class="'tapa-card tapa-card--v2' + (selectedTapaId === tapa.id ? ' tapa-card--selected' : '')"
-                                    :disabled="limitReached || left === 0"
+                                    :disabled="left === 0"
                                     :style="'--i:' + idx"
                                     @click="selectedTapaId = selectedTapaId === tapa.id ? null : tapa.id"
                                     :aria-pressed="(selectedTapaId === tapa.id).toString()">
@@ -3384,9 +3386,9 @@
                         Ahora no
                     </button>
                     <button type="button" class="tapas-foot__primary"
-                            :disabled="!selectedTapaId || limitReached || left === 0"
+                            :disabled="!selectedTapaId || left === 0"
                             @click="$store.cart.addTapa($store.cart.tapaProducts.find(t => t.id === selectedTapaId)); selectedTapaId = null">
-                        <span x-text="limitReached ? 'Límite alcanzado' : (selectedTapaId ? 'Añadir tapa' : 'Elige una tapa')"></span>
+                        <span x-text="selectedTapaId ? 'Añadir tapa' : 'Elige una tapa'"></span>
                         <span class="tapas-foot__arrow" x-show="selectedTapaId && !limitReached" aria-hidden="true">→</span>
                     </button>
                 </footer>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1873,17 +1873,24 @@
                             <button type="button"
                                     class="cart-foot__tapaPending"
                                     @click="$store.cart.showTapaModal = true"
-                                    aria-live="polite">
-                                <span aria-hidden="true">🫕</span>
-                                <span>Tienes <strong x-text="Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed)"></strong> tapa<template x-if="Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed) !== 1"><span>s</span></template> disponible<template x-if="Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed) !== 1"><span>s</span></template> — Elegir →</span>
+                                    aria-live="polite"
+                                    :aria-label="'Tienes ' + Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed) + ' tapa' + (Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed) !== 1 ? 's' : '') + ' disponibles — Elegir'">
+                                <span class="cart-foot__tapaPending__ic" aria-hidden="true">🫕</span>
+                                <span class="cart-foot__tapaPending__txt">
+                                    Tienes <strong x-text="Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed)"></strong>
+                                    tapa<template x-if="Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed) !== 1"><span>s</span></template>
+                                    disponible<template x-if="Math.max(0, $store.cart._barItemsCount - $store.cart._variantsUsed) !== 1"><span>s</span></template>
+                                    — Elegir
+                                </span>
+                                <span class="cart-foot__tapaPending__arrow" aria-hidden="true">→</span>
                             </button>
                         </template>
                         <button type="button"
                                 class="cart-foot__cta"
                                 :class="{ 'cart-foot__cta--sending': $store.cart.sending }"
                                 @click="$store.cart.send()"
-                                :disabled="$store.cart.sending || $store.cart._tapaPending"
-                                :title="$store.cart._tapaPending ? 'Elige tus tapas antes de enviar' : ''">
+                                :disabled="$store.cart.sending || $store.cart._tapaSendBlocked"
+                                :title="$store.cart._tapaSendBlocked ? 'Elige tus tapas antes de enviar' : ''">
                             <span class="cart-foot__ctaIc" aria-hidden="true">
                                 <template x-if="$store.cart.sent">✓</template>
                                 <template x-if="$store.cart.sending && !$store.cart.sent">


### PR DESCRIPTION
## Resumen

- **Orders panel**: integración fiel al Design System (`order-row`, `orders-detail`, `orders-line`, `orders-foot`) + popup `order-confirmed` automático al enviar pedido
- **FAB Mis pedidos**: rediseño con fondo índigo/cobalto, círculo blanco para el icono y badge rojo con animación de pulso
- **Tapas — lógica**: `_tapasTotal` como métrica única (cantidad real vs tipos distintos), permite repetir tapas ya elegidas cuando se alcanza el límite de variantes, botón de enviar nunca bloqueado por tapas pendientes
- **Tapas — indicador**: rediseño notable con fondo sólido, animación `lift + ring pulse` en bucle, tokens sincronizados a `_tapasTotal`; soporte completo para 6 modos (modern/classic/minimal × light/dark) via CSS custom properties
- **Tapas — botón carrito**: mismo sistema de CSS vars con animación adaptada a cada tema
- **Carta — animación de entrada**: fade + rise en bloques con stagger al cargar/recargar (header → filtros → contenido → cart bar)
- **Correcciones varias**: `shouldShowTapaModal` corregida, `$tapasQuantityUsed` pasado correctamente en `compact()`, monedas del modal sincronizadas

## Test plan

- [ ] Abrir carta → animación de entrada visible en los 3 temas
- [ ] Añadir bebida de barra → indicador de tapas aparece con animación; botón en carrito visible
- [ ] Elegir tapa → contador e icono de tokens se actualizan correctamente
- [ ] Elegir todas las variantes (límite maxVariants) → botón sigue activo, permite repetir tipo
- [ ] Agotar todas las tapas disponibles → indicador desaparece, botón carrito desaparece
- [ ] Enviar pedido → popup `order-confirmed` aparece; FAB "Mis pedidos" aparece con badge rojo
- [ ] Abrir "Mis pedidos" → lista con `order-row` / detalle con `orders-detail` / footer con total
- [ ] Verificar en modo dark y en temas classic y minimal