### PR TITLE
feat: product availability management for kitchen and bar panels

### DIFF
--- a/app/Http/Controllers/Api/OrderController.php
+++ b/app/Http/Controllers/Api/OrderController.php
@@ -81,6 +81,13 @@ class OrderController extends Controller
             $variantId = $itemData['variant_id'] ?? null;
             $variant   = null;
 
+            if (! $product->is_active || ! $product->is_available) {
+                return response()->json([
+                    'success' => false,
+                    'message' => '"' . $product->name . '" ya no está disponible. Retíralo del carrito e inténtalo de nuevo.',
+                ], 422);
+            }
+
             if ($variantId !== null) {
                 $variant = ProductVariant::findOrFail($variantId);
                 if ($variant->product_id !== $product->id) {

--- a/app/Http/Controllers/BarPanelController.php
+++ b/app/Http/Controllers/BarPanelController.php
@@ -4,10 +4,12 @@ namespace App\Http\Controllers;
 
 use App\Models\Order;
 use App\Models\OrderItem;
+use App\Models\Product;
 use App\Models\Table;
 use App\Models\Zone;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\View\View;
 
 /**
@@ -57,7 +59,9 @@ class BarPanelController extends Controller
                             ->whereHas('items', fn ($q) => $q->where('destination', 'bar')->where('status', 'queued'))
                             ->get();
 
-        return view('bar.index', compact('tables', 'zones', 'floorWidth', 'floorHeight', 'readyOrders', 'orders'));
+        $barProducts = $this->getBarProducts($ownerId);
+
+        return view('bar.index', compact('tables', 'zones', 'floorWidth', 'floorHeight', 'readyOrders', 'orders', 'barProducts'));
     }
 
     /**
@@ -269,12 +273,57 @@ class BarPanelController extends Controller
     }
 
     /**
+     * Activa o desactiva temporalmente un producto de barra durante el servicio.
+     * Solo permite gestionar productos cuya categoría tenga destination=bar.
+     *
+     * @param  Product  $product
+     * @return JsonResponse
+     */
+    public function toggleAvailability(Product $product): JsonResponse
+    {
+        abort_if(! Auth::user()->canAccessBar(), 403, 'Acceso denegado.');
+
+        $ownerId = Auth::user()->ownerUserId();
+        abort_if($product->user_id !== $ownerId, 403, 'Acceso denegado.');
+
+        $isBarProduct = $product->categories()
+            ->where('destination', 'bar')
+            ->exists();
+        abort_if(! $isBarProduct, 403, 'Este producto no pertenece a la barra.');
+
+        $product->update(['is_available' => ! $product->is_available]);
+
+        Cache::forget("menu:{$ownerId}");
+
+        return response()->json([
+            'product_id'   => $product->id,
+            'is_available' => $product->is_available,
+        ]);
+    }
+
+    /**
      * @deprecated Usar tableStatus() en su lugar. Se mantiene por compatibilidad.
      * @return JsonResponse
      */
     public function pendingItems(): JsonResponse
     {
         return $this->tableStatus();
+    }
+
+    /**
+     * Devuelve los productos activos de barra del restaurante para gestionar disponibilidad.
+     *
+     * @param  int  $ownerId
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    private function getBarProducts(int $ownerId): \Illuminate\Database\Eloquent\Collection
+    {
+        return Product::where('user_id', $ownerId)
+            ->where('is_active', true)
+            ->whereHas('categories', fn ($q) => $q->where('destination', 'bar'))
+            ->with('categories:id,name')
+            ->orderBy('name')
+            ->get(['id', 'name', 'is_available']);
     }
 
     /**

--- a/app/Http/Controllers/BarPanelController.php
+++ b/app/Http/Controllers/BarPanelController.php
@@ -59,9 +59,7 @@ class BarPanelController extends Controller
                             ->whereHas('items', fn ($q) => $q->where('destination', 'bar')->where('status', 'queued'))
                             ->get();
 
-        $barProducts = $this->getBarProducts($ownerId);
-
-        return view('bar.index', compact('tables', 'zones', 'floorWidth', 'floorHeight', 'readyOrders', 'orders', 'barProducts'));
+        return view('bar.index', compact('tables', 'zones', 'floorWidth', 'floorHeight', 'readyOrders', 'orders'));
     }
 
     /**
@@ -270,6 +268,21 @@ class BarPanelController extends Controller
             'order_status' => $order->fresh()->status,
             'all_ready'    => $allReady,
         ]);
+    }
+
+    /**
+     * Vista de gestión de disponibilidad de productos de barra.
+     *
+     * @return View
+     */
+    public function barAvailability(): View
+    {
+        abort_if(! Auth::user()->canAccessBar(), 403, 'Acceso denegado.');
+
+        $ownerId     = Auth::user()->ownerUserId();
+        $barProducts = $this->getBarProducts($ownerId);
+
+        return view('bar.availability', compact('barProducts'));
     }
 
     /**

--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -2,10 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Category;
 use App\Models\Order;
 use App\Models\OrderItem;
+use App\Models\Product;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\View\View;
 
 /**
@@ -30,9 +33,10 @@ class KitchenController extends Controller
     {
         abort_if(! Auth::user()->canAccessKitchen(), 403, 'Acceso denegado.');
 
-        $orders = $this->getActiveOrders();
+        $orders   = $this->getActiveOrders();
+        $products = $this->getKitchenProducts();
 
-        return view('kitchen.index', compact('orders'));
+        return view('kitchen.index', compact('orders', 'products'));
     }
 
     /**
@@ -150,6 +154,35 @@ class KitchenController extends Controller
     }
 
     /**
+     * Activa o desactiva temporalmente un producto de cocina durante el servicio.
+     * Solo permite gestionar productos cuya categoría tenga destination=kitchen.
+     *
+     * @param  Product  $product
+     * @return JsonResponse
+     */
+    public function toggleAvailability(Product $product): JsonResponse
+    {
+        abort_if(! Auth::user()->canAccessKitchen(), 403, 'Acceso denegado.');
+
+        $ownerId = Auth::user()->ownerUserId();
+        abort_if($product->user_id !== $ownerId, 403, 'Acceso denegado.');
+
+        $isKitchenProduct = $product->categories()
+            ->where('destination', 'kitchen')
+            ->exists();
+        abort_if(! $isKitchenProduct, 403, 'Este producto no pertenece a cocina.');
+
+        $product->update(['is_available' => ! $product->is_available]);
+
+        Cache::forget("menu:{$ownerId}");
+
+        return response()->json([
+            'product_id'   => $product->id,
+            'is_available' => $product->is_available,
+        ]);
+    }
+
+    /**
      * Consulta los pedidos activos (cooking o pending) con ítems en cola
      * pertenecientes al restaurante autenticado.
      *
@@ -169,5 +202,22 @@ class KitchenController extends Controller
         ->whereIn('status', ['pending', 'cooking'])
         ->orderBy('created_at')
         ->get();
+    }
+
+    /**
+     * Devuelve los productos activos de cocina del restaurante para gestionar disponibilidad.
+     *
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    private function getKitchenProducts(): \Illuminate\Database\Eloquent\Collection
+    {
+        $ownerId = Auth::user()->ownerUserId();
+
+        return Product::where('user_id', $ownerId)
+            ->where('is_active', true)
+            ->whereHas('categories', fn ($q) => $q->where('destination', 'kitchen'))
+            ->with('categories:id,name')
+            ->orderBy('name')
+            ->get(['id', 'name', 'is_available']);
     }
 }

--- a/app/Http/Controllers/KitchenController.php
+++ b/app/Http/Controllers/KitchenController.php
@@ -33,10 +33,23 @@ class KitchenController extends Controller
     {
         abort_if(! Auth::user()->canAccessKitchen(), 403, 'Acceso denegado.');
 
-        $orders   = $this->getActiveOrders();
+        $orders = $this->getActiveOrders();
+
+        return view('kitchen.index', compact('orders'));
+    }
+
+    /**
+     * Vista de gestión de disponibilidad de productos de cocina.
+     *
+     * @return View
+     */
+    public function availability(): View
+    {
+        abort_if(! Auth::user()->canAccessKitchen(), 403, 'Acceso denegado.');
+
         $products = $this->getKitchenProducts();
 
-        return view('kitchen.index', compact('orders', 'products'));
+        return view('kitchen.availability', compact('products'));
     }
 
     /**

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -50,6 +50,7 @@ class MenuController extends Controller
                 ->with([
                     'products' => function ($query) {
                         $query->where('is_active', true)
+                              ->where('is_available', true)
                               ->with([
                                   'ingredients' => function ($q) {
                                       $q->withPivot(['is_removable', 'is_extra', 'extra_price'])
@@ -124,6 +125,7 @@ class MenuController extends Controller
 
                 $tapaProducts = $tapaCategory->products()
                                              ->where('is_active', true)
+                                             ->where('is_available', true)
                                              ->orderBy('name')
                                              ->get(['id', 'name', 'price', 'description']);
             }

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -50,6 +50,11 @@ class Product extends Model
         });
     }
 
+    protected $casts = [
+        'is_active'    => 'boolean',
+        'is_available' => 'boolean',
+    ];
+
     protected $fillable = [
         'user_id',
         'category_id',

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -17,9 +17,10 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @author SebastianBCF
  * @author BenjaminDTS
  *
- * @property string  $image       Ruta relativa de la imagen almacenada en storage/app/public/products
- * @property float|null $price   Precio base del producto (null si tiene variantes)
- * @property boolean $is_active  Si está disponible para pedir
+ * @property string  $image        Ruta relativa de la imagen almacenada en storage/app/public/products
+ * @property float|null $price    Precio base del producto (null si tiene variantes)
+ * @property boolean $is_active   Activo de forma permanente (lo gestiona el gerente)
+ * @property boolean $is_available Disponible en el turno actual (lo gestiona cocina/barra)
  */
 class Product extends Model
 {
@@ -56,6 +57,7 @@ class Product extends Model
         'description',
         'price',
         'is_active',
+        'is_available',
         'image',
         'sort_order',
     ];

--- a/database/migrations/2026_06_02_000004_add_is_available_to_products_table.php
+++ b/database/migrations/2026_06_02_000004_add_is_available_to_products_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Añade is_available a products para baja temporal durante el servicio.
+ * Diferente a is_active (permanente, del gerente): este lo gestiona
+ * cocina/barra cuando un producto se agota en el turno.
+ *
+ * @author BenjaminDTS
+ */
+return new class extends Migration
+{
+    /**
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->boolean('is_available')->default(true)->after('is_active');
+        });
+    }
+
+    /**
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('is_available');
+        });
+    }
+};

--- a/resources/js/alpine/kitchen-panel.js
+++ b/resources/js/alpine/kitchen-panel.js
@@ -174,13 +174,16 @@ export function productAvailability({ available, toggleUrl }) {
 
         /**
          * Sends a PATCH to the toggle endpoint and updates local state.
+         * Guard against double-clicks and absorb any network/parse errors so
+         * Alpine's reactivity system is never left in a broken state.
          *
          * @returns {Promise<void>}
          */
         async toggle() {
+            if (this.loading) return;
             this.loading = true;
             try {
-                const res  = await fetch(toggleUrl, {
+                const res = await fetch(toggleUrl, {
                     method:  'PATCH',
                     headers: {
                         'X-CSRF-TOKEN':     document.querySelector('meta[name="csrf-token"]').content,
@@ -188,8 +191,11 @@ export function productAvailability({ available, toggleUrl }) {
                         'Accept':           'application/json',
                     },
                 });
+                if (!res.ok) return;
                 const data = await res.json();
                 this.available = data.is_available;
+            } catch {
+                // silent — leave state as-is on network/parse error
             } finally {
                 this.loading = false;
             }

--- a/resources/js/alpine/kitchen-panel.js
+++ b/resources/js/alpine/kitchen-panel.js
@@ -158,11 +158,52 @@ export function kitchenPanel(initialOrders, urls) {
 }
 
 /**
- * Registers the `kitchenPanel` Alpine.data component.
+ * Alpine component for toggling a product's temporary availability.
+ * Used in both kitchen and bar panels to retire products during service.
+ *
+ * @param {{ available: boolean, toggleUrl: string }} params
+ * @returns {Object} Alpine component definition.
+ */
+export function productAvailability({ available, toggleUrl }) {
+    return {
+        /** @type {boolean} Whether the product is currently available on the menu. */
+        available,
+
+        /** @type {boolean} Whether a toggle request is in flight. */
+        loading: false,
+
+        /**
+         * Sends a PATCH to the toggle endpoint and updates local state.
+         *
+         * @returns {Promise<void>}
+         */
+        async toggle() {
+            this.loading = true;
+            try {
+                const res  = await fetch(toggleUrl, {
+                    method:  'PATCH',
+                    headers: {
+                        'X-CSRF-TOKEN':     document.querySelector('meta[name="csrf-token"]').content,
+                        'X-Requested-With': 'XMLHttpRequest',
+                        'Accept':           'application/json',
+                    },
+                });
+                const data = await res.json();
+                this.available = data.is_available;
+            } finally {
+                this.loading = false;
+            }
+        },
+    };
+}
+
+/**
+ * Registers the `kitchenPanel` and `productAvailability` Alpine.data components.
  * Reads initial state from injected JSON script tags.
  *
  * @returns {void}
  */
 export function registerKitchenPanel() {
-    Alpine.data('kitchenPanel', () => kitchenPanel(readKitchenInit(), readKitchenUrls()));
+    Alpine.data('kitchenPanel',        () => kitchenPanel(readKitchenInit(), readKitchenUrls()));
+    Alpine.data('productAvailability', (params) => productAvailability(params));
 }

--- a/resources/views/bar/availability.blade.php
+++ b/resources/views/bar/availability.blade.php
@@ -1,0 +1,69 @@
+{{-- @author BenjaminDTS --}}
+<x-app-layout>
+  <div class="max-w-3xl mx-auto px-4 sm:px-6 py-6 mt-4 sm:mt-10">
+
+    <div class="mb-6">
+      <h2 class="text-xl sm:text-2xl font-bold text-gray-800 dark:text-gray-100">Disponibilidad — Barra</h2>
+      <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+        Desactiva los productos que se agoten durante el servicio. Desaparecen de la carta al instante y se pueden reactivar en cualquier momento.
+      </p>
+    </div>
+
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
+
+      @php $unavailableCount = $barProducts->where('is_available', false)->count(); @endphp
+      @if($unavailableCount > 0)
+        <div class="px-4 py-2 bg-red-50 dark:bg-red-900/20 border-b border-red-200 dark:border-red-800">
+          <p class="text-xs font-semibold text-red-700 dark:text-red-300">
+            {{ $unavailableCount }} producto{{ $unavailableCount > 1 ? 's' : '' }} marcado{{ $unavailableCount > 1 ? 's' : '' }} como agotado{{ $unavailableCount > 1 ? 's' : '' }}
+          </p>
+        </div>
+      @endif
+
+      @if($barProducts->isEmpty())
+        <p class="px-4 py-10 text-sm text-center text-gray-400 dark:text-gray-500">No hay productos de barra activos.</p>
+      @else
+        <ul class="divide-y divide-gray-100 dark:divide-gray-700" role="list" aria-label="Productos de barra">
+          @foreach($barProducts as $product)
+          <li
+            class="flex items-center justify-between gap-3 px-4 py-3 transition-colors"
+            x-data="productAvailability({
+              available: {{ $product->is_available ? 'true' : 'false' }},
+              toggleUrl: '{{ url('/bar/productos/' . $product->id . '/disponibilidad') }}'
+            })"
+            :class="available ? '' : 'bg-red-50 dark:bg-red-900/20'"
+          >
+            <div class="flex-1 min-w-0">
+              <span
+                class="text-sm font-medium transition-colors"
+                :class="available ? 'text-gray-800 dark:text-gray-200' : 'text-red-500 dark:text-red-400 line-through'"
+              >{{ $product->name }}</span>
+              <span
+                class="ml-2 text-xs transition-colors"
+                :class="available ? 'text-gray-400' : 'text-red-500 font-semibold'"
+                x-text="available ? '' : 'Agotado'"
+              ></span>
+            </div>
+
+            <button
+              @click="toggle()"
+              :disabled="loading"
+              class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 disabled:opacity-50"
+              :class="available ? 'bg-amber-500' : 'bg-gray-300 dark:bg-gray-600'"
+              role="switch"
+              :aria-checked="available.toString()"
+              :aria-label="'{{ $product->name }}: ' + (available ? 'disponible, pulsa para marcar agotado' : 'agotado, pulsa para restaurar')"
+            >
+              <span
+                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                :class="available ? 'translate-x-5' : 'translate-x-0'"
+              ></span>
+            </button>
+          </li>
+          @endforeach
+        </ul>
+      @endif
+
+    </div>
+  </div>
+</x-app-layout>

--- a/resources/views/bar/index.blade.php
+++ b/resources/views/bar/index.blade.php
@@ -223,6 +223,82 @@
 
   </div>
 
+  {{-- Sección de disponibilidad de productos de barra --}}
+  @if($barProducts->isNotEmpty())
+  <div
+    class="max-w-6xl mx-auto px-4 sm:px-6 pb-8"
+    x-data="{ open: false }"
+  >
+    <button
+      @click="open = !open"
+      class="flex items-center gap-2 text-sm font-semibold text-gray-600 dark:text-gray-300 hover:text-amber-600 dark:hover:text-amber-400 transition focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 rounded"
+      :aria-expanded="open"
+      aria-controls="bar-products-panel"
+    >
+      <svg class="w-4 h-4 transition-transform" :class="open ? 'rotate-90' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+      </svg>
+      Gestión de disponibilidad
+      @php $unavailableBarCount = $barProducts->where('is_available', false)->count(); @endphp
+      @if($unavailableBarCount > 0)
+        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200">
+          {{ $unavailableBarCount }} agotado{{ $unavailableBarCount > 1 ? 's' : '' }}
+        </span>
+      @endif
+    </button>
+
+    <div
+      id="bar-products-panel"
+      x-show="open"
+      x-transition
+      class="mt-3 bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700"
+    >
+      <div class="px-4 py-3 bg-amber-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600">
+        <p class="text-xs text-gray-500 dark:text-gray-400">
+          Retira temporalmente un producto de la carta si se agota durante el servicio. Se restaura al reiniciar el turno o manualmente.
+        </p>
+      </div>
+
+      <ul
+        class="divide-y divide-gray-100 dark:divide-gray-700"
+        role="list"
+        aria-label="Productos de barra"
+      >
+        @foreach($barProducts as $product)
+        <li
+          class="flex items-center justify-between gap-3 px-4 py-3"
+          x-data="productAvailability({
+            available: {{ $product->is_available ? 'true' : 'false' }},
+            toggleUrl: '{{ url('/bar/productos/' . $product->id . '/disponibilidad') }}'
+          })"
+          :class="available ? '' : 'bg-red-50 dark:bg-red-900/20'"
+        >
+          <span
+            class="text-sm font-medium"
+            :class="available ? 'text-gray-800 dark:text-gray-200' : 'text-red-600 dark:text-red-400 line-through'"
+          >{{ $product->name }}</span>
+
+          <button
+            @click="toggle()"
+            :disabled="loading"
+            class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 disabled:opacity-50"
+            :class="available ? 'bg-amber-500' : 'bg-gray-300 dark:bg-gray-600'"
+            role="switch"
+            :aria-checked="available.toString()"
+            :aria-label="'{{ $product->name }}: ' + (available ? 'disponible' : 'agotado')"
+          >
+            <span
+              class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+              :class="available ? 'translate-x-5' : 'translate-x-0'"
+            ></span>
+          </button>
+        </li>
+        @endforeach
+      </ul>
+    </div>
+  </div>
+  @endif
+
   @push('scripts')
   @php
     $ordersForJs = $orders->map(fn($o) => [

--- a/resources/views/bar/index.blade.php
+++ b/resources/views/bar/index.blade.php
@@ -224,80 +224,62 @@
   </div>
 
   {{-- Sección de disponibilidad de productos de barra --}}
-  @if($barProducts->isNotEmpty())
-  <div
-    class="max-w-6xl mx-auto px-4 sm:px-6 pb-8"
-    x-data="{ open: false }"
-  >
-    <button
-      @click="open = !open"
-      class="flex items-center gap-2 text-sm font-semibold text-gray-600 dark:text-gray-300 hover:text-amber-600 dark:hover:text-amber-400 transition focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 rounded"
-      :aria-expanded="open"
-      aria-controls="bar-products-panel"
-    >
-      <svg class="w-4 h-4 transition-transform" :class="open ? 'rotate-90' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-      </svg>
-      Gestión de disponibilidad
-      @php $unavailableBarCount = $barProducts->where('is_available', false)->count(); @endphp
-      @if($unavailableBarCount > 0)
-        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200">
-          {{ $unavailableBarCount }} agotado{{ $unavailableBarCount > 1 ? 's' : '' }}
-        </span>
-      @endif
-    </button>
+  <div class="max-w-6xl mx-auto px-4 sm:px-6 pb-10">
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
 
-    <div
-      id="bar-products-panel"
-      x-show="open"
-      x-transition
-      class="mt-3 bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700"
-    >
-      <div class="px-4 py-3 bg-amber-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600">
-        <p class="text-xs text-gray-500 dark:text-gray-400">
-          Retira temporalmente un producto de la carta si se agota durante el servicio. Se restaura al reiniciar el turno o manualmente.
-        </p>
+      {{-- Cabecera de la sección --}}
+      <div class="flex items-center justify-between px-4 py-3 bg-amber-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600">
+        <div>
+          <h3 class="text-sm font-semibold text-gray-800 dark:text-gray-100">Disponibilidad de productos</h3>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Desactiva los que se agoten durante el servicio — desaparecen de la carta al instante.</p>
+        </div>
+        @php $unavailableBarCount = $barProducts->where('is_available', false)->count(); @endphp
+        @if($unavailableBarCount > 0)
+          <span class="shrink-0 inline-flex items-center px-2.5 py-1 rounded-full text-xs font-bold bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200">
+            {{ $unavailableBarCount }} agotado{{ $unavailableBarCount > 1 ? 's' : '' }}
+          </span>
+        @endif
       </div>
 
-      <ul
-        class="divide-y divide-gray-100 dark:divide-gray-700"
-        role="list"
-        aria-label="Productos de barra"
-      >
-        @foreach($barProducts as $product)
-        <li
-          class="flex items-center justify-between gap-3 px-4 py-3"
-          x-data="productAvailability({
-            available: {{ $product->is_available ? 'true' : 'false' }},
-            toggleUrl: '{{ url('/bar/productos/' . $product->id . '/disponibilidad') }}'
-          })"
-          :class="available ? '' : 'bg-red-50 dark:bg-red-900/20'"
-        >
-          <span
-            class="text-sm font-medium"
-            :class="available ? 'text-gray-800 dark:text-gray-200' : 'text-red-600 dark:text-red-400 line-through'"
-          >{{ $product->name }}</span>
-
-          <button
-            @click="toggle()"
-            :disabled="loading"
-            class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 disabled:opacity-50"
-            :class="available ? 'bg-amber-500' : 'bg-gray-300 dark:bg-gray-600'"
-            role="switch"
-            :aria-checked="available.toString()"
-            :aria-label="'{{ $product->name }}: ' + (available ? 'disponible' : 'agotado')"
+      @if($barProducts->isEmpty())
+        <p class="px-4 py-6 text-sm text-center text-gray-400 dark:text-gray-500">No hay productos de barra activos.</p>
+      @else
+        <ul class="divide-y divide-gray-100 dark:divide-gray-700" role="list" aria-label="Productos de barra">
+          @foreach($barProducts as $product)
+          <li
+            class="flex items-center justify-between gap-3 px-4 py-3 transition-colors"
+            x-data="productAvailability({
+              available: {{ $product->is_available ? 'true' : 'false' }},
+              toggleUrl: '{{ url('/bar/productos/' . $product->id . '/disponibilidad') }}'
+            })"
+            :class="available ? '' : 'bg-red-50 dark:bg-red-900/20'"
           >
             <span
-              class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-              :class="available ? 'translate-x-5' : 'translate-x-0'"
-            ></span>
-          </button>
-        </li>
-        @endforeach
-      </ul>
+              class="text-sm font-medium transition-colors"
+              :class="available ? 'text-gray-800 dark:text-gray-200' : 'text-red-500 dark:text-red-400 line-through'"
+            >{{ $product->name }}</span>
+
+            <button
+              @click="toggle()"
+              :disabled="loading"
+              class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 disabled:opacity-50"
+              :class="available ? 'bg-amber-500' : 'bg-gray-300 dark:bg-gray-600'"
+              role="switch"
+              :aria-checked="available.toString()"
+              :aria-label="'{{ $product->name }}: ' + (available ? 'disponible, pulsa para marcar agotado' : 'agotado, pulsa para restaurar')"
+            >
+              <span
+                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                :class="available ? 'translate-x-5' : 'translate-x-0'"
+              ></span>
+            </button>
+          </li>
+          @endforeach
+        </ul>
+      @endif
+
     </div>
   </div>
-  @endif
 
   @push('scripts')
   @php

--- a/resources/views/bar/index.blade.php
+++ b/resources/views/bar/index.blade.php
@@ -223,64 +223,6 @@
 
   </div>
 
-  {{-- Sección de disponibilidad de productos de barra --}}
-  <div class="max-w-6xl mx-auto px-4 sm:px-6 pb-10">
-    <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
-
-      {{-- Cabecera de la sección --}}
-      <div class="flex items-center justify-between px-4 py-3 bg-amber-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600">
-        <div>
-          <h3 class="text-sm font-semibold text-gray-800 dark:text-gray-100">Disponibilidad de productos</h3>
-          <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Desactiva los que se agoten durante el servicio — desaparecen de la carta al instante.</p>
-        </div>
-        @php $unavailableBarCount = $barProducts->where('is_available', false)->count(); @endphp
-        @if($unavailableBarCount > 0)
-          <span class="shrink-0 inline-flex items-center px-2.5 py-1 rounded-full text-xs font-bold bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200">
-            {{ $unavailableBarCount }} agotado{{ $unavailableBarCount > 1 ? 's' : '' }}
-          </span>
-        @endif
-      </div>
-
-      @if($barProducts->isEmpty())
-        <p class="px-4 py-6 text-sm text-center text-gray-400 dark:text-gray-500">No hay productos de barra activos.</p>
-      @else
-        <ul class="divide-y divide-gray-100 dark:divide-gray-700" role="list" aria-label="Productos de barra">
-          @foreach($barProducts as $product)
-          <li
-            class="flex items-center justify-between gap-3 px-4 py-3 transition-colors"
-            x-data="productAvailability({
-              available: {{ $product->is_available ? 'true' : 'false' }},
-              toggleUrl: '{{ url('/bar/productos/' . $product->id . '/disponibilidad') }}'
-            })"
-            :class="available ? '' : 'bg-red-50 dark:bg-red-900/20'"
-          >
-            <span
-              class="text-sm font-medium transition-colors"
-              :class="available ? 'text-gray-800 dark:text-gray-200' : 'text-red-500 dark:text-red-400 line-through'"
-            >{{ $product->name }}</span>
-
-            <button
-              @click="toggle()"
-              :disabled="loading"
-              class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 disabled:opacity-50"
-              :class="available ? 'bg-amber-500' : 'bg-gray-300 dark:bg-gray-600'"
-              role="switch"
-              :aria-checked="available.toString()"
-              :aria-label="'{{ $product->name }}: ' + (available ? 'disponible, pulsa para marcar agotado' : 'agotado, pulsa para restaurar')"
-            >
-              <span
-                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                :class="available ? 'translate-x-5' : 'translate-x-0'"
-              ></span>
-            </button>
-          </li>
-          @endforeach
-        </ul>
-      @endif
-
-    </div>
-  </div>
-
   @push('scripts')
   @php
     $ordersForJs = $orders->map(fn($o) => [

--- a/resources/views/kitchen/availability.blade.php
+++ b/resources/views/kitchen/availability.blade.php
@@ -1,0 +1,69 @@
+{{-- @author BenjaminDTS --}}
+<x-app-layout>
+  <div class="max-w-3xl mx-auto px-4 sm:px-6 py-6 mt-4 sm:mt-10">
+
+    <div class="mb-6">
+      <h2 class="text-xl sm:text-2xl font-bold text-gray-800 dark:text-gray-100">Disponibilidad — Cocina</h2>
+      <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+        Desactiva los productos que se agoten durante el servicio. Desaparecen de la carta al instante y se pueden reactivar en cualquier momento.
+      </p>
+    </div>
+
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
+
+      @php $unavailableCount = $products->where('is_available', false)->count(); @endphp
+      @if($unavailableCount > 0)
+        <div class="px-4 py-2 bg-red-50 dark:bg-red-900/20 border-b border-red-200 dark:border-red-800">
+          <p class="text-xs font-semibold text-red-700 dark:text-red-300">
+            {{ $unavailableCount }} producto{{ $unavailableCount > 1 ? 's' : '' }} marcado{{ $unavailableCount > 1 ? 's' : '' }} como agotado{{ $unavailableCount > 1 ? 's' : '' }}
+          </p>
+        </div>
+      @endif
+
+      @if($products->isEmpty())
+        <p class="px-4 py-10 text-sm text-center text-gray-400 dark:text-gray-500">No hay productos de cocina activos.</p>
+      @else
+        <ul class="divide-y divide-gray-100 dark:divide-gray-700" role="list" aria-label="Productos de cocina">
+          @foreach($products as $product)
+          <li
+            class="flex items-center justify-between gap-3 px-4 py-3 transition-colors"
+            x-data="productAvailability({
+              available: {{ $product->is_available ? 'true' : 'false' }},
+              toggleUrl: '{{ url('/cocina/productos/' . $product->id . '/disponibilidad') }}'
+            })"
+            :class="available ? '' : 'bg-red-50 dark:bg-red-900/20'"
+          >
+            <div class="flex-1 min-w-0">
+              <span
+                class="text-sm font-medium transition-colors"
+                :class="available ? 'text-gray-800 dark:text-gray-200' : 'text-red-500 dark:text-red-400 line-through'"
+              >{{ $product->name }}</span>
+              <span
+                class="ml-2 text-xs transition-colors"
+                :class="available ? 'text-gray-400' : 'text-red-500 font-semibold'"
+                x-text="available ? '' : 'Agotado'"
+              ></span>
+            </div>
+
+            <button
+              @click="toggle()"
+              :disabled="loading"
+              class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
+              :class="available ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+              role="switch"
+              :aria-checked="available.toString()"
+              :aria-label="'{{ $product->name }}: ' + (available ? 'disponible, pulsa para marcar agotado' : 'agotado, pulsa para restaurar')"
+            >
+              <span
+                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                :class="available ? 'translate-x-5' : 'translate-x-0'"
+              ></span>
+            </button>
+          </li>
+          @endforeach
+        </ul>
+      @endif
+
+    </div>
+  </div>
+</x-app-layout>

--- a/resources/views/kitchen/index.blade.php
+++ b/resources/views/kitchen/index.blade.php
@@ -130,64 +130,6 @@
 
   </div>
 
-  {{-- Sección de disponibilidad de productos --}}
-  <div class="max-w-6xl mx-auto px-4 sm:px-6 pb-10">
-    <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
-
-      {{-- Cabecera de la sección --}}
-      <div class="flex items-center justify-between px-4 py-3 bg-indigo-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600">
-        <div>
-          <h3 class="text-sm font-semibold text-gray-800 dark:text-gray-100">Disponibilidad de productos</h3>
-          <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Desactiva los que se agoten durante el servicio — desaparecen de la carta al instante.</p>
-        </div>
-        @php $unavailableCount = $products->where('is_available', false)->count(); @endphp
-        @if($unavailableCount > 0)
-          <span class="shrink-0 inline-flex items-center px-2.5 py-1 rounded-full text-xs font-bold bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200">
-            {{ $unavailableCount }} agotado{{ $unavailableCount > 1 ? 's' : '' }}
-          </span>
-        @endif
-      </div>
-
-      @if($products->isEmpty())
-        <p class="px-4 py-6 text-sm text-center text-gray-400 dark:text-gray-500">No hay productos de cocina activos.</p>
-      @else
-        <ul class="divide-y divide-gray-100 dark:divide-gray-700" role="list" aria-label="Productos de cocina">
-          @foreach($products as $product)
-          <li
-            class="flex items-center justify-between gap-3 px-4 py-3 transition-colors"
-            x-data="productAvailability({
-              available: {{ $product->is_available ? 'true' : 'false' }},
-              toggleUrl: '{{ url('/cocina/productos/' . $product->id . '/disponibilidad') }}'
-            })"
-            :class="available ? '' : 'bg-red-50 dark:bg-red-900/20'"
-          >
-            <span
-              class="text-sm font-medium transition-colors"
-              :class="available ? 'text-gray-800 dark:text-gray-200' : 'text-red-500 dark:text-red-400 line-through'"
-            >{{ $product->name }}</span>
-
-            <button
-              @click="toggle()"
-              :disabled="loading"
-              class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
-              :class="available ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
-              role="switch"
-              :aria-checked="available.toString()"
-              :aria-label="'{{ $product->name }}: ' + (available ? 'disponible, pulsa para marcar agotado' : 'agotado, pulsa para restaurar')"
-            >
-              <span
-                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                :class="available ? 'translate-x-5' : 'translate-x-0'"
-              ></span>
-            </button>
-          </li>
-          @endforeach
-        </ul>
-      @endif
-
-    </div>
-  </div>
-
   @push('scripts')
   @php
     $ordersForJs = $orders->map(fn($o) => [

--- a/resources/views/kitchen/index.blade.php
+++ b/resources/views/kitchen/index.blade.php
@@ -130,6 +130,82 @@
 
   </div>
 
+  {{-- Sección de disponibilidad de productos --}}
+  @if($products->isNotEmpty())
+  <div
+    class="max-w-6xl mx-auto px-4 sm:px-6 pb-8"
+    x-data="{ open: false }"
+  >
+    <button
+      @click="open = !open"
+      class="flex items-center gap-2 text-sm font-semibold text-gray-600 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400 transition focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 rounded"
+      :aria-expanded="open"
+      aria-controls="kitchen-products-panel"
+    >
+      <svg class="w-4 h-4 transition-transform" :class="open ? 'rotate-90' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+      </svg>
+      Gestión de disponibilidad
+      @php $unavailableCount = $products->where('is_available', false)->count(); @endphp
+      @if($unavailableCount > 0)
+        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200">
+          {{ $unavailableCount }} agotado{{ $unavailableCount > 1 ? 's' : '' }}
+        </span>
+      @endif
+    </button>
+
+    <div
+      id="kitchen-products-panel"
+      x-show="open"
+      x-transition
+      class="mt-3 bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700"
+    >
+      <div class="px-4 py-3 bg-indigo-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600">
+        <p class="text-xs text-gray-500 dark:text-gray-400">
+          Retira temporalmente un producto de la carta si se agota durante el servicio. Se restaura al reiniciar el turno o manualmente.
+        </p>
+      </div>
+
+      <ul
+        class="divide-y divide-gray-100 dark:divide-gray-700"
+        role="list"
+        aria-label="Productos de cocina"
+      >
+        @foreach($products as $product)
+        <li
+          class="flex items-center justify-between gap-3 px-4 py-3"
+          x-data="productAvailability({
+            available: {{ $product->is_available ? 'true' : 'false' }},
+            toggleUrl: '{{ url('/cocina/productos/' . $product->id . '/disponibilidad') }}'
+          })"
+          :class="available ? '' : 'bg-red-50 dark:bg-red-900/20'"
+        >
+          <span
+            class="text-sm font-medium"
+            :class="available ? 'text-gray-800 dark:text-gray-200' : 'text-red-600 dark:text-red-400 line-through'"
+          >{{ $product->name }}</span>
+
+          <button
+            @click="toggle()"
+            :disabled="loading"
+            class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
+            :class="available ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+            role="switch"
+            :aria-checked="available.toString()"
+            :aria-label="'{{ $product->name }}: ' + (available ? 'disponible' : 'agotado')"
+          >
+            <span
+              class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+              :class="available ? 'translate-x-5' : 'translate-x-0'"
+            ></span>
+          </button>
+        </li>
+        @endforeach
+      </ul>
+    </div>
+  </div>
+  @endif
+
   @push('scripts')
   @php
     $ordersForJs = $orders->map(fn($o) => [
@@ -153,7 +229,10 @@
     ])->values();
   @endphp
   <script id="kitchen-init" type="application/json">@json($ordersForJs)</script>
-  <script id="kitchen-urls" type="application/json">@json(['pending' => route('kitchen.pending')])</script>
+  <script id="kitchen-urls" type="application/json">@json([
+    'pending'              => route('kitchen.pending'),
+    'toggleAvailability'   => url('/cocina/productos/__ID__/disponibilidad'),
+  ])</script>
   @endpush
 
 </x-app-layout>

--- a/resources/views/kitchen/index.blade.php
+++ b/resources/views/kitchen/index.blade.php
@@ -131,80 +131,62 @@
   </div>
 
   {{-- Sección de disponibilidad de productos --}}
-  @if($products->isNotEmpty())
-  <div
-    class="max-w-6xl mx-auto px-4 sm:px-6 pb-8"
-    x-data="{ open: false }"
-  >
-    <button
-      @click="open = !open"
-      class="flex items-center gap-2 text-sm font-semibold text-gray-600 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400 transition focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 rounded"
-      :aria-expanded="open"
-      aria-controls="kitchen-products-panel"
-    >
-      <svg class="w-4 h-4 transition-transform" :class="open ? 'rotate-90' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-      </svg>
-      Gestión de disponibilidad
-      @php $unavailableCount = $products->where('is_available', false)->count(); @endphp
-      @if($unavailableCount > 0)
-        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200">
-          {{ $unavailableCount }} agotado{{ $unavailableCount > 1 ? 's' : '' }}
-        </span>
-      @endif
-    </button>
+  <div class="max-w-6xl mx-auto px-4 sm:px-6 pb-10">
+    <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
 
-    <div
-      id="kitchen-products-panel"
-      x-show="open"
-      x-transition
-      class="mt-3 bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700"
-    >
-      <div class="px-4 py-3 bg-indigo-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600">
-        <p class="text-xs text-gray-500 dark:text-gray-400">
-          Retira temporalmente un producto de la carta si se agota durante el servicio. Se restaura al reiniciar el turno o manualmente.
-        </p>
+      {{-- Cabecera de la sección --}}
+      <div class="flex items-center justify-between px-4 py-3 bg-indigo-50 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600">
+        <div>
+          <h3 class="text-sm font-semibold text-gray-800 dark:text-gray-100">Disponibilidad de productos</h3>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Desactiva los que se agoten durante el servicio — desaparecen de la carta al instante.</p>
+        </div>
+        @php $unavailableCount = $products->where('is_available', false)->count(); @endphp
+        @if($unavailableCount > 0)
+          <span class="shrink-0 inline-flex items-center px-2.5 py-1 rounded-full text-xs font-bold bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-200">
+            {{ $unavailableCount }} agotado{{ $unavailableCount > 1 ? 's' : '' }}
+          </span>
+        @endif
       </div>
 
-      <ul
-        class="divide-y divide-gray-100 dark:divide-gray-700"
-        role="list"
-        aria-label="Productos de cocina"
-      >
-        @foreach($products as $product)
-        <li
-          class="flex items-center justify-between gap-3 px-4 py-3"
-          x-data="productAvailability({
-            available: {{ $product->is_available ? 'true' : 'false' }},
-            toggleUrl: '{{ url('/cocina/productos/' . $product->id . '/disponibilidad') }}'
-          })"
-          :class="available ? '' : 'bg-red-50 dark:bg-red-900/20'"
-        >
-          <span
-            class="text-sm font-medium"
-            :class="available ? 'text-gray-800 dark:text-gray-200' : 'text-red-600 dark:text-red-400 line-through'"
-          >{{ $product->name }}</span>
-
-          <button
-            @click="toggle()"
-            :disabled="loading"
-            class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
-            :class="available ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
-            role="switch"
-            :aria-checked="available.toString()"
-            :aria-label="'{{ $product->name }}: ' + (available ? 'disponible' : 'agotado')"
+      @if($products->isEmpty())
+        <p class="px-4 py-6 text-sm text-center text-gray-400 dark:text-gray-500">No hay productos de cocina activos.</p>
+      @else
+        <ul class="divide-y divide-gray-100 dark:divide-gray-700" role="list" aria-label="Productos de cocina">
+          @foreach($products as $product)
+          <li
+            class="flex items-center justify-between gap-3 px-4 py-3 transition-colors"
+            x-data="productAvailability({
+              available: {{ $product->is_available ? 'true' : 'false' }},
+              toggleUrl: '{{ url('/cocina/productos/' . $product->id . '/disponibilidad') }}'
+            })"
+            :class="available ? '' : 'bg-red-50 dark:bg-red-900/20'"
           >
             <span
-              class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-              :class="available ? 'translate-x-5' : 'translate-x-0'"
-            ></span>
-          </button>
-        </li>
-        @endforeach
-      </ul>
+              class="text-sm font-medium transition-colors"
+              :class="available ? 'text-gray-800 dark:text-gray-200' : 'text-red-500 dark:text-red-400 line-through'"
+            >{{ $product->name }}</span>
+
+            <button
+              @click="toggle()"
+              :disabled="loading"
+              class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
+              :class="available ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+              role="switch"
+              :aria-checked="available.toString()"
+              :aria-label="'{{ $product->name }}: ' + (available ? 'disponible, pulsa para marcar agotado' : 'agotado, pulsa para restaurar')"
+            >
+              <span
+                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                :class="available ? 'translate-x-5' : 'translate-x-0'"
+              ></span>
+            </button>
+          </li>
+          @endforeach
+        </ul>
+      @endif
+
     </div>
   </div>
-  @endif
 
   @push('scripts')
   @php

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -3,6 +3,8 @@
     $cartaActive   = request()->routeIs('categories.*', 'ingredients.*', 'products.*', 'daily-menus.*');
     $localActive   = request()->routeIs('tables.*', 'zones.*', 'staff.*');
     $negocioActive = request()->routeIs('tapas.*', 'negocio.*', 'manager.*', 'ticket-config.*', 'negocio.menu-style.*');
+    $cocinaActive  = request()->routeIs('kitchen.*');
+    $barraActive   = request()->routeIs('bar.*');
 @endphp
 
 <aside
@@ -220,48 +222,168 @@
 
         {{-- Cocina --}}
         @if(Auth::user()->canAccessKitchen())
+          @if(Auth::user()->role === 'admin')
+            {{-- Admin: grupo desplegable con sub-items --}}
+            <div x-data="{
+                cocinaOpen: JSON.parse(localStorage.getItem('nav_cocina') ?? 'true'),
+                toggle() { this.cocinaOpen = !this.cocinaOpen; localStorage.setItem('nav_cocina', JSON.stringify(this.cocinaOpen)); }
+            }">
+                <button @click="toggle()"
+                        :aria-expanded="cocinaOpen.toString()"
+                        aria-controls="nav-cocina"
+                        class="w-full flex items-center justify-between gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors
+                               {{ $cocinaActive
+                                  ? 'text-red-700 dark:text-red-300'
+                                  : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100' }}">
+                    <span class="flex items-center gap-3">
+                        <svg class="h-5 w-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/>
+                        </svg>
+                        Cocina
+                    </span>
+                    <svg :class="cocinaOpen ? 'rotate-90' : ''"
+                         class="h-4 w-4 transition-transform flex-shrink-0"
+                         fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
+                    </svg>
+                </button>
+                <div id="nav-cocina" x-show="cocinaOpen" x-cloak class="mt-0.5 ml-7 pl-3 border-l border-gray-200 dark:border-gray-700 space-y-0.5">
+                    <span x-data="kitchenBadge('{{ route('kitchen.badge') }}')" x-init="init()">
+                        <a href="{{ route('kitchen.index') }}"
+                           aria-current="{{ request()->routeIs('kitchen.index') ? 'page' : 'false' }}"
+                           class="flex items-center justify-between px-3 py-1.5 rounded-md text-sm transition-colors
+                                  {{ request()->routeIs('kitchen.index')
+                                     ? 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 font-medium'
+                                     : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-200' }}">
+                            Comandas
+                            <span x-show="count > 0" x-cloak x-text="count"
+                                  class="inline-flex items-center justify-center min-w-[1.25rem] h-4 px-1 text-xs font-bold text-white bg-red-500 rounded-full"
+                                  :aria-label="count + ' pedidos nuevos'"></span>
+                        </a>
+                    </span>
+                    <a href="{{ route('kitchen.availability') }}"
+                       aria-current="{{ request()->routeIs('kitchen.availability') ? 'page' : 'false' }}"
+                       class="flex items-center px-3 py-1.5 rounded-md text-sm transition-colors
+                              {{ request()->routeIs('kitchen.availability')
+                                 ? 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 font-medium'
+                                 : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-200' }}">
+                        Disponibilidad
+                    </a>
+                </div>
+            </div>
+          @else
+            {{-- Staff de cocina: dos links planos --}}
             <span x-data="kitchenBadge('{{ route('kitchen.badge') }}')" x-init="init()" class="block">
                 <a href="{{ route('kitchen.index') }}"
-                   aria-current="{{ request()->routeIs('kitchen.*') ? 'page' : 'false' }}"
+                   aria-current="{{ request()->routeIs('kitchen.index') ? 'page' : 'false' }}"
                    class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors
-                          {{ request()->routeIs('kitchen.*')
+                          {{ request()->routeIs('kitchen.index')
                              ? 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300'
                              : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800' }}">
                     <svg class="h-5 w-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/>
                     </svg>
                     Cocina
-                    <span x-show="count > 0"
-                          x-cloak
-                          x-text="count"
+                    <span x-show="count > 0" x-cloak x-text="count"
                           class="ml-auto inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-bold text-white bg-red-500 rounded-full"
-                          :aria-label="count + ' pedidos nuevos sin atender'">
-                    </span>
+                          :aria-label="count + ' pedidos nuevos sin atender'"></span>
                 </a>
             </span>
+            <a href="{{ route('kitchen.availability') }}"
+               aria-current="{{ request()->routeIs('kitchen.availability') ? 'page' : 'false' }}"
+               class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors
+                      {{ request()->routeIs('kitchen.availability')
+                         ? 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300'
+                         : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800' }}">
+                <svg class="h-5 w-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"/>
+                </svg>
+                Disponibilidad
+            </a>
+          @endif
         @endif
 
         {{-- Barra --}}
         @if(Auth::user()->canAccessBar())
+          @if(Auth::user()->role === 'admin')
+            {{-- Admin: grupo desplegable con sub-items --}}
+            <div x-data="{
+                barraOpen: JSON.parse(localStorage.getItem('nav_barra') ?? 'true'),
+                toggle() { this.barraOpen = !this.barraOpen; localStorage.setItem('nav_barra', JSON.stringify(this.barraOpen)); }
+            }">
+                <button @click="toggle()"
+                        :aria-expanded="barraOpen.toString()"
+                        aria-controls="nav-barra"
+                        class="w-full flex items-center justify-between gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors
+                               {{ $barraActive
+                                  ? 'text-amber-700 dark:text-amber-300'
+                                  : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100' }}">
+                    <span class="flex items-center gap-3">
+                        <svg class="h-5 w-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                        </svg>
+                        Barra
+                    </span>
+                    <svg :class="barraOpen ? 'rotate-90' : ''"
+                         class="h-4 w-4 transition-transform flex-shrink-0"
+                         fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7"/>
+                    </svg>
+                </button>
+                <div id="nav-barra" x-show="barraOpen" x-cloak class="mt-0.5 ml-7 pl-3 border-l border-gray-200 dark:border-gray-700 space-y-0.5">
+                    <span x-data="barBadge('{{ route('bar.badge') }}')" x-init="init()">
+                        <a href="{{ route('bar.index') }}"
+                           aria-current="{{ request()->routeIs('bar.index') ? 'page' : 'false' }}"
+                           class="flex items-center justify-between px-3 py-1.5 rounded-md text-sm transition-colors
+                                  {{ request()->routeIs('bar.index')
+                                     ? 'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 font-medium'
+                                     : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-200' }}">
+                            Pedidos
+                            <span x-show="count > 0" x-cloak x-text="count"
+                                  class="inline-flex items-center justify-center min-w-[1.25rem] h-4 px-1 text-xs font-bold text-white bg-amber-500 rounded-full"
+                                  :aria-label="count + ' bebidas pendientes'"></span>
+                        </a>
+                    </span>
+                    <a href="{{ route('bar.availability') }}"
+                       aria-current="{{ request()->routeIs('bar.availability') ? 'page' : 'false' }}"
+                       class="flex items-center px-3 py-1.5 rounded-md text-sm transition-colors
+                              {{ request()->routeIs('bar.availability')
+                                 ? 'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 font-medium'
+                                 : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-200' }}">
+                        Disponibilidad
+                    </a>
+                </div>
+            </div>
+          @else
+            {{-- Staff de barra: dos links planos --}}
             <span x-data="barBadge('{{ route('bar.badge') }}')" x-init="init()" class="block">
                 <a href="{{ route('bar.index') }}"
-                   aria-current="{{ request()->routeIs('bar.*') ? 'page' : 'false' }}"
+                   aria-current="{{ request()->routeIs('bar.index') ? 'page' : 'false' }}"
                    class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors
-                          {{ request()->routeIs('bar.*')
+                          {{ request()->routeIs('bar.index')
                              ? 'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300'
                              : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800' }}">
                     <svg class="h-5 w-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
                     </svg>
                     Barra
-                    <span x-show="count > 0"
-                          x-cloak
-                          x-text="count"
+                    <span x-show="count > 0" x-cloak x-text="count"
                           class="ml-auto inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1 text-xs font-bold text-white bg-amber-500 rounded-full"
-                          :aria-label="count + ' bebidas pendientes en barra'">
-                    </span>
+                          :aria-label="count + ' bebidas pendientes en barra'"></span>
                 </a>
             </span>
+            <a href="{{ route('bar.availability') }}"
+               aria-current="{{ request()->routeIs('bar.availability') ? 'page' : 'false' }}"
+               class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors
+                      {{ request()->routeIs('bar.availability')
+                         ? 'bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300'
+                         : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800' }}">
+                <svg class="h-5 w-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4"/>
+                </svg>
+                Disponibilidad
+            </a>
+          @endif
         @endif
 
         @if(Auth::user()->canAccessKitchen() || Auth::user()->canAccessBar())

--- a/routes/web.php
+++ b/routes/web.php
@@ -141,6 +141,7 @@ Route::middleware(['auth', 'business.active'])->group(function () {
     // Panel de cocina — requiere canAccessKitchen() (rol nativo 'kitchen' o admin con is_kitchen=true)
     Route::middleware('can.kitchen')->group(function () {
         Route::get('/cocina', [KitchenController::class, 'index'])->name('kitchen.index');
+        Route::get('/cocina/disponibilidad', [KitchenController::class, 'availability'])->name('kitchen.availability');
         Route::get('/cocina/badge', [KitchenController::class, 'badgeCount'])->name('kitchen.badge');
         Route::get('/cocina/pendientes', [KitchenController::class, 'pendingOrders'])->name('kitchen.pending');
         Route::post('/cocina/items/{item}/listo', [KitchenController::class, 'markItemReady'])->name('kitchen.item.ready');
@@ -151,6 +152,7 @@ Route::middleware(['auth', 'business.active'])->group(function () {
     // Panel de barra y notificaciones al camarero — requiere canAccessBar() (rol nativo 'waiter' o admin con is_waiter=true)
     Route::middleware('can.bar')->group(function () {
         Route::get('/bar', [BarPanelController::class, 'index'])->name('bar.index');
+        Route::get('/bar/disponibilidad', [BarPanelController::class, 'barAvailability'])->name('bar.availability');
         Route::get('/bar/badge', [BarPanelController::class, 'badgeCount'])->name('bar.badge');
         Route::get('/bar/status', [BarPanelController::class, 'tableStatus'])->name('bar.table.status');
         Route::get('/bar/tables/{table}', [BarPanelController::class, 'tableDetail'])->name('bar.table.detail');

--- a/routes/web.php
+++ b/routes/web.php
@@ -145,6 +145,7 @@ Route::middleware(['auth', 'business.active'])->group(function () {
         Route::get('/cocina/pendientes', [KitchenController::class, 'pendingOrders'])->name('kitchen.pending');
         Route::post('/cocina/items/{item}/listo', [KitchenController::class, 'markItemReady'])->name('kitchen.item.ready');
         Route::post('/cocina/orders/{order}/servido', [KitchenController::class, 'markOrderServed'])->name('kitchen.order.served');
+        Route::patch('/cocina/productos/{product}/disponibilidad', [KitchenController::class, 'toggleAvailability'])->name('kitchen.product.availability');
     });
 
     // Panel de barra y notificaciones al camarero — requiere canAccessBar() (rol nativo 'waiter' o admin con is_waiter=true)
@@ -156,6 +157,7 @@ Route::middleware(['auth', 'business.active'])->group(function () {
         Route::get('/bar/pendientes', [BarPanelController::class, 'pendingItems'])->name('bar.pending');
         Route::patch('/bar/items/{item}', [BarPanelController::class, 'updateItem'])->name('bar.items.update');
         Route::patch('/bar/items/{item}/served', [BarPanelController::class, 'markItemServed'])->name('bar.items.served');
+        Route::patch('/bar/productos/{product}/disponibilidad', [BarPanelController::class, 'toggleAvailability'])->name('bar.product.availability');
 
         Route::get('/notifications/ready', [NotificationController::class, 'ready'])
              ->name('notifications.ready');


### PR DESCRIPTION
## Summary

- Añade columna `is_available` (boolean, default `true`) en `products` para retirar productos temporalmente durante el servicio, sin tocar `is_active` (que es permanente y del gerente)
- Panel de cocina y panel de barra tienen cada uno una página dedicada (`/cocina/disponibilidad`, `/bar/disponibilidad`) con switches toggle por producto — el cocinero solo gestiona los suyos, el camarero los suyos
- Al retirar un producto la caché de la carta se invalida al instante; el `MenuController` ya filtra por `is_available = true`
- Validación en `OrderController::store()`: si el cliente tenía un producto en el carrito y se retira antes de confirmar, el pedido se rechaza con 422 y mensaje claro
- Sidebar actualizado: el gerente (admin) ve "Cocina" y "Barra" como grupos desplegables con sub-items *Comandas* y *Disponibilidad*; el staff de cocina/barra ve dos links planos independientes

## Test plan

- [ ] Retirar un producto desde `/cocina/disponibilidad` → desaparece de la carta al recargar
- [ ] Cliente con ese producto ya en el carrito intenta pedir → recibe error 422 con nombre del producto
- [ ] Restaurar el producto → vuelve a aparecer en la carta
- [ ] Cocinero solo ve productos con `destination=kitchen`; camarero solo `destination=bar`
- [ ] Admin con `is_kitchen=true` ve el grupo "Cocina" desplegable en el sidebar
- [ ] Staff puro (role=kitchen) ve dos links planos "Cocina" y "Disponibilidad"
- [ ] Toggle funciona sin quedarse bloqueado (doble-click ignorado, errores de red manejados)

🤖 Generated with [Claude Code](https://claude.com/claude-code)