### PR TITLE
feat(mapa): mobiliario, colisiones, copiar/pegar y ajuste de canvas

### DIFF
--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -53,7 +53,7 @@ class TableController extends Controller
         $ownerId = Auth::user()->ownerUserId();
         $tables  = Table::where('user_id', $ownerId)
                        ->servicePoints()
-                       ->whereNotIn('shape', ['bar', 'stool'])
+                       ->whereNotIn('shape', ['bar', 'stool', 'chair', 'fireplace', 'pillar', 'column'])
                        ->with('activeOrder')
                        ->orderBy('name')
                        ->get()
@@ -63,7 +63,7 @@ class TableController extends Controller
         $elements    = Table::where('user_id', $ownerId)
                            ->where(function ($q) {
                                $q->where('is_service_point', false)
-                                 ->orWhereIn('shape', ['bar', 'stool']);
+                                 ->orWhereIn('shape', ['bar', 'stool', 'chair', 'fireplace', 'pillar', 'column']);
                            })
                            ->orderBy('name')
                            ->get();
@@ -238,22 +238,33 @@ class TableController extends Controller
     {
         $data = $request->validate([
             'name'             => 'nullable|string|max:50',
-            'shape'            => 'required|in:square,round,rectangle,bar,stool',
+            'shape'            => 'required|in:square,round,rectangle,bar,stool,chair,fireplace,pillar,column',
             'position_x'       => 'required|integer|min:0',
             'position_y'       => 'required|integer|min:0',
-            'width'            => 'required|integer|min:40|max:800',
-            'height'           => 'required|integer|min:40|max:400',
+            'width'            => 'required|integer|min:20|max:800',
+            'height'           => 'required|integer|min:20|max:800',
+            'rotation'         => 'sometimes|numeric|min:0|max:360',
             'is_service_point' => 'sometimes|boolean',
             'floor'            => 'sometimes|integer|min:1|max:5',
             'zone_id'          => ['sometimes', 'nullable', Rule::exists('zones', 'id')->where('user_id', Auth::id())],
         ]);
 
-        $isServicePoint = in_array($data['shape'], ['bar', 'stool'])
+        $specialShapes = ['bar', 'stool', 'chair', 'fireplace', 'pillar', 'column'];
+        $isServicePoint = in_array($data['shape'], $specialShapes)
             ? false
             : ($data['is_service_point'] ?? true);
 
-        if (in_array($data['shape'], ['bar', 'stool'])) {
-            $data['name'] = $data['shape'] === 'bar' ? 'Barra' : 'Taburete';
+        $specialNames = [
+            'bar'       => 'Barra',
+            'stool'     => 'Taburete',
+            'chair'     => 'Silla',
+            'fireplace' => 'Chimenea',
+            'pillar'    => 'Pilar',
+            'column'    => 'Columna',
+        ];
+
+        if (in_array($data['shape'], $specialShapes)) {
+            $data['name'] = $data['name'] ?? $specialNames[$data['shape']];
         } elseif (empty($data['name'])) {
             $usedNumbers = Table::where('user_id', Auth::id())
                 ->servicePoints()
@@ -409,7 +420,7 @@ class TableController extends Controller
         abort_if($table->user_id !== Auth::user()->ownerUserId(), 403, 'Acceso denegado.');
 
         $data = $request->validate([
-            'shape' => 'required|in:square,round,rectangle,bar,stool',
+            'shape' => 'required|in:square,round,rectangle,bar,stool,chair,fireplace,pillar,column',
         ]);
 
         $table->update($data);

--- a/database/migrations/2026_06_02_000001_add_new_shapes_to_tables_shape_enum.php
+++ b/database/migrations/2026_06_02_000001_add_new_shapes_to_tables_shape_enum.php
@@ -11,11 +11,15 @@ return new class extends Migration
 {
     public function up(): void
     {
-        DB::statement("ALTER TABLE `tables` MODIFY `shape` ENUM('square','round','rectangle','bar','stool','chair','fireplace','pillar','column') NOT NULL DEFAULT 'square'");
+        if (Schema::getConnection()->getDriverName() !== 'sqlite') {
+            DB::statement("ALTER TABLE `tables` MODIFY `shape` ENUM('square','round','rectangle','bar','stool','chair','fireplace','pillar','column') NOT NULL DEFAULT 'square'");
+        }
     }
 
     public function down(): void
     {
-        DB::statement("ALTER TABLE `tables` MODIFY `shape` ENUM('square','round','rectangle','bar','stool') NOT NULL DEFAULT 'square'");
+        if (Schema::getConnection()->getDriverName() !== 'sqlite') {
+            DB::statement("ALTER TABLE `tables` MODIFY `shape` ENUM('square','round','rectangle','bar','stool') NOT NULL DEFAULT 'square'");
+        }
     }
 };

--- a/database/migrations/2026_06_02_000001_add_new_shapes_to_tables_shape_enum.php
+++ b/database/migrations/2026_06_02_000001_add_new_shapes_to_tables_shape_enum.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Extends the tables.shape ENUM to support chair, fireplace, pillar and column
+ * decorative elements on the visual map.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE `tables` MODIFY `shape` ENUM('square','round','rectangle','bar','stool','chair','fireplace','pillar','column') NOT NULL DEFAULT 'square'");
+    }
+
+    public function down(): void
+    {
+        DB::statement("ALTER TABLE `tables` MODIFY `shape` ENUM('square','round','rectangle','bar','stool') NOT NULL DEFAULT 'square'");
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -4,12 +4,13 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
 use App\Models\User;
 use App\Models\Plan;
 use App\Models\Table;
 use App\Models\Category;
-use App\Models\Product;
 use App\Models\Ingredient;
+use App\Models\Zone;
 
 /**
  * @author BenjaminDTS
@@ -19,17 +20,19 @@ class DatabaseSeeder extends Seeder
     /**
      * Seed the application's database.
      *
-     * Crea un escenario completo de prueba:
-     * 1. Tres superadmins del equipo Zampa (BenjaminDTS, SebastianBCF, Ayrton)
+     * Escenario completo basado en el estado real del negocio demo:
+     * 1. Tres superadmins del equipo Zampa
      * 2. Tres planes: Básico · Profesional · Premium
-     * 3. Usuario Admin de demo (admin@zampa.app / password) con plan Premium
-     * 4. 10 Mesas, 50 Ingredientes reales con alérgenos UE 1169/2011, 5 Categorías con Productos conectados
+     * 3. Usuario Admin de demo (admin@zampa.app / password) con plan Básico
+     * 4. 12 Categorías reales del negocio
+     * 5. Mapa real: 16 mesas + 66 elementos de mobiliario + 2 zonas
+     * 6. 50 Ingredientes reales con alérgenos UE 1169/2011
      *
      * @return void
      */
     public function run(): void
     {
-        // 1. Superadmins del equipo Zampa
+        // ── 1. Superadmins del equipo Zampa ───────────────────────────────────
         User::firstOrCreate(
             ['email' => 'benjamin@zampa.app'],
             [
@@ -60,8 +63,8 @@ class DatabaseSeeder extends Seeder
             ]
         );
 
-        // 2. Crear los tres planes de Zampa
-        Plan::updateOrCreate(
+        // ── 2. Planes de Zampa ────────────────────────────────────────────────
+        $planBasico = Plan::updateOrCreate(
             ['name' => 'Básico'],
             [
                 'price'         => 29.99,
@@ -85,7 +88,7 @@ class DatabaseSeeder extends Seeder
             ]
         );
 
-        $plan = Plan::updateOrCreate(
+        Plan::updateOrCreate(
             ['name' => 'Premium'],
             [
                 'price'         => 119.99,
@@ -97,26 +100,29 @@ class DatabaseSeeder extends Seeder
             ]
         );
 
-        // 3. Admin de demo con datos de negocio
+        // ── 3. Admin demo ─────────────────────────────────────────────────────
         $user = User::firstOrCreate(
             ['email' => 'admin@zampa.app'],
             [
-                'name'          => 'Admin Demo',
-                'password'      => Hash::make('password'),
-                'role'          => 'admin',
-                'plan_id'       => $plan->id,
-                'admin_id'      => null,
-                'business_name' => 'Bar Zampa Demo',
-                'address'       => 'Calle Mayor 1, Madrid',
-                'lat'           => 40.4168,
-                'lng'           => -3.7038,
+                'name'                   => 'Admin Demo',
+                'password'               => Hash::make('password'),
+                'role'                   => 'admin',
+                'plan_id'                => $planBasico->id,
+                'admin_id'               => null,
+                'business_name'          => 'Bar Zampa Demo',
+                'address'                => 'Calle Mayor 1, Madrid',
+                'lat'                    => 40.4168,
+                'lng'                    => -3.7038,
                 'is_waiter'              => true,
                 'is_kitchen'             => true,
                 'split_payment_enabled'  => false,
+                'floors_enabled'         => false,
+                'floor_count'            => 1,
+                'floor_canvas_sizes'     => ['1' => ['width' => 1600, 'height' => 1000]],
             ]
         );
 
-        // 4. Staff del gerente demo: camarero y cocinero
+        // ── 4. Staff del gerente demo ─────────────────────────────────────────
         User::firstOrCreate(
             ['email' => 'camarero@zampa.app'],
             [
@@ -137,10 +143,210 @@ class DatabaseSeeder extends Seeder
             ]
         );
 
-        // 5. Crear 10 Mesas para este usuario
-        Table::factory(10)->create(['user_id' => $user->id]);
+        // ── 5. Categorías reales del negocio ──────────────────────────────────
+        $categoryData = [
+            ['name' => 'Desayunos',  'destination' => 'bar'],
+            ['name' => 'Refrescos',  'destination' => 'bar'],
+            ['name' => 'Tostadas',   'destination' => 'kitchen'],
+            ['name' => 'Ensaladas',  'destination' => 'kitchen'],
+            ['name' => 'Bocadillos', 'destination' => 'kitchen'],
+            ['name' => 'Roscas',     'destination' => 'kitchen'],
+            ['name' => 'Pizzas',     'destination' => 'kitchen'],
+            ['name' => 'Raciones',   'destination' => 'kitchen'],
+            ['name' => 'Cerveza',    'destination' => 'bar'],
+            ['name' => 'Vino',       'destination' => 'bar'],
+            ['name' => 'Licores',    'destination' => 'bar'],
+            ['name' => 'Copas',      'destination' => 'bar'],
+        ];
 
-        // 6. Ingredientes reales del menú con alérgenos UE 1169/2011
+        foreach ($categoryData as $cat) {
+            Category::firstOrCreate(
+                ['name' => $cat['name'], 'user_id' => $user->id],
+                ['destination' => $cat['destination']]
+            );
+        }
+
+        // ── 6. Mapa real: mesas de servicio ───────────────────────────────────
+        // Limpiamos mesas existentes del usuario para evitar duplicados al re-seed
+        Table::where('user_id', $user->id)->delete();
+        Zone::where('user_id', $user->id)->delete();
+
+        $tableData = [
+            // Mesas numeradas (zona terraza - rotación 45°)
+            ['name' => '101', 'shape' => 'square',    'x' =>   88, 'y' =>  43, 'w' => 75, 'h' => 79, 'rot' => 45,  'svc' => true],
+            ['name' => '102', 'shape' => 'square',    'x' =>   84, 'y' => 179, 'w' => 75, 'h' => 79, 'rot' => 45,  'svc' => true],
+            ['name' => '103', 'shape' => 'square',    'x' =>   81, 'y' => 319, 'w' => 75, 'h' => 79, 'rot' => 45,  'svc' => true],
+            ['name' => '104', 'shape' => 'square',    'x' =>   77, 'y' => 458, 'w' => 75, 'h' => 79, 'rot' => 45,  'svc' => true],
+            // Mesas zona barra (rotación 45°)
+            ['name' => '2',   'shape' => 'square',    'x' =>  898, 'y' => 382, 'w' => 75, 'h' => 79, 'rot' => 45,  'svc' => true],
+            ['name' => '3',   'shape' => 'square',    'x' =>  721, 'y' => 382, 'w' => 75, 'h' => 79, 'rot' => 45,  'svc' => true],
+            ['name' => '4',   'shape' => 'square',    'x' =>  555, 'y' => 428, 'w' => 75, 'h' => 79, 'rot' => 45,  'svc' => true],
+            ['name' => '5',   'shape' => 'square',    'x' =>  412, 'y' => 430, 'w' => 75, 'h' => 79, 'rot' => 45,  'svc' => true],
+            ['name' => '6',   'shape' => 'square',    'x' =>  265, 'y' => 435, 'w' => 75, 'h' => 79, 'rot' => 45,  'svc' => true],
+            ['name' => '7',   'shape' => 'square',    'x' =>  100, 'y' => 100, 'w' => 75, 'h' => 79, 'rot' =>  0,  'svc' => true],
+            ['name' => '8',   'shape' => 'square',    'x' =>  100, 'y' => 100, 'w' => 75, 'h' => 79, 'rot' =>  0,  'svc' => true],
+            // Mesa VIP (esquina derecha)
+            ['name' => '1',   'shape' => 'square',    'x' => 1400, 'y' => 438, 'w' => 75, 'h' => 79, 'rot' =>  1,  'svc' => true],
+            // Isla central y tableros
+            ['name' => 'Isla',    'shape' => 'rectangle', 'x' => 1138, 'y' => 116, 'w' => 213, 'h' => 107, 'rot' => 90, 'svc' => true],
+            ['name' => 'Tabla 1', 'shape' => 'rectangle', 'x' => 1189, 'y' => 467, 'w' => 149, 'h' =>  42, 'rot' => 90, 'svc' => true],
+            ['name' => 'Tabla 2', 'shape' => 'rectangle', 'x' => 1091, 'y' => 467, 'w' => 149, 'h' =>  42, 'rot' => 90, 'svc' => true],
+            ['name' => 'Tabla 3', 'shape' => 'rectangle', 'x' =>  995, 'y' => 467, 'w' => 149, 'h' =>  42, 'rot' => 90, 'svc' => true],
+        ];
+
+        foreach ($tableData as $t) {
+            Table::create([
+                'user_id'         => $user->id,
+                'name'            => $t['name'],
+                'shape'           => $t['shape'],
+                'position_x'      => $t['x'],
+                'position_y'      => $t['y'],
+                'width'           => $t['w'],
+                'height'          => $t['h'],
+                'rotation'        => $t['rot'],
+                'floor'           => 1,
+                'is_service_point'=> $t['svc'],
+                'unique_hash'     => Str::uuid()->toString(),
+                'status'          => 'free',
+            ]);
+        }
+
+        // ── 7. Mapa real: mobiliario ─────────────────────────────────────────
+        $elementData = [
+            // Barra principal (polígono)
+            ['name' => 'Barra',     'shape' => 'bar',       'x' =>  532, 'y' =>  71, 'w' => 477, 'h' => 40,  'rot' =>  0,
+             'vertices' => [['x'=>-174,'y'=>1],['x'=>236.5,'y'=>0],['x'=>354.75,'y'=>0],['x'=>426.8125,'y'=>-1],['x'=>428.875,'y'=>-70],['x'=>472.9375,'y'=>-70],['x'=>473,'y'=>0],['x'=>473,'y'=>40],['x'=>-175,'y'=>42]]],
+            // Chimenea
+            ['name' => 'Chimenea',  'shape' => 'fireplace', 'x' =>  794, 'y' => 520, 'w' => 102, 'h' => 40,  'rot' =>  0],
+            // Columnas
+            ['name' => 'Columna',   'shape' => 'column',    'x' =>  887, 'y' => 240, 'w' =>  60, 'h' => 57,  'rot' =>  0],
+            ['name' => 'Columna',   'shape' => 'column',    'x' =>  648, 'y' => 238, 'w' =>  60, 'h' => 57,  'rot' =>  0],
+            // Taburetes barra
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' => 1011, 'y' =>  34, 'w' =>  41, 'h' => 40,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' =>  749, 'y' => 118, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' =>  872, 'y' => 117, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' =>  633, 'y' => 118, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' =>  510, 'y' => 118, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' =>  383, 'y' => 119, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            // Taburetes isla
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' => 1225, 'y' =>  19, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' => 1140, 'y' =>  92, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' => 1306, 'y' =>  94, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' => 1136, 'y' => 195, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' => 1307, 'y' => 195, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' => 1223, 'y' => 281, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            // Taburetes tableros
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' => 1093, 'y' => 442, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' => 1093, 'y' => 501, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' => 1188, 'y' => 442, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' => 1187, 'y' => 499, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' => 1288, 'y' => 499, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            ['name' => 'Taburete',  'shape' => 'stool',     'x' => 1286, 'y' => 441, 'w' =>  41, 'h' => 41,  'rot' =>  0],
+            // Sillas terraza (izquierda)
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>   62, 'y' =>  24, 'w' =>  40, 'h' => 40,  'rot' => 315],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  151, 'y' =>  22, 'w' =>  40, 'h' => 40,  'rot' =>  45],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>   59, 'y' => 159, 'w' =>  40, 'h' => 40,  'rot' => 315],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  148, 'y' => 160, 'w' =>  40, 'h' => 40,  'rot' =>  45],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>   58, 'y' => 100, 'w' =>  40, 'h' => 40,  'rot' => 225],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  149, 'y' => 102, 'w' =>  40, 'h' => 40,  'rot' => 135],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>   57, 'y' => 239, 'w' =>  40, 'h' => 40,  'rot' => 225],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  139, 'y' => 243, 'w' =>  40, 'h' => 40,  'rot' => 135],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>   58, 'y' => 296, 'w' =>  40, 'h' => 40,  'rot' => 315],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  142, 'y' => 297, 'w' =>  40, 'h' => 40,  'rot' =>  45],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>   54, 'y' => 380, 'w' =>  40, 'h' => 40,  'rot' => 225],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  139, 'y' => 380, 'w' =>  40, 'h' => 40,  'rot' => 135],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>   53, 'y' => 436, 'w' =>  40, 'h' => 40,  'rot' => 315],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  139, 'y' => 437, 'w' =>  40, 'h' => 40,  'rot' =>  45],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>   49, 'y' => 517, 'w' =>  40, 'h' => 40,  'rot' => 225],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  137, 'y' => 517, 'w' =>  40, 'h' => 40,  'rot' => 135],
+            // Sillas mesas bar
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  240, 'y' => 415, 'w' =>  40, 'h' => 40,  'rot' => 315],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  329, 'y' => 415, 'w' =>  40, 'h' => 40,  'rot' =>  45],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  240, 'y' => 497, 'w' =>  40, 'h' => 40,  'rot' => 225],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  326, 'y' => 497, 'w' =>  40, 'h' => 40,  'rot' => 135],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  388, 'y' => 409, 'w' =>  40, 'h' => 40,  'rot' => 315],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  474, 'y' => 407, 'w' =>  40, 'h' => 40,  'rot' =>  45],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  385, 'y' => 490, 'w' =>  40, 'h' => 40,  'rot' => 225],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  470, 'y' => 492, 'w' =>  40, 'h' => 40,  'rot' => 135],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  530, 'y' => 491, 'w' =>  40, 'h' => 40,  'rot' => 225],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  532, 'y' => 406, 'w' =>  40, 'h' => 40,  'rot' => 315],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  613, 'y' => 489, 'w' =>  40, 'h' => 40,  'rot' => 135],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  617, 'y' => 407, 'w' =>  40, 'h' => 40,  'rot' =>  45],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  694, 'y' => 442, 'w' =>  40, 'h' => 40,  'rot' => 225],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  697, 'y' => 361, 'w' =>  40, 'h' => 40,  'rot' => 315],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  782, 'y' => 443, 'w' =>  40, 'h' => 40,  'rot' => 135],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  784, 'y' => 362, 'w' =>  40, 'h' => 40,  'rot' =>  45],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  871, 'y' => 444, 'w' =>  40, 'h' => 40,  'rot' => 225],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  872, 'y' => 361, 'w' =>  40, 'h' => 40,  'rot' => 315],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  955, 'y' => 445, 'w' =>  40, 'h' => 40,  'rot' => 135],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  963, 'y' => 359, 'w' =>  40, 'h' => 40,  'rot' =>  45],
+            // Sillas mesa VIP (1)
+            ['name' => 'Silla',     'shape' => 'chair',     'x' => 1360, 'y' => 456, 'w' =>  40, 'h' => 40,  'rot' =>   1],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' => 1422, 'y' => 396, 'w' =>  40, 'h' => 40,  'rot' =>   1],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' => 1420, 'y' => 519, 'w' =>  40, 'h' => 40,  'rot' =>   1],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' => 1476, 'y' => 457, 'w' =>  40, 'h' => 40,  'rot' =>   1],
+            // Sillas zona central
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  299, 'y' => 203, 'w' =>  40, 'h' => 40,  'rot' =>   0],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  299, 'y' => 326, 'w' =>  40, 'h' => 40,  'rot' => 180],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  529, 'y' => 240, 'w' =>  40, 'h' => 40,  'rot' => 270],
+            ['name' => 'Silla',     'shape' => 'chair',     'x' =>  586, 'y' => 305, 'w' =>  40, 'h' => 40,  'rot' => 180],
+        ];
+
+        foreach ($elementData as $e) {
+            Table::create([
+                'user_id'          => $user->id,
+                'name'             => $e['name'],
+                'shape'            => $e['shape'],
+                'position_x'       => $e['x'],
+                'position_y'       => $e['y'],
+                'width'            => $e['w'],
+                'height'           => $e['h'],
+                'rotation'         => $e['rot'],
+                'floor'            => 1,
+                'is_service_point' => false,
+                'unique_hash'      => Str::uuid()->toString(),
+                'status'           => 'free',
+                'vertices'         => $e['vertices'] ?? null,
+            ]);
+        }
+
+        // ── 8. Zonas del mapa ─────────────────────────────────────────────────
+        Zone::create([
+            'user_id'    => $user->id,
+            'name'       => 'Bar',
+            'color'      => '#6366f1',
+            'position_x' => 489,
+            'position_y' => 1,
+            'width'      => 876,
+            'height'     => 595,
+            'rotation'   => 0,
+            'floor'      => 1,
+            'vertices'   => [
+                ['x' => -251,   'y' => 0],
+                ['x' =>  876,   'y' => 0],
+                ['x' =>  876,   'y' => 297.5],
+                ['x' =>  875,   'y' => 350.875],
+                ['x' => 1039,   'y' => 352.25],
+                ['x' => 1039,   'y' => 562.625],
+                ['x' =>  893,   'y' => 563],
+                ['x' => -252,   'y' => 563],
+            ],
+        ]);
+
+        Zone::create([
+            'user_id'    => $user->id,
+            'name'       => 'Terraza',
+            'color'      => '#9ac997',
+            'position_x' => 0,
+            'position_y' => 0,
+            'width'      => 236,
+            'height'     => 565,
+            'rotation'   => 0,
+            'floor'      => 1,
+            'vertices'   => null,
+        ]);
+
+        // ── 9. Ingredientes reales con alérgenos UE 1169/2011 ─────────────────
         $ingredientData = [
             ['name' => 'Aceite',            'allergen_types' => []],
             ['name' => 'Aceitunas',         'allergen_types' => []],
@@ -194,29 +400,15 @@ class DatabaseSeeder extends Seeder
             ['name' => 'Vino',              'allergen_types' => ['sulfitos']],
         ];
 
-        $ingredients = collect();
         foreach ($ingredientData as $data) {
             $hasAllergens = !empty($data['allergen_types']);
-            $ingredients->push(Ingredient::firstOrCreate(
+            Ingredient::firstOrCreate(
                 ['name' => $data['name'], 'user_id' => $user->id],
                 [
                     'is_allergen'    => $hasAllergens,
                     'allergen_types' => $hasAllergens ? $data['allergen_types'] : null,
                 ]
-            ));
+            );
         }
-
-        // 7. Crear 5 Categorías y llenarlas de productos
-        Category::factory(5)->create(['user_id' => $user->id])->each(function ($category) use ($user, $ingredients) {
-            $products = Product::factory(4)->create(['user_id' => $user->id]);
-
-            foreach ($products as $product) {
-                $product->categories()->syncWithoutDetaching([$category->id]);
-                $product->ingredients()->attach(
-                    $ingredients->random(3),
-                    ['quantity_base' => 1]
-                );
-            }
-        });
     }
 }

--- a/resources/js/pages/table-map.js
+++ b/resources/js/pages/table-map.js
@@ -426,6 +426,7 @@ export function registerTableMap() {
             rotTooltip:            { show: false, x: 0, y: 0, deg: 0 },
             undoStack:             [],
             redoStack:             [],
+            clipboard:             null,
             isPanning:             false,
             focusedVertexIdx:      null,
             contextMenu:           { show: false, x: 0, y: 0, type: null, item: null },
@@ -445,6 +446,25 @@ export function registerTableMap() {
                 });
                 this.pollStatuses();
                 setInterval(() => this.pollStatuses(), 25000);
+                if (!window._zampaResizeListener) {
+                    window._zampaResizeListener = () => { if (!this.editMode) this._applyOverviewZoom(); };
+                    window.addEventListener('resize', window._zampaResizeListener);
+                }
+                if (!window._zampaKbListener) {
+                    window._zampaKbListener = (e) => {
+                        if (this._isTyping()) return;
+                        if (e.ctrlKey && (e.key === 'c' || e.key === 'C')) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            this.copySelected();
+                        } else if (e.ctrlKey && (e.key === 'v' || e.key === 'V')) {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            this.pasteSelected();
+                        }
+                    };
+                    document.addEventListener('keydown', window._zampaKbListener, true);
+                }
             },
 
             _prefetchQrSvgs() {
@@ -629,7 +649,7 @@ export function registerTableMap() {
 
             hasCollision(item) {
                 if (this.floorsEnabled && this.currentView === 'general') return false;
-                const isSpecial = ['bar', 'stool'].includes(item.shape);
+                const isSpecial = ['bar', 'stool', 'chair', 'fireplace', 'pillar', 'column'].includes(item.shape);
                 const selfId    = item.id ?? null;
                 const itemFloor = this.floorsEnabled ? (item.floor ?? this.currentFloor) : null;
                 const sameFloor = (other) => !this.floorsEnabled || (other.floor ?? 1) === (itemFloor ?? 1);
@@ -756,7 +776,7 @@ export function registerTableMap() {
                 interact('.table-item').unset();
                 interact('.table-item')
                     .draggable({
-                        ignoreFrom:  '.rotation-handle, .resize-handle',
+                        ignoreFrom:  '.rotation-handle, .resize-handle, .bar-vertex-handle',
                         inertia:    false,
                         autoScroll: true,
                         listeners: {
@@ -768,8 +788,9 @@ export function registerTableMap() {
                                 const id   = parseInt(el.dataset.tableId);
                                 const item = this.tables.find(t => t.id === id) ?? this.elements.find(e => e.id === id);
                                 this.closeEditPanels();
-                                this.draggingId      = id;
-                                el._startedColliding = item ? this.hasCollision(item) : false;
+                                this.draggingId    = id;
+                                el._dragStartX     = item?.position_x;
+                                el._dragStartY     = item?.position_y;
                             },
                             move: (event) => {
                                 const el   = event.target;
@@ -782,44 +803,31 @@ export function registerTableMap() {
                                     : { minX: 0, maxX: this.floorWidth - 100, minY: 0, maxY: this.floorHeight - 100 };
                                 const propX = Math.max(minX, Math.min(maxX, Math.round(curX + event.dx / this.canvasZoom)));
                                 const propY = Math.max(minY, Math.min(maxY, Math.round(curY + event.dy / this.canvasZoom)));
-                                if (!item) {
-                                    el.style.left = `${propX}px`;
-                                    el.style.top  = `${propY}px`;
-                                    return;
-                                }
-                                if (el._startedColliding) {
-                                    item.position_x = propX;
-                                    item.position_y = propY;
-                                    el.style.left   = `${propX}px`;
-                                    el.style.top    = `${propY}px`;
-                                    if (!this.hasCollision(item)) el._startedColliding = false;
-                                    return;
-                                }
-                                const testXY = { ...item, position_x: propX, position_y: propY };
-                                const testX  = { ...item, position_x: propX, position_y: item.position_y };
-                                const testY  = { ...item, position_x: item.position_x, position_y: propY };
-                                let newX = item.position_x;
-                                let newY = item.position_y;
-                                if (!this.hasCollision(testXY)) {
-                                    newX = propX; newY = propY;
-                                } else if (!this.hasCollision(testX)) {
-                                    newX = propX;
-                                } else if (!this.hasCollision(testY)) {
-                                    newY = propY;
-                                }
-                                item.position_x = newX;
-                                item.position_y = newY;
-                                el.style.left   = `${newX}px`;
-                                el.style.top    = `${newY}px`;
+                                if (item) { item.position_x = propX; item.position_y = propY; }
+                                el.style.left = `${propX}px`;
+                                el.style.top  = `${propY}px`;
                             },
                             end: (event) => {
-                                const el = event.target;
-                                const id = parseInt(el.dataset.tableId);
-                                const x  = Math.round(parseFloat(el.style.left) || 0);
-                                const y  = Math.round(parseFloat(el.style.top)  || 0);
-                                const w  = Math.round(parseFloat(el.style.width)  || 100);
-                                const h  = Math.round(parseFloat(el.style.height) || 100);
+                                const el   = event.target;
+                                const id   = parseInt(el.dataset.tableId);
+                                const x    = Math.round(parseFloat(el.style.left) || 0);
+                                const y    = Math.round(parseFloat(el.style.top)  || 0);
+                                const w    = Math.round(parseFloat(el.style.width)  || 100);
+                                const h    = Math.round(parseFloat(el.style.height) || 100);
+                                const item = this.tables.find(t => t.id === id) ?? this.elements.find(e => e.id === id);
                                 this.draggingId = null;
+                                if (item && this.hasCollision(item)) {
+                                    const origX = el._dragStartX ?? x;
+                                    const origY = el._dragStartY ?? y;
+                                    item.position_x = origX;
+                                    item.position_y = origY;
+                                    el.style.left   = `${origX}px`;
+                                    el.style.top    = `${origY}px`;
+                                    this.undoStack.pop();
+                                    this.showToast('No se puede superponer con otra mesa.', true);
+                                    this.persistPosition(id, origX, origY, w, h);
+                                    return;
+                                }
                                 this.persistPosition(id, x, y, w, h);
                             },
                         },
@@ -940,35 +948,25 @@ export function registerTableMap() {
                 this.closeEditPanels();
                 this.draggingId            = element.id;
                 document.body.style.cursor = 'grabbing';
-                let startedColliding = this.hasCollision(element);
                 const onMove = (e) => {
                     const { minX, maxX, minY, maxY } = this.canvasBounds(element);
-                    const propX = Math.max(minX, Math.min(maxX, Math.round(startPx + (e.clientX - startMX) / this.canvasZoom)));
-                    const propY = Math.max(minY, Math.min(maxY, Math.round(startPy + (e.clientY - startMY) / this.canvasZoom)));
-                    if (startedColliding) {
-                        element.position_x = propX;
-                        element.position_y = propY;
-                        if (!this.hasCollision(element)) startedColliding = false;
-                        return;
-                    }
-                    const testXY = { ...element, position_x: propX, position_y: propY };
-                    const testX  = { ...element, position_x: propX, position_y: element.position_y };
-                    const testY  = { ...element, position_x: element.position_x, position_y: propY };
-                    if (!this.hasCollision(testXY)) {
-                        element.position_x = propX;
-                        element.position_y = propY;
-                    } else if (!this.hasCollision(testX)) {
-                        element.position_x = propX;
-                    } else if (!this.hasCollision(testY)) {
-                        element.position_y = propY;
-                    }
+                    element.position_x = Math.max(minX, Math.min(maxX, Math.round(startPx + (e.clientX - startMX) / this.canvasZoom)));
+                    element.position_y = Math.max(minY, Math.min(maxY, Math.round(startPy + (e.clientY - startMY) / this.canvasZoom)));
                 };
                 const onUp = async () => {
                     document.removeEventListener('mousemove', onMove);
                     document.removeEventListener('mouseup',   onUp);
                     this.draggingId            = null;
                     document.body.style.cursor = '';
-                    await this.persistPosition(element.id, element.position_x, element.position_y, element.width, element.height);
+                    if (this.hasCollision(element)) {
+                        element.position_x = startPx;
+                        element.position_y = startPy;
+                        this.undoStack.pop();
+                        this.showToast('No se puede superponer con otro elemento.', true);
+                        await this.persistPosition(element.id, startPx, startPy, element.width, element.height);
+                    } else {
+                        await this.persistPosition(element.id, element.position_x, element.position_y, element.width, element.height);
+                    }
                 };
                 document.addEventListener('mousemove', onMove);
                 document.addEventListener('mouseup',   onUp);
@@ -1050,9 +1048,12 @@ export function registerTableMap() {
                             ghost.style.width        = `${dW}px`;
                             ghost.style.height       = `${dH}px`;
                             ghost.style.borderRadius = shape === 'stool' ? '9999px' : '8px';
-                            ghost.style.borderColor  = '#d97706';
-                            ghost.style.background   = 'rgba(251,191,36,0.3)';
-                            ghost.querySelector('span').textContent = shape === 'bar' ? 'Nueva barra' : 'Nuevo taburete';
+                            const isGray = shape === 'pillar' || shape === 'column';
+                            const isRed  = shape === 'fireplace';
+                            ghost.style.borderColor  = shape === 'bar' ? '#d97706' : isRed ? '#b91c1c' : isGray ? '#6b7280' : '#4ade80';
+                            ghost.style.background   = shape === 'bar' ? 'rgba(251,191,36,0.3)' : isRed ? 'rgba(185,28,28,0.15)' : isGray ? 'rgba(107,114,128,0.2)' : 'rgba(74,222,128,0.2)';
+                            const nameMap = { bar: 'Nueva barra', chair: 'Nueva silla', fireplace: 'Nueva chimenea', pillar: 'Nuevo pilar', column: 'Nueva columna' };
+                            ghost.querySelector('span').textContent = nameMap[shape] ?? 'Nuevo elemento';
                             ghost.classList.remove('hidden');
                             ghost.classList.add('flex');
                             this.isDraggingFromPalette = true;
@@ -1086,7 +1087,8 @@ export function registerTableMap() {
                                 this.showToast('No se puede colocar aquí: colisiona con otra mesa o elemento.', true);
                                 return;
                             }
-                            const name = dropShape === 'bar' ? 'Barra' : 'Taburete';
+                            const dropNames = { bar: 'Barra', chair: 'Silla', stool: 'Taburete', fireplace: 'Chimenea', pillar: 'Pilar', column: 'Columna' };
+                            const name = dropNames[dropShape] ?? 'Elemento';
                             await this.createSpecialElement(name, dropShape, dropX, dropY, dropW, dropH);
                         },
                     },
@@ -1143,12 +1145,12 @@ export function registerTableMap() {
                 });
             },
 
-            async createTable(name, shape, x, y, w, h) {
+            async createTable(name, shape, x, y, w, h, rotation = 0) {
                 try {
                     const res = await fetch(this._urls.store, {
                         method:  'POST',
                         headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
-                        body: JSON.stringify({ name: name || null, shape, position_x: x, position_y: y, width: w, height: h, is_service_point: true, floor: this.floorsEnabled ? this.currentFloor : 1 }),
+                        body: JSON.stringify({ name: name || null, shape, position_x: x, position_y: y, width: w, height: h, rotation, is_service_point: true, floor: this.floorsEnabled ? this.currentFloor : 1 }),
                     });
                     const json = await res.json();
                     if (!res.ok || !json.success) { this.showToast(json.message ?? 'Error al crear la mesa.', true); return; }
@@ -1160,12 +1162,12 @@ export function registerTableMap() {
                 }
             },
 
-            async createSpecialElement(name, shape, x, y, w, h) {
+            async createSpecialElement(name, shape, x, y, w, h, rotation = 0) {
                 try {
                     const res = await fetch(this._urls.store, {
                         method:  'POST',
                         headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content, 'Accept': 'application/json' },
-                        body: JSON.stringify({ name, shape, position_x: x, position_y: y, width: w, height: h, is_service_point: false, floor: this.floorsEnabled ? this.currentFloor : 1 }),
+                        body: JSON.stringify({ name, shape, position_x: x, position_y: y, width: w, height: h, rotation, is_service_point: false, floor: this.floorsEnabled ? this.currentFloor : 1 }),
                     });
                     const json = await res.json();
                     if (!res.ok || !json.success) { this.showToast(json.message ?? 'Error al crear el elemento.', true); return; }
@@ -1487,32 +1489,37 @@ export function registerTableMap() {
                 this.resizingId            = table.id;
                 document.body.style.cursor = 'se-resize';
                 const onMove = (e) => {
-                    const dx     = (e.clientX - startMX) / this.canvasZoom;
-                    const dy     = (e.clientY - startMY) / this.canvasZoom;
+                    const dx      = (e.clientX - startMX) / this.canvasZoom;
+                    const dy      = (e.clientY - startMY) / this.canvasZoom;
                     const localDX =  dx * cosθ + dy * sinθ;
                     const localDY = -dx * sinθ + dy * cosθ;
-                    const newW = Math.min(800, Math.max(40, startW + localDX));
-                    const newH = Math.min(800, Math.max(40, startH + localDY));
+                    const newW = Math.min(800, Math.max(20, startW + localDX));
+                    const newH = Math.min(800, Math.max(20, startH + localDY));
                     const dW   = newW - startW;
                     const dH   = newH - startH;
                     const rawX = Math.round(startPx + dW / 2 * (cosθ - 1) - dH / 2 * sinθ);
                     const rawY = Math.round(startPy + dW / 2 * sinθ + dH / 2 * (cosθ - 1));
-                    const newX = Math.max(0, Math.min(this.floorWidth  - Math.round(newW), rawX));
-                    const newY = Math.max(0, Math.min(this.floorHeight - Math.round(newH), rawY));
-                    const testItem = { ...table, width: Math.round(newW), height: Math.round(newH), position_x: newX, position_y: newY };
-                    if (!this.hasCollision(testItem)) {
-                        table.width      = Math.round(newW);
-                        table.height     = Math.round(newH);
-                        table.position_x = newX;
-                        table.position_y = newY;
-                    }
+                    table.width      = Math.round(newW);
+                    table.height     = Math.round(newH);
+                    table.position_x = Math.max(0, Math.min(this.floorWidth  - Math.round(newW), rawX));
+                    table.position_y = Math.max(0, Math.min(this.floorHeight - Math.round(newH), rawY));
                 };
                 const onUp = async () => {
                     document.removeEventListener('mousemove', onMove);
                     document.removeEventListener('mouseup',   onUp);
                     this.resizingId            = null;
                     document.body.style.cursor = '';
-                    await this.persistPosition(table.id, table.position_x, table.position_y, table.width, table.height);
+                    if (this.hasCollision(table)) {
+                        table.width      = startW;
+                        table.height     = startH;
+                        table.position_x = startPx;
+                        table.position_y = startPy;
+                        this.undoStack.pop();
+                        this.showToast('No se puede superponer con otra mesa.', true);
+                        await this.persistPosition(table.id, startPx, startPy, startW, startH);
+                    } else {
+                        await this.persistPosition(table.id, table.position_x, table.position_y, table.width, table.height);
+                    }
                 };
                 document.addEventListener('mousemove', onMove);
                 document.addEventListener('mouseup',   onUp);
@@ -1604,14 +1611,8 @@ export function registerTableMap() {
                     const dy       = e.clientY - centerY;
                     let   angle    = Math.atan2(dy, dx) * (180 / Math.PI) + 90;
                     angle = ((angle % 360) + 360) % 360;
-                    const proposed = Math.round(angle);
-                    const testItem = { ...table, rotation: proposed };
-                    if (!this.hasCollision(testItem)) {
-                        table.rotation    = proposed;
-                        lastValidRotation = proposed;
-                    } else {
-                        table.rotation = lastValidRotation;
-                    }
+                    table.rotation    = Math.round(angle);
+                    lastValidRotation = table.rotation;
                     this.rotTooltip.x   = e.clientX;
                     this.rotTooltip.y   = e.clientY;
                     this.rotTooltip.deg = table.rotation;
@@ -1796,12 +1797,13 @@ export function registerTableMap() {
             },
 
             _applyOverviewZoom() {
-                const headerH = document.querySelector('header')?.offsetHeight ?? 65;
-                const availW  = window.innerWidth  - 48;
-                const availH  = window.innerHeight - headerH - 48;
-                const scaleX  = availW  / this.floorWidth;
-                const scaleY  = availH  / this.floorHeight;
-                this.canvasZoom = Math.max(0.5, Math.min(1, Math.min(scaleX, scaleY)));
+                const headerH  = document.querySelector('header')?.offsetHeight ?? 65;
+                const floorNavH = document.querySelector('nav[aria-label="Selector de planta"]')?.offsetHeight ?? 0;
+                const availW   = window.innerWidth  - 32;
+                const availH   = window.innerHeight - headerH - floorNavH - 32;
+                const scaleX   = availW  / this.floorWidth;
+                const scaleY   = availH  / this.floorHeight;
+                this.canvasZoom = Math.min(1, Math.min(scaleX, scaleY));
                 const main = this.$refs.canvas?.parentElement;
                 if (main) { main.scrollTop = 0; main.scrollLeft = 0; }
             },
@@ -2035,6 +2037,40 @@ export function registerTableMap() {
                     await this.persistZoneVertices(item.id, item.vertices);
                 } else {
                     await this.persistBarVertices(item.id, item.vertices);
+                }
+            },
+
+            copySelected() {
+                if (this.readonly || !this.selectedId) return;
+                const item = this.tables.find(t => t.id === this.selectedId)
+                          ?? this.elements.find(e => e.id === this.selectedId);
+                if (!item) return;
+                const specialShapes = ['bar', 'stool', 'chair', 'fireplace', 'pillar', 'column'];
+                this.clipboard = {
+                    shape: item.shape,
+                    width: item.width,
+                    height: item.height,
+                    rotation: item.rotation ?? 0,
+                    is_service_point: !specialShapes.includes(item.shape),
+                };
+                this.showToast('Copiado. Ctrl+V para pegar.');
+            },
+
+            async pasteSelected() {
+                if (!this.clipboard || this.readonly || !this.editMode) return;
+                const src  = this.tables.find(t => t.id === this.selectedId) ?? this.elements.find(e => e.id === this.selectedId);
+                const offX = src ? Math.min(src.position_x + 30, this.floorWidth  - this.clipboard.width)  : 100;
+                const offY = src ? Math.min(src.position_y + 30, this.floorHeight - this.clipboard.height) : 100;
+                if (this.clipboard.is_service_point) {
+                    if (this.tables.length >= this._init.maxTables) {
+                        this.showToast(`Límite de ${this._init.maxTables} mesas alcanzado.`, true);
+                        return;
+                    }
+                    await this.createTable(null, this.clipboard.shape, offX, offY, this.clipboard.width, this.clipboard.height, this.clipboard.rotation);
+                } else {
+                    const pasteNames = { bar: 'Barra', chair: 'Silla', stool: 'Taburete', fireplace: 'Chimenea', pillar: 'Pilar', column: 'Columna' };
+                    const name = pasteNames[this.clipboard.shape] ?? 'Elemento';
+                    await this.createSpecialElement(name, this.clipboard.shape, offX, offY, this.clipboard.width, this.clipboard.height, this.clipboard.rotation);
                 }
             },
 

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -421,15 +421,86 @@
             <div class="special-item group flex flex-col items-center gap-2 select-none cursor-grab active:cursor-grabbing transition-opacity"
                  data-shape="stool" data-width="50" data-height="50"
                  title="Arrastrar al plano (no genera QR)">
-                <div class="w-10 h-10 rounded-full border-2 border-dashed border-amber-600
-                            bg-amber-50 dark:bg-amber-900/30
-                            group-hover:border-amber-700 group-hover:bg-amber-100 transition-colors
+                <div class="w-10 h-10 rounded-full border-2 border-dashed border-green-500
+                            bg-green-50 dark:bg-green-900/30
+                            group-hover:border-green-600 group-hover:bg-green-100 transition-colors
                             flex items-center justify-center">
-                    <svg aria-hidden="true" class="w-5 h-5 text-amber-600" fill="currentColor" viewBox="0 0 24 24">
+                    <svg aria-hidden="true" class="w-5 h-5 text-green-600" fill="currentColor" viewBox="0 0 24 24">
                         <circle cx="12" cy="12" r="6"/>
                     </svg>
                 </div>
                 <span class="text-xs font-medium text-gray-600 dark:text-gray-300">Taburete</span>
+            </div>
+
+            {{-- Silla --}}
+            <div class="special-item group flex flex-col items-center gap-2 select-none cursor-grab active:cursor-grabbing transition-opacity"
+                 data-shape="chair" data-width="50" data-height="60"
+                 title="Arrastrar al plano (no genera QR)">
+                <div class="w-10 h-12 rounded border-2 border-dashed border-green-500
+                            bg-green-50 dark:bg-green-900/30
+                            group-hover:border-green-600 group-hover:bg-green-100 transition-colors
+                            flex items-center justify-center relative">
+                    <svg aria-hidden="true" class="w-6 h-8 text-green-600" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 32">
+                        <rect x="3" y="0" width="18" height="8" rx="2"/>
+                        <rect x="3" y="10" width="18" height="14" rx="2"/>
+                        <line x1="5" y1="24" x2="5" y2="32"/>
+                        <line x1="19" y1="24" x2="19" y2="32"/>
+                    </svg>
+                </div>
+                <span class="text-xs font-medium text-gray-600 dark:text-gray-300">Silla</span>
+            </div>
+
+            {{-- Chimenea --}}
+            <div class="special-item group flex flex-col items-center gap-2 select-none cursor-grab active:cursor-grabbing transition-opacity"
+                 data-shape="fireplace" data-width="80" data-height="80"
+                 title="Arrastrar al plano (no genera QR)">
+                <div class="w-12 h-12 rounded border-2 border-dashed border-red-700
+                            bg-red-50 dark:bg-red-900/30
+                            group-hover:border-red-800 group-hover:bg-red-100 transition-colors
+                            flex items-center justify-center">
+                    <svg aria-hidden="true" class="w-7 h-7 text-red-700" fill="none" stroke="currentColor" stroke-width="1.8" viewBox="0 0 24 24">
+                        <rect x="3" y="10" width="18" height="11" rx="1"/>
+                        <path d="M7 10V7a5 5 0 0110 0v3"/>
+                        <line x1="9" y1="21" x2="9" y2="17"/>
+                        <line x1="15" y1="21" x2="15" y2="17"/>
+                        <path d="M12 3 C10 5 13 7 11 9" stroke-linecap="round"/>
+                    </svg>
+                </div>
+                <span class="text-xs font-medium text-gray-600 dark:text-gray-300">Chimenea</span>
+            </div>
+
+            {{-- Pilar --}}
+            <div class="special-item group flex flex-col items-center gap-2 select-none cursor-grab active:cursor-grabbing transition-opacity"
+                 data-shape="pillar" data-width="40" data-height="40"
+                 title="Arrastrar al plano (no genera QR)">
+                <div class="w-10 h-10 rounded-full border-2 border-dashed border-gray-500
+                            bg-gray-100 dark:bg-gray-700/40
+                            group-hover:border-gray-600 group-hover:bg-gray-200 dark:group-hover:bg-gray-700 transition-colors
+                            flex items-center justify-center">
+                    <svg aria-hidden="true" class="w-5 h-5 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 24 24">
+                        <ellipse cx="12" cy="4" rx="6" ry="2"/>
+                        <rect x="9" y="4" width="6" height="16"/>
+                        <ellipse cx="12" cy="20" rx="6" ry="2"/>
+                    </svg>
+                </div>
+                <span class="text-xs font-medium text-gray-600 dark:text-gray-300">Pilar</span>
+            </div>
+
+            {{-- Columna --}}
+            <div class="special-item group flex flex-col items-center gap-2 select-none cursor-grab active:cursor-grabbing transition-opacity"
+                 data-shape="column" data-width="35" data-height="35"
+                 title="Arrastrar al plano (no genera QR)">
+                <div class="w-9 h-9 rounded border-2 border-dashed border-gray-500
+                            bg-gray-100 dark:bg-gray-700/40
+                            group-hover:border-gray-600 group-hover:bg-gray-200 dark:group-hover:bg-gray-700 transition-colors
+                            flex items-center justify-center">
+                    <svg aria-hidden="true" class="w-4 h-4 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 24 24">
+                        <rect x="4" y="2" width="16" height="3" rx="1"/>
+                        <rect x="8" y="5" width="8" height="14"/>
+                        <rect x="4" y="19" width="16" height="3" rx="1"/>
+                    </svg>
+                </div>
+                <span class="text-xs font-medium text-gray-600 dark:text-gray-300">Columna</span>
             </div>
 
             <hr class="border-gray-200 dark:border-gray-700">
@@ -755,24 +826,23 @@
                         @keydown.stop="if ($event.key === 'ContextMenu' || ($event.shiftKey && $event.key === 'F10')) openContextMenu($event, bar, 'bar')"
                         :aria-label="`Barra: ${bar.name}`"
                     >
-                        <div class="w-full h-full relative flex items-center justify-center
-                                    rounded-lg
-                                    bg-amber-100 dark:bg-amber-900
-                                    border-2 border-amber-400 dark:border-amber-600
-                                    shadow-md cursor-grab active:cursor-grabbing
-                                    transition-shadow hover:shadow-lg"
-                             :class="{'zampa-selected': isActive(bar.id)}">
+                        <div class="w-full h-full relative flex items-center justify-center cursor-grab active:cursor-grabbing transition-shadow"
+                             :class="{
+                                 'rounded-lg bg-amber-100 dark:bg-amber-900 border-2 border-amber-400 dark:border-amber-600 shadow-md hover:shadow-lg': !(bar.vertices && bar.vertices.length >= 3),
+                                 'zampa-selected': isActive(bar.id)
+                             }">
 
-                            {{-- Polígono SVG de la barra --}}
+                            {{-- Polígono SVG de la barra — en modo polígono reemplaza al rect --}}
                             <svg x-show="bar.vertices && bar.vertices.length >= 3"
-                                 class="absolute inset-0 pointer-events-none overflow-visible"
+                                 class="absolute inset-0 overflow-visible pointer-events-none"
                                  :width="bar.width"
                                  :height="bar.height"
                                  aria-hidden="true">
                                 <polygon :points="vertexPoints(bar)"
-                                         fill="rgba(251,191,36,0.2)"
-                                         stroke="#f59e0b"
-                                         stroke-width="2"
+                                         fill="rgba(251,191,36,0.45)"
+                                         :stroke="isActive(bar.id) ? '#6366f1' : '#d97706'"
+                                         :stroke-width="isActive(bar.id) ? '3' : '2'"
+                                         :stroke-dasharray="isActive(bar.id) ? '8 4' : 'none'"
                                          fill-rule="evenodd"/>
                             </svg>
 
@@ -781,17 +851,19 @@
                                 <div class="absolute inset-0 pointer-events-none">
                                     <template x-for="(v, idx) in bar.vertices" :key="idx">
                                         <div class="absolute" :style="`left:${v.x - 6}px; top:${v.y - 6}px;`">
-                                            <div class="w-3 h-3 rounded-full border-2 border-amber-500 bg-white pointer-events-auto cursor-move z-10 shadow focus:outline-none focus:ring-2 focus:ring-amber-400"
+                                            <div class="bar-vertex-handle w-3 h-3 rounded-full border-2 border-amber-500 bg-white pointer-events-auto cursor-move z-10 shadow focus:outline-none focus:ring-2 focus:ring-amber-400"
                                                  tabindex="0"
                                                  @focus="focusedVertexIdx = idx"
                                                  @blur="if (focusedVertexIdx === idx) focusedVertexIdx = null"
+                                                 @pointerdown.stop
                                                  @mousedown.stop.prevent="startBarVertexDrag($event, bar, idx)"
                                                  :aria-label="`Vértice ${idx + 1} de la barra`">
                                             </div>
                                             <div x-show="bar.vertices.length > 3"
-                                                 class="absolute -top-2 -right-2 z-[11] w-3.5 h-3.5 rounded-full bg-red-500 text-white flex items-center justify-center leading-none pointer-events-auto cursor-pointer shadow text-[9px] font-bold select-none focus:outline-none focus:ring-2 focus:ring-red-400"
+                                                 class="bar-vertex-handle absolute -top-2 -right-2 z-[11] w-3.5 h-3.5 rounded-full bg-red-500 text-white flex items-center justify-center leading-none pointer-events-auto cursor-pointer shadow text-[9px] font-bold select-none focus:outline-none focus:ring-2 focus:ring-red-400"
                                                  role="button"
                                                  tabindex="0"
+                                                 @pointerdown.stop
                                                  @click.stop.prevent="removeBarVertex(bar, idx)"
                                                  @keydown.enter.space.stop.prevent="removeBarVertex(bar, idx)"
                                                  :aria-label="`Eliminar vértice ${idx + 1} de la barra`">×</div>
@@ -799,10 +871,11 @@
                                     </template>
                                     {{-- Botones "+" en el punto medio de cada arista para añadir vértices --}}
                                     <template x-for="(v, idx) in bar.vertices" :key="`e${idx}`">
-                                        <div class="absolute w-4 h-4 rounded-full bg-white border border-amber-500 pointer-events-auto cursor-pointer z-9 shadow flex items-center justify-center text-xs font-bold leading-none select-none text-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-400"
+                                        <div class="bar-vertex-handle absolute w-4 h-4 rounded-full bg-white border border-amber-500 pointer-events-auto cursor-pointer z-9 shadow flex items-center justify-center text-xs font-bold leading-none select-none text-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-400"
                                              :style="`left:${((v.x + bar.vertices[(idx+1)%bar.vertices.length].x)/2)-8}px; top:${((v.y + bar.vertices[(idx+1)%bar.vertices.length].y)/2)-8}px;`"
                                              role="button"
                                              tabindex="0"
+                                             @pointerdown.stop
                                              @click.stop.prevent="addBarVertex(bar, idx)"
                                              @keydown.enter.space.stop.prevent="addBarVertex(bar, idx)"
                                              :aria-label="`Añadir vértice en arista ${idx + 1}`">+</div>
@@ -906,19 +979,19 @@
                     >
                         <div class="w-full h-full relative flex items-center justify-center
                                     rounded-full
-                                    bg-amber-100 dark:bg-amber-900
-                                    border-2 border-amber-400 dark:border-amber-600
+                                    bg-green-50 dark:bg-green-900/30
+                                    border-2 border-green-400 dark:border-green-500
                                     shadow-md cursor-grab active:cursor-grabbing
                                     transition-shadow hover:shadow-lg"
                              :class="{'zampa-selected': isActive(stool.id)}"
                              @mousedown.prevent="startElementDrag($event, stool)">
 
-                            <span class="text-xs font-semibold text-amber-800 dark:text-amber-300
+                            <span class="text-xs font-semibold text-green-700 dark:text-green-300
                                          text-center px-1 leading-tight pointer-events-none"
                                   x-text="stool.name">
                             </span>
 
-                            <span class="absolute top-1 left-1 text-xs text-amber-600 dark:text-amber-400 pointer-events-none leading-none" aria-hidden="true">●</span>
+                            <span class="absolute top-1 left-1 text-xs text-green-500 dark:text-green-400 pointer-events-none leading-none" aria-hidden="true">●</span>
 
                             {{-- Botón eliminar --}}
                             <button type="button"
@@ -951,15 +1024,15 @@
                              :aria-label="`Rotar ${stool.name} (arrastra para girar)`">
                             <div class="w-6 h-6 rounded-full
                                         bg-white dark:bg-gray-800
-                                        border-2 border-amber-400 shadow-md
-                                        flex items-center justify-center text-amber-500
+                                        border-2 border-green-400 shadow-md
+                                        flex items-center justify-center text-green-500
                                         transition-all duration-150
-                                        hover:bg-amber-500 hover:border-amber-600 hover:text-white hover:scale-110">
+                                        hover:bg-green-500 hover:border-green-600 hover:text-white hover:scale-110">
                                 <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"/>
                                 </svg>
                             </div>
-                            <div class="w-px h-3 bg-amber-400"></div>
+                            <div class="w-px h-3 bg-green-400"></div>
                         </div>
 
                         {{-- Handle de redimensionado --}}
@@ -969,9 +1042,226 @@
                              @mousedown.stop.prevent="startResize($event, stool)"
                              role="button"
                              :aria-label="`Redimensionar ${stool.name}`">
-                            <svg aria-hidden="true" viewBox="0 0 10 10" fill="none" class="w-full h-full text-amber-400">
+                            <svg aria-hidden="true" viewBox="0 0 10 10" fill="none" class="w-full h-full text-green-400">
                                 <path d="M9 1L1 9M9 5L5 9M9 9H9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
                             </svg>
+                        </div>
+                    </div>
+                </template>
+
+                {{-- Sillas: drag Alpine-nativo --}}
+                <template x-for="chair in visibleElements().filter(e => e.shape === 'chair')" :key="'c'+chair.id">
+                    <div
+                        :data-table-id="chair.id"
+                        class="element-item absolute group select-none touch-none"
+                        tabindex="0"
+                        @focus="selectedId = chair.id; editingTableId=null; editingTable=null; editingZoneId=null; editingZone=null;"
+                        @keydown.enter.space.prevent.stop="selectedId = chair.id; editingTableId=null; editingTable=null; editingZoneId=null; editingZone=null;"
+                        :style="`left:${chair.position_x}px; top:${chair.position_y}px;
+                                 width:${chair.width}px; height:${chair.height}px;
+                                 transform:rotate(${chair.rotation ?? 0}deg);
+                                 transform-origin:center;
+                                 z-index:${hoveredId === chair.id || selectedId === chair.id || rotatingId === chair.id ? 30 : 10};`"
+                        @mouseenter="hoveredId = chair.id"
+                        @mouseleave="hoveredId = null"
+                        @click.stop="selectedId = chair.id; editingTableId = null; editingTable = null; editingZoneId = null; editingZone = null;"
+                        @contextmenu.prevent.stop="openContextMenu($event, chair, 'stool')"
+                        @keydown.stop="if ($event.key === 'ContextMenu' || ($event.shiftKey && $event.key === 'F10')) openContextMenu($event, chair, 'stool')"
+                        :aria-label="`Silla: ${chair.name}`"
+                    >
+                        <div class="w-full h-full relative flex flex-col items-center justify-center
+                                    rounded
+                                    bg-green-50 dark:bg-green-900/30
+                                    border-2 border-green-400 dark:border-green-500
+                                    shadow-md cursor-grab active:cursor-grabbing
+                                    transition-shadow hover:shadow-lg"
+                             :class="{'zampa-selected': isActive(chair.id)}"
+                             @mousedown.prevent="startElementDrag($event, chair)">
+
+                            {{-- Respaldo visual --}}
+                            <div class="w-4/5 h-1/3 rounded-t bg-green-200 dark:bg-green-700 border border-green-400 dark:border-green-500 pointer-events-none"></div>
+
+                            <span class="text-[9px] font-semibold text-green-700 dark:text-green-300
+                                         text-center leading-tight pointer-events-none mt-0.5"
+                                  x-text="chair.name">
+                            </span>
+
+                            {{-- Botón eliminar --}}
+                            <button type="button"
+                                    x-show="!(isRotating && rotatingId === chair.id)"
+                                    @mousedown.stop
+                                    @click.stop="deleteElement(chair)"
+                                    class="absolute -top-2.5 -right-2.5
+                                           w-6 h-6 rounded-full bg-red-500 text-white
+                                           flex items-center justify-center transition-opacity
+                                           hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400
+                                           shadow-md"
+                                    :class="selectedId === chair.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'"
+                                    :tabindex="selectedId === chair.id || hoveredId === chair.id ? 0 : -1"
+                                    :aria-label="`Eliminar ${chair.name}`">
+                                <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+                                </svg>
+                            </button>
+                        </div>
+
+                        {{-- Handle de rotación --}}
+                        <div class="rotation-handle absolute -top-9 left-1/2 -translate-x-1/2
+                                    flex flex-col items-center gap-0
+                                    transition-opacity z-10"
+                             :class="selectedId === chair.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'"
+                             @mousedown.stop.prevent="startRotation($event, chair)"
+                             role="button"
+                             tabindex="0"
+                             style="cursor: url('data:image/svg+xml,%3Csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2720%27 height=%2720%27 viewBox=%270 0 24 24%27 fill=%27none%27 stroke-linecap=%27round%27 stroke-linejoin=%27round%27%3E%3Cpath d=%27M21 2v6h-6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 12a9 9 0 0 1 15-6.7L21 8%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M3 22v-6h6%27 stroke=%27%23ffffff%27 stroke-width=%275%27/%3E%3Cpath d=%27M21 12a9 9 0 0 1-15 6.7L3 16%27 stroke=%27%23111827%27 stroke-width=%272.5%27/%3E%3C/svg%3E') 10 10, grab;"
+                             :aria-label="`Rotar ${chair.name} (arrastra para girar)`">
+                            <div class="w-6 h-6 rounded-full
+                                        bg-white dark:bg-gray-800
+                                        border-2 border-green-400 shadow-md
+                                        flex items-center justify-center text-green-500
+                                        transition-all duration-150
+                                        hover:bg-green-500 hover:border-green-600 hover:text-white hover:scale-110">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true">
+                                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"/>
+                                </svg>
+                            </div>
+                            <div class="w-px h-3 bg-green-400"></div>
+                        </div>
+
+                        {{-- Handle de redimensionado --}}
+                        <div class="resize-handle absolute bottom-0 right-0
+                                    w-4 h-4 cursor-se-resize opacity-0 group-hover:opacity-100
+                                    transition-opacity"
+                             @mousedown.stop.prevent="startResize($event, chair)"
+                             role="button"
+                             :aria-label="`Redimensionar ${chair.name}`">
+                            <svg aria-hidden="true" viewBox="0 0 10 10" fill="none" class="w-full h-full text-green-400">
+                                <path d="M9 1L1 9M9 5L5 9M9 9H9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                            </svg>
+                        </div>
+                    </div>
+                </template>
+
+                {{-- Chimeneas --}}
+                <template x-for="fp in visibleElements().filter(e => e.shape === 'fireplace')" :key="'fp'+fp.id">
+                    <div :data-table-id="fp.id"
+                         class="element-item absolute group select-none touch-none"
+                         tabindex="0"
+                         @focus="selectedId = fp.id; editingTableId=null; editingTable=null; editingZoneId=null; editingZone=null;"
+                         @keydown.enter.space.prevent.stop="selectedId = fp.id;"
+                         :style="`left:${fp.position_x}px; top:${fp.position_y}px; width:${fp.width}px; height:${fp.height}px; transform:rotate(${fp.rotation ?? 0}deg); transform-origin:center; z-index:${hoveredId === fp.id || selectedId === fp.id ? 30 : 10};`"
+                         @mouseenter="hoveredId = fp.id" @mouseleave="hoveredId = null"
+                         @click.stop="selectedId = fp.id; editingTableId=null; editingTable=null; editingZoneId=null; editingZone=null;"
+                         @contextmenu.prevent.stop="openContextMenu($event, fp, 'stool')"
+                         :aria-label="`Chimenea: ${fp.name}`">
+                        <div class="w-full h-full relative flex items-center justify-center rounded bg-red-100 dark:bg-red-900/40 border-2 border-red-700 dark:border-red-600 shadow-md cursor-grab active:cursor-grabbing transition-shadow hover:shadow-lg"
+                             :class="{'zampa-selected': isActive(fp.id)}"
+                             @mousedown.prevent="startElementDrag($event, fp)">
+                            <span class="text-lg pointer-events-none" aria-hidden="true">🔥</span>
+                            <span class="absolute bottom-0.5 left-0 right-0 text-[9px] font-semibold text-red-800 dark:text-red-300 text-center pointer-events-none" x-text="fp.name"></span>
+                            <button type="button" @mousedown.stop @click.stop="deleteElement(fp)"
+                                    class="absolute -top-2.5 -right-2.5 w-6 h-6 rounded-full bg-red-500 text-white flex items-center justify-center transition-opacity hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400 shadow-md"
+                                    :class="selectedId === fp.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'"
+                                    :tabindex="selectedId === fp.id || hoveredId === fp.id ? 0 : -1"
+                                    :aria-label="`Eliminar ${fp.name}`">
+                                <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                            </button>
+                        </div>
+                        <div class="rotation-handle absolute -top-9 left-1/2 -translate-x-1/2 flex flex-col items-center gap-0 transition-opacity z-10"
+                             :class="selectedId === fp.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'"
+                             @mousedown.stop.prevent="startRotation($event, fp)" role="button" tabindex="0"
+                             style="cursor:grab;" :aria-label="`Rotar ${fp.name}`">
+                            <div class="w-6 h-6 rounded-full bg-white dark:bg-gray-800 border-2 border-red-500 shadow-md flex items-center justify-center text-red-500 transition-all hover:bg-red-500 hover:text-white hover:scale-110">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"/></svg>
+                            </div>
+                            <div class="w-px h-3 bg-red-500"></div>
+                        </div>
+                        <div class="resize-handle absolute bottom-0 right-0 w-4 h-4 cursor-se-resize opacity-0 group-hover:opacity-100 transition-opacity"
+                             @mousedown.stop.prevent="startResize($event, fp)" role="button" :aria-label="`Redimensionar ${fp.name}`">
+                            <svg aria-hidden="true" viewBox="0 0 10 10" fill="none" class="w-full h-full text-red-500"><path d="M9 1L1 9M9 5L5 9M9 9H9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+                        </div>
+                    </div>
+                </template>
+
+                {{-- Pilares --}}
+                <template x-for="pl in visibleElements().filter(e => e.shape === 'pillar')" :key="'pl'+pl.id">
+                    <div :data-table-id="pl.id"
+                         class="element-item absolute group select-none touch-none"
+                         tabindex="0"
+                         @focus="selectedId = pl.id; editingTableId=null; editingTable=null; editingZoneId=null; editingZone=null;"
+                         @keydown.enter.space.prevent.stop="selectedId = pl.id;"
+                         :style="`left:${pl.position_x}px; top:${pl.position_y}px; width:${pl.width}px; height:${pl.height}px; transform:rotate(${pl.rotation ?? 0}deg); transform-origin:center; z-index:${hoveredId === pl.id || selectedId === pl.id ? 30 : 10};`"
+                         @mouseenter="hoveredId = pl.id" @mouseleave="hoveredId = null"
+                         @click.stop="selectedId = pl.id; editingTableId=null; editingTable=null; editingZoneId=null; editingZone=null;"
+                         @contextmenu.prevent.stop="openContextMenu($event, pl, 'stool')"
+                         :aria-label="`Pilar: ${pl.name}`">
+                        <div class="w-full h-full relative flex items-center justify-center rounded-full bg-gray-200 dark:bg-gray-600 border-2 border-gray-500 dark:border-gray-400 shadow-md cursor-grab active:cursor-grabbing transition-shadow hover:shadow-lg"
+                             :class="{'zampa-selected': isActive(pl.id)}"
+                             @mousedown.prevent="startElementDrag($event, pl)">
+                            <span class="text-[9px] font-bold text-gray-600 dark:text-gray-300 pointer-events-none" x-text="pl.name"></span>
+                            <button type="button" @mousedown.stop @click.stop="deleteElement(pl)"
+                                    class="absolute -top-2.5 -right-2.5 w-6 h-6 rounded-full bg-red-500 text-white flex items-center justify-center transition-opacity hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400 shadow-md"
+                                    :class="selectedId === pl.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'"
+                                    :tabindex="selectedId === pl.id || hoveredId === pl.id ? 0 : -1"
+                                    :aria-label="`Eliminar ${pl.name}`">
+                                <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                            </button>
+                        </div>
+                        <div class="rotation-handle absolute -top-9 left-1/2 -translate-x-1/2 flex flex-col items-center gap-0 transition-opacity z-10"
+                             :class="selectedId === pl.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'"
+                             @mousedown.stop.prevent="startRotation($event, pl)" role="button" tabindex="0" style="cursor:grab"
+                             :aria-label="`Rotar ${pl.name}`">
+                            <div class="w-6 h-6 rounded-full bg-white dark:bg-gray-800 border-2 border-gray-500 shadow-md flex items-center justify-center text-gray-500 transition-all hover:bg-gray-500 hover:text-white hover:scale-110">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"/></svg>
+                            </div>
+                            <div class="w-px h-3 bg-gray-500"></div>
+                        </div>
+                        <div class="resize-handle absolute bottom-0 right-0 w-4 h-4 cursor-se-resize opacity-0 group-hover:opacity-100 transition-opacity"
+                             @mousedown.stop.prevent="startResize($event, pl)" role="button" :aria-label="`Redimensionar ${pl.name}`">
+                            <svg aria-hidden="true" viewBox="0 0 10 10" fill="none" class="w-full h-full text-gray-400"><path d="M9 1L1 9M9 5L5 9M9 9H9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+                        </div>
+                    </div>
+                </template>
+
+                {{-- Columnas --}}
+                <template x-for="col in visibleElements().filter(e => e.shape === 'column')" :key="'col'+col.id">
+                    <div :data-table-id="col.id"
+                         class="element-item absolute group select-none touch-none"
+                         tabindex="0"
+                         @focus="selectedId = col.id; editingTableId=null; editingTable=null; editingZoneId=null; editingZone=null;"
+                         @keydown.enter.space.prevent.stop="selectedId = col.id;"
+                         :style="`left:${col.position_x}px; top:${col.position_y}px; width:${col.width}px; height:${col.height}px; transform:rotate(${col.rotation ?? 0}deg); transform-origin:center; z-index:${hoveredId === col.id || selectedId === col.id ? 30 : 10};`"
+                         @mouseenter="hoveredId = col.id" @mouseleave="hoveredId = null"
+                         @click.stop="selectedId = col.id; editingTableId=null; editingTable=null; editingZoneId=null; editingZone=null;"
+                         @contextmenu.prevent.stop="openContextMenu($event, col, 'stool')"
+                         :aria-label="`Columna: ${col.name}`">
+                        <div class="w-full h-full relative flex items-center justify-center rounded-sm bg-gray-300 dark:bg-gray-500 border-2 border-gray-600 dark:border-gray-300 shadow-md cursor-grab active:cursor-grabbing transition-shadow hover:shadow-lg"
+                             :class="{'zampa-selected': isActive(col.id)}"
+                             @mousedown.prevent="startElementDrag($event, col)">
+                            {{-- Capitel y basa decorativos --}}
+                            <div class="absolute top-0 left-0 right-0 h-1.5 bg-gray-500 dark:bg-gray-300 rounded-t-sm pointer-events-none"></div>
+                            <div class="absolute bottom-0 left-0 right-0 h-1.5 bg-gray-500 dark:bg-gray-300 rounded-b-sm pointer-events-none"></div>
+                            <span class="text-[9px] font-bold text-gray-700 dark:text-gray-200 pointer-events-none" x-text="col.name"></span>
+                            <button type="button" @mousedown.stop @click.stop="deleteElement(col)"
+                                    class="absolute -top-2.5 -right-2.5 w-6 h-6 rounded-full bg-red-500 text-white flex items-center justify-center transition-opacity hover:bg-red-600 focus:outline-none focus:ring-2 focus:ring-red-400 shadow-md"
+                                    :class="selectedId === col.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'"
+                                    :tabindex="selectedId === col.id || hoveredId === col.id ? 0 : -1"
+                                    :aria-label="`Eliminar ${col.name}`">
+                                <svg aria-hidden="true" class="w-3 h-3" fill="none" stroke="currentColor" stroke-width="3" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                            </button>
+                        </div>
+                        <div class="rotation-handle absolute -top-9 left-1/2 -translate-x-1/2 flex flex-col items-center gap-0 transition-opacity z-10"
+                             :class="selectedId === col.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'"
+                             @mousedown.stop.prevent="startRotation($event, col)" role="button" tabindex="0" style="cursor:grab"
+                             :aria-label="`Rotar ${col.name}`">
+                            <div class="w-6 h-6 rounded-full bg-white dark:bg-gray-800 border-2 border-gray-500 shadow-md flex items-center justify-center text-gray-500 transition-all hover:bg-gray-500 hover:text-white hover:scale-110">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"/></svg>
+                            </div>
+                            <div class="w-px h-3 bg-gray-500"></div>
+                        </div>
+                        <div class="resize-handle absolute bottom-0 right-0 w-4 h-4 cursor-se-resize opacity-0 group-hover:opacity-100 transition-opacity"
+                             @mousedown.stop.prevent="startResize($event, col)" role="button" :aria-label="`Redimensionar ${col.name}`">
+                            <svg aria-hidden="true" viewBox="0 0 10 10" fill="none" class="w-full h-full text-gray-400"><path d="M9 1L1 9M9 5L5 9M9 9H9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
                         </div>
                     </div>
                 </template>
@@ -1008,11 +1298,11 @@
                                 'rounded-xl':      table.shape === 'square',
                                 'rounded-lg':      table.shape === 'rectangle',
                                 'zampa-selected':  isActive(table.id),
-                                'bg-indigo-100 dark:bg-indigo-900 border-indigo-300 dark:border-indigo-600':
+                                'bg-green-50 dark:bg-green-900/30 border-green-400 dark:border-green-500':
                                     !table.orderStatus || table.orderStatus === 'free',
                                 'bg-amber-100 dark:bg-amber-900/60 border-amber-400 dark:border-amber-500':
                                     table.orderStatus === 'occupied',
-                                'bg-green-100 dark:bg-green-900/60 border-green-500 dark:border-green-400 animate-pulse':
+                                'bg-emerald-200 dark:bg-emerald-800/60 border-emerald-500 dark:border-emerald-400 animate-pulse':
                                     table.orderStatus === 'ready',
                                 'bg-blue-100 dark:bg-blue-900/60 border-blue-400 dark:border-blue-500':
                                     table.orderStatus === 'payment_pending',
@@ -1022,10 +1312,10 @@
                             {{-- Nombre --}}
                             <span class="text-xs font-semibold text-center px-1 leading-tight pointer-events-none"
                                   :class="{
-                                      'text-indigo-700 dark:text-indigo-300': !table.orderStatus || table.orderStatus === 'free',
-                                      'text-amber-800 dark:text-amber-200':  table.orderStatus === 'occupied',
-                                      'text-green-800 dark:text-green-200':  table.orderStatus === 'ready',
-                                      'text-blue-800  dark:text-blue-200':   table.orderStatus === 'payment_pending',
+                                      'text-green-700 dark:text-green-300':   !table.orderStatus || table.orderStatus === 'free',
+                                      'text-amber-800 dark:text-amber-200':   table.orderStatus === 'occupied',
+                                      'text-emerald-800 dark:text-emerald-200': table.orderStatus === 'ready',
+                                      'text-blue-800  dark:text-blue-200':    table.orderStatus === 'payment_pending',
                                   }"
                                   x-text="table.name">
                             </span>
@@ -2292,6 +2582,14 @@
                 <section>
                     <h3 class="text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500 mb-3">General</h3>
                     <dl class="space-y-2.5">
+                        <div class="flex items-center justify-between gap-4">
+                            <dt class="text-sm text-gray-700 dark:text-gray-300">Copiar elemento seleccionado</dt>
+                            <dd class="flex items-center gap-1 shrink-0"><kbd>Ctrl</kbd><span class="text-gray-400 text-[11px] font-medium select-none mx-px">+</span><kbd>C</kbd></dd>
+                        </div>
+                        <div class="flex items-center justify-between gap-4">
+                            <dt class="text-sm text-gray-700 dark:text-gray-300">Pegar copia</dt>
+                            <dd class="flex items-center gap-1 shrink-0"><kbd>Ctrl</kbd><span class="text-gray-400 text-[11px] font-medium select-none mx-px">+</span><kbd>V</kbd></dd>
+                        </div>
                         <div class="flex items-center justify-between gap-4">
                             <dt class="text-sm text-gray-700 dark:text-gray-300">Eliminar elemento seleccionado</dt>
                             <dd class="flex items-center gap-1 shrink-0"><kbd>Delete</kbd><span class="text-gray-400 dark:text-gray-400 text-[11px] font-medium select-none mx-0.5"> / </span><kbd>Backspace</kbd></dd>


### PR DESCRIPTION
## Summary

- Nuevos elementos especiales en paleta + canvas: **silla, chimenea, pilar, columna**
- Extensión del ENUM `shape` en BD (migración) + validación en `TableController`
- Colores unificados de mesas/mobiliario alineados con leyenda (verde=libre, ámbar=ocupada, esmeralda=lista, azul=cobro)
- Sistema de colisión tipo zona: arrastre libre sin bloqueo, snap-back si hay superposición al soltar
- Fix bug `hasCollision` que bloqueaba rotación/resize en formas nuevas (auto-colisión con sí mismo)
- Fix arrastre de vértices de barra poligonal (`pointerdown` capture + `bar-vertex-handle` en `ignoreFrom`)
- Handles de rotación añadidos a pilar y columna
- Copiar/pegar elementos con **Ctrl+C / Ctrl+V** conservando forma, tamaño y rotación
- `rotation` enviada al backend al crear elemento desde paleta y al pegar
- Canvas auto-fit en modo vista sin cap mínimo 0.5 + listener `window.resize`
- `DatabaseSeeder` actualizado con layout real del negocio: 12 categorías, 16 mesas, 66 elementos de mobiliario, 2 zonas, canvas 1600×1000

## Test plan

- [ ] Arrastrar silla/chimenea/pilar/columna desde paleta → se crea sin error SQL
- [ ] Rotar y redimensionar todos los elementos nuevos y mesas
- [ ] Arrastrar mesa sobre otra → snap-back + toast
- [ ] Barra en modo polígono → mover vértice sin mover la barra entera
- [ ] Ctrl+C en mesa rotada → Ctrl+V → copia con misma rotación
- [ ] Cambiar tamaño de ventana en modo vista → canvas recalcula zoom
- [ ] `php artisan migrate:fresh --seed` → mapa con layout real