### PR TITLE
style: redesign kitchen, bar and availability panels

### DIFF
--- a/resources/views/bar/availability.blade.php
+++ b/resources/views/bar/availability.blade.php
@@ -2,63 +2,123 @@
 <x-app-layout>
   <div class="max-w-3xl mx-auto px-4 sm:px-6 py-6 mt-4 sm:mt-10">
 
-    <div class="mb-6">
-      <h2 class="text-xl sm:text-2xl font-bold text-gray-800 dark:text-gray-100">Disponibilidad — Barra</h2>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-        Desactiva los productos que se agoten durante el servicio. Desaparecen de la carta al instante y se pueden reactivar en cualquier momento.
-      </p>
+    {{-- Cabecera --}}
+    <div class="flex items-start gap-4 mb-6">
+      <div class="w-10 h-10 rounded-xl bg-amber-50 dark:bg-amber-900/30 flex items-center justify-center shrink-0 mt-0.5">
+        <svg class="w-5 h-5 text-amber-600 dark:text-amber-400" viewBox="0 0 24 24" fill="none"
+             stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"
+             aria-hidden="true">
+          <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+        </svg>
+      </div>
+      <div>
+        <h2 class="text-xl sm:text-2xl font-bold text-gray-900 dark:text-gray-100">
+          Disponibilidad — Barra
+        </h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Desactiva los productos que se agoten. Desaparecen de la carta al instante.
+        </p>
+      </div>
     </div>
 
-    <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
+    <div class="bg-white dark:bg-gray-800 shadow-sm rounded-2xl overflow-hidden
+                border border-gray-200 dark:border-gray-700">
 
+      {{-- Banner de agotados --}}
       @php $unavailableCount = $barProducts->where('is_available', false)->count(); @endphp
       @if($unavailableCount > 0)
-        <div class="px-4 py-2 bg-red-50 dark:bg-red-900/20 border-b border-red-200 dark:border-red-800">
-          <p class="text-xs font-semibold text-red-700 dark:text-red-300">
-            {{ $unavailableCount }} producto{{ $unavailableCount > 1 ? 's' : '' }} marcado{{ $unavailableCount > 1 ? 's' : '' }} como agotado{{ $unavailableCount > 1 ? 's' : '' }}
+        <div class="flex items-center gap-2 px-4 py-2.5
+                    bg-amber-50 dark:bg-amber-900/20 border-b border-amber-200 dark:border-amber-800">
+          <svg class="w-4 h-4 text-amber-500 dark:text-amber-400 shrink-0" viewBox="0 0 24 24" fill="none"
+               stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+               aria-hidden="true">
+            <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+            <line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
+          </svg>
+          <p class="text-xs font-semibold text-amber-700 dark:text-amber-300">
+            {{ $unavailableCount }} producto{{ $unavailableCount > 1 ? 's' : '' }}
+            agotado{{ $unavailableCount > 1 ? 's' : '' }}
           </p>
         </div>
       @endif
 
+      {{-- Lista --}}
       @if($barProducts->isEmpty())
-        <p class="px-4 py-10 text-sm text-center text-gray-400 dark:text-gray-500">No hay productos de barra activos.</p>
+        <div class="px-4 py-12 text-center">
+          <svg class="mx-auto mb-3 w-10 h-10 text-gray-300 dark:text-gray-600" viewBox="0 0 24 24"
+               fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+               stroke-linejoin="round" aria-hidden="true">
+            <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+          </svg>
+          <p class="text-sm text-gray-400 dark:text-gray-500">No hay productos de barra activos.</p>
+        </div>
       @else
-        <ul class="divide-y divide-gray-100 dark:divide-gray-700" role="list" aria-label="Productos de barra">
+        <ul class="divide-y divide-gray-100 dark:divide-gray-700/60" role="list"
+            aria-label="Productos de barra">
           @foreach($barProducts as $product)
           <li
-            class="flex items-center justify-between gap-3 px-4 py-3 transition-colors"
+            class="flex items-center gap-3 px-4 py-3.5 transition-colors
+                   hover:bg-gray-50 dark:hover:bg-gray-800/60"
             x-data="productAvailability({
               available: {{ $product->is_available ? 'true' : 'false' }},
               toggleUrl: '{{ url('/bar/productos/' . $product->id . '/disponibilidad') }}'
             })"
-            :class="available ? '' : 'bg-red-50 dark:bg-red-900/20'"
+            :class="available ? '' : 'bg-amber-50/60 dark:bg-amber-900/10'"
           >
-            <div class="flex-1 min-w-0">
-              <span
-                class="text-sm font-medium transition-colors"
-                :class="available ? 'text-gray-800 dark:text-gray-200' : 'text-red-500 dark:text-red-400 line-through'"
-              >{{ $product->name }}</span>
-              <span
-                class="ml-2 text-xs transition-colors"
-                :class="available ? 'text-gray-400' : 'text-red-500 font-semibold'"
-                x-text="available ? '' : 'Agotado'"
-              ></span>
+            {{-- Dot de estado --}}
+            <span class="shrink-0 w-2 h-2 rounded-full transition-colors"
+                  :class="available ? 'bg-green-500' : 'bg-amber-400'"
+                  aria-hidden="true"></span>
+
+            {{-- Nombre + badge agotado --}}
+            <div class="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
+              <span class="text-sm font-medium transition-colors leading-snug"
+                    :class="available
+                      ? 'text-gray-800 dark:text-gray-200'
+                      : 'text-amber-700 dark:text-amber-400 line-through'">
+                {{ $product->name }}
+              </span>
+              <span x-show="!available" x-cloak
+                    class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md text-xs font-semibold
+                           bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300">
+                <svg class="w-2.5 h-2.5" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                     stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+                  <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
+                Agotado
+              </span>
             </div>
 
-            <button
-              @click="toggle()"
-              :disabled="loading"
-              class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 disabled:opacity-50"
-              :class="available ? 'bg-amber-500' : 'bg-gray-300 dark:bg-gray-600'"
-              role="switch"
-              :aria-checked="available.toString()"
-              :aria-label="'{{ $product->name }}: ' + (available ? 'disponible, pulsa para marcar agotado' : 'agotado, pulsa para restaurar')"
-            >
-              <span
-                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                :class="available ? 'translate-x-5' : 'translate-x-0'"
-              ></span>
-            </button>
+            {{-- Spinner + toggle --}}
+            <div class="flex items-center gap-2 shrink-0">
+              <svg x-show="loading" x-cloak
+                   class="w-4 h-4 text-gray-400 animate-spin"
+                   viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+              </svg>
+
+              <button
+                @click="toggle()"
+                :disabled="loading"
+                class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2
+                       border-transparent transition-colors duration-200 ease-in-out
+                       focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+                :class="available ? 'bg-amber-500' : 'bg-gray-300 dark:bg-gray-600'"
+                role="switch"
+                :aria-checked="available.toString()"
+                :aria-label="'{{ $product->name }}: ' + (available
+                  ? 'disponible, pulsa para marcar agotado'
+                  : 'agotado, pulsa para restaurar')"
+              >
+                <span
+                  class="pointer-events-none inline-block h-5 w-5 transform rounded-full
+                         bg-white shadow ring-0 transition duration-200 ease-in-out"
+                  :class="available ? 'translate-x-5' : 'translate-x-0'"
+                ></span>
+              </button>
+            </div>
           </li>
           @endforeach
         </ul>

--- a/resources/views/bar/index.blade.php
+++ b/resources/views/bar/index.blade.php
@@ -12,47 +12,66 @@
   >
     <template x-for="order in billOrders" :key="order.id">
       <div
-        class="bg-indigo-50 border border-indigo-400 rounded-lg px-4 py-3 mb-2 shadow-sm"
+        class="bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-300 dark:border-indigo-700
+               rounded-xl px-4 py-3 mb-2 shadow-sm"
         role="alert"
       >
         <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
-          <div class="flex items-center gap-2 min-w-0">
-            <span class="text-indigo-800 font-medium text-sm">
-              &#128179; <strong x-text="order.table"></strong> &mdash; solicita la cuenta
-            </span>
+          <div class="flex items-center gap-2 min-w-0 flex-wrap">
+            <div class="flex items-center gap-1.5 text-indigo-800 dark:text-indigo-200 font-medium text-sm">
+              <svg class="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/></svg>
+              <strong x-text="order.table"></strong>
+              <span class="font-normal opacity-80">solicita la cuenta</span>
+            </div>
             <span
               x-show="order.payment_method === 'cash'"
-              class="inline-flex items-center gap-1 text-xs font-semibold bg-green-100 text-green-700 px-2 py-0.5 rounded-full"
+              class="inline-flex items-center gap-1 text-xs font-semibold bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300 px-2 py-0.5 rounded-full"
               aria-label="Paga en efectivo"
-            >&#128181; Efectivo</span>
+            >
+              <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"/></svg>
+              Efectivo
+            </span>
             <span
               x-show="order.payment_method === 'card'"
-              class="inline-flex items-center gap-1 text-xs font-semibold bg-indigo-100 text-indigo-700 px-2 py-0.5 rounded-full"
+              class="inline-flex items-center gap-1 text-xs font-semibold bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 px-2 py-0.5 rounded-full"
               aria-label="Paga con tarjeta"
-            >&#128179; Tarjeta</span>
+            >
+              <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/></svg>
+              Tarjeta
+            </span>
           </div>
           <div class="flex items-center gap-2 shrink-0">
             <template x-if="order.payment_method === 'cash'">
               <button
                 @click="cashPayment(order)"
                 :disabled="order.paying"
-                class="bg-green-600 hover:bg-green-700 disabled:opacity-50 text-white text-xs font-semibold px-3 py-1.5 rounded focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition"
+                class="inline-flex items-center gap-1.5 bg-green-600 hover:bg-green-700 disabled:opacity-50 text-white text-xs font-semibold px-3 py-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors cursor-pointer"
                 :aria-label="'Cobrar en efectivo: ' + order.table"
               >
-                <span x-show="!order.paying">&#128181; Cobrar en efectivo</span>
-                <span x-show="order.paying">...</span>
+                <template x-if="!order.paying">
+                  <span class="inline-flex items-center gap-1">
+                    <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 9V7a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2m2 4h10a2 2 0 002-2v-6a2 2 0 00-2-2H9a2 2 0 00-2 2v6a2 2 0 002 2zm7-5a2 2 0 11-4 0 2 2 0 014 0z"/></svg>
+                    Cobrar efectivo
+                  </span>
+                </template>
+                <template x-if="order.paying">
+                  <svg class="w-3.5 h-3.5 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/></svg>
+                </template>
               </button>
             </template>
             <template x-if="order.payment_method === 'card'">
               <button
                 disabled
-                class="bg-indigo-200 text-indigo-500 text-xs font-semibold px-3 py-1.5 rounded cursor-not-allowed"
+                class="inline-flex items-center gap-1.5 bg-indigo-200 dark:bg-indigo-800 text-indigo-500 dark:text-indigo-400 text-xs font-semibold px-3 py-1.5 rounded-lg cursor-not-allowed"
                 :aria-label="'Cobro con tarjeta pendiente: ' + order.table"
-              >&#128179; Cobrar con tarjeta</button>
+              >
+                <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"/></svg>
+                Cobrar con tarjeta
+              </button>
             </template>
             <button
               @click="dismiss(order.id)"
-              class="bg-white hover:bg-indigo-100 text-indigo-700 border border-indigo-300 text-xs font-semibold px-3 py-1.5 rounded focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2 transition"
+              class="bg-white dark:bg-gray-800 hover:bg-indigo-50 dark:hover:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 border border-indigo-200 dark:border-indigo-700 text-xs font-semibold px-3 py-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-offset-2 transition-colors cursor-pointer"
               :aria-label="'Ignorar solicitud de cuenta: ' + order.table"
             >
               Ignorar
@@ -62,17 +81,17 @@
 
         {{-- Desglose de importe solo para efectivo --}}
         <template x-if="order.payment_method === 'cash'">
-          <div class="mt-2 flex flex-wrap items-center gap-3 text-sm">
-            <span class="text-gray-600">
-              Subtotal: <strong class="text-gray-800" x-text="'€' + order.subtotal.toFixed(2)"></strong>
+          <div class="mt-2 pt-2 border-t border-indigo-200 dark:border-indigo-800 flex flex-wrap items-center gap-3 text-sm">
+            <span class="text-gray-600 dark:text-gray-400">
+              Subtotal: <strong class="text-gray-800 dark:text-gray-200 tabular-nums" x-text="'€' + order.subtotal.toFixed(2)"></strong>
             </span>
             <template x-if="order.tip > 0">
-              <span class="text-amber-700">
-                + Propina: <strong x-text="'€' + order.tip.toFixed(2)"></strong>
+              <span class="text-amber-700 dark:text-amber-400">
+                + Propina: <strong class="tabular-nums" x-text="'€' + order.tip.toFixed(2)"></strong>
               </span>
             </template>
-            <span class="font-bold text-green-800 text-base">
-              &#128181; Total a cobrar: <span x-text="'€' + order.amount_to_collect.toFixed(2)"></span>
+            <span class="font-bold text-green-700 dark:text-green-400 text-base tabular-nums">
+              Total: <span x-text="'€' + order.amount_to_collect.toFixed(2)"></span>
             </span>
           </div>
         </template>
@@ -90,31 +109,41 @@
   >
     <template x-for="order in readyOrders" :key="order.id">
       <div
-        class="bg-green-50 border border-green-400 rounded-lg px-4 py-3 mb-2 shadow-sm"
+        class="bg-green-50 dark:bg-green-900/20 border border-green-300 dark:border-green-800
+               rounded-xl px-4 py-3 mb-2 shadow-sm"
         role="alert"
       >
-        <div class="flex items-center justify-between">
-          <span class="text-green-800 font-medium text-sm">
-            &#128276; <strong x-text="order.table"></strong> &mdash; lista para servir
-          </span>
+        <div class="flex items-center justify-between gap-3">
+          <div class="flex items-center gap-2 text-green-800 dark:text-green-300 font-medium text-sm min-w-0">
+            <svg class="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 01-3.46 0"/>
+            </svg>
+            <strong x-text="order.table"></strong>
+            <span class="font-normal opacity-80 truncate">lista para servir</span>
+          </div>
           <button
             @click="dismiss(order.id)"
-            class="ml-4 shrink-0 bg-green-600 hover:bg-green-700 text-white text-xs font-semibold px-3 py-1.5 rounded focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition"
+            class="shrink-0 inline-flex items-center gap-1.5 bg-green-600 hover:bg-green-700 text-white text-xs font-semibold px-3 py-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors cursor-pointer"
             :aria-label="'Confirmar comanda lista: ' + order.table"
           >
-            &#10003; Confirmado
+            <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
+            Confirmado
           </button>
         </div>
         <template x-if="order.items && order.items.length > 0">
-          <ul class="mt-2 flex flex-wrap gap-2">
+          <ul class="mt-2 flex flex-wrap gap-1.5">
             <template x-for="(item, i) in order.items" :key="i">
               <li
                 class="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full"
-                :class="item.is_tapa ? 'bg-amber-100 text-amber-800' : 'bg-green-100 text-green-800'"
+                :class="item.is_tapa
+                  ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-300'
+                  : 'bg-green-100 dark:bg-green-900/40 text-green-800 dark:text-green-300'"
               >
                 <span x-text="'×' + item.quantity"></span>
                 <span x-text="item.name"></span>
-                <span x-show="item.is_tapa" class="text-amber-600 font-bold">&#127798;</span>
+                <template x-if="item.is_tapa">
+                  <svg class="w-3 h-3 text-amber-600 dark:text-amber-400 shrink-0" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><circle cx="12" cy="12" r="5"/></svg>
+                </template>
               </li>
             </template>
           </ul>
@@ -132,7 +161,7 @@
     {{-- Cabecera --}}
     <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6">
       <div>
-        <h2 class="text-xl sm:text-2xl font-bold text-gray-800">Panel de Barra</h2>
+        <h2 class="text-xl sm:text-2xl font-bold text-gray-800 dark:text-gray-100">Panel de Barra</h2>
         <p class="text-sm text-gray-500 mt-1">
           Actualización automática cada 5 segundos &mdash;
           <span x-text="lastUpdated" class="font-medium text-amber-600"></span>
@@ -196,11 +225,18 @@
                   <button
                     @click="markReady(item, order)"
                     :disabled="item.marking"
-                    class="shrink-0 bg-amber-500 hover:bg-amber-600 disabled:opacity-50 text-white text-xs font-semibold px-3 py-1.5 rounded focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 transition"
+                    class="shrink-0 inline-flex items-center gap-1.5 bg-amber-500 hover:bg-amber-600 disabled:opacity-50 text-white text-xs font-semibold px-3 py-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 transition-colors cursor-pointer"
                     :aria-label="'Marcar como servido: ' + item.product_name"
                   >
-                    <span x-show="!item.marking">Listo ✓</span>
-                    <span x-show="item.marking">...</span>
+                    <template x-if="!item.marking">
+                      <span class="inline-flex items-center gap-1">
+                        <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
+                        Listo
+                      </span>
+                    </template>
+                    <template x-if="item.marking">
+                      <svg class="w-3.5 h-3.5 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/></svg>
+                    </template>
                   </button>
 
                 </div>

--- a/resources/views/kitchen/availability.blade.php
+++ b/resources/views/kitchen/availability.blade.php
@@ -2,63 +2,123 @@
 <x-app-layout>
   <div class="max-w-3xl mx-auto px-4 sm:px-6 py-6 mt-4 sm:mt-10">
 
-    <div class="mb-6">
-      <h2 class="text-xl sm:text-2xl font-bold text-gray-800 dark:text-gray-100">Disponibilidad — Cocina</h2>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-        Desactiva los productos que se agoten durante el servicio. Desaparecen de la carta al instante y se pueden reactivar en cualquier momento.
-      </p>
+    {{-- Cabecera --}}
+    <div class="flex items-start gap-4 mb-6">
+      <div class="w-10 h-10 rounded-xl bg-red-50 dark:bg-red-900/30 flex items-center justify-center shrink-0 mt-0.5">
+        <svg class="w-5 h-5 text-red-600 dark:text-red-400" viewBox="0 0 24 24" fill="none"
+             stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"
+             aria-hidden="true">
+          <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+        </svg>
+      </div>
+      <div>
+        <h2 class="text-xl sm:text-2xl font-bold text-gray-900 dark:text-gray-100">
+          Disponibilidad — Cocina
+        </h2>
+        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
+          Desactiva los productos que se agoten. Desaparecen de la carta al instante.
+        </p>
+      </div>
     </div>
 
-    <div class="bg-white dark:bg-gray-800 shadow rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
+    <div class="bg-white dark:bg-gray-800 shadow-sm rounded-2xl overflow-hidden
+                border border-gray-200 dark:border-gray-700">
 
+      {{-- Banner de agotados --}}
       @php $unavailableCount = $products->where('is_available', false)->count(); @endphp
       @if($unavailableCount > 0)
-        <div class="px-4 py-2 bg-red-50 dark:bg-red-900/20 border-b border-red-200 dark:border-red-800">
+        <div class="flex items-center gap-2 px-4 py-2.5
+                    bg-red-50 dark:bg-red-900/20 border-b border-red-200 dark:border-red-800">
+          <svg class="w-4 h-4 text-red-500 dark:text-red-400 shrink-0" viewBox="0 0 24 24" fill="none"
+               stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+               aria-hidden="true">
+            <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+            <line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
+          </svg>
           <p class="text-xs font-semibold text-red-700 dark:text-red-300">
-            {{ $unavailableCount }} producto{{ $unavailableCount > 1 ? 's' : '' }} marcado{{ $unavailableCount > 1 ? 's' : '' }} como agotado{{ $unavailableCount > 1 ? 's' : '' }}
+            {{ $unavailableCount }} producto{{ $unavailableCount > 1 ? 's' : '' }}
+            agotado{{ $unavailableCount > 1 ? 's' : '' }}
           </p>
         </div>
       @endif
 
+      {{-- Lista --}}
       @if($products->isEmpty())
-        <p class="px-4 py-10 text-sm text-center text-gray-400 dark:text-gray-500">No hay productos de cocina activos.</p>
+        <div class="px-4 py-12 text-center">
+          <svg class="mx-auto mb-3 w-10 h-10 text-gray-300 dark:text-gray-600" viewBox="0 0 24 24"
+               fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+               stroke-linejoin="round" aria-hidden="true">
+            <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+          </svg>
+          <p class="text-sm text-gray-400 dark:text-gray-500">No hay productos de cocina activos.</p>
+        </div>
       @else
-        <ul class="divide-y divide-gray-100 dark:divide-gray-700" role="list" aria-label="Productos de cocina">
+        <ul class="divide-y divide-gray-100 dark:divide-gray-700/60" role="list"
+            aria-label="Productos de cocina">
           @foreach($products as $product)
           <li
-            class="flex items-center justify-between gap-3 px-4 py-3 transition-colors"
+            class="flex items-center gap-3 px-4 py-3.5 transition-colors
+                   hover:bg-gray-50 dark:hover:bg-gray-800/60"
             x-data="productAvailability({
               available: {{ $product->is_available ? 'true' : 'false' }},
               toggleUrl: '{{ url('/cocina/productos/' . $product->id . '/disponibilidad') }}'
             })"
-            :class="available ? '' : 'bg-red-50 dark:bg-red-900/20'"
+            :class="available ? '' : 'bg-red-50/60 dark:bg-red-900/10'"
           >
-            <div class="flex-1 min-w-0">
-              <span
-                class="text-sm font-medium transition-colors"
-                :class="available ? 'text-gray-800 dark:text-gray-200' : 'text-red-500 dark:text-red-400 line-through'"
-              >{{ $product->name }}</span>
-              <span
-                class="ml-2 text-xs transition-colors"
-                :class="available ? 'text-gray-400' : 'text-red-500 font-semibold'"
-                x-text="available ? '' : 'Agotado'"
-              ></span>
+            {{-- Dot de estado --}}
+            <span class="shrink-0 w-2 h-2 rounded-full transition-colors"
+                  :class="available ? 'bg-green-500' : 'bg-red-400'"
+                  aria-hidden="true"></span>
+
+            {{-- Nombre + badge agotado --}}
+            <div class="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
+              <span class="text-sm font-medium transition-colors leading-snug"
+                    :class="available
+                      ? 'text-gray-800 dark:text-gray-200'
+                      : 'text-red-600 dark:text-red-400 line-through'">
+                {{ $product->name }}
+              </span>
+              <span x-show="!available" x-cloak
+                    class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md text-xs font-semibold
+                           bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300">
+                <svg class="w-2.5 h-2.5" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                     stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+                  <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
+                Agotado
+              </span>
             </div>
 
-            <button
-              @click="toggle()"
-              :disabled="loading"
-              class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50"
-              :class="available ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
-              role="switch"
-              :aria-checked="available.toString()"
-              :aria-label="'{{ $product->name }}: ' + (available ? 'disponible, pulsa para marcar agotado' : 'agotado, pulsa para restaurar')"
-            >
-              <span
-                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
-                :class="available ? 'translate-x-5' : 'translate-x-0'"
-              ></span>
-            </button>
+            {{-- Spinner + toggle --}}
+            <div class="flex items-center gap-2 shrink-0">
+              <svg x-show="loading" x-cloak
+                   class="w-4 h-4 text-gray-400 animate-spin"
+                   viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
+              </svg>
+
+              <button
+                @click="toggle()"
+                :disabled="loading"
+                class="relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2
+                       border-transparent transition-colors duration-200 ease-in-out
+                       focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+                :class="available ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'"
+                role="switch"
+                :aria-checked="available.toString()"
+                :aria-label="'{{ $product->name }}: ' + (available
+                  ? 'disponible, pulsa para marcar agotado'
+                  : 'agotado, pulsa para restaurar')"
+              >
+                <span
+                  class="pointer-events-none inline-block h-5 w-5 transform rounded-full
+                         bg-white shadow ring-0 transition duration-200 ease-in-out"
+                  :class="available ? 'translate-x-5' : 'translate-x-0'"
+                ></span>
+              </button>
+            </div>
           </li>
           @endforeach
         </ul>

--- a/resources/views/kitchen/index.blade.php
+++ b/resources/views/kitchen/index.blade.php
@@ -43,9 +43,14 @@
         <div class="bg-white dark:bg-gray-800 shadow-md rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
 
           {{-- Cabecera de la comanda --}}
-          <div class="flex items-center justify-between px-4 py-3 bg-indigo-600 text-white">
-            <span class="font-bold text-base" x-text="order.table_name"></span>
-            <span class="text-xs bg-white/20 rounded px-2 py-1" x-text="order.created_at"></span>
+          <div class="flex items-center justify-between px-4 py-3 bg-red-600 dark:bg-red-700 text-white">
+            <div class="flex items-center gap-2">
+                <svg class="w-4 h-4 text-red-200 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+                </svg>
+                <span class="font-bold text-base" x-text="order.table_name"></span>
+            </div>
+            <span class="text-xs bg-white/20 rounded-md px-2 py-1 tabular-nums" x-text="order.created_at"></span>
           </div>
 
           {{-- Ítems pendientes --}}
@@ -72,16 +77,25 @@
 
                     {{-- Modificaciones del cliente --}}
                     <template x-if="item.modifications && item.modifications.length > 0">
-                      <ul class="mt-1 space-y-0.5" aria-label="Modificaciones del cliente">
+                      <ul class="mt-1.5 space-y-1" aria-label="Modificaciones del cliente">
                         <template x-for="mod in item.modifications" :key="mod.ingredient">
-                          <li class="flex items-center gap-1 text-xs">
+                          <li class="flex items-center gap-1.5 text-xs">
                             <span
                               :class="mod.action === 'remove'
-                                ? 'bg-red-100 text-red-700'
-                                : 'bg-green-100 text-green-700'"
-                              class="inline-block px-1.5 py-0.5 rounded font-medium"
-                              x-text="mod.action === 'remove' ? 'Sin' : 'Extra'"
-                            ></span>
+                                ? 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-800'
+                                : 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300 border border-green-200 dark:border-green-800'"
+                              class="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md font-semibold leading-none"
+                            >
+                              <svg class="w-2.5 h-2.5 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" aria-hidden="true">
+                                <template x-if="mod.action === 'remove'">
+                                  <path d="M18 6L6 18M6 6l12 12"/>
+                                </template>
+                                <template x-if="mod.action !== 'remove'">
+                                  <path d="M12 5v14M5 12h14"/>
+                                </template>
+                              </svg>
+                              <span x-text="mod.action === 'remove' ? 'Sin' : 'Extra'"></span>
+                            </span>
                             <span class="text-gray-600 dark:text-gray-400" x-text="mod.ingredient"></span>
                           </li>
                         </template>
@@ -94,11 +108,18 @@
                   <button
                     @click="markReady(item, order)"
                     :disabled="item.marking"
-                    class="shrink-0 bg-green-500 hover:bg-green-600 disabled:opacity-50 text-white text-xs font-semibold px-3 py-1.5 rounded focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-offset-2 transition"
+                    class="shrink-0 inline-flex items-center gap-1.5 bg-green-500 hover:bg-green-600 disabled:opacity-50 text-white text-xs font-semibold px-3 py-1.5 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-offset-2 transition-colors cursor-pointer"
                     :aria-label="'Marcar como listo: ' + item.product_name"
                   >
-                    <span x-show="!item.marking">Listo ✓</span>
-                    <span x-show="item.marking">...</span>
+                    <template x-if="!item.marking">
+                      <span class="inline-flex items-center gap-1">
+                        <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
+                        Listo
+                      </span>
+                    </template>
+                    <template x-if="item.marking">
+                      <svg class="w-3.5 h-3.5 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/></svg>
+                    </template>
                   </button>
 
                 </div>
@@ -109,18 +130,28 @@
           {{-- Footer: pedido completo --}}
           <div
             x-show="order.all_ready"
-            class="px-4 py-3 bg-green-50 border-t border-green-200 flex items-center justify-between gap-3"
+            class="px-4 py-3 bg-green-50 dark:bg-green-900/20 border-t border-green-200 dark:border-green-800 flex items-center justify-between gap-3"
             role="status"
           >
-            <span class="text-green-700 text-xs font-semibold">¡Pedido completo! Listo para servir.</span>
+            <div class="flex items-center gap-2">
+              <svg class="w-4 h-4 text-green-600 dark:text-green-400 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
+              <span class="text-green-700 dark:text-green-300 text-xs font-semibold">Pedido completo</span>
+            </div>
             <button
               @click="markServed(order)"
               :disabled="order.serving"
-              class="text-xs font-semibold px-3 py-1 rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-1"
+              class="inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1.5 rounded-lg bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-1 transition-colors cursor-pointer"
               aria-label="Marcar pedido como servido"
             >
-              <span x-show="!order.serving">Servido ✓</span>
-              <span x-show="order.serving">...</span>
+              <template x-if="!order.serving">
+                <span class="inline-flex items-center gap-1">
+                  <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
+                  Servido
+                </span>
+              </template>
+              <template x-if="order.serving">
+                <svg class="w-3.5 h-3.5 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/></svg>
+              </template>
             </button>
           </div>
 


### PR DESCRIPTION
## Summary

Visual polish across the four operational panels used by kitchen and bar staff during service.

### Kitchen panel (`kitchen/index`)
- Order card header changed from `bg-indigo-600` → `bg-red-600 dark:bg-red-700` — aligns with the red kitchen theme already used in the sidebar and nav badges.
- Ingredient modification badges: added `border`, full `dark:` variant support, and `+`/`×` SVG prefix icons per action type.
- **Listo / Servido** buttons: replaced plain text + Unicode checkmark with an inline SVG checkmark. During the async request, the checkmark is swapped for an `animate-spin` spinner. Buttons now use `rounded-lg` and `cursor-pointer`.
- "Pedido completo" footer: added checkmark SVG, dark mode `bg-green-900/20`.

### Availability panels (`kitchen/availability` + `bar/availability`)
Both redesigned consistently:
- `rounded-lg shadow` → `rounded-2xl shadow-sm` (matches other panel cards).
- Coloured section header with SVG icon (red icon for kitchen, amber for bar).
- Unavailable count banner: kitchen keeps red, bar switches to amber (semantic).
- List rows gain `hover:bg-gray-50 dark:hover:bg-gray-800/60`, a status dot (green / red|amber), and an `Agotado` pill badge with `×` SVG replacing plain styled text.
- Toggle: `animate-spin` spinner appears adjacent during async toggle.
- `disabled:cursor-not-allowed` added. Empty state upgraded with SVG.

### Bar panel (`bar/index`)
- All HTML entities (`&#128179;` `&#128181;` `&#128276;` `&#127798;` `&#10003;`) replaced with Heroicons SVGs.
- Bill request alert: `rounded-xl`, full dark mode, desglose totals with separator line.
- Ready-order notification: bell SVG, dark mode on item badge pills, tapa dot SVG.
- **Confirmado / Listo** buttons: SVG checkmark + `animate-spin` spinner, `rounded-lg`, `cursor-pointer`.
- Missing `dark:text-gray-100` added to bar panel title.
- Disabled card-payment button has dark mode.

## Test plan

- [ ] Kitchen: order cards show red header, spinner appears when marking item ready
- [ ] Kitchen: modification badges show correctly in light and dark mode
- [ ] Kitchen/Bar availability: status dot, Agotado badge, spinner on toggle
- [ ] Bar: bill request shows SVG icons, correct dark mode
- [ ] Bar: "Confirmado" button shows spinner while dismissing

🤖 Generated with [Claude Code](https://claude.com/claude-code)