### PR TITLE
fix(tapas): qty en carrito, animaciones y reactividad desde detalle

### DIFF
--- a/public/css/carta/themes/themes.css
+++ b/public/css/carta/themes/themes.css
@@ -872,6 +872,11 @@
   max-width: calc(100% - 32px);
 }
 
+/* ── Alpine x-transition helpers (usan variables del DS, sin Tailwind) ── */
+.x-slide-in  { transition: opacity 220ms var(--ease-out), transform 220ms var(--ease-out); }
+.x-slide-up  { opacity: 0; transform: translateY(-8px) scale(0.97); }
+.x-slide-vis { opacity: 1; transform: translateY(0)    scale(1);    }
+
 
 /* ============================================================
    Tapas modal â€” REDISEÃ‘O "tasca artesanal"

--- a/resources/js/alpine/menu-filters.js
+++ b/resources/js/alpine/menu-filters.js
@@ -173,7 +173,16 @@ export function registerMenuFilters() {
                 const targetQty  = this.pdetailQty;
 
                 if (targetQty > currentQty) {
-                    for (let i = 0; i < targetQty - currentQty; i++) cart.add(product);
+                    if (!cartItem) {
+                        // Primer añadido: usa add() para inicializar el item en el store
+                        cart.add(product);
+                        const added = cart.items.find(i => i._key === key);
+                        if (added && targetQty > 1) added.quantity = targetQty;
+                    } else {
+                        // Item ya existe: actualiza quantity directamente y notifica tapas
+                        cartItem.quantity = targetQty;
+                        if (product.destination === 'bar') cart._checkTapaSuggestion();
+                    }
                 } else if (targetQty < currentQty) {
                     for (let i = 0; i < currentQty - targetQty; i++) cart.dec(key);
                 }

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1599,18 +1599,16 @@
                                                         <span style="font-family:var(--font-body);font-size:11px;font-weight:700;color:var(--color-amber-800);background:linear-gradient(135deg,#F5DC92,#ECC25A);padding:3px 8px;border-radius:9999px;white-space:nowrap;">
                                                             🫕 Cortesía
                                                         </span>
-                                                        <template x-if="item.quantity > 1">
-                                                            <div class="qty">
-                                                                <button class="qty-minus"
-                                                                        @click="$store.cart.dec(item._key)"
-                                                                        aria-label="Quitar una tapa">−</button>
-                                                                <span class="qty-n" x-text="item.quantity"></span>
-                                                                <button class="qty-plus"
-                                                                        @click="$store.cart.addTapa($store.cart.tapaProducts.find(t => t.id === item.productId))"
-                                                                        :disabled="$store.cart._tapasTotal >= $store.cart._barItemsCount"
-                                                                        aria-label="Añadir una tapa más">+</button>
-                                                            </div>
-                                                        </template>
+                                                        <div class="qty">
+                                                            <button class="qty-minus"
+                                                                    @click="$store.cart.dec(item._key)"
+                                                                    aria-label="Quitar una tapa">−</button>
+                                                            <span class="qty-n" x-text="item.quantity"></span>
+                                                            <button class="qty-plus"
+                                                                    @click="$store.cart.addTapa($store.cart.tapaProducts.find(t => t.id === item.productId))"
+                                                                    :disabled="$store.cart._tapasTotal >= $store.cart._barItemsCount"
+                                                                    aria-label="Añadir una tapa más">+</button>
+                                                        </div>
                                                     </div>
                                                 </template>
                                                 {{-- Ítem normal: qty control --}}

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -949,12 +949,12 @@
         <button type="button"
                 class="tapas-indicator"
                 x-show="$store.cart.tapaConfig.enabled && $store.cart._barItemsCount > 0 && $store.cart._tapasTotal < $store.cart._barItemsCount"
-                x-transition:enter="transition ease-out duration-200"
-                x-transition:enter-start="opacity-0 translate-y-1"
-                x-transition:enter-end="opacity-100 translate-y-0"
-                x-transition:leave="transition ease-in duration-200"
-                x-transition:leave-start="opacity-100 translate-y-0 scale-100"
-                x-transition:leave-end="opacity-0 -translate-y-2 scale-95"
+                x-transition:enter="x-slide-in"
+                x-transition:enter-start="x-slide-up"
+                x-transition:enter-end="x-slide-vis"
+                x-transition:leave="x-slide-in"
+                x-transition:leave-start="x-slide-vis"
+                x-transition:leave-end="x-slide-up"
                 style="display:none"
                 @click="$store.cart.showTapaModal = true"
                 :aria-label="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) + ' ' + (Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) === 1 ? 'tapa' : 'tapas') + ' ' + ($store.cart.tapaConfig.free ? 'de cortesía' : 'incluidas') + ' — Pedir'">
@@ -1670,22 +1670,28 @@
                             <span class="cart-foot__totalVal"
                                   x-text="Number($store.cart.total).toFixed(2).replace('.',',') + ' €'"></span>
                         </div>
-                        <template x-if="$store.cart._tapaPending">
-                            <button type="button"
-                                    class="cart-foot__tapaPending"
-                                    @click="$store.cart.showTapaModal = true"
-                                    aria-live="polite"
-                                    :aria-label="'Tienes ' + Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) + ' tapa' + (Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) !== 1 ? 's' : '') + ' disponibles — Elegir'">
-                                <span class="cart-foot__tapaPending__ic" aria-hidden="true">🫕</span>
-                                <span class="cart-foot__tapaPending__txt">
-                                    Tienes <strong x-text="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal)"></strong>
-                                    tapa<template x-if="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) !== 1"><span>s</span></template>
-                                    disponible<template x-if="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) !== 1"><span>s</span></template>
-                                    — Elegir
-                                </span>
-                                <span class="cart-foot__tapaPending__arrow" aria-hidden="true">→</span>
-                            </button>
-                        </template>
+                        <button type="button"
+                                class="cart-foot__tapaPending"
+                                x-show="$store.cart._tapaPending"
+                                x-transition:enter="x-slide-in"
+                                x-transition:enter-start="x-slide-up"
+                                x-transition:enter-end="x-slide-vis"
+                                x-transition:leave="x-slide-in"
+                                x-transition:leave-start="x-slide-vis"
+                                x-transition:leave-end="x-slide-up"
+                                style="display:none"
+                                @click="$store.cart.showTapaModal = true"
+                                aria-live="polite"
+                                :aria-label="'Tienes ' + Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) + ' tapa' + (Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) !== 1 ? 's' : '') + ' disponibles — Elegir'">
+                            <span class="cart-foot__tapaPending__ic" aria-hidden="true">🫕</span>
+                            <span class="cart-foot__tapaPending__txt">
+                                Tienes <strong x-text="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal)"></strong>
+                                <span x-text="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) !== 1 ? 'tapas' : 'tapa'"></span>
+                                <span x-text="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) !== 1 ? 'disponibles' : 'disponible'"></span>
+                                — Elegir
+                            </span>
+                            <span class="cart-foot__tapaPending__arrow" aria-hidden="true">→</span>
+                        </button>
                         <button type="button"
                                 class="cart-foot__cta"
                                 :class="{ 'cart-foot__cta--sending': $store.cart.sending }"

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -952,9 +952,9 @@
                 x-transition:enter="transition ease-out duration-200"
                 x-transition:enter-start="opacity-0 translate-y-1"
                 x-transition:enter-end="opacity-100 translate-y-0"
-                x-transition:leave="transition ease-in duration-150"
-                x-transition:leave-start="opacity-100"
-                x-transition:leave-end="opacity-0"
+                x-transition:leave="transition ease-in duration-200"
+                x-transition:leave-start="opacity-100 translate-y-0 scale-100"
+                x-transition:leave-end="opacity-0 -translate-y-2 scale-95"
                 style="display:none"
                 @click="$store.cart.showTapaModal = true"
                 :aria-label="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) + ' ' + (Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) === 1 ? 'tapa' : 'tapas') + ' ' + ($store.cart.tapaConfig.free ? 'de cortesía' : 'incluidas') + ' — Pedir'">

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1607,6 +1607,7 @@
                                                                 <span class="qty-n" x-text="item.quantity"></span>
                                                                 <button class="qty-plus"
                                                                         @click="$store.cart.addTapa($store.cart.tapaProducts.find(t => t.id === item.productId))"
+                                                                        :disabled="$store.cart._tapasTotal >= $store.cart._barItemsCount"
                                                                         aria-label="Añadir una tapa más">+</button>
                                                             </div>
                                                         </template>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1593,11 +1593,24 @@
                                                 </template>
                                             </div>
                                             <div class="citem__side">
-                                                {{-- Tapa de cortesía: cantidad fija, sin controles --}}
+                                                {{-- Tapa de cortesía: badge + cantidad si qty > 1 --}}
                                                 <template x-if="item.isTapa">
-                                                    <span style="font-family:var(--font-body);font-size:11px;font-weight:700;color:var(--color-amber-800);background:linear-gradient(135deg,#F5DC92,#ECC25A);padding:3px 8px;border-radius:9999px;white-space:nowrap;">
-                                                        🫕 Cortesía
-                                                    </span>
+                                                    <div style="display:flex;flex-direction:column;align-items:flex-end;gap:4px;">
+                                                        <span style="font-family:var(--font-body);font-size:11px;font-weight:700;color:var(--color-amber-800);background:linear-gradient(135deg,#F5DC92,#ECC25A);padding:3px 8px;border-radius:9999px;white-space:nowrap;">
+                                                            🫕 Cortesía
+                                                        </span>
+                                                        <template x-if="item.quantity > 1">
+                                                            <div class="qty">
+                                                                <button class="qty-minus"
+                                                                        @click="$store.cart.dec(item._key)"
+                                                                        aria-label="Quitar una tapa">−</button>
+                                                                <span class="qty-n" x-text="item.quantity"></span>
+                                                                <button class="qty-plus"
+                                                                        @click="$store.cart.addTapa($store.cart.tapaProducts.find(t => t.id === item.productId))"
+                                                                        aria-label="Añadir una tapa más">+</button>
+                                                            </div>
+                                                        </template>
+                                                    </div>
                                                 </template>
                                                 {{-- Ítem normal: qty control --}}
                                                 <template x-if="!item.isTapa">


### PR DESCRIPTION
## Summary

- Muestra el control `−/N/+` en el carrito para tapas del mismo tipo (la cantidad ya se acumulaba en el store pero no se renderizaba)
- El botón `+` se deshabilita al alcanzar el límite de tapas disponibles (1 tapa por bebida de barra)
- Animaciones de entrada/salida en el indicador de tapas de la carta y en el botón de tapas pendientes del carrito, usando las variables CSS del DS (`--ease-out`, `--duration-fast`) sin mezclar Tailwind
- Corrige que al añadir un artículo de barra desde el modal de detalle, el contador de tapas disponibles no se actualizaba reactivamente

## Test plan

- [ ] Añadir la misma tapa varias veces: el carrito debe mostrar `−/N/+` con la cantidad correcta
- [ ] Agotar las tapas disponibles: el `+` se deshabilita, los controles siguen visibles
- [ ] Añadir cervezas desde la carta: el indicador "X tapas disponibles" aparece con animación
- [ ] Agotar tapas: el indicador desaparece con animación de salida
- [ ] Añadir artículo de barra desde el modal de detalle del producto: el contador de tapas disponibles se actualiza inmediatamente