### PR TITLE
feat: manual product sort order with drag and drop

### DIFF
--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -62,6 +62,7 @@ class MenuController extends Controller
                                   },
                                   'variants',
                               ])
+                              ->orderBy('sort_order')
                               ->orderBy('name');
                     },
                 ])

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -44,6 +44,8 @@ class ProductController extends Controller
       ->when($request->filled('search'), fn ($q) => $q->where('name', 'like', '%' . $request->search . '%'))
       ->when($request->filled('category'), fn ($q) => $q->whereHas('categories', fn ($q2) => $q2->where('categories.id', $request->category)))
       ->when($request->filled('allergen'), fn ($q) => $q->whereHas('ingredients', fn ($q2) => $q2->whereJsonContains('allergen_types', $request->allergen)))
+      ->orderBy('sort_order')
+      ->orderBy('id')
       ->paginate(15)
       ->withQueryString();
 
@@ -88,6 +90,8 @@ class ProductController extends Controller
     ]);
 
     $validatedData['user_id'] = Auth::user()->ownerUserId();
+
+    $validatedData['sort_order'] = Product::where('user_id', $validatedData['user_id'])->max('sort_order') + 1;
 
     if ($hasVariants) {
       $validatedData['price'] = null;
@@ -270,6 +274,36 @@ class ProductController extends Controller
                                  ->get();
 
         return view('products.ingredients', compact('product', 'ingredients'));
+    }
+
+    /**
+     * Persiste el orden manual de productos arrastrado por el usuario.
+     * Recibe un array de IDs en el nuevo orden; asigna sort_order = offset + posición.
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function reorder(Request $request): \Illuminate\Http\JsonResponse
+    {
+        $validated = $request->validate([
+            'ids'    => 'required|array|min:1',
+            'ids.*'  => 'required|integer',
+            'offset' => 'required|integer|min:0',
+        ]);
+
+        $ownerId = Auth::user()->ownerUserId();
+
+        DB::transaction(function () use ($validated, $ownerId) {
+            foreach ($validated['ids'] as $index => $id) {
+                Product::where('id', $id)
+                    ->where('user_id', $ownerId)
+                    ->update(['sort_order' => $validated['offset'] + $index]);
+            }
+        });
+
+        Cache::forget("menu:{$ownerId}");
+
+        return response()->json(['success' => true]);
     }
 
     /**

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -56,7 +56,8 @@ class Product extends Model
         'description',
         'price',
         'is_active',
-        'image'
+        'image',
+        'sort_order',
     ];
 
     /**

--- a/database/migrations/2026_06_02_000003_add_sort_order_to_products_table.php
+++ b/database/migrations/2026_06_02_000003_add_sort_order_to_products_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Añade sort_order a products para permitir ordenación manual en la carta.
+ * Productos existentes quedan con sort_order=0; el primer drag los ordena correctamente.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->unsignedInteger('sort_order')->default(0)->after('image');
+            $table->index(['user_id', 'sort_order'], 'products_user_sort_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropIndex('products_user_sort_index');
+            $table->dropColumn('sort_order');
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "sortablejs": "^1.15.7"
+            },
             "devDependencies": {
                 "@tailwindcss/forms": "^0.5.2",
                 "@tailwindcss/vite": "^4.0.0",
@@ -3830,6 +3833,12 @@
             "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/sortablejs": {
+            "version": "1.15.7",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
+            "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
+            "license": "MIT"
         },
         "node_modules/source-map-js": {
             "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
         "tailwindcss": "^3.1.0",
         "vite": "^7.0.7",
         "vitest": "^4.1.7"
+    },
+    "dependencies": {
+        "sortablejs": "^1.15.7"
     }
 }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -12,6 +12,7 @@ import { registerBill }          from './alpine/bill.js';
 import { registerOrders }        from './alpine/orders.js';
 import { registerChatWidget }    from './alpine/chat-widget.js';
 import { registerTableMap }      from './pages/table-map.js';
+import { initProductReorder }   from './pages/product-reorder.js';
 import { registerLanding }       from './alpine/landing.js';
 
 window.Alpine = Alpine;
@@ -32,3 +33,5 @@ document.addEventListener('alpine:init', () => {
 });
 
 Alpine.start();
+
+initProductReorder();

--- a/resources/js/pages/product-reorder.js
+++ b/resources/js/pages/product-reorder.js
@@ -1,0 +1,53 @@
+import Sortable from 'sortablejs';
+
+/**
+ * Drag-and-drop reordering for the products admin table.
+ * Reads config from data attributes on the tbody element.
+ */
+export function initProductReorder() {
+    const tbody = document.querySelector('tbody[data-reorder-url]');
+    if (!tbody) return;
+
+    const reorderUrl  = tbody.dataset.reorderUrl;
+    const offset      = parseInt(tbody.dataset.offset, 10);
+    const csrfToken   = document.querySelector('meta[name="csrf-token"]').content;
+    const feedbackOk  = document.getElementById('reorder-feedback');
+    const feedbackErr = document.getElementById('reorder-error');
+    let feedbackTimer = null;
+
+    function showFeedback(el) {
+        [feedbackOk, feedbackErr].forEach(e => e && e.classList.add('hidden'));
+        if (el) {
+            el.classList.remove('hidden');
+            clearTimeout(feedbackTimer);
+            feedbackTimer = setTimeout(() => el.classList.add('hidden'), 3000);
+        }
+    }
+
+    Sortable.create(tbody, {
+        handle: '.drag-handle',
+        animation: 180,
+        easing: 'cubic-bezier(0.25, 1, 0.5, 1)',
+        ghostClass: 'sortable-ghost',
+        dragClass: 'sortable-drag',
+        onEnd() {
+            const ids = Array.from(tbody.querySelectorAll('tr[data-product-id]'))
+                            .map(tr => parseInt(tr.dataset.productId, 10));
+
+            fetch(reorderUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': csrfToken,
+                    'Accept': 'application/json',
+                },
+                body: JSON.stringify({ ids, offset }),
+            })
+            .then(res => {
+                if (!res.ok) throw new Error('server error');
+                showFeedback(feedbackOk);
+            })
+            .catch(() => showFeedback(feedbackErr));
+        },
+    });
+}

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -1,3 +1,8 @@
+@php
+  $filtersActive = request()->hasAny(['search', 'category', 'allergen']);
+  $pageOffset    = $products->firstItem() ? $products->firstItem() - 1 : 0;
+@endphp
+
 <x-app-layout>
   <div class="max-w-6xl mx-auto px-4 sm:px-6 py-6 mt-4 sm:mt-10">
 
@@ -83,6 +88,29 @@
       @endif
     </form>
 
+    {{-- Banner reordenación --}}
+    @if($filtersActive)
+    <div class="rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 p-3 mb-4 flex items-center gap-2.5">
+      <svg class="h-4 w-4 text-amber-500 shrink-0" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 110 20A10 10 0 0112 2z"/>
+      </svg>
+      <p class="text-xs text-amber-800 dark:text-amber-300">Desactiva los filtros para reordenar la carta con drag & drop.</p>
+    </div>
+    @else
+    <div id="reorder-feedback" class="hidden rounded-md bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-700 p-3 mb-4 flex items-center gap-2.5" aria-live="polite">
+      <svg class="h-4 w-4 text-emerald-500 shrink-0" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+      </svg>
+      <p class="text-xs text-emerald-800 dark:text-emerald-300">Orden guardado en la carta.</p>
+    </div>
+    <div id="reorder-error" class="hidden rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 p-3 mb-4 flex items-center gap-2.5" aria-live="assertive">
+      <svg class="h-4 w-4 text-red-500 shrink-0" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+      </svg>
+      <p class="text-xs text-red-800 dark:text-red-300">Error al guardar el orden. Inténtalo de nuevo.</p>
+    </div>
+    @endif
+
     {{-- Flash de éxito --}}
     @if(session('success'))
     <div role="alert" aria-live="polite"
@@ -100,6 +128,13 @@
         <caption class="sr-only">Listado de productos de mi carta digital</caption>
         <thead class="bg-gray-50 dark:bg-gray-700">
           <tr>
+            {{-- Drag handle --}}
+            <th scope="col" class="w-10 px-3 py-3 @if($filtersActive) opacity-30 @endif" aria-label="Reordenar">
+              <svg class="h-4 w-4 text-gray-400 mx-auto" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/>
+              </svg>
+            </th>
+
             {{-- Imagen --}}
             <th scope="col" class="hidden sm:table-cell px-4 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
               <span class="inline-flex items-center gap-1.5">
@@ -147,9 +182,32 @@
           </tr>
         </thead>
 
-        <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+        <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700"
+               @if(!$filtersActive) data-reorder-url="{{ route('products.reorder') }}" data-offset="{{ $pageOffset }}" @endif>
           @forelse($products as $product)
-          <tr class="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
+          <tr class="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors" data-product-id="{{ $product->id }}">
+
+            {{-- Drag handle --}}
+            <td class="w-10 px-3 py-4 text-center">
+              @if(!$filtersActive)
+              <span class="drag-handle inline-flex items-center justify-center w-7 h-7 rounded cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors"
+                    aria-label="Arrastrar para reordenar {{ $product->name }}" role="button" tabindex="0">
+                <svg class="h-4 w-4" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
+                  <circle cx="9" cy="5" r="1.5"/><circle cx="15" cy="5" r="1.5"/>
+                  <circle cx="9" cy="12" r="1.5"/><circle cx="15" cy="12" r="1.5"/>
+                  <circle cx="9" cy="19" r="1.5"/><circle cx="15" cy="19" r="1.5"/>
+                </svg>
+              </span>
+              @else
+              <span class="inline-flex items-center justify-center w-7 h-7 text-gray-300 dark:text-gray-600 cursor-not-allowed" aria-hidden="true">
+                <svg class="h-4 w-4" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
+                  <circle cx="9" cy="5" r="1.5"/><circle cx="15" cy="5" r="1.5"/>
+                  <circle cx="9" cy="12" r="1.5"/><circle cx="15" cy="12" r="1.5"/>
+                  <circle cx="9" cy="19" r="1.5"/><circle cx="15" cy="19" r="1.5"/>
+                </svg>
+              </span>
+              @endif
+            </td>
 
             {{-- Imagen / Placeholder --}}
             <td class="hidden sm:table-cell px-4 sm:px-6 py-4 whitespace-nowrap">
@@ -290,7 +348,7 @@
           @empty
           {{-- Estado vacío --}}
           <tr>
-            <td colspan="5" class="px-6 py-16 text-center">
+            <td colspan="6" class="px-6 py-16 text-center">
               <div class="flex flex-col items-center gap-3">
                 <div class="h-16 w-16 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
                   <svg class="h-8 w-8 text-gray-300 dark:text-gray-600" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -323,4 +381,14 @@
     @endif
 
   </div>
+
+@if(!$filtersActive)
+<style>
+  .sortable-ghost { opacity: 0.4; background: #eef2ff; }
+  .dark .sortable-ghost { background: #1e1b4b; }
+  .sortable-drag { box-shadow: 0 8px 24px rgba(0,0,0,.15); background: white; }
+  .dark .sortable-drag { background: #1f2937; }
+</style>
+@endif
+
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -49,6 +49,7 @@ Route::middleware(['auth', 'business.active'])->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
     Route::resource('categories', CategoryController::class);
     Route::resource('ingredients', IngredientController::class);
+    Route::post('/productos/reorder', [ProductController::class, 'reorder'])->name('products.reorder');
     Route::resource('products', ProductController::class);
     Route::get('/productos/{product}/ingredientes', [ProductController::class, 'editIngredients'])
          ->name('products.ingredients.edit');


### PR DESCRIPTION
## Summary

- Adds `sort_order` column to `products` table (migration + index on `user_id, sort_order`)
- New products auto-assign `sort_order = max + 1` so they appear at the bottom
- Admin panel: drag-and-drop reordering via SortableJS (180ms smooth animation)
- Drag handles disabled automatically when filters are active
- AJAX `POST /productos/reorder` endpoint persists order + clears menu cache
- Public menu (`MenuController`) now respects `sort_order`

## Test plan

- [ ] Run `php artisan migrate` to apply migration
- [ ] Go to `/products` — drag handle column visible on left
- [ ] Drag a product row — smooth animation, row moves, "Orden guardado en la carta" toast appears
- [ ] Reload page — new order persists
- [ ] Apply a filter (search/category/allergen) — drag handles grey out, amber info banner shows
- [ ] Check public menu via QR — products appear in the dragged order
- [ ] Create a new product — appears at the bottom of the list