### PR TITLE
feat(carta): polish visual del botón CTA — íconos DS, flecha, animaciones

### DIFF
--- a/public/css/carta/themes/themes.css
+++ b/public/css/carta/themes/themes.css
@@ -587,6 +587,7 @@
   box-shadow: var(--ctp-shadow-base);
   animation: tapa-attention 5s var(--ease-smooth) 0.8s infinite;
   transition: filter var(--duration-fast);
+  position: relative; overflow: hidden;
 }
 .cart-foot__tapaPending:hover { filter: brightness(1.07); }
 .cart-foot__tapaPending:active { transform: translateY(0); }
@@ -654,12 +655,12 @@
   font-family: var(--font-display); font-weight: 900; font-size: 15px;
 }
 .cart-foot__tapaPending__arrow {
-  flex-shrink: 0;
-  font-family: var(--font-display); font-weight: 900; font-size: 18px;
-  opacity: 0.85;
+  position: absolute; right: 16px; top: 50%; transform: translateY(-50%);
+  font-family: var(--font-display); font-weight: 900; font-size: 22px;
+  line-height: 1;
   transition: transform 200ms var(--ease-smooth);
 }
-.cart-foot__tapaPending:hover .cart-foot__tapaPending__arrow { transform: translateX(3px); }
+.cart-foot__tapaPending:hover .cart-foot__tapaPending__arrow { transform: translateY(-50%) translateX(3px); }
 
 /* Rebote + ring pulse usando CSS vars — se adapta a cada tema */
 @keyframes tapa-attention {

--- a/public/css/carta/themes/themes.css
+++ b/public/css/carta/themes/themes.css
@@ -890,10 +890,13 @@
   max-width: calc(100% - 32px);
 }
 
-/* ── Alpine x-transition helpers (usan variables del DS, sin Tailwind) ── */
+/* ── Alpine x-transition helpers (variables del DS, sin Tailwind) ── */
 .x-slide-in  { transition: opacity 220ms var(--ease-out), transform 220ms var(--ease-out); }
 .x-slide-up  { opacity: 0; transform: translateY(-8px) scale(0.97); }
-.x-slide-vis { opacity: 1; transform: translateY(0)    scale(1);    }
+.x-slide-vis { opacity: 1; transform: translateY(0) scale(1); }
+.x-modal-in   { transition: opacity 220ms var(--ease-out), transform 220ms var(--ease-smooth); }
+.x-modal-from { opacity: 0; transform: scale(0.93) translateY(8px); }
+.x-modal-vis  { opacity: 1; transform: scale(1) translateY(0); }
 
 
 /* ============================================================

--- a/public/css/carta/themes/themes.css
+++ b/public/css/carta/themes/themes.css
@@ -525,9 +525,26 @@
   transition: transform 140ms var(--ease-bounce), filter var(--duration-fast);
   position: relative; overflow: hidden;
 }
+.cart-foot__cta::after {
+  content: '';
+  position: absolute; inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 50% 50%, rgba(255,255,255,0.34) 0%, rgba(255,255,255,0.10) 60%, transparent 100%);
+  transform: scale(0);
+  opacity: 0;
+  animation: cta-radiance 3.5s var(--ease-smooth) 1s infinite;
+  pointer-events: none;
+}
+@keyframes cta-radiance {
+  0%   { transform: scale(0);    opacity: 0;    }
+  30%  { transform: scale(1);    opacity: 1;    }
+  70%  { transform: scale(1);    opacity: 0.6;  }
+  100% { transform: scale(1.4);  opacity: 0;    }
+}
 .cart-foot__cta:hover { filter: brightness(1.06); transform: translateY(-1px); }
 .cart-foot__cta:active { transform: translateY(0); }
 .cart-foot__cta:disabled { opacity: 0.6; cursor: wait; transform: none; }
+.cart-foot__cta:disabled::after { animation: none; }
 .cart-foot__ctaIc {
   width: 30px; height: 30px; border-radius: 9999px;
   background: rgba(255,255,255,0.18);

--- a/public/css/carta/themes/themes.css
+++ b/public/css/carta/themes/themes.css
@@ -761,7 +761,7 @@
   flex-shrink: 0;
 }
 .chip-quitar--on::before {
-  content: "âœ•";
+  content: "\2715";
   background: #FFFFFF;
   color: var(--color-amber-800);
 }

--- a/resources/js/alpine/cart.js
+++ b/resources/js/alpine/cart.js
@@ -378,10 +378,15 @@ export function registerCart() {
         },
 
         get sendLabel() {
-            const dests = [...new Set(this.items.map(i => i.destination).filter(Boolean))];
-            if (dests.length === 1 && dests[0] === 'bar')     return '🍺 Enviar pedido a barra';
-            if (dests.length === 1 && dests[0] === 'kitchen') return '🍽️ Enviar pedido a cocina';
-            return '🛎️ Enviar pedido';
+            const dests = [...new Set(this.items.filter(i => !i.isTapa).map(i => i.destination).filter(Boolean))];
+            if (dests.length === 1 && dests[0] === 'bar')     return 'Enviar pedido a barra';
+            if (dests.length === 1 && dests[0] === 'kitchen') return 'Enviar pedido a cocina';
+            return 'Enviar pedido';
+        },
+
+        get _isBarOnly() {
+            const dests = [...new Set(this.items.filter(i => !i.isTapa).map(i => i.destination).filter(Boolean))];
+            return dests.length === 1 && dests[0] === 'bar';
         },
 
         fmt(n) {

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1706,7 +1706,7 @@
                                     </svg>
                                 </template>
                                 <template x-if="!$store.cart.sending && !$store.cart.sent && !$store.cart._isBarOnly">
-                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <svg width="16" height="16" viewBox="-1 1 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                         <path d="M6 9a4 4 0 0 1 4-4 4 4 0 0 1 4 0 4 4 0 0 1 4 4 3 3 0 0 1-2 2.83V19a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2v-7.17A3 3 0 0 1 6 9z"/>
                                         <path d="M8 19h8"/>
                                     </svg>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1697,13 +1697,27 @@
                                 @click="$store.cart.send()"
                                 :disabled="$store.cart.sending">
                             <span class="cart-foot__ctaIc" aria-hidden="true">
-                                <template x-if="$store.cart.sent">✓</template>
+                                <template x-if="$store.cart.sent">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                                </template>
                                 <template x-if="$store.cart.sending && !$store.cart.sent">
-                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="animation:spin 1s linear infinite">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="animation:spin 1s linear infinite">
                                         <circle cx="12" cy="12" r="10" stroke-dasharray="31.4" stroke-dashoffset="10"/>
                                     </svg>
                                 </template>
-                                <template x-if="!$store.cart.sending && !$store.cart.sent">👨‍🍳</template>
+                                <template x-if="!$store.cart.sending && !$store.cart.sent && !$store.cart._isBarOnly">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                        <path d="M6 9a4 4 0 0 1 4-4 4 4 0 0 1 4 0 4 4 0 0 1 4 4 3 3 0 0 1-2 2.83V19a2 2 0 0 1-2 2H10a2 2 0 0 1-2-2v-7.17A3 3 0 0 1 6 9z"/>
+                                        <path d="M8 19h8"/>
+                                    </svg>
+                                </template>
+                                <template x-if="!$store.cart.sending && !$store.cart.sent && $store.cart._isBarOnly">
+                                    <svg width="16" height="16" viewBox="1 3 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                        <path d="M7 8h10v12a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V8z"/>
+                                        <path d="M17 11h2a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2h-2"/>
+                                        <path d="M10 12v6M14 12v6"/>
+                                    </svg>
+                                </template>
                             </span>
                             <span class="cart-foot__ctaLab"
                                   x-text="$store.cart.sending ? 'Enviando a cocina…' : ($store.cart.sent ? 'Pedido enviado' : $store.cart.sendLabel)"></span>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1682,13 +1682,12 @@
                                 style="display:none"
                                 @click="$store.cart.showTapaModal = true"
                                 aria-live="polite"
-                                :aria-label="'Tienes ' + Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) + ' tapa' + (Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) !== 1 ? 's' : '') + ' disponibles — Elegir'">
+                                :aria-label="'Tienes ' + Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) + ' tapa' + (Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) !== 1 ? 's' : '') + ' disponibles'">
                             <span class="cart-foot__tapaPending__ic" aria-hidden="true">🫕</span>
                             <span class="cart-foot__tapaPending__txt">
                                 Tienes <strong x-text="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal)"></strong>
                                 <span x-text="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) !== 1 ? 'tapas' : 'tapa'"></span>
                                 <span x-text="Math.max(0, $store.cart._barItemsCount - $store.cart._tapasTotal) !== 1 ? 'disponibles' : 'disponible'"></span>
-                                — Elegir
                             </span>
                             <span class="cart-foot__tapaPending__arrow" aria-hidden="true">→</span>
                         </button>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -3022,12 +3022,12 @@
         <div class="scrim scrim--center order-confirmed"
              x-show="$store.orders.confirmedOrder !== null"
              style="display:none"
-             x-transition:enter="transition duration-200"
-             x-transition:enter-start="opacity-0"
-             x-transition:enter-end="opacity-100"
-             x-transition:leave="transition duration-200"
-             x-transition:leave-start="opacity-100"
-             x-transition:leave-end="opacity-0"
+             x-transition:enter="x-modal-in"
+             x-transition:enter-start="x-modal-from"
+             x-transition:enter-end="x-modal-vis"
+             x-transition:leave="x-modal-in"
+             x-transition:leave-start="x-modal-vis"
+             x-transition:leave-end="x-modal-from"
              @click.self="$store.orders.dismissConfirmed()"
              role="dialog" aria-modal="true" aria-label="Pedido enviado">
 


### PR DESCRIPTION
## Summary

- Reemplaza emoji `👨‍🍳` por íconos SVG Lucide del DS (`IconChef` / `IconBeer`) en el botón enviar pedido; el ícono cambia según destino (barra → beer, cocina/mixto → chef hat)
- Flecha `→` del botón de tapas pendientes igualada en posición y grosor a la del botón enviar pedido (`position: absolute`, `font-size: 22px`)
- Eliminado el label "— Elegir" del botón de tapas en todos los breakpoints
- Animación de resplandor radial (`cta-radiance`) en el botón enviar pedido, 3.5s, se pausa al estar deshabilitado
- Animación de entrada/salida con escala + fade (`x-modal-*`) en el popup de pedido confirmado
- Getter `_isBarOnly` en el cart store para detectar pedidos exclusivamente de barra
- Clases helper `x-slide-*` y `x-modal-*` añadidas al DS CSS para transiciones Alpine sin dependencia de Tailwind

## Test plan

- [ ] Carrito con solo ítems de barra → botón muestra ícono beer centrado
- [ ] Carrito con ítems de cocina o mixto → botón muestra ícono chef hat centrado
- [ ] Botón enviar pedido → animación de resplandor radial cada 3.5s
- [ ] Botón de tapas disponibles → flecha alineada a la derecha igual que enviar pedido
- [ ] Enviar pedido → popup aparece con escala+fade y desaparece con animación de salida