### PR TITLE
feat: plan limit alerts across staff, tables and floors

### DIFF
--- a/app/Http/Controllers/StaffController.php
+++ b/app/Http/Controllers/StaffController.php
@@ -27,9 +27,12 @@ class StaffController extends Controller
      */
     public function index(): View
     {
-        $staff = Auth::user()->staff()->paginate(15);
+        $owner        = Auth::user();
+        $staff        = $owner->staff()->paginate(15);
+        $staffCurrent = $owner->staff()->count();
+        $staffLimit   = $owner->plan?->max_staff;
 
-        return view('staff.index', compact('staff'));
+        return view('staff.index', compact('staff', 'staffCurrent', 'staffLimit'));
     }
 
     /**
@@ -39,7 +42,11 @@ class StaffController extends Controller
      */
     public function create(): View
     {
-        return view('staff.create');
+        $owner        = Auth::user();
+        $staffCurrent = $owner->staff()->count();
+        $staffLimit   = $owner->plan?->max_staff;
+
+        return view('staff.create', compact('staffCurrent', 'staffLimit'));
     }
 
     /**

--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -70,6 +70,7 @@ class TableController extends Controller
         $zones       = Zone::where('user_id', $ownerId)->orderBy('name')->get();
         $owner         = Auth::user()->isAdmin() ? Auth::user() : Auth::user()->admin;
         $maxTables     = $owner?->plan?->max_tables;
+        $maxFloors     = $owner?->plan?->max_floors;
         $floorWidth    = $owner?->floor_width    ?? 1200;
         $floorHeight   = $owner?->floor_height   ?? 800;
         $floorCount    = $owner?->floor_count    ?? 1;
@@ -86,7 +87,7 @@ class TableController extends Controller
         }
 
         return view('tables.map', compact(
-            'tables', 'elements', 'zones', 'maxTables',
+            'tables', 'elements', 'zones', 'maxTables', 'maxFloors',
             'floorWidth', 'floorHeight', 'floorCount', 'floorsEnabled',
             'floorCanvasSizes', 'readonly'
         ));

--- a/resources/views/components/plan-limit-alert.blade.php
+++ b/resources/views/components/plan-limit-alert.blade.php
@@ -1,0 +1,55 @@
+{{--
+ | Alerta de límite de plan.
+ | Muestra aviso ámbar (≥80 %) o rojo (100 %) cuando un recurso se acerca
+ | o alcanza el tope del plan. No renderiza nada si es ilimitado o < 80 %.
+ |
+ | @props
+ |   current   int        Unidades actualmente en uso
+ |   limit     int|null   Máximo del plan (null = ilimitado)
+ |   label     string     Nombre plural del recurso (ej. "mesas", "miembros de personal")
+--}}
+@props([
+    'current' => 0,
+    'limit'   => null,
+    'label'   => 'elementos',
+])
+
+@php
+    if ($limit === null) return;          // ilimitado → nada
+    $pct     = $limit > 0 ? round($current / $limit * 100) : 100;
+    if ($pct < 80) return;               // cómodo → nada
+    $atLimit = $pct >= 100;
+@endphp
+
+<div role="alert"
+     class="flex items-start gap-3 px-4 py-3 rounded-xl border text-sm
+            {{ $atLimit
+                ? 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800'
+                : 'bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-800' }}">
+
+    {{-- Icono triángulo de advertencia --}}
+    <svg class="w-5 h-5 shrink-0 mt-0.5 {{ $atLimit ? 'text-red-500 dark:text-red-400' : 'text-amber-500 dark:text-amber-400' }}"
+         viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"
+         aria-hidden="true">
+        <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+        <line x1="12" y1="9" x2="12" y2="13"/>
+        <line x1="12" y1="17" x2="12.01" y2="17"/>
+    </svg>
+
+    <div class="{{ $atLimit ? 'text-red-800 dark:text-red-200' : 'text-amber-800 dark:text-amber-200' }}">
+        @if($atLimit)
+            <p class="font-semibold leading-tight">Límite alcanzado</p>
+            <p class="mt-0.5 text-xs opacity-80">
+                Has llegado al máximo de <strong>{{ $limit }} {{ $label }}</strong> de tu plan.
+                Actualiza tu plan para añadir más.
+            </p>
+        @else
+            <p class="font-semibold leading-tight">Próximo al límite</p>
+            <p class="mt-0.5 text-xs opacity-80">
+                Usas <strong>{{ $current }} de {{ $limit }} {{ $label }}</strong>.
+                Considera actualizar tu plan antes de alcanzar el tope.
+            </p>
+        @endif
+    </div>
+</div>

--- a/resources/views/components/plan-usage.blade.php
+++ b/resources/views/components/plan-usage.blade.php
@@ -1,10 +1,6 @@
 @props(['planUsage'])
 
 @php
-    /**
-     * Calcula el porcentaje de uso para una barra de progreso.
-     * Devuelve 0 si el recurso es ilimitado.
-     */
     $pct = function (array $resource): int {
         if ($resource['unlimited'] || $resource['limit'] === null) {
             return 0;
@@ -12,99 +8,150 @@
         return (int) min(100, round($resource['current'] / $resource['limit'] * 100));
     };
 
-    /**
-     * Devuelve las clases de color según el porcentaje de uso.
-     * ≥100 → rojo, ≥80 → naranja, <80 → indigo
-     */
     $barColor = function (int $percent): string {
-        if ($percent >= 100) {
-            return 'bg-red-500';
-        }
-        if ($percent >= 80) {
-            return 'bg-amber-500';
-        }
+        if ($percent >= 100) return 'bg-red-500';
+        if ($percent >= 80)  return 'bg-amber-500';
         return 'bg-indigo-500';
     };
 
     $textColor = function (int $percent): string {
-        if ($percent >= 100) {
-            return 'text-red-500 dark:text-red-400';
-        }
-        if ($percent >= 80) {
-            return 'text-amber-500 dark:text-amber-400';
-        }
-        return 'text-gray-600 dark:text-gray-400';
+        if ($percent >= 100) return 'text-red-600 dark:text-red-400 font-semibold';
+        if ($percent >= 80)  return 'text-amber-600 dark:text-amber-400 font-semibold';
+        return 'text-gray-900 dark:text-white font-semibold';
     };
 
     $resources = [
-        'tables' => ['label' => 'Mesas',    'icon' => '🪑', 'data' => $planUsage['tables']],
-        'staff'  => ['label' => 'Personal', 'icon' => '👥', 'data' => $planUsage['staff']],
-        'floors' => ['label' => 'Plantas',  'icon' => '🏢', 'data' => $planUsage['floors']],
+        'tables' => [
+            'label' => 'Mesas',
+            'data'  => $planUsage['tables'],
+            'icon'  => <<<'SVG'
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <rect x="3" y="3" width="7" height="7" rx="1.5"/>
+  <rect x="14" y="3" width="7" height="7" rx="1.5"/>
+  <rect x="3" y="14" width="7" height="7" rx="1.5"/>
+  <rect x="14" y="14" width="7" height="7" rx="1.5"/>
+</svg>
+SVG,
+        ],
+        'staff' => [
+            'label' => 'Personal',
+            'data'  => $planUsage['staff'],
+            'icon'  => <<<'SVG'
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <path d="M15 19.128a9.38 9.38 0 002.625.372 9.337 9.337 0 004.121-.952 4.125 4.125 0 00-7.533-2.493M15 19.128v-.003c0-1.113-.285-2.16-.786-3.07M15 19.128v.106A12.318 12.318 0 018.624 21c-2.331 0-4.512-.645-6.374-1.766l-.001-.109a6.375 6.375 0 0111.964-3.07M12 6.375a3.375 3.375 0 11-6.75 0 3.375 3.375 0 016.75 0zm8.25 2.25a2.625 2.625 0 11-5.25 0 2.625 2.625 0 015.25 0z"/>
+</svg>
+SVG,
+        ],
+        'floors' => [
+            'label' => 'Plantas',
+            'data'  => $planUsage['floors'],
+            'icon'  => <<<'SVG'
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <path d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21"/>
+</svg>
+SVG,
+        ],
     ];
 @endphp
 
 <section aria-labelledby="plan-usage-heading"
-         class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 p-5">
+         class="bg-white dark:bg-gray-800 rounded-2xl shadow-sm
+                border border-gray-200 dark:border-gray-700 px-5 py-4">
 
-    <div class="flex items-center justify-between mb-4">
-        <h2 id="plan-usage-heading" class="text-sm font-semibold text-gray-900 dark:text-white">
-            Plan
-            @if($planUsage['plan'])
-                <span class="ml-1.5 px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300">
-                    {{ $planUsage['plan']->name }}
-                </span>
-            @endif
-        </h2>
-        @if($planUsage['plan'])
-            <span class="text-xs text-gray-400 dark:text-gray-500">
-                {{ number_format($planUsage['plan']->price_monthly, 2, ',', '.') }}&nbsp;€/mes
-            </span>
-        @endif
-    </div>
+    <div class="flex flex-wrap items-center gap-5 sm:gap-8">
 
-    <div class="space-y-4">
-        @foreach($resources as $key => $resource)
-            @php
-                $data    = $resource['data'];
-                $percent = $pct($data);
-                $color   = $barColor($percent);
-                $tColor  = $textColor($percent);
-            @endphp
-
+        {{-- ── Plan badge ─────────────────────────────────────────── --}}
+        <div class="flex items-center gap-3 shrink-0">
+            <div class="w-9 h-9 rounded-xl bg-indigo-50 dark:bg-indigo-900/30
+                        flex items-center justify-center shrink-0">
+                <svg class="w-5 h-5 text-indigo-600 dark:text-indigo-400"
+                     viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                     stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"
+                     aria-hidden="true">
+                    <path d="M9 12.75L11.25 15 15 9.75M21 12c0 1.268-.63 2.39-1.593 3.068a3.745 3.745 0 01-1.043 3.296 3.745 3.745 0 01-3.296 1.043A3.745 3.745 0 0112 21c-1.268 0-2.39-.63-3.068-1.593a3.746 3.746 0 01-3.296-1.043 3.745 3.745 0 01-1.043-3.296A3.745 3.745 0 013 12c0-1.268.63-2.39 1.593-3.068a3.745 3.745 0 011.043-3.296 3.746 3.746 0 013.296-1.043A3.746 3.746 0 0112 3c1.268 0 2.39.63 3.068 1.593a3.746 3.746 0 013.296 1.043 3.746 3.746 0 011.043 3.296A3.745 3.745 0 0121 12z"/>
+                </svg>
+            </div>
             <div>
-                <div class="flex items-center justify-between mb-1">
-                    <span class="flex items-center gap-1.5 text-xs font-medium text-gray-700 dark:text-gray-300">
-                        <span aria-hidden="true">{{ $resource['icon'] }}</span>
-                        {{ $resource['label'] }}
-                    </span>
-                    <span class="text-xs {{ $tColor }} tabular-nums">
-                        @if($data['unlimited'])
-                            <span class="text-emerald-500 dark:text-emerald-400 font-medium">Ilimitado</span>
-                        @else
-                            {{ $data['current'] }} / {{ $data['limit'] }}
-                        @endif
-                    </span>
-                </div>
-
-                @if(!$data['unlimited'])
-                    <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1.5"
-                         role="progressbar"
-                         aria-valuenow="{{ $data['current'] }}"
-                         aria-valuemin="0"
-                         aria-valuemax="{{ $data['limit'] }}"
-                         aria-label="{{ $resource['label'] }}: {{ $data['current'] }} de {{ $data['limit'] }}">
-                        <div class="{{ $color }} h-1.5 rounded-full transition-all duration-300"
-                             style="width: {{ $percent }}%"></div>
-                    </div>
-
-                    @if($percent >= 100)
-                        <p class="mt-1 text-xs text-red-500 dark:text-red-400">
-                            Límite alcanzado. Actualiza tu plan para continuar.
-                        </p>
+                <p id="plan-usage-heading"
+                   class="text-sm font-semibold text-gray-900 dark:text-white leading-tight">
+                    @if($planUsage['plan'])
+                        {{ $planUsage['plan']->name }}
+                    @else
+                        Sin plan
                     @endif
+                </p>
+                @if($planUsage['plan'])
+                    <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5 tabular-nums">
+                        {{ number_format($planUsage['plan']->price_monthly, 2, ',', '.') }}&nbsp;€/mes
+                    </p>
                 @endif
             </div>
-        @endforeach
+        </div>
+
+        {{-- ── Separator ───────────────────────────────────────────── --}}
+        <div class="hidden sm:block self-stretch w-px bg-gray-200 dark:bg-gray-700"
+             aria-hidden="true"></div>
+
+        {{-- ── Resources ───────────────────────────────────────────── --}}
+        <div class="flex flex-wrap gap-5 sm:gap-8 flex-1">
+            @foreach($resources as $key => $resource)
+                @php
+                    $data    = $resource['data'];
+                    $percent = $pct($data);
+                    $color   = $barColor($percent);
+                    $tColor  = $textColor($percent);
+                @endphp
+
+                <div class="flex items-center gap-2.5 min-w-[130px] flex-1">
+                    {{-- Icon --}}
+                    <div class="w-8 h-8 rounded-lg bg-gray-100 dark:bg-gray-700
+                                flex items-center justify-center shrink-0
+                                {{ $percent >= 100 ? 'bg-red-50 dark:bg-red-900/20' : ($percent >= 80 ? 'bg-amber-50 dark:bg-amber-900/20' : '') }}">
+                        <span class="w-4 h-4 {{ $percent >= 100 ? 'text-red-500 dark:text-red-400' : ($percent >= 80 ? 'text-amber-500 dark:text-amber-400' : 'text-gray-500 dark:text-gray-400') }}">
+                            {!! $resource['icon'] !!}
+                        </span>
+                    </div>
+
+                    {{-- Label + bar --}}
+                    <div class="flex-1 min-w-0"
+                         role="group"
+                         aria-label="{{ $resource['label'] }}">
+                        <div class="flex items-baseline justify-between gap-2 mb-1.5">
+                            <span class="text-xs text-gray-500 dark:text-gray-400 truncate">
+                                {{ $resource['label'] }}
+                            </span>
+                            <span class="text-xs {{ $tColor }} tabular-nums shrink-0">
+                                @if($data['unlimited'])
+                                    <span class="text-emerald-600 dark:text-emerald-400 font-medium">∞</span>
+                                @else
+                                    {{ $data['current'] }}<span class="font-normal text-gray-400 dark:text-gray-500">/{{ $data['limit'] }}</span>
+                                @endif
+                            </span>
+                        </div>
+
+                        @if(!$data['unlimited'])
+                            <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1.5"
+                                 role="progressbar"
+                                 aria-valuenow="{{ $data['current'] }}"
+                                 aria-valuemin="0"
+                                 aria-valuemax="{{ $data['limit'] }}"
+                                 aria-label="{{ $resource['label'] }}: {{ $data['current'] }} de {{ $data['limit'] }}">
+                                <div class="{{ $color }} h-1.5 rounded-full transition-all duration-500"
+                                     style="width: {{ $percent }}%"></div>
+                            </div>
+                            @if($percent >= 100)
+                                <p class="mt-1 text-xs text-red-500 dark:text-red-400 leading-snug">
+                                    Límite alcanzado
+                                </p>
+                            @endif
+                        @else
+                            <div class="h-1.5 rounded-full bg-emerald-100 dark:bg-emerald-900/30" aria-hidden="true"></div>
+                        @endif
+                    </div>
+                </div>
+            @endforeach
+        </div>
+
     </div>
 
 </section>

--- a/resources/views/staff/create.blade.php
+++ b/resources/views/staff/create.blade.php
@@ -11,6 +11,19 @@
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow">
 
+        {{-- Error de límite devuelto por el backend --}}
+        @if(session('error'))
+          <div role="alert" class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800
+                                   text-red-800 dark:text-red-300 px-4 py-3 rounded-xl mb-6 text-sm">
+            {{ session('error') }}
+          </div>
+        @endif
+
+        {{-- Aviso proactivo de límite (antes de intentar enviar el formulario) --}}
+        @php $staffAtLimit = $staffLimit !== null && $staffCurrent >= $staffLimit; @endphp
+        <x-plan-limit-alert :current="$staffCurrent" :limit="$staffLimit" label="miembros de personal"
+                            class="mb-6" />
+
         <form method="POST" action="{{ route('staff.store') }}">
           @csrf
 
@@ -80,7 +93,11 @@
 
           <div class="flex items-center gap-4">
             <button type="submit"
-                    class="bg-orange-500 text-white px-4 py-2 rounded hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2">
+                    @if($staffAtLimit) disabled aria-disabled="true" @endif
+                    class="px-4 py-2 rounded focus:outline-none focus:ring-2 focus:ring-offset-2
+                           {{ $staffAtLimit
+                               ? 'bg-gray-300 dark:bg-gray-600 text-gray-400 dark:text-gray-500 cursor-not-allowed'
+                               : 'bg-indigo-600 hover:bg-indigo-700 text-white focus:ring-indigo-500' }}">
               Dar de alta
             </button>
             <a href="{{ route('staff.index') }}"

--- a/resources/views/staff/index.blade.php
+++ b/resources/views/staff/index.blade.php
@@ -17,11 +17,24 @@
           </div>
         @endif
 
+        {{-- Aviso de límite de personal --}}
+        @php $staffAtLimit = $staffLimit !== null && $staffCurrent >= $staffLimit; @endphp
+        <x-plan-limit-alert :current="$staffCurrent" :limit="$staffLimit" label="miembros de personal"
+                            class="mb-4" />
+
         <div class="flex justify-end mb-4">
-          <a href="{{ route('staff.create') }}"
-             class="bg-orange-500 hover:bg-orange-700 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 text-white font-bold py-2 px-4 rounded">
-            + Añadir persona
-          </a>
+          @if($staffAtLimit)
+            <span class="inline-flex items-center gap-2 bg-gray-200 dark:bg-gray-700
+                         text-gray-400 dark:text-gray-500 font-bold py-2 px-4 rounded cursor-not-allowed"
+                  title="Has alcanzado el límite de personal de tu plan">
+              + Añadir persona
+            </span>
+          @else
+            <a href="{{ route('staff.create') }}"
+               class="bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 text-white font-bold py-2 px-4 rounded">
+              + Añadir persona
+            </a>
+          @endif
         </div>
 
         <div class="overflow-x-auto">

--- a/resources/views/tables/map.blade.php
+++ b/resources/views/tables/map.blade.php
@@ -9,34 +9,8 @@
 
 {{-- ══════════════════════════════════════════════════════
      OVERLAY — Girar dispositivo (portrait mobile/tablet)
+     CSS → resources/css/components/table-map.css
 ══════════════════════════════════════════════════════ --}}
-<style>
-    @keyframes zampa-rotate-phone {
-        0%   { transform: rotate(0deg); }
-        35%  { transform: rotate(90deg); }
-        65%  { transform: rotate(90deg); }
-        100% { transform: rotate(0deg); }
-    }
-    #rotate-device-overlay {
-        display: none;
-        position: fixed;
-        inset: 0;
-        z-index: 9999;
-        background-color: rgba(17, 24, 39, 0.97);
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        gap: 1.5rem;
-        padding: 2rem;
-        text-align: center;
-    }
-    @media screen and (orientation: portrait) and (max-width: 1023px) {
-        #rotate-device-overlay { display: flex; }
-    }
-    #rotate-device-overlay .zampa-phone-icon {
-        animation: zampa-rotate-phone 2.5s ease-in-out infinite;
-    }
-</style>
 
 <div id="rotate-device-overlay"
      role="alertdialog"
@@ -371,9 +345,9 @@
               class="w-px h-4 bg-gray-300 dark:bg-gray-600 mx-0.5"
               aria-hidden="true"></span>
 
-        {{-- Añadir planta — solo en modo edición --}}
+        {{-- Añadir planta — solo en modo edición y cuando el plan lo permite --}}
         <button type="button"
-                x-show="editMode && floorCount < 5"
+                x-show="editMode && floorCount < 5 && floorCount < {{ $maxFloors ?? 999 }}"
                 @click="addFloor()"
                 aria-label="Añadir planta"
                 class="px-2 py-1 rounded text-xs font-semibold
@@ -381,6 +355,21 @@
                        transition-colors focus:outline-none focus:ring-2 focus:ring-inset focus:ring-green-400">
             + P
         </button>
+
+        {{-- Aviso límite de plantas del plan (plan saturado pero no llegó a 5) --}}
+        <span x-show="editMode && floorCount >= {{ $maxFloors ?? 999 }} && floorCount < 5"
+              x-cloak
+              class="inline-flex items-center gap-1 text-xs font-medium
+                     text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20
+                     border border-red-200 dark:border-red-700 rounded px-2 py-1">
+            <svg class="w-3.5 h-3.5 shrink-0" viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                 stroke-linejoin="round" aria-hidden="true">
+                <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+                <line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
+            </svg>
+            Límite del plan
+        </span>
 
         {{-- Eliminar planta — solo en modo edición --}}
         <button type="button"
@@ -441,6 +430,46 @@
             <p class="text-xs font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500">
                 Arrastrar al plano
             </p>
+
+            {{-- Aviso límite de mesas alcanzado --}}
+            <div x-show="tables.length >= {{ $maxTables }}"
+                 x-cloak
+                 role="alert"
+                 class="w-full flex items-start gap-2 p-3 rounded-xl
+                        bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
+                <svg class="w-4 h-4 shrink-0 mt-0.5 text-red-500 dark:text-red-400"
+                     viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                     aria-hidden="true">
+                    <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+                    <line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
+                </svg>
+                <div class="text-xs text-red-700 dark:text-red-300">
+                    <p class="font-semibold">Límite de mesas alcanzado</p>
+                    <p class="mt-0.5 opacity-80">{{ $maxTables }} mesas en tu plan.</p>
+                </div>
+            </div>
+
+            {{-- Aviso previo al límite de mesas (≥80 %) --}}
+            <div x-show="tables.length / {{ $maxTables }} >= 0.8 && tables.length < {{ $maxTables }}"
+                 x-cloak
+                 role="status"
+                 class="w-full flex items-start gap-2 p-3 rounded-xl
+                        bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
+                <svg class="w-4 h-4 shrink-0 mt-0.5 text-amber-500 dark:text-amber-400"
+                     viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                     stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                     aria-hidden="true">
+                    <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+                    <line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
+                </svg>
+                <div class="text-xs text-amber-700 dark:text-amber-300">
+                    <p class="font-semibold">Próximo al límite</p>
+                    <p class="mt-0.5 opacity-80">
+                        <span x-text="tables.length"></span> de {{ $maxTables }} mesas usadas.
+                    </p>
+                </div>
+            </div>
 
             {{-- Cuadrada --}}
             <div class="palette-item group flex flex-col items-center gap-2 select-none transition-opacity"


### PR DESCRIPTION
## Summary

Proactive UI warnings when approaching or reaching plan resource limits, so users know before hitting the backend guard.

- **`x-plan-limit-alert` component** — reusable Blade component: renders nothing below 80%, amber warning at ≥80%, red blocking alert at 100%. Accepts `:current`, `:limit`, `:label`. Null limit (unlimited plan) renders nothing.
- **`plan-usage` widget** — full redesign: horizontal full-width bar replacing the 1/3-column card. SVG Heroicons replace emoji (🪑👥🏢). Plan badge on left, separator, three resource meters in a row with icon + progress bar. Icon backgrounds tint red/amber when at limit.
- **Staff views** — `StaffController` now passes `$staffCurrent`/`$staffLimit` to `index` and `create`. The index disables the create button and shows the alert; create shows the session error flash (previously unhandled) plus proactive alert, and disables submit.
- **Table map** — `TableController` passes `$maxFloors` to the view. Palette shows amber warning at ≥80% table usage and red alert at 100% via Alpine `x-show`. Floor bar: `+ P` button checks `floorCount < maxFloors`; at plan limit shows a `Límite del plan` red badge.

## Test plan

- [ ] Staff index at limit: create button grey + disabled, alert shown
- [ ] Staff create at limit: submit button disabled, alert shown
- [ ] Staff at 80% usage: amber warning visible
- [ ] Table map at 80%/100% table usage: palette shows correct alert
- [ ] Table map at floor plan limit: `+ P` hidden, badge shown
- [ ] Plan usage widget renders horizontally with SVG icons
- [ ] Unlimited plan: no alerts or progress bars shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)