### PR TITLE
feat: waiter read-only table map + bar badge fixes

### DIFF
--- a/app/Http/Controllers/BarPanelController.php
+++ b/app/Http/Controllers/BarPanelController.php
@@ -73,6 +73,7 @@ class BarPanelController extends Controller
 
         $ownerId = Auth::user()->ownerUserId();
         $count = Order::whereHas('table', fn($q) => $q->where('user_id', $ownerId))
+            ->where('status', '!=', 'closed')
             ->where(fn($q) => $q
                 ->where(fn($inner) => $inner
                     ->whereIn('status', ['pending', 'cooking'])

--- a/database/migrations/2026_06_02_213052_add_served_to_order_items_status_enum.php
+++ b/database/migrations/2026_06_02_213052_add_served_to_order_items_status_enum.php
@@ -17,6 +17,12 @@ return new class extends Migration
 {
     public function up(): void
     {
+        // SQLite (used in tests) has no ENUM type and accepts any string value,
+        // so 'served' already works there without schema changes.
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
         DB::statement("ALTER TABLE order_items MODIFY COLUMN status ENUM('queued','ready','served') NOT NULL DEFAULT 'queued'");
 
         // Clean up orders stuck in 'ready' because markItemServed could never
@@ -37,6 +43,10 @@ return new class extends Migration
 
     public function down(): void
     {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
         DB::statement("ALTER TABLE order_items MODIFY COLUMN status ENUM('queued','ready') NOT NULL DEFAULT 'queued'");
     }
 };

--- a/database/migrations/2026_06_02_213052_add_served_to_order_items_status_enum.php
+++ b/database/migrations/2026_06_02_213052_add_served_to_order_items_status_enum.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Adds 'served' to the order_items.status ENUM.
+ *
+ * The original migration only defined 'queued' and 'ready', which meant
+ * BarPanelController::markItemServed() silently failed at the DB level
+ * and orders got stuck in 'ready' / notification_ready=true forever.
+ *
+ * Also closes any pre-existing stuck orders (status='ready', all items 'ready')
+ * so stale badge counts are cleared immediately after running this migration.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE order_items MODIFY COLUMN status ENUM('queued','ready','served') NOT NULL DEFAULT 'queued'");
+
+        // Clean up orders stuck in 'ready' because markItemServed could never
+        // persist 'served' to the DB before this migration.
+        DB::statement("
+            UPDATE orders
+            SET status = 'closed',
+                notification_ready = 0
+            WHERE status = 'ready'
+              AND notification_ready = 1
+              AND NOT EXISTS (
+                  SELECT 1 FROM order_items
+                  WHERE order_items.order_id = orders.id
+                    AND order_items.status != 'ready'
+              )
+        ");
+    }
+
+    public function down(): void
+    {
+        DB::statement("ALTER TABLE order_items MODIFY COLUMN status ENUM('queued','ready') NOT NULL DEFAULT 'queued'");
+    }
+};

--- a/resources/js/pages/table-map.js
+++ b/resources/js/pages/table-map.js
@@ -445,7 +445,10 @@ export function registerTableMap() {
                     this._prefetchQrSvgs();
                 });
                 this.pollStatuses();
-                setInterval(() => this.pollStatuses(), 25000);
+                setInterval(() => this.pollStatuses(), 5000);
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === 'visible') this.pollStatuses();
+                });
                 if (!window._zampaResizeListener) {
                     window._zampaResizeListener = () => { if (!this.editMode) this._applyOverviewZoom(); };
                     window.addEventListener('resize', window._zampaResizeListener);

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -201,6 +201,13 @@
                         ></span>
                     </span>
                     @endif
+
+                    {{-- Mapa de mesas (solo lectura) — camarero --}}
+                    @if(Auth::user()->role === 'waiter')
+                    <x-nav-link :href="route('tables.map')" :active="request()->routeIs('tables.map')">
+                        {{ __('Mapa') }}
+                    </x-nav-link>
+                    @endif
                 </div>
 
                 <!-- Dark mode toggle (desktop) -->
@@ -346,6 +353,13 @@
                         ></span>
                     </x-responsive-nav-link>
                 </span>
+                @endif
+
+                {{-- Mapa de mesas (solo lectura) — camarero --}}
+                @if(Auth::user()->role === 'waiter')
+                <x-responsive-nav-link :href="route('tables.map')" :active="request()->routeIs('tables.map')">
+                    {{ __('Mapa de mesas') }}
+                </x-responsive-nav-link>
                 @endif
 
                 {{-- Panel de Barra: admin y waiter --}}

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -386,6 +386,21 @@
           @endif
         @endif
 
+        {{-- Mapa de mesas (solo lectura) — camarero --}}
+        @if(Auth::user()->role === 'waiter')
+        <a href="{{ route('tables.map') }}"
+           aria-current="{{ request()->routeIs('tables.map') ? 'page' : 'false' }}"
+           class="flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors
+                  {{ request()->routeIs('tables.map')
+                     ? 'bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300'
+                     : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800' }}">
+            <svg class="h-5 w-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"/>
+            </svg>
+            Mapa de mesas
+        </a>
+        @endif
+
         @if(Auth::user()->canAccessKitchen() || Auth::user()->canAccessBar())
         </div>
         @endif


### PR DESCRIPTION
## Summary

- Waiter role can now view the table map (read-only) — link added to sidebar, top nav, and responsive hamburger menu; all interactions disabled via existing `readonly` flag and Alpine.js guards
- Portrait overlay (rotate device prompt) works for waiters on mobile, same as admin
- Table map status polling reduced from 25 s → 5 s; re-polls immediately when the tab regains focus
- Bar badge no longer counts `closed` orders with stale `notification_ready` or `bill_requested` flags
- **Root-cause fix**: `order_items.status` ENUM was missing `served`, causing `markItemServed()` to silently fail in MySQL and leave orders permanently stuck in `ready` with `notification_ready = true`; migration adds the value and cleans up existing stuck orders

## Test plan

- [ ] Log in as waiter — "Mapa de mesas" link visible in sidebar and nav
- [ ] Map loads in read-only mode (badge "Solo lectura", no drag/resize/edit controls)
- [ ] Rotate phone to portrait → overlay appears; rotate to landscape → map shown
- [ ] Place an order, mark bar item ready → badge increments; mark item served → badge clears
- [ ] Pay an order → badge does not linger after order is closed
- [ ] Status colours on map update without page reload (within ~5 s)
- [ ] `php artisan test` passes at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)