### PR TITLE
fix: Blade parse error in ticket-config init JSON block

### DIFF
--- a/resources/views/ticket-config/edit.blade.php
+++ b/resources/views/ticket-config/edit.blade.php
@@ -90,17 +90,20 @@
             @endif
 
             {{-- Datos de inicialización para ticketConfigData() (resources/js/alpine/ticket-config.js) --}}
-            <script id="ticket-config-init" type="application/json">@json([
-                'template'       => old('template', $ticketConfig->template),
-                'savedTemplate'  => $ticketConfig->template,
-                'taxId'          => old('tax_id', $ticketConfig->tax_id),
-                'savedTaxId'     => $ticketConfig->tax_id,
-                'footerText'     => old('footer_text', $ticketConfig->footer_text ?? ''),
-                'savedFooterText'=> $ticketConfig->footer_text ?? '',
-                'footerCount'    => mb_strlen(old('footer_text', $ticketConfig->footer_text ?? '')),
-                'logoUrl'        => $ticketConfig->hasLogo() ? $ticketConfig->getLogoUrl() : '',
-                'businessName'   => Auth::user()->business_name ?? Auth::user()->name,
-            ])</script>
+            @php
+                $ticketConfigInit = [
+                    'template'        => old('template', $ticketConfig->template),
+                    'savedTemplate'   => $ticketConfig->template,
+                    'taxId'           => old('tax_id', $ticketConfig->tax_id),
+                    'savedTaxId'      => $ticketConfig->tax_id,
+                    'footerText'      => old('footer_text', $ticketConfig->footer_text ?? ''),
+                    'savedFooterText' => $ticketConfig->footer_text ?? '',
+                    'footerCount'     => mb_strlen(old('footer_text', $ticketConfig->footer_text ?? '')),
+                    'logoUrl'         => $ticketConfig->hasLogo() ? $ticketConfig->getLogoUrl() : '',
+                    'businessName'    => Auth::user()->business_name ?? Auth::user()->name,
+                ];
+            @endphp
+            <script id="ticket-config-init" type="application/json">@json($ticketConfigInit)</script>
 
             {{-- ─── FORMULARIO con Alpine.js reactivo ─── --}}
             <div x-data="ticketConfigData()">


### PR DESCRIPTION
## Summary

Blade's directive parser fails to correctly balance brackets in a multi-line `@json([...])` call that spans 10+ lines and contains expressions with `??`, `old()`, and ternary operators.

**Error:** `Unclosed '[' on line 104 does not match ')'`

**Fix:** Build the array in an `@php` block first, then pass the single variable to `@json($var)`. This is the pattern used by kitchen/bar panels throughout the project.

## Test plan

- [ ] `php artisan test tests/Feature/Bloque17/TicketConfigTest.php` passes
- [ ] Ticket config page loads without Blade compilation error
- [ ] Ticket config data (template, logo, footer) initializes correctly in Alpine

🤖 Generated with [Claude Code](https://claude.com/claude-code)