### PR TITLE
refactor: métodos de pago carta digital — UX, navegación y fixes de flujo

### DIFF
--- a/app/Http/Controllers/Api/BillRequestController.php
+++ b/app/Http/Controllers/Api/BillRequestController.php
@@ -45,13 +45,6 @@ class BillRequestController extends Controller
             ], 404);
         }
 
-        if ($order->bill_requested) {
-            return response()->json([
-                'success' => false,
-                'message' => 'La cuenta ya fue solicitada. El camarero está en camino.',
-            ], 422);
-        }
-
         $order->update([
             'bill_requested'           => true,
             'requested_payment_method' => $validated['payment_method'],

--- a/app/Http/Controllers/Api/SplitPaymentController.php
+++ b/app/Http/Controllers/Api/SplitPaymentController.php
@@ -51,11 +51,12 @@ class SplitPaymentController extends Controller
 
         $items = $order->items()->with('splitPayments')->get()
             ->map(fn (OrderItem $item) => [
-                'id'      => $item->id,
-                'name'    => $item->product?->name ?? 'Producto',
-                'price'   => (float) $item->price,
-                'total'   => round((float) $item->price * $item->quantity, 2),
-                'claimed' => $equitativeLocked || $item->isClaimed(),
+                'id'           => $item->id,
+                'name'         => $item->product?->name ?? 'Producto',
+                'price'        => (float) $item->price,
+                'total'        => round((float) $item->price * $item->quantity, 2),
+                'claimed'      => $equitativeLocked || $item->isClaimed(),
+                'is_courtesy'  => (float) $item->price === 0.0,
             ]);
 
         return response()->json([

--- a/app/Http/Controllers/Api/SplitPaymentController.php
+++ b/app/Http/Controllers/Api/SplitPaymentController.php
@@ -291,6 +291,44 @@ class SplitPaymentController extends Controller
     }
 
     /**
+     * Devuelve cuántas partes equitativas han sido pagadas en el pedido activo.
+     * Usado por el frontend para actualizar el donut y los dots en tiempo real.
+     *
+     * @param  string  $hash
+     * @return JsonResponse
+     */
+    public function eqStatus(string $hash): JsonResponse
+    {
+        $table = Table::with('user')->where('unique_hash', $hash)->firstOrFail();
+
+        if ($guard = $this->guardSplitEnabled($table)) {
+            return $guard;
+        }
+
+        $order = $this->activeOrder($table->id);
+
+        if (! $order) {
+            return response()->json(['success' => false, 'paid_parts' => 0, 'parts_total' => 0]);
+        }
+
+        $paid = OrderItemPayment::where('order_id', $order->id)
+            ->where('mode', 'equitative')
+            ->where('status', 'paid')
+            ->count();
+
+        $total = OrderItemPayment::where('order_id', $order->id)
+            ->where('mode', 'equitative')
+            ->whereIn('status', ['pending', 'paid'])
+            ->max('parts_total') ?? 0;
+
+        return response()->json([
+            'success'     => true,
+            'paid_parts'  => $paid,
+            'parts_total' => (int) $total,
+        ]);
+    }
+
+    /**
      * Devuelve 403 si el cobro partido no está activado para este restaurante.
      *
      * @param  Table  $table

--- a/app/Http/Controllers/Api/SplitPaymentController.php
+++ b/app/Http/Controllers/Api/SplitPaymentController.php
@@ -163,9 +163,10 @@ class SplitPaymentController extends Controller
     public function payEquitative(Request $request, string $hash): JsonResponse
     {
         $validated = $request->validate([
-            'people'      => 'required|integer|min:2|max:50',
-            'part_number' => 'required|integer|min:1',
-            'tip'         => 'nullable|numeric|min:0|max:500',
+            'people'        => 'required|integer|min:2|max:50',
+            'part_number'   => 'required|integer|min:1',
+            'tip'           => 'nullable|numeric|min:0|max:500',
+            'session_color' => 'nullable|string|regex:/^#[0-9A-Fa-f]{6}$/',
         ]);
 
         $table = Table::with('user')->where('unique_hash', $hash)->firstOrFail();
@@ -180,9 +181,10 @@ class SplitPaymentController extends Controller
             return response()->json(['success' => false, 'message' => 'No hay pedido activo.'], 404);
         }
 
-        $people     = (int) $validated['people'];
-        $partNumber = (int) $validated['part_number'];
-        $tip        = (float) ($validated['tip'] ?? 0);
+        $people       = (int) $validated['people'];
+        $partNumber   = (int) $validated['part_number'];
+        $tip          = (float) ($validated['tip'] ?? 0);
+        $sessionColor = $validated['session_color'] ?? null;
 
         $maxParts = $table->user->split_payment_max_parts;
         if ($maxParts !== null && $people > $maxParts) {
@@ -222,6 +224,7 @@ class SplitPaymentController extends Controller
             'mode'                     => 'equitative',
             'parts_total'              => $people,
             'part_number'              => $partNumber,
+            'session_color'            => $sessionColor,
         ]);
 
         return response()->json([
@@ -311,20 +314,28 @@ class SplitPaymentController extends Controller
             return response()->json(['success' => false, 'paid_parts' => 0, 'parts_total' => 0]);
         }
 
-        $paid = OrderItemPayment::where('order_id', $order->id)
-            ->where('mode', 'equitative')
-            ->where('status', 'paid')
-            ->count();
-
-        $total = OrderItemPayment::where('order_id', $order->id)
+        $total = (int) (OrderItemPayment::where('order_id', $order->id)
             ->where('mode', 'equitative')
             ->whereIn('status', ['pending', 'paid'])
-            ->max('parts_total') ?? 0;
+            ->max('parts_total') ?? 0);
+
+        $paidRows = OrderItemPayment::where('order_id', $order->id)
+            ->where('mode', 'equitative')
+            ->where('status', 'paid')
+            ->get(['part_number', 'session_color']);
+
+        // Indexar por part_number (0-based) → color
+        $slotColors = [];
+        foreach ($paidRows as $row) {
+            $idx = $row->part_number - 1;
+            $slotColors[$idx] = $row->session_color ?? '#16A34A';
+        }
 
         return response()->json([
             'success'     => true,
-            'paid_parts'  => $paid,
-            'parts_total' => (int) $total,
+            'paid_parts'  => $paidRows->count(),
+            'parts_total' => $total,
+            'slot_colors' => $slotColors, // { "0": "#E84FAC", "2": "#3B82F6" }
         ]);
     }
 

--- a/database/migrations/2026_06_07_015148_add_session_color_to_order_item_payments.php
+++ b/database/migrations/2026_06_07_015148_add_session_color_to_order_item_payments.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('order_item_payments', function (Blueprint $table) {
+            $table->string('session_color', 7)->nullable()->after('part_number');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('order_item_payments', function (Blueprint $table) {
+            $table->dropColumn('session_color');
+        });
+    }
+};

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -1817,8 +1817,8 @@
   font-variant-numeric: tabular-nums;
 }
 .breakdown__cell--card .v { color: var(--color-blue-400); }
-[data-theme="dark"] .breakdown__cell--card .v { color: var(--color-blue-200); }
-[data-theme="dark"] .breakdown__cell--card .dot { background: var(--color-blue-200); }
+[data-theme="dark"] .breakdown__cell--card .v { color: var(--color-blue-300); }
+[data-theme="dark"] .breakdown__cell--card .dot { background: var(--color-blue-300); }
 
 /* Validation alert */
 .mixed-alert {
@@ -1880,7 +1880,7 @@
   color: var(--fg-primary);
 }
 .recap__row--card .v { color: var(--color-blue-400); }
-[data-theme="dark"] .recap__row--card .v { color: var(--color-blue-200); }
+[data-theme="dark"] .recap__row--card .v { color: var(--color-blue-300); }
 .recap__row--cash .v { color: var(--color-green-700); }
 
 /* Section label */

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -1817,6 +1817,8 @@
   font-variant-numeric: tabular-nums;
 }
 .breakdown__cell--card .v { color: var(--color-blue-400); }
+[data-theme="dark"] .breakdown__cell--card .v { color: var(--color-blue-200); }
+[data-theme="dark"] .breakdown__cell--card .dot { background: var(--color-blue-200); }
 
 /* Validation alert */
 .mixed-alert {
@@ -1878,6 +1880,7 @@
   color: var(--fg-primary);
 }
 .recap__row--card .v { color: var(--color-blue-400); }
+[data-theme="dark"] .recap__row--card .v { color: var(--color-blue-200); }
 .recap__row--cash .v { color: var(--color-green-700); }
 
 /* Section label */

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -1613,3 +1613,497 @@
   --dm-gold-ink: #FFF8E6;
 }
 
+/* ════════════════════════════════════════════════════════════
+   MIXED PAYMENT — Sheet 1: split bar draggable + presets + fine
+   ════════════════════════════════════════════════════════════ */
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.split__bar {
+  position: relative;
+  display: flex;
+  height: 96px;
+  border-radius: 18px;
+  overflow: hidden;
+  background: var(--bg-chip);
+  box-shadow: inset 0 0 0 1px var(--border-subtle);
+  cursor: ew-resize;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: none;
+}
+.split__side {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0 8px;
+  color: #FFFFFF;
+  transition: flex-basis .14s ease;
+}
+.split__side--cash {
+  background: linear-gradient(135deg, #1FAE5A 0%, #138A45 100%);
+  border-right: 2px solid rgba(255,255,255,0.5);
+}
+.split__side--card {
+  background: linear-gradient(135deg, #2E63C8 0%, #2BA6C9 100%);
+}
+.split__lab {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.82);
+  white-space: nowrap;
+}
+.split__amt {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 25px;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  line-height: 1;
+  text-shadow: 0 1px 6px rgba(0,0,0,0.18);
+}
+.split__handle {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: var(--bg-surface);
+  box-shadow: 0 4px 14px rgba(0,0,0,0.32), inset 0 0 0 1px var(--border-subtle);
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  cursor: ew-resize;
+  transition: left .14s ease;
+}
+.split__handle::before,
+.split__handle::after {
+  content: "";
+  width: 2px;
+  height: 13px;
+  border-radius: 2px;
+  background: var(--fg-muted);
+}
+.split__bar.is-dragging .split__side  { transition: none; }
+.split__bar.is-dragging .split__handle { transition: none; }
+
+/* Quick preset chips */
+.split-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 20px;
+}
+.split-chip {
+  appearance: none;
+  cursor: pointer;
+  background: var(--bg-chip);
+  border: 1px solid var(--border-subtle);
+  color: var(--fg-secondary);
+  border-radius: 999px;
+  padding: 9px 17px;
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 13.5px;
+  font-variant-numeric: tabular-nums;
+  transition: background 150ms ease, border-color 150ms ease, color 150ms ease, transform 150ms ease;
+}
+.split-chip:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  color: var(--fg-primary);
+  transform: translateY(-1px);
+}
+.split-chip:focus-visible { outline: 3px solid rgba(201,152,54,0.45); outline-offset: 2px; }
+.split-chip:disabled { opacity: 0.4; cursor: default; }
+.split-chip.is-active { background: #3B5BDB; border-color: #3B5BDB; color: #FFFFFF; }
+.split-chip--solo { color: var(--fg-muted); }
+
+/* Fine adjustment widget */
+.fine {
+  margin-top: 16px;
+  padding: 11px 14px;
+  background: var(--bg-chip);
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.fine__lab {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.fine__main { display: flex; align-items: center; gap: 10px; }
+.fine__val {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 20px;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-primary);
+  min-width: 78px;
+  text-align: center;
+  letter-spacing: -0.01em;
+}
+.fine__btn {
+  appearance: none;
+  cursor: pointer;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  padding: 9px 12px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-weight: 700;
+  color: var(--fg-secondary);
+  font-variant-numeric: tabular-nums;
+  min-width: 58px;
+  transition: border-color 150ms ease, color 150ms ease;
+}
+.fine__btn:hover:not(:disabled) { border-color: var(--border-strong); color: var(--fg-primary); }
+.fine__btn:focus-visible { outline: 3px solid rgba(201,152,54,0.45); outline-offset: 2px; }
+.fine__btn:disabled { opacity: 0.4; cursor: default; }
+
+/* Breakdown: cash vs card summary grid */
+.breakdown {
+  margin-top: 16px;
+  padding: 6px;
+  border-radius: 16px;
+  background: var(--bg-chip);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+.breakdown__cell {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.breakdown__cell .k {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.breakdown__cell .k .dot { width: 8px; height: 8px; border-radius: 3px; flex-shrink: 0; }
+.breakdown__cell--cash .dot { background: var(--color-green-600); }
+.breakdown__cell--card .dot { background: var(--color-blue-400); }
+.breakdown__cell .v {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+  color: var(--fg-primary);
+  font-variant-numeric: tabular-nums;
+}
+.breakdown__cell--card .v { color: var(--color-blue-400); }
+
+/* Validation alert */
+.mixed-alert {
+  margin: 14px 0 0;
+  padding: 11px 14px;
+  background: rgba(220, 38, 38, 0.08);
+  color: var(--color-red-800);
+  border: 1px solid rgba(220, 38, 38, 0.20);
+  border-radius: 12px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.4;
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+}
+.mixed-alert__ic {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  display: inline-grid;
+  place-items: center;
+  background: var(--color-red-600);
+  color: #FFFFFF;
+  border-radius: 50%;
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 11px;
+}
+[data-theme="dark"] .mixed-alert { background: rgba(220, 38, 38, 0.14); color: #FCA5A5; border-color: rgba(220, 38, 38, 0.40); }
+
+/* ════════════════════════════════════════════════════════════
+   MIXED PAYMENT — Sheet 2: recap + tip grid + summary
+   ════════════════════════════════════════════════════════════ */
+
+/* Read-only recap rows */
+.recap {
+  display: grid;
+  gap: 1px;
+  background: var(--border-subtle);
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  overflow: hidden;
+}
+.recap__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: var(--bg-chip);
+  font-family: var(--font-body);
+  font-size: 14px;
+  color: var(--fg-secondary);
+}
+.recap__row .v {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-primary);
+}
+.recap__row--card .v { color: var(--color-blue-400); }
+.recap__row--cash .v { color: var(--color-green-700); }
+
+/* Section label */
+.mixed-sec-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+  margin: 18px 0 10px;
+}
+.mixed-sec-label .hint {
+  font-family: var(--font-body);
+  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--fg-muted);
+}
+
+/* Tip grid (5 columns) */
+.tip-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 7px; }
+.tip-chip {
+  appearance: none;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  padding: 12px 4px 10px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  transition: border-color 150ms ease, background 150ms ease, transform 150ms ease;
+  font-family: var(--font-body);
+}
+.tip-chip:hover { border-color: var(--border-strong); transform: translateY(-1px); }
+.tip-chip:focus-visible { outline: 3px solid rgba(201,152,54,0.45); outline-offset: 2px; }
+.tip-chip__pct {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+  color: var(--fg-primary);
+  line-height: 1;
+}
+.tip-chip__amt {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+.tip-chip.is-active { background: var(--color-green-600); border-color: var(--color-green-700); }
+.tip-chip.is-active .tip-chip__pct { color: #FFFFFF; }
+.tip-chip.is-active .tip-chip__amt { color: rgba(255,255,255,0.82); }
+[data-theme="dark"] .tip-chip.is-active { background: var(--color-green-600); border-color: var(--color-green-500); }
+
+/* Custom tip input */
+.tip-input {
+  margin-top: 10px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: stretch;
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  background: var(--bg-surface);
+  overflow: hidden;
+  transition: border-color 150ms ease;
+}
+.tip-input:focus-within { border-color: var(--color-green-600); }
+.tip-input input {
+  border: none;
+  background: transparent;
+  padding: 14px 14px 14px 16px;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 18px;
+  color: var(--fg-primary);
+  font-variant-numeric: tabular-nums;
+  width: 100%;
+  outline: none;
+}
+.tip-input input::placeholder { color: var(--fg-muted); font-weight: 500; }
+.tip-input__currency {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 16px;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 16px;
+  color: var(--fg-muted);
+  border-left: 1px solid var(--border-subtle);
+}
+
+/* Summary block */
+.mixed-summary {
+  margin-top: 16px;
+  padding: 14px 16px;
+  background: var(--bg-chip);
+  border-radius: 14px;
+  display: grid;
+  gap: 6px;
+  font-family: var(--font-body);
+  font-size: 14px;
+}
+.mixed-summary__row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  color: var(--fg-secondary);
+}
+.mixed-summary__row--tip { color: var(--color-green-700); font-weight: 600; }
+.mixed-summary__row--total {
+  padding-top: 8px;
+  margin-top: 2px;
+  border-top: 1px solid var(--border-subtle);
+  color: var(--fg-primary);
+}
+.mixed-summary__row .v {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+.mixed-summary__row--total .v { font-size: 18px; color: var(--price-gold); }
+
+/* ════════════════════════════════════════════════════════════
+   MIXED PAYMENT — Sheet 3: Stripe element
+   ════════════════════════════════════════════════════════════ */
+
+/* Card charge banner */
+.stripe-charge {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 4px 0 16px;
+  padding: 14px 16px;
+  background: rgba(46, 80, 176, 0.10);
+  border-radius: 14px;
+}
+.stripe-charge .k {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-blue-400);
+}
+.stripe-charge .v {
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 22px;
+  color: var(--color-blue-400);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+[data-theme="dark"] .stripe-charge { background: rgba(46, 80, 176, 0.24); }
+[data-theme="dark"] .stripe-charge .k,
+[data-theme="dark"] .stripe-charge .v { color: var(--color-blue-200); }
+
+/* Stripe element loading frame */
+.stripe-frame { position: relative; min-height: 188px; }
+.stripe-loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.stripe-loading .ring {
+  width: 28px;
+  height: 28px;
+  border: 3px solid var(--border-strong);
+  border-top-color: var(--color-green-600);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+#mixed-stripe-element {
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  padding: 16px;
+  background: var(--bg-surface);
+  min-height: 188px;
+}
+
+/* Stripe error */
+.stripe-error {
+  margin: 12px 0 0;
+  padding: 11px 14px;
+  background: rgba(220, 38, 38, 0.08);
+  color: var(--color-red-800);
+  border: 1px solid rgba(220, 38, 38, 0.20);
+  border-radius: 12px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.4;
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+}
+.stripe-error__ic {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  display: inline-grid;
+  place-items: center;
+  background: var(--color-red-600);
+  color: #FFFFFF;
+  border-radius: 50%;
+  font-family: var(--font-display);
+  font-weight: 900;
+  font-size: 11px;
+}
+[data-theme="dark"] .stripe-error { background: rgba(220, 38, 38, 0.14); color: #FCA5A5; border-color: rgba(220, 38, 38, 0.40); }
+[data-theme="dark"] .stripe-error__ic { background: #F87171; }
+

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -681,7 +681,7 @@
 }
 .bill__footRow--stack > .btn-primary,
 .bill__footRow--stack > .btn-secondary { width: 100%; }
-.bill__footRow--stack > .back { align-self: center; width: auto; margin-top: 2px; }
+.bill__footRow--stack > .back { width: 100%; }
 
 /* Mobile compaction inside cashTip */
 .carta[data-bp="mobile"] .cashTip { gap: 14px; }

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -2107,3 +2107,74 @@
 [data-theme="dark"] .stripe-error { background: rgba(220, 38, 38, 0.14); color: #FCA5A5; border-color: rgba(220, 38, 38, 0.40); }
 [data-theme="dark"] .stripe-error__ic { background: #F87171; }
 
+/* ════════════════════════════════════════════════════════════
+   MIXED PAYMENT — Responsive mobile (.carta[data-bp="mobile"])
+   ════════════════════════════════════════════════════════════ */
+
+/* Sheet 1: split bar */
+.carta[data-bp="mobile"] .split__bar { height: 84px; border-radius: 16px; }
+.carta[data-bp="mobile"] .split__amt { font-size: 20px; }
+.carta[data-bp="mobile"] .split__handle { width: 30px; height: 30px; }
+
+/* Sheet 1: preset chips — más compactos */
+.carta[data-bp="mobile"] .split-chips { gap: 6px; margin-top: 16px; }
+.carta[data-bp="mobile"] .split-chip { padding: 7px 13px; font-size: 12.5px; }
+
+/* Sheet 1: ajuste fino */
+.carta[data-bp="mobile"] .fine { padding: 9px 12px; margin-top: 12px; }
+.carta[data-bp="mobile"] .fine__val { font-size: 18px; min-width: 68px; }
+.carta[data-bp="mobile"] .fine__btn { padding: 8px 10px; font-size: 10.5px; min-width: 50px; }
+
+/* Sheet 1: breakdown */
+.carta[data-bp="mobile"] .breakdown { margin-top: 12px; }
+.carta[data-bp="mobile"] .breakdown__cell { padding: 10px 12px; }
+.carta[data-bp="mobile"] .breakdown__cell .v { font-size: 17px; }
+
+/* Sheet 1: alerta */
+.carta[data-bp="mobile"] .mixed-alert { font-size: 12px; padding: 9px 12px; }
+
+/* Sheet 2: recap */
+.carta[data-bp="mobile"] .recap__row { padding: 10px 14px; font-size: 13px; }
+
+/* Sheet 2: section label */
+.carta[data-bp="mobile"] .mixed-sec-label { margin: 14px 0 8px; }
+
+/* Sheet 2: tip grid — chips más compactos en 5 columnas */
+.carta[data-bp="mobile"] .tip-grid { gap: 5px; }
+.carta[data-bp="mobile"] .tip-chip { padding: 10px 2px 8px; border-radius: 12px; }
+.carta[data-bp="mobile"] .tip-chip__pct { font-size: 13px; }
+.carta[data-bp="mobile"] .tip-chip__amt { font-size: 8.5px; }
+
+/* Sheet 2: tip input — mínimo 16px para evitar zoom en iOS */
+.carta[data-bp="mobile"] .tip-input input { font-size: 16px; padding: 12px 12px 12px 14px; }
+.carta[data-bp="mobile"] .tip-input__currency { font-size: 15px; padding: 0 14px; }
+
+/* Sheet 2: summary */
+.carta[data-bp="mobile"] .mixed-summary { padding: 12px 14px; font-size: 13px; }
+.carta[data-bp="mobile"] .mixed-summary__row--total .v { font-size: 16px; }
+
+/* Sheet 3: stripe charge banner */
+.carta[data-bp="mobile"] .stripe-charge { padding: 12px 14px; margin-bottom: 12px; }
+.carta[data-bp="mobile"] .stripe-charge .v { font-size: 19px; }
+
+/* Sheet 3: stripe frame */
+.carta[data-bp="mobile"] .stripe-frame { min-height: 164px; }
+.carta[data-bp="mobile"] .stripe-loading { font-size: 10px; gap: 10px; }
+.carta[data-bp="mobile"] .stripe-loading .ring { width: 24px; height: 24px; }
+
+/* Sheet 3: error */
+.carta[data-bp="mobile"] .stripe-error { font-size: 12px; padding: 9px 12px; }
+
+/* ── Pantallas muy pequeñas ≤ 360 px ──────────────────────── */
+@media (max-width: 360px) {
+  .split__bar { height: 76px; }
+  .split__amt { font-size: 17px; }
+  .split-chip { padding: 6px 10px; font-size: 11.5px; }
+  .fine__val { font-size: 16px; min-width: 60px; }
+  .fine__btn { padding: 7px 8px; min-width: 44px; font-size: 10px; }
+  .breakdown { grid-template-columns: 1fr; }
+  .tip-chip__pct { font-size: 12px; }
+  .tip-chip__amt { font-size: 8px; }
+  .stripe-charge .v { font-size: 17px; }
+}
+

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -681,6 +681,7 @@
 }
 .bill__footRow--stack > .btn-primary,
 .bill__footRow--stack > .btn-secondary { width: 100%; }
+.bill__footRow--stack > .back { align-self: center; width: auto; margin-top: 2px; }
 
 /* Mobile compaction inside cashTip */
 .carta[data-bp="mobile"] .cashTip { gap: 14px; }

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -387,7 +387,16 @@
 .bill__footRow > .btn-primary { flex: 1 1 auto; width: auto; }
 .bill__footRow > .btn-secondary { flex: 0 0 auto; width: auto; }
 .bill__footRow > .btn-text { flex: 0 0 auto; width: auto; margin-right: auto; }
-.bill__cancelNotice { color: var(--fg-muted); }
+.bill__cancelNotice {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  margin: 0 auto; width: auto !important; flex: none !important;
+  padding: 11px 22px; border-radius: 12px;
+  background: #fee2e2; color: #dc2626;
+  border: 1.5px solid #fca5a5;
+  font-weight: 700; font-size: 14px;
+  cursor: pointer; transition: background 0.15s, border-color 0.15s;
+}
+.bill__cancelNotice:hover { background: #fecaca; border-color: #f87171; color: #b91c1c; }
 .bill__callWaiter { display: inline-flex; align-items: center; justify-content: center; gap: 8px; }
 .bill__doneAmt { color: var(--price-gold); font-variant-numeric: tabular-nums; }
 

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -40,13 +40,11 @@
 /* ----- Bill flow (bottom-sheet variant of the drawer) ----- */
 .drawer--bill { height: auto; max-height: 70%; }
 
-/* Mobile: the bill drawer must stay in the lower thumb-zone.
-   The cart drawer rule above pins .drawer to 70% on mobile, which is
-   too tall for the bill (only 2 short steps). Override to a compact
-   auto-height capped under half the carta height. */
+/* Mobile: tall enough to show all 4 payment method cards (2×2 grid)
+   without any scroll. Previous 48% was too short. */
 .carta[data-bp="mobile"] .drawer--bill {
   height: auto;
-  max-height: 48%;
+  max-height: 72%;
 }
 .drawer__total {
   display: flex; flex-direction: column;
@@ -75,20 +73,36 @@
 }
 .btn-text:hover { color: var(--fg-primary); }
 
-.bill__methods { 
-  display: grid; 
-  grid-template-columns: 1fr;
+.bill__methods {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 12px;
 }
 .carta[data-bp="tablet"] .bill__methods {
-  display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 12px;
 }
 .carta[data-bp="desktop"] .bill__methods {
-  display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 12px;
+}
+/* Mobile: compact cards so 2×2 fits without scroll */
+.carta[data-bp="mobile"] .bill__methods {
+  gap: 10px;
+}
+.carta[data-bp="mobile"] .bill__method {
+  padding: 14px 10px;
+  gap: 7px;
+}
+.carta[data-bp="mobile"] .bill__method .ic {
+  width: 40px;
+  height: 40px;
+}
+.carta[data-bp="mobile"] .bill__method .nm {
+  font-size: 13px;
+}
+.carta[data-bp="mobile"] .bill__method .ds {
+  font-size: 10px;
 }
 .bill__method {
   padding: 22px 14px; border: 1px solid var(--glass-border); border-radius: 16px;

--- a/public/css/carta/flows/features.css
+++ b/public/css/carta/flows/features.css
@@ -762,68 +762,109 @@
 .carta[data-bp="mobile"] .split-items__yourTotal .val { font-size: 22px; }
 .carta[data-bp="mobile"] .split-items__foot { padding: 12px 14px; }
 
-/* Stage: equit */
-.split-equit { display: flex; flex-direction: column; gap: 14px; align-items: center; }
-.split-equit > * { width: 100%; }
+/* ════════════════════════════════════════════════════════════
+   SPLIT EQUIT — partes iguales (DS)
+   ════════════════════════════════════════════════════════════ */
+.split-equit { display: flex; flex-direction: column; gap: 14px; }
+
+/* Chip "Total a dividir" en la cabecera */
+.split-equit__total-chip {
+  display: flex; flex-direction: column; align-items: flex-end; gap: 1px;
+}
+.split-equit__total-chip .k {
+  font-family: var(--font-mono); font-size: 9px; font-weight: 700;
+  letter-spacing: 0.18em; text-transform: uppercase; color: var(--fg-muted);
+}
+.split-equit__total-chip .v {
+  font-family: var(--font-display); font-weight: 900; font-size: 15px;
+  color: var(--price-gold); font-variant-numeric: tabular-nums; letter-spacing: -0.01em;
+}
+
+/* Donut */
 .split-equit__pie {
-  display: flex; justify-content: center; padding: 8px 0 4px;
+  display: flex; justify-content: center; padding: 4px 0;
 }
 .split-equit__pie .slice { transition: transform 180ms var(--ease-bounce); }
-.split-equit__pie .slice:hover { transform: scale(1.02); }
-.split-equit__pie .slice--mine path { filter: drop-shadow(0 4px 12px rgba(34,197,94,0.35)); }
-.split-equit__pie .slice--paid path { opacity: 1; }
+.split-equit__pie .slice:hover { transform: scale(1.03); }
+.split-equit__pie .slice:focus-visible { outline: none; }
+.split-equit__pie .slice:focus-visible path { stroke: var(--color-green-500); stroke-width: 4; }
+.split-equit__pie .slice--mine { transform-origin: 60px 60px; }
+.split-equit__pie .slice--mine path {
+  filter: drop-shadow(0 4px 14px rgba(22,163,74,0.45));
+}
 
+/* Mobile: donut más pequeño */
+.carta[data-bp="mobile"] .split-equit__pie svg { width: 180px; height: 180px; }
+
+/* Stepper */
 .split-equit__stepper {
-  display: flex; align-items: center; gap: 12px;
+  display: flex; align-items: center; gap: 10px;
   padding: 12px 14px;
   background: var(--bg-surface); border: 1px solid var(--border-subtle);
   border-radius: 14px;
 }
 .split-equit__stepper .lab {
-  font-family: var(--font-body); font-weight: 700; font-size: 13px; color: var(--fg-primary);
-  flex: 1;
+  font-family: var(--font-body); font-weight: 600; font-size: 13px;
+  color: var(--fg-primary); flex: 1;
 }
 .split-equit__stepper .step {
-  display: inline-flex; align-items: center; gap: 4px;
-  background: var(--bg-base); border: 1px solid var(--border-strong);
-  border-radius: 9999px; padding: 4px;
+  display: inline-flex; align-items: center; gap: 2px;
+  background: var(--bg-chip); border: 1px solid var(--border-strong);
+  border-radius: 9999px; padding: 3px;
 }
 .split-equit__stepper .step button {
   width: 32px; height: 32px; border-radius: 50%;
   background: transparent; border: none; cursor: pointer;
   font-family: var(--font-display); font-weight: 900; font-size: 18px;
-  color: var(--fg-primary);
+  color: var(--fg-primary); line-height: 1;
+  transition: background 120ms ease;
 }
-.split-equit__stepper .step button:hover:not(:disabled) { background: var(--bg-chip); }
+.split-equit__stepper .step button:hover:not(:disabled) {
+  background: var(--bg-surface);
+}
+.split-equit__stepper .step button:focus-visible {
+  outline: 2px solid var(--color-green-500); outline-offset: 1px;
+}
 .split-equit__stepper .step button:disabled { opacity: 0.3; cursor: not-allowed; }
 .split-equit__stepper .step__num {
-  min-width: 24px; text-align: center;
+  min-width: 28px; text-align: center;
   font-family: var(--font-display); font-weight: 900; font-size: 18px;
   color: var(--fg-primary); font-variant-numeric: tabular-nums;
 }
 .split-equit__stepper .hint {
-  font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-muted);
+  font-family: var(--font-mono); font-size: 10px;
+  letter-spacing: 0.08em; color: var(--fg-muted);
 }
 
+/* Live dots row */
 .split-equit__live {
-  display: flex; align-items: center; gap: 12px;
-  padding: 10px 12px;
-  background: var(--bg-base); border: 1px solid var(--border-subtle);
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 14px;
+  background: var(--bg-chip); border: 1px solid var(--border-subtle);
   border-radius: 12px;
   font-family: var(--font-body); font-size: 12.5px; color: var(--fg-secondary);
 }
-.split-equit__live .dots { display: inline-flex; gap: 4px; margin-left: auto; }
+.split-equit__live .dots { display: inline-flex; gap: 6px; margin-left: auto; flex-wrap: wrap; justify-content: flex-end; }
 .split-equit__live .dots .dot {
-  width: 10px; height: 10px; border-radius: 50%;
-  background: var(--bg-chip);
-  border: 1.5px solid var(--border-strong);
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--bg-surface); border: 1.5px solid var(--border-strong);
+  cursor: pointer; padding: 0;
+  transition: transform 120ms var(--ease-bounce), box-shadow 120ms ease, background 120ms ease;
 }
-.split-equit__live .dots .dot--paid {
-  background: var(--color-green-500); border-color: var(--color-green-600);
-}
+.split-equit__live .dots .dot:hover { transform: scale(1.2); }
+.split-equit__live .dots .dot:focus-visible { outline: 2px solid var(--color-green-500); outline-offset: 2px; }
+.split-equit__live .dots .dot--paid { background: var(--color-green-500); border-color: var(--color-green-600); }
 .split-equit__live .dots .dot--mine {
-  box-shadow: 0 0 0 2px var(--color-green-500);
+  background: var(--color-green-600); border-color: var(--color-green-700);
+  box-shadow: 0 0 0 3px rgba(34,197,94,0.35);
+  transform: scale(1.3);
 }
+
+/* Mobile */
+.carta[data-bp="mobile"] .split-equit__stepper { padding: 10px 12px; }
+.carta[data-bp="mobile"] .split-equit__stepper .lab { font-size: 12px; }
+.carta[data-bp="mobile"] .split-equit__stepper .step button { width: 28px; height: 28px; font-size: 16px; }
+.carta[data-bp="mobile"] .split-equit__live { font-size: 12px; padding: 9px 12px; }
 
 /* Stage: pay (per-person) */
 .split-pay { display: flex; flex-direction: column; gap: 14px; }

--- a/public/css/carta/flows/features.css
+++ b/public/css/carta/flows/features.css
@@ -863,11 +863,18 @@
 }
 .split-equit__live .dots .dot:hover { transform: scale(1.2); }
 .split-equit__live .dots .dot:focus-visible { outline: 2px solid var(--color-green-500); outline-offset: 2px; }
-.split-equit__live .dots .dot--paid { background: var(--color-green-500); border-color: var(--color-green-600); }
+/* dot--paid: sólido verde (ya pagó alguien) */
+.split-equit__live .dots .dot--paid {
+  background: var(--color-green-500);
+  border-color: var(--color-green-600);
+  cursor: not-allowed;
+}
+/* dot--mine: anillo verde hueco (mi porción, aún pendiente de pago) */
 .split-equit__live .dots .dot--mine {
-  background: var(--color-green-600); border-color: var(--color-green-700);
-  box-shadow: 0 0 0 3px rgba(34,197,94,0.35);
-  transform: scale(1.3);
+  background: transparent;
+  border: 2px solid var(--color-green-500);
+  box-shadow: 0 0 0 2px rgba(34,197,94,0.30);
+  transform: scale(1.25);
 }
 
 /* Mobile */

--- a/public/css/carta/flows/features.css
+++ b/public/css/carta/flows/features.css
@@ -793,7 +793,14 @@
 .split-equit__pie .slice:focus-visible { outline: none; }
 .split-equit__pie .slice:focus-visible path { stroke: var(--color-green-500) !important; }
 .split-equit__pie .slice--mine path {
-  filter: drop-shadow(0 3px 10px rgba(22,163,74,0.50));
+  filter: drop-shadow(0 4px 14px rgba(22,163,74,0.55));
+}
+[data-theme="dark"] .split-equit__pie .slice--mine path {
+  filter: drop-shadow(0 4px 16px rgba(34,197,94,0.60));
+}
+[data-theme="dark"] .split-equit__pie path[fill*="bg-chip"] {
+  /* En dark mode los slices inactivos son más visibles */
+  opacity: 0.7;
 }
 
 /* Mobile: donut algo más pequeño */

--- a/public/css/carta/flows/features.css
+++ b/public/css/carta/flows/features.css
@@ -652,6 +652,16 @@
   background: var(--color-green-50);
 }
 .split-line--claimed { opacity: 0.6; }
+.split-line--courtesy {
+  border-color: var(--brand-primary);
+  background: rgba(99,102,241,0.06);
+  cursor: default !important;
+  pointer-events: none;
+}
+[data-theme="dark"] .split-line--courtesy {
+  border-color: var(--brand-primary);
+  background: rgba(99,102,241,0.12);
+}
 [data-theme="dark"] .split-line--mine {
   border-color: var(--color-green-600);
   background: rgba(34,197,94,0.08);
@@ -673,6 +683,22 @@
   font-family: var(--font-display); font-weight: 800; font-size: 13px;
   color: var(--price-gold); margin-top: 2px;
   font-variant-numeric: tabular-nums;
+}
+.split-line__badge {
+  display: inline-flex; align-items: center;
+  margin-top: 3px; padding: 1px 7px;
+  border-radius: 20px; font-size: 10px; font-weight: 700;
+  letter-spacing: 0.04em; text-transform: uppercase;
+}
+.split-line__badge--courtesy {
+  background: rgba(99,102,241,0.15);
+  color: var(--brand-primary);
+  border: 1px solid rgba(99,102,241,0.3);
+}
+[data-theme="dark"] .split-line__badge--courtesy {
+  background: rgba(99,102,241,0.2);
+  color: #a5b4fc;
+  border-color: rgba(99,102,241,0.4);
 }
 
 /* Slot button — one per item */
@@ -718,6 +744,20 @@
   cursor: not-allowed;
 }
 [data-theme="dark"] .slot--other { border-color: rgba(255,255,255,0.12); }
+
+/* Courtesy item → indigo heart icon, non-interactive */
+.slot--courtesy {
+  background: rgba(99,102,241,0.1);
+  border: 2px solid rgba(99,102,241,0.35);
+  border-style: solid;
+  color: var(--brand-primary);
+  cursor: default;
+}
+[data-theme="dark"] .slot--courtesy {
+  background: rgba(99,102,241,0.18);
+  border-color: rgba(99,102,241,0.5);
+  color: #a5b4fc;
+}
 
 @keyframes slotPop {
   0%   { transform: scale(0.5); box-shadow: 0 0 0 0 rgba(34,197,94,0.6); }

--- a/public/css/carta/flows/features.css
+++ b/public/css/carta/flows/features.css
@@ -589,12 +589,21 @@
   gap: 12px;
 }
 .back {
-  font: inherit; background: transparent; border: none;
-  color: var(--fg-secondary); cursor: pointer;
+  font: inherit; cursor: pointer;
   font-family: var(--font-body); font-size: 12.5px; font-weight: 600;
-  padding: 4px 0;
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 7px 12px; border-radius: 10px;
+  background: var(--glass-bg-surface);
+  border: 1px solid var(--glass-border);
+  color: var(--fg-secondary);
+  transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
 }
-.back:hover { color: var(--fg-primary); }
+.back:hover {
+  color: var(--fg-primary);
+  background: var(--bg-chip);
+  border-color: var(--border-strong);
+}
+.back:focus-visible { outline: 2px solid var(--brand-primary); outline-offset: 2px; }
 .split-items__diners { display: flex; align-items: center; gap: 8px; }
 .split-items__diners .lab {
   font-family: var(--font-body); font-size: 11px; font-weight: 600;

--- a/public/css/carta/flows/features.css
+++ b/public/css/carta/flows/features.css
@@ -590,9 +590,9 @@
 }
 .back {
   font: inherit; cursor: pointer;
-  font-family: var(--font-body); font-size: 13px; font-weight: 600;
+  font-family: var(--font-body); font-size: 14px; font-weight: 700;
   display: inline-flex; align-items: center; justify-content: center; gap: 5px;
-  padding: 10px 16px; border-radius: 12px;
+  padding: 12px 16px; border-radius: 12px;
   background: var(--glass-bg-surface);
   border: 1px solid var(--glass-border);
   color: var(--fg-primary);

--- a/public/css/carta/flows/features.css
+++ b/public/css/carta/flows/features.css
@@ -636,84 +636,131 @@
 
 .split-items__list {
   display: flex; flex-direction: column; gap: 8px;
-  max-height: 260px; overflow-y: auto; padding: 2px;
+  max-height: 280px; overflow-y: auto; padding: 2px;
 }
+
+/* Item card */
 .split-line {
   display: flex; align-items: center; gap: 12px;
-  padding: 10px 12px;
+  padding: 11px 14px;
   background: var(--bg-surface); border: 1px solid var(--border-subtle);
-  border-radius: 12px;
+  border-radius: 14px;
+  transition: border-color 140ms ease, background 140ms ease;
 }
+.split-line--mine {
+  border-color: var(--color-green-500);
+  background: var(--color-green-50);
+}
+.split-line--claimed { opacity: 0.6; }
+[data-theme="dark"] .split-line--mine {
+  border-color: var(--color-green-600);
+  background: rgba(34,197,94,0.08);
+}
+
 .split-line__photo {
-  width: 44px; height: 44px; border-radius: 10px;
+  width: 42px; height: 42px; border-radius: 10px;
   background: var(--bg-chip);
   display: inline-flex; align-items: center; justify-content: center;
-  font-size: 22px; flex-shrink: 0;
+  font-size: 20px; flex-shrink: 0;
 }
 .split-line__main { flex: 1; min-width: 0; }
 .split-line__name {
   font-family: var(--font-body); font-weight: 700; font-size: 14px;
   color: var(--fg-primary); line-height: 1.2;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-.split-line__price {
+.split-line__total {
   font-family: var(--font-display); font-weight: 800; font-size: 13px;
-  color: var(--price-gold); margin-top: 3px;
+  color: var(--price-gold); margin-top: 2px;
   font-variant-numeric: tabular-nums;
 }
-.split-line__price span {
-  font-family: var(--font-body); font-weight: 500; color: var(--fg-muted);
-  font-size: 11px; margin-left: 2px;
-}
-.split-line__slots { display: inline-flex; gap: 6px; flex-shrink: 0; }
+
+/* Slot button — one per item */
 .slot {
-  width: 32px; height: 32px; border-radius: 50%;
-  background: var(--bg-base);
+  flex-shrink: 0;
+  width: 36px; height: 36px; border-radius: 50%;
+  background: var(--bg-chip);
   border: 2px dashed var(--border-strong);
   display: inline-flex; align-items: center; justify-content: center;
-  font-family: var(--font-display); font-weight: 900; font-size: 12px;
   color: var(--fg-muted); cursor: pointer;
-  transition: transform 160ms var(--ease-bounce), background-color var(--duration-fast), border-color var(--duration-fast);
+  transition: transform 160ms var(--ease-bounce),
+              background 140ms ease,
+              border-color 140ms ease,
+              color 140ms ease;
 }
-.slot:hover:not(:disabled) { border-color: var(--brand-primary); color: var(--brand-primary); }
-.slot--you, .slot--other {
-  background: var(--c, var(--brand-primary));
+.slot:hover:not(:disabled) {
+  border-color: var(--color-green-600);
   border-style: solid;
-  border-color: rgba(0,0,0,0.10);
-  color: #fff;
+  color: var(--color-green-600);
+  transform: scale(1.08);
 }
-[data-theme="dark"] .slot--you, [data-theme="dark"] .slot--other { border-color: rgba(255,255,255,0.10); }
-.slot--you { outline: 2px solid var(--color-green-500); outline-offset: 1px; }
-.slot--other { cursor: not-allowed; }
-.slot--just { animation: slotPop 480ms var(--ease-bounce); }
+.slot:focus-visible { outline: 3px solid rgba(34,197,94,0.45); outline-offset: 2px; }
+
+/* Claimed by me → green solid */
+.slot--you {
+  background: var(--color-green-600);
+  border: 2px solid var(--color-green-700);
+  color: #FFFFFF;
+}
+.slot--you:hover:not(:disabled) {
+  background: var(--color-green-700);
+  border-color: var(--color-green-700);
+  color: #FFFFFF;
+  transform: scale(1.08);
+}
+
+/* Claimed by other → muted gray/locked */
+.slot--other {
+  background: var(--bg-chip);
+  border: 2px solid var(--border-subtle);
+  border-style: solid;
+  color: var(--fg-muted);
+  cursor: not-allowed;
+}
+[data-theme="dark"] .slot--other { border-color: rgba(255,255,255,0.12); }
+
 @keyframes slotPop {
   0%   { transform: scale(0.5); box-shadow: 0 0 0 0 rgba(34,197,94,0.6); }
   60%  { transform: scale(1.18); box-shadow: 0 0 0 8px rgba(34,197,94,0); }
   100% { transform: scale(1); }
 }
+.slot--just { animation: slotPop 480ms var(--ease-bounce); }
 
+/* Footer: total display + hint */
 .split-items__foot {
-  display: flex; flex-direction: column; gap: 10px;
-  padding: 12px;
-  background: var(--bg-base);
+  display: flex; flex-direction: column; gap: 8px;
+  padding: 14px 16px;
+  background: var(--bg-chip);
   border: 1px solid var(--border-subtle);
-  border-radius: 14px;
+  border-radius: 16px;
 }
 .split-items__yourTotal {
-  display: flex; align-items: baseline; justify-content: space-between;
+  display: flex; align-items: baseline; justify-content: space-between; gap: 8px;
 }
 .split-items__yourTotal .lab {
-  font-family: var(--font-body); font-size: 12px; font-weight: 600;
-  color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.08em;
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  color: var(--fg-muted); text-transform: uppercase; letter-spacing: 0.18em;
 }
 .split-items__yourTotal .val {
-  font-family: var(--font-display); font-weight: 900; font-size: 24px;
+  font-family: var(--font-display); font-weight: 900; font-size: 26px;
   color: var(--fg-primary); font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
 }
 .split-items__hint {
   font-family: var(--font-body); font-size: 12px; color: var(--color-green-700);
-  text-align: center;
+  line-height: 1.4;
 }
 [data-theme="dark"] .split-items__hint { color: var(--color-green-400); }
+
+/* Mobile */
+.carta[data-bp="mobile"] .split-items__list { max-height: 240px; }
+.carta[data-bp="mobile"] .split-line { padding: 10px 12px; gap: 10px; }
+.carta[data-bp="mobile"] .split-line__photo { width: 38px; height: 38px; font-size: 18px; }
+.carta[data-bp="mobile"] .split-line__name { font-size: 13px; }
+.carta[data-bp="mobile"] .split-line__total { font-size: 12px; }
+.carta[data-bp="mobile"] .slot { width: 34px; height: 34px; }
+.carta[data-bp="mobile"] .split-items__yourTotal .val { font-size: 22px; }
+.carta[data-bp="mobile"] .split-items__foot { padding: 12px 14px; }
 
 /* Stage: equit */
 .split-equit { display: flex; flex-direction: column; gap: 14px; align-items: center; }

--- a/public/css/carta/flows/features.css
+++ b/public/css/carta/flows/features.css
@@ -590,19 +590,19 @@
 }
 .back {
   font: inherit; cursor: pointer;
-  font-family: var(--font-body); font-size: 12.5px; font-weight: 600;
-  display: inline-flex; align-items: center; gap: 5px;
-  padding: 7px 12px; border-radius: 10px;
+  font-family: var(--font-body); font-size: 13px; font-weight: 600;
+  display: inline-flex; align-items: center; justify-content: center; gap: 5px;
+  padding: 10px 16px; border-radius: 12px;
   background: var(--glass-bg-surface);
   border: 1px solid var(--glass-border);
-  color: var(--fg-secondary);
+  color: var(--fg-primary);
   transition: background 140ms ease, color 140ms ease, border-color 140ms ease;
 }
 .back:hover {
-  color: var(--fg-primary);
   background: var(--bg-chip);
   border-color: var(--border-strong);
 }
+.back:focus-visible { outline: 2px solid var(--brand-primary); outline-offset: 2px; }
 .back:focus-visible { outline: 2px solid var(--brand-primary); outline-offset: 2px; }
 .split-items__diners { display: flex; align-items: center; gap: 8px; }
 .split-items__diners .lab {

--- a/public/css/carta/flows/features.css
+++ b/public/css/carta/flows/features.css
@@ -784,17 +784,20 @@
 .split-equit__pie {
   display: flex; justify-content: center; padding: 4px 0;
 }
-.split-equit__pie .slice { transition: transform 180ms var(--ease-bounce); }
+.split-equit__pie .slice {
+  transition: transform 200ms var(--ease-bounce);
+  transform-box: fill-box;
+  transform-origin: center;
+}
 .split-equit__pie .slice:hover { transform: scale(1.03); }
 .split-equit__pie .slice:focus-visible { outline: none; }
-.split-equit__pie .slice:focus-visible path { stroke: var(--color-green-500); stroke-width: 4; }
-.split-equit__pie .slice--mine { transform-origin: 60px 60px; }
+.split-equit__pie .slice:focus-visible path { stroke: var(--color-green-500) !important; }
 .split-equit__pie .slice--mine path {
-  filter: drop-shadow(0 4px 14px rgba(22,163,74,0.45));
+  filter: drop-shadow(0 3px 10px rgba(22,163,74,0.50));
 }
 
-/* Mobile: donut más pequeño */
-.carta[data-bp="mobile"] .split-equit__pie svg { width: 180px; height: 180px; }
+/* Mobile: donut algo más pequeño */
+.carta[data-bp="mobile"] .split-equit__pie svg { width: 170px; height: 170px; }
 
 /* Stepper */
 .split-equit__stepper {

--- a/resources/js/alpine/bill.js
+++ b/resources/js/alpine/bill.js
@@ -376,8 +376,8 @@ export function registerBill() {
             return this.splitSelected.includes(id);
         },
 
-        toggleSplitItem(id, claimed) {
-            if (claimed) return;
+        toggleSplitItem(id, claimed, isCourtesy) {
+            if (claimed || isCourtesy) return;
             const idx = this.splitSelected.indexOf(id);
             if (idx === -1) this.splitSelected.push(id);
             else            this.splitSelected.splice(idx, 1);

--- a/resources/js/alpine/bill.js
+++ b/resources/js/alpine/bill.js
@@ -173,6 +173,7 @@ export function registerBill() {
             this.showingMixed     = false;
             this.showingMixedTip  = false;
             this.mixedPayingCard  = false;
+            this.requested        = false;
             this.choosing         = true;
             this.step             = 'method';
         },

--- a/resources/js/alpine/bill.js
+++ b/resources/js/alpine/bill.js
@@ -226,8 +226,9 @@ export function registerBill() {
             } catch {
                 // use cached total from page load
             }
-            this.tipAmount  = 0;
             this.tipPercent = 10;
+            this.tipAmount  = calculateTipFromPercent(this.orderTotal, 10);
+            this.grandTotal = this.orderTotal + this.tipAmount;
             this.showingTip = true;
             this.step       = 'tip';
         },

--- a/resources/js/alpine/bill.js
+++ b/resources/js/alpine/bill.js
@@ -98,6 +98,8 @@ export function registerBill() {
         splitItems:       [],
         splitSelected:    [],
         splitPeople:      2,
+        splitEqSlice:     0,
+        splitEqColor:     null,
         splitPayingCard:  false,
         splitStripeReady: false,
         splitStripeError: null,
@@ -747,7 +749,7 @@ export function registerBill() {
                     : '/api/v1/payment/' + this.tableHash + '/split/pay-eq';
                 const body = type === 'items'
                     ? { item_ids: ids, tip }
-                    : { people: Math.max(2, parseInt(this.splitPeople) || 2), part_number: 1, tip };
+                    : { people: Math.max(2, parseInt(this.splitPeople) || 2), part_number: this.splitEqSlice + 1, session_color: this.splitEqColor, tip };
                 const res = await fetch(url, {
                     method:  'POST',
                     headers: {

--- a/resources/js/alpine/bill.js
+++ b/resources/js/alpine/bill.js
@@ -313,6 +313,16 @@ export function registerBill() {
             this._stripe     = null;
         },
 
+        backToTip() {
+            this.payingCard  = false;
+            this.stripeReady = false;
+            this.stripeError = null;
+            this.sending     = false;
+            this._elements   = null;
+            this._stripe     = null;
+            this.step        = 'tip';
+        },
+
         async submitCardPayment() {
             if (!this._stripe || !this._elements || this.sending) return;
             this.sending     = true;
@@ -522,8 +532,10 @@ export function registerBill() {
             this.splitTipPercent = null;
             if (this.splitTipType === 'items') {
                 this.splitShowItems = true;
+                this.step           = 'splitItems';
             } else {
                 this.splitShowEq = true;
+                this.step        = 'splitEq';
             }
         },
 
@@ -802,8 +814,7 @@ export function registerBill() {
             this.splitMode        = null;
             this._splitElements   = null;
             this._splitStripe     = null;
-            this.step             = 'method';
-            this.choosing         = true;
+            this.step             = 'splitTip';
         },
 
         payMixedCard() {

--- a/resources/js/alpine/bill.js
+++ b/resources/js/alpine/bill.js
@@ -140,9 +140,10 @@ export function registerBill() {
 
         open() {
             if (this.sending) return;
-            this.error    = null;
-            this.choosing = true;
-            this.step     = 'method';
+            this.error     = null;
+            this.requested = false;
+            this.choosing  = true;
+            this.step      = 'method';
         },
 
         close() {

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2047,21 +2047,62 @@
 
                     {{-- ── tip: selector de propina para tarjeta ─── --}}
                     <div x-show="$store.bill.step === 'tip'">
-                        <div class="tip-row" role="group" aria-label="Porcentaje de propina">
-                            <template x-for="pct in [0, 10, 15, 20]" :key="pct">
-                                <div :class="'tip' + ($store.bill.tipPercent === pct ? ' tip--selected' : '')"
-                                     @click="$store.bill.setTipPercent(pct)"
-                                     role="button" tabindex="0"
-                                     :aria-pressed="($store.bill.tipPercent === pct).toString()"
-                                     @keydown.enter="$store.bill.setTipPercent(pct)">
-                                    <div class="pct" x-text="pct + '%'"></div>
-                                    <div class="amt"
-                                         x-text="pct === 0 ? '—' : Number(Math.round($store.bill.orderTotal * pct) / 100).toFixed(2).replace('.',',') + ' €'"></div>
+                        <div class="cashTip">
+                            <div class="cashTip__hero">
+                                <span class="lab">Total del pedido</span>
+                                <span class="val" x-text="Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></span>
+                            </div>
+                            <section class="cashTip__section">
+                                <div class="cashTip__label">
+                                    <span>Propina sugerida</span>
+                                    <span class="hint">Toca para elegir</span>
                                 </div>
-                            </template>
+                                <div class="cashTip__grid">
+                                    <template x-for="pct in [5, 10, 15, 20]" :key="pct">
+                                        <button type="button"
+                                                class="cashTip__chip"
+                                                :class="$store.bill.tipPercent === pct ? 'is-active' : ''"
+                                                :aria-pressed="($store.bill.tipPercent === pct).toString()"
+                                                @click="$store.bill.setTipPercent(pct)">
+                                            <span class="cashTip__pct" x-text="pct + '%'"></span>
+                                            <span class="cashTip__amt"
+                                                  x-text="Number(Math.round($store.bill.orderTotal * pct) / 100).toFixed(2).replace('.',',') + ' €'"></span>
+                                        </button>
+                                    </template>
+                                </div>
+                                <div class="cashTip__input">
+                                    <label for="card-tip-bill" class="sr-only">Propina personalizada en euros</label>
+                                    <input id="card-tip-bill"
+                                           type="number" min="0" step="0.50" inputmode="decimal"
+                                           placeholder="Otra cantidad…"
+                                           @input="$store.bill.updateCustomTip($event.target.value)"
+                                           :value="$store.bill.tipPercent === null && $store.bill.tipAmount > 0 ? $store.bill.tipAmount : ''">
+                                    <span class="cashTip__currency" aria-hidden="true">€</span>
+                                </div>
+                            </section>
+                            <section class="cashTip__summary" aria-live="polite">
+                                <div class="cashTip__row">
+                                    <span>Pedido</span>
+                                    <span class="v" x-text="Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></span>
+                                </div>
+                                <div class="cashTip__row cashTip__row--tip"
+                                     x-show="($store.bill.tipAmount || 0) > 0">
+                                    <span>Propina</span>
+                                    <span class="v" x-text="'+ ' + Number($store.bill.tipAmount || 0).toFixed(2).replace('.',',') + ' €'"></span>
+                                </div>
+                                <div class="cashTip__row cashTip__row--total">
+                                    <span>Total a pagar</span>
+                                    <span class="v" x-text="Number($store.bill.grandTotal || $store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></span>
+                                </div>
+                            </section>
+                            <p class="cashTip__info">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+                                </svg>
+                                <span>La propina se incluye en el cargo de Stripe.</span>
+                            </p>
                         </div>
                     </div>
-
                     {{-- ── pay: formulario Stripe ─── --}}
                     <div x-show="$store.bill.step === 'pay'">
                         <div class="stripe-mock" style="display:flex;flex-direction:column;gap:16px">
@@ -2909,10 +2950,18 @@
                     {{-- tip --}}
                     <div x-show="$store.bill.step === 'tip'">
                         <div class="bill__footRow bill__footRow--stack">
-                            <button type="button" class="btn-primary"
+                            <button type="button" class="btn-primary cashTip__cta"
+                                    :disabled="$store.bill.sending"
                                     @click="$store.bill.proceedToStripe()">
-                                Continuar —
-                                <span x-text="Number($store.bill.orderTotal + ($store.bill.tipAmount || 0)).toFixed(2).replace('.',',') + ' €'"></span>
+                                <span x-show="$store.bill.sending">
+                                    <span class="cashTip__spin" aria-hidden="true"></span>
+                                    Procesando…
+                                </span>
+                                <span x-show="!$store.bill.sending"
+                                      x-text="($store.bill.tipAmount || 0) > 0
+                                          ? 'Pagar con tarjeta · ' + Number($store.bill.grandTotal).toFixed(2).replace('.',',') + ' € (con propina)'
+                                          : 'Pagar con tarjeta · ' + Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' € (sin propina)'">
+                                </span>
                             </button>
                             <button type="button" class="btn-secondary" @click="$store.bill.backToMethod()">← Cambiar método</button>
                         </div>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2265,64 +2265,82 @@
                         </div>
                     </div>
 
-                    {{-- ── splitEq: partes iguales con donut ─── --}}
-                    <div x-show="$store.bill.step === 'splitEq'">
-                        <div class="split-equit"
-                             x-data="{
-                                 parts: $store.bill.splitPeople || 2,
-                                 mySlice: 0,
-                                 get slice() { return $store.bill.orderTotal / this.parts; },
-                                 get fmt() { return (n) => Number(n).toFixed(2).replace('.',',') + ' €'; },
-                                 arc(i) {
-                                     const R_OUT = 48, R_IN = 26, CX = 60, CY = 60;
-                                     const a0 = (i / this.parts) * Math.PI * 2 - Math.PI / 2;
-                                     const a1 = ((i + 1) / this.parts) * Math.PI * 2 - Math.PI / 2;
-                                     const lg = (a1 - a0) > Math.PI ? 1 : 0;
-                                     const x0o = CX + R_OUT * Math.cos(a0), y0o = CY + R_OUT * Math.sin(a0);
-                                     const x1o = CX + R_OUT * Math.cos(a1), y1o = CY + R_OUT * Math.sin(a1);
-                                     const x0i = CX + R_IN  * Math.cos(a1), y0i = CY + R_IN  * Math.sin(a1);
-                                     const x1i = CX + R_IN  * Math.cos(a0), y1i = CY + R_IN  * Math.sin(a0);
-                                     return 'M '+x0o+' '+y0o+' A '+R_OUT+' '+R_OUT+' 0 '+lg+' 1 '+x1o+' '+y1o+' L '+x0i+' '+y0i+' A '+R_IN+' '+R_IN+' 0 '+lg+' 0 '+x1i+' '+y1i+' Z';
-                                 },
-                                 labelPos(i) {
-                                     const mid = ((i + 0.5) / this.parts) * Math.PI * 2 - Math.PI / 2;
-                                     const r = 37;
-                                     return { x: 60 + r * Math.cos(mid), y: 60 + r * Math.sin(mid) };
-                                 },
-                             }">
+                    {{-- ── splitEq: partes iguales con donut (DS) ─── --}}
+                    <div x-show="$store.bill.step === 'splitEq'"
+                         x-data="{
+                             mySlice: 0,
+                             get parts() { return $store.bill.splitPeople || 2; },
+                             get slice() { return $store.bill.splitMyPart || ($store.bill.orderTotal / this.parts); },
+                             fmt(n) { return Number(n).toFixed(2).replace('.', ',') + ' €'; },
+                             decParts() {
+                                 if (this.parts > 2) $store.bill.splitPeople = this.parts - 1;
+                                 if (this.mySlice >= $store.bill.splitPeople) this.mySlice = $store.bill.splitPeople - 1;
+                             },
+                             incParts() {
+                                 if (this.parts < ($store.bill.splitMaxParts || 10)) $store.bill.splitPeople = this.parts + 1;
+                             },
+                             arc(i) {
+                                 const R_OUT = 48, R_IN = 30, CX = 60, CY = 60;
+                                 const a0 = (i / this.parts) * Math.PI * 2 - Math.PI / 2;
+                                 const a1 = ((i + 1) / this.parts) * Math.PI * 2 - Math.PI / 2;
+                                 const lg = (a1 - a0) > Math.PI ? 1 : 0;
+                                 const x0o = CX + R_OUT * Math.cos(a0), y0o = CY + R_OUT * Math.sin(a0);
+                                 const x1o = CX + R_OUT * Math.cos(a1), y1o = CY + R_OUT * Math.sin(a1);
+                                 const x0i = CX + R_IN  * Math.cos(a1), y0i = CY + R_IN  * Math.sin(a1);
+                                 const x1i = CX + R_IN  * Math.cos(a0), y1i = CY + R_IN  * Math.sin(a0);
+                                 return 'M '+x0o+' '+y0o+' A '+R_OUT+' '+R_OUT+' 0 '+lg+' 1 '+x1o+' '+y1o+' L '+x0i+' '+y0i+' A '+R_IN+' '+R_IN+' 0 '+lg+' 0 '+x1i+' '+y1i+' Z';
+                             },
+                             labelPos(i) {
+                                 const mid = ((i + 0.5) / this.parts) * Math.PI * 2 - Math.PI / 2;
+                                 return { x: 60 + 39 * Math.cos(mid), y: 60 + 39 * Math.sin(mid) };
+                             },
+                         }">
+                        <div class="split-equit">
+
+                            {{-- Cabecera: cambiar modo + total chip --}}
                             <div class="split-items__head">
-                                <button type="button" class="back" @click="$store.bill.setSplitStage('intro')">← Cambiar modo</button>
-                                <div class="split-items__diners">
-                                    <span class="lab">Total a dividir</span>
-                                    <span class="val" x-text="Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></span>
+                                <button type="button" class="back" @click="$store.bill.setSplitStage('intro')">
+                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
+                                    Cambiar modo
+                                </button>
+                                <div class="split-equit__total-chip">
+                                    <span class="k">Total a dividir</span>
+                                    <span class="v" x-text="fmt($store.bill.orderTotal)"></span>
                                 </div>
                             </div>
 
                             {{-- Donut SVG --}}
                             <div class="split-equit__pie">
-                                <svg viewBox="0 0 120 120" width="220" height="220" aria-hidden="true">
+                                <svg viewBox="0 0 120 120" width="220" height="220"
+                                     role="group" :aria-label="`Donut de ${parts} partes iguales, tu porción ${mySlice + 1}`">
                                     <template x-for="i in Array.from({length: parts}, (_, k) => k)" :key="i">
                                         <g :class="'slice' + (i === mySlice ? ' slice--mine' : '')"
                                            @click="mySlice = i"
-                                           style="cursor:pointer">
+                                           @keydown.enter="mySlice = i"
+                                           @keydown.space.prevent="mySlice = i"
+                                           tabindex="0" role="button"
+                                           :aria-label="`Porción ${i + 1}${i === mySlice ? ' · tuya' : ''}`"
+                                           style="cursor:pointer; outline:none">
                                             <path :d="arc(i)"
                                                   :fill="i === mySlice ? 'var(--brand-primary)' : 'var(--bg-chip)'"
-                                                  stroke="var(--bg-base)" stroke-width="2"
-                                                  :opacity="i === mySlice ? 1 : 0.55"/>
+                                                  stroke="var(--bg-canvas)" stroke-width="2.5"/>
                                             <text :x="labelPos(i).x" :y="labelPos(i).y"
                                                   text-anchor="middle" dominant-baseline="middle"
-                                                  font-size="10" font-weight="800"
+                                                  font-size="9" font-weight="800"
                                                   :fill="i === mySlice ? '#fff' : 'var(--fg-secondary)'"
                                                   x-text="i === mySlice ? 'TÚ' : (i + 1)">
                                             </text>
                                         </g>
                                     </template>
                                     {{-- Centro --}}
-                                    <circle cx="60" cy="60" r="24" fill="var(--bg-surface)"/>
-                                    <text x="60" y="57" text-anchor="middle" font-size="6.5" font-weight="600" fill="var(--fg-muted)">TU PARTE</text>
-                                    <text x="60" y="68" text-anchor="middle" font-size="13" font-weight="900" fill="var(--fg-primary)"
-                                          font-family="var(--font-display)"
-                                          x-text="Number(slice).toFixed(2).replace('.',',') + ' €'">
+                                    <circle cx="60" cy="60" r="28" fill="var(--bg-surface)"/>
+                                    <text x="60" y="55" text-anchor="middle"
+                                          font-size="6" font-weight="600" letter-spacing="0.08em"
+                                          fill="var(--fg-muted)" font-family="monospace">TU PARTE</text>
+                                    <text x="60" y="70" text-anchor="middle"
+                                          font-size="14" font-weight="900" letter-spacing="-0.02em"
+                                          fill="var(--fg-primary)"
+                                          x-text="fmt(slice)">
                                     </text>
                                 </svg>
                             </div>
@@ -2331,31 +2349,32 @@
                             <div class="split-equit__stepper">
                                 <span class="lab">¿Cuántos sois?</span>
                                 <div class="step">
-                                    <button type="button"
-                                            @click="parts = Math.max(2, parts - 1); $store.bill.splitPeople = parts"
+                                    <button type="button" aria-label="Reducir número de personas"
+                                            @click="decParts()"
                                             :disabled="parts <= 2">−</button>
-                                    <span class="step__num" x-text="parts"></span>
-                                    <button type="button"
-                                            @click="parts = Math.min($store.bill.splitMaxParts || 10, parts + 1); $store.bill.splitPeople = parts"
+                                    <span class="step__num" x-text="parts" aria-live="polite"></span>
+                                    <button type="button" aria-label="Aumentar número de personas"
+                                            @click="incParts()"
                                             :disabled="parts >= ($store.bill.splitMaxParts || 10)">+</button>
                                 </div>
                                 <span class="hint" x-text="'máx. ' + ($store.bill.splitMaxParts || 10)"></span>
                             </div>
 
+                            {{-- Selector de porción con dots --}}
                             <div class="split-equit__live">
-                                <span>Tú pagas</span>
-                                <div class="dots">
+                                <span x-text="'Tu porción: ' + (mySlice + 1) + ' de ' + parts"></span>
+                                <div class="dots" role="group" aria-label="Elige tu porción">
                                     <template x-for="i in Array.from({length: parts}, (_, k) => k)" :key="i">
-                                        <span :class="'dot' + (i === mySlice ? ' dot--mine' : '')"></span>
+                                        <button type="button"
+                                                :class="'dot' + (i === mySlice ? ' dot--mine' : '')"
+                                                @click="mySlice = i"
+                                                :aria-label="`Porción ${i + 1}`"
+                                                :aria-pressed="(i === mySlice).toString()">
+                                        </button>
                                     </template>
                                 </div>
                             </div>
 
-                            <button type="button" class="btn-primary"
-                                    @click="$store.bill.splitPeople = parts; $store.bill.payEquitative()">
-                                Pagar mi parte ·
-                                <span x-text="Number(slice).toFixed(2).replace('.',',') + ' €'"></span>
-                            </button>
                         </div>
                     </div>
 
@@ -2849,10 +2868,15 @@
 
                     {{-- splitEq --}}
                     <div x-show="$store.bill.step === 'splitEq'">
-                        <button type="button" class="btn-primary" @click="$store.bill.payEquitative()">
-                            Pagar mi parte con tarjeta
-                        </button>
-                        <button type="button" class="btn-text" @click="$store.bill.closeSplitEq()">Atrás</button>
+                        <div class="bill__footRow bill__footRow--stack">
+                            <button type="button" class="btn-primary"
+                                    @click="$store.bill.payEquitative()"
+                                    :disabled="$store.bill.sending">
+                                <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
+                                <span x-text="'Pagar mi parte · ' + Number($store.bill.splitMyPart || 0).toFixed(2).replace('.',',') + ' €'"></span>
+                            </button>
+                            <button type="button" class="btn-text" @click="$store.bill.closeSplitEq()">Atrás</button>
+                        </div>
                     </div>
 
                     {{-- splitTip --}}

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2042,7 +2042,7 @@
                                         Ticket de cortesía
                                     </a>
                                 </template>
-                                <button type="button" class="ps__btn ps__btn--ghost" @click="$store.bill.close()">Ver carta</button>
+                                <button type="button" class="ps__btn ps__btn--primary" @click="$store.bill.close()">Ver carta</button>
                             </div>
                         </div>
                     </div>
@@ -2947,7 +2947,7 @@
 
                     {{-- cashDone --}}
                     <div x-show="$store.bill.step === 'cashDone'">
-                        <div class="bill__footRow">
+                        <div class="bill__footRow" style="justify-content:center;">
                             <button type="button" class="btn-text bill__cancelNotice" @click="$store.bill.backToMethod()">Cancelar aviso</button>
                         </div>
                     </div>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1903,6 +1903,8 @@
                             </button>
 
                             <button type="button" class="method method--mixed"
+                                    :disabled="$store.bill.requested"
+                                    :title="$store.bill.requested ? 'Ya se ha solicitado la cuenta por otro método' : ''"
                                     @click="$store.bill.openMixed()">
                                 <span class="method__ic" aria-hidden="true">
                                     <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -1922,6 +1924,8 @@
 
                             @if($splitPaymentEnabled)
                             <button type="button" class="method method--split"
+                                    :disabled="$store.bill.requested"
+                                    :title="$store.bill.requested ? 'Ya se ha solicitado la cuenta por otro método' : ''"
                                     @click="$store.bill.openSplit()">
                                 <span class="method__ic" aria-hidden="true">
                                     <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2300,13 +2300,12 @@
                             // Pagado → color del pagador | Mío → mi color | Libre → gris
                             var fill  = isPaid ? slotColors[i] : (isMine ? myColor : gray);
                             var mid   = ((i + 0.5) / parts) * Math.PI * 2 - Math.PI / 2;
-                            var inside = isPaid || isMine;
-                            var r     = inside ? 37 : 53;
+                            var r     = 37;
                             var lx    = (CX + r*Math.cos(mid)).toFixed(2);
                             var ly    = (CY + r*Math.sin(mid)).toFixed(2);
                             var lbl   = isPaid ? '✓' : (isMine ? 'TÚ' : String(i + 1));
-                            var lFill = inside ? '#FFFFFF' : muted;
-                            var lSize = inside ? '9' : '9.5';
+                            var lFill = (isPaid || isMine) ? '#FFFFFF' : muted;
+                            var lSize = '9';
                             var cur   = isPaid ? 'default' : 'pointer';
                             s += '<g data-slice="' + i + '" style="cursor:' + cur + '">' +
                                  '<path d="' + d + '" fill="' + fill + '" stroke="#FFFFFF" stroke-width="3"/>' +

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2290,40 +2290,49 @@
                                      if (this.mySlice >= this.parts) this.mySlice = this.parts - 1;
                                  }
                              },
-                             arc(i) {
-                                 const R_OUT = 46, R_IN = 28, CX = 60, CY = 60;
-                                 const a0 = (i / this.parts) * Math.PI * 2 - Math.PI / 2;
-                                 const a1 = ((i + 1) / this.parts) * Math.PI * 2 - Math.PI / 2;
-                                 const lg = (a1 - a0) > Math.PI ? 1 : 0;
-                                 const x0o = CX + R_OUT*Math.cos(a0), y0o = CY + R_OUT*Math.sin(a0);
-                                 const x1o = CX + R_OUT*Math.cos(a1), y1o = CY + R_OUT*Math.sin(a1);
-                                 const x0i = CX + R_IN *Math.cos(a1), y0i = CY + R_IN *Math.sin(a1);
-                                 const x1i = CX + R_IN *Math.cos(a0), y1i = CY + R_IN *Math.sin(a0);
-                                 return `M ${x0o} ${y0o} A ${R_OUT} ${R_OUT} 0 ${lg} 1 ${x1o} ${y1o} L ${x0i} ${y0i} A ${R_IN} ${R_IN} 0 ${lg} 0 ${x1i} ${y1i} Z`;
-                             },
-                             labelPos(i) {
-                                 const mid = ((i + 0.5) / this.parts) * Math.PI * 2 - Math.PI / 2;
-                                 const inside = (i === this.mySlice || i < this.paidCount);
-                                 const r = inside ? 37 : 53;
-                                 return { x: 60 + r * Math.cos(mid), y: 60 + r * Math.sin(mid) };
-                             },
-                             sliceColor(i) {
-                                 if (i === this.mySlice) return '#16A34A';
-                                 if (i < this.paidCount) return '#E84FAC';
-                                 return 'var(--bg-chip)';
-                             },
-                             sliceLabel(i) {
-                                 if (i === this.mySlice) return 'TÚ';
-                                 if (i < this.paidCount) return '✓';
-                                 return String(i + 1);
-                             },
-                             sliceLabelFill(i) {
-                                 return (i === this.mySlice || i < this.paidCount) ? '#ffffff' : 'var(--fg-secondary)';
-                             },
                              dotClass(i) {
                                  if (i < this.paidCount) return 'dot dot--paid';
                                  if (i === this.mySlice) return 'dot dot--mine';
                                  return 'dot';
+                             },
+                             buildSvg() {
+                                 const P = this.parts, ms = this.mySlice, pc = this.paidCount;
+                                 const R_OUT = 46, R_IN = 28, CX = 60, CY = 60;
+                                 const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+                                 const graySlice  = isDark ? '#1E2A4A' : '#E5E7EB';
+                                 const centerBg   = isDark ? '#0E1A38' : '#FFFFFF';
+                                 const muteClr    = isDark ? '#6E84C0' : '#6B7280';
+                                 const primaryClr = isDark ? '#C8D8FF' : '#111827';
+                                 let svg = '<svg viewBox="0 0 120 120" width="200" height="200" style="overflow:visible;display:block">';
+                                 for (let i = 0; i < P; i++) {
+                                     const a0 = (i / P) * Math.PI * 2 - Math.PI / 2;
+                                     const a1 = ((i + 1) / P) * Math.PI * 2 - Math.PI / 2;
+                                     const lg = (a1 - a0) > Math.PI ? 1 : 0;
+                                     const x0o = CX + R_OUT*Math.cos(a0), y0o = CY + R_OUT*Math.sin(a0);
+                                     const x1o = CX + R_OUT*Math.cos(a1), y1o = CY + R_OUT*Math.sin(a1);
+                                     const x0i = CX + R_IN *Math.cos(a1), y0i = CY + R_IN *Math.sin(a1);
+                                     const x1i = CX + R_IN *Math.cos(a0), y1i = CY + R_IN *Math.sin(a0);
+                                     const d = `M ${x0o.toFixed(2)} ${y0o.toFixed(2)} A ${R_OUT} ${R_OUT} 0 ${lg} 1 ${x1o.toFixed(2)} ${y1o.toFixed(2)} L ${x0i.toFixed(2)} ${y0i.toFixed(2)} A ${R_IN} ${R_IN} 0 ${lg} 0 ${x1i.toFixed(2)} ${y1i.toFixed(2)} Z`;
+                                     const fill  = i === ms ? '#16A34A' : (i < pc ? '#E84FAC' : graySlice);
+                                     const mid   = ((i + 0.5) / P) * Math.PI * 2 - Math.PI / 2;
+                                     const inside = (i === ms || i < pc);
+                                     const r = inside ? 37 : 53;
+                                     const lx = (CX + r*Math.cos(mid)).toFixed(2);
+                                     const ly = (CY + r*Math.sin(mid)).toFixed(2);
+                                     const label = i === ms ? 'TÚ' : (i < pc ? '✓' : String(i + 1));
+                                     const lFill = inside ? '#FFFFFF' : muteClr;
+                                     const lSize = inside ? 9 : 9.5;
+                                     const cursor = i < pc ? 'default' : 'pointer';
+                                     svg += `<g data-slice="${i}" style="cursor:${cursor}">` +
+                                            `<path d="${d}" fill="${fill}" stroke="#FFFFFF" stroke-width="3"/>` +
+                                            `<text x="${lx}" y="${ly}" text-anchor="middle" dominant-baseline="middle" font-size="${lSize}" font-weight="800" fill="${lFill}">${label}</text>` +
+                                            `</g>`;
+                                 }
+                                 svg += `<circle cx="${CX}" cy="${CY}" r="${R_IN}" fill="${centerBg}"/>`;
+                                 svg += `<text x="${CX}" y="54" text-anchor="middle" font-size="5.5" font-weight="700" letter-spacing="2" fill="${muteClr}">TU PARTE</text>`;
+                                 svg += `<text x="${CX}" y="68" text-anchor="middle" font-size="13" font-weight="900" fill="${primaryClr}">${this.fmt(this.slice)}</text>`;
+                                 svg += '</svg>';
+                                 return svg;
                              },
                          }">
                         <div class="split-equit">
@@ -2341,43 +2350,18 @@
                                 </div>
                             </div>
 
-                            {{-- Donut --}}
-                            <div class="split-equit__pie">
-                                <svg viewBox="0 0 120 120" width="200" height="200"
-                                     :aria-label="`Reparto en ${parts} partes iguales`">
-                                    <template x-for="i in Array.from({length: parts}, (_, k) => k)" :key="i">
-                                        <g @click="if (i >= paidCount) mySlice = i"
-                                           @keydown.enter="if (i >= paidCount) mySlice = i"
-                                           @keydown.space.prevent="if (i >= paidCount) mySlice = i"
-                                           tabindex="0" role="button"
-                                           :aria-label="`Porción ${i + 1}${i < paidCount ? ' · pagada' : (i === mySlice ? ' · la tuya' : '')}`"
-                                           :aria-pressed="(i === mySlice).toString()"
-                                           style="cursor:pointer"
-                                           :class="i === mySlice ? 'slice slice--mine' : 'slice'">
-                                            <path :d="arc(i)"
-                                                  :fill="sliceColor(i)"
-                                                  stroke="#FFFFFF" stroke-width="3"/>
-                                            <text :x="labelPos(i).x"
-                                                  :y="labelPos(i).y"
-                                                  text-anchor="middle" dominant-baseline="middle"
-                                                  :font-size="i === mySlice || i < paidCount ? '9' : '9.5'"
-                                                  font-weight="800"
-                                                  :fill="sliceLabelFill(i)"
-                                                  x-text="sliceLabel(i)">
-                                            </text>
-                                        </g>
-                                    </template>
-                                    {{-- Centro blanco (r = R_IN = 28) --}}
-                                    <circle cx="60" cy="60" r="28" fill="var(--bg-surface)"/>
-                                    <text x="60" y="54" text-anchor="middle"
-                                          font-size="5.5" font-weight="700" letter-spacing="0.14em"
-                                          fill="var(--fg-muted)">TU PARTE</text>
-                                    <text x="60" y="68" text-anchor="middle"
-                                          font-size="13" font-weight="900" letter-spacing="-0.02em"
-                                          fill="var(--fg-primary)"
-                                          x-text="fmt(slice)">
-                                    </text>
-                                </svg>
+                            {{-- Donut — generado via innerHTML para respetar el namespace SVG --}}
+                            <div class="split-equit__pie"
+                                 x-ref="pie"
+                                 x-effect="$refs.pie.innerHTML = buildSvg()"
+                                 :aria-label="`Reparto en ${parts} partes iguales`"
+                                 @click="
+                                     const g = $event.target.closest('[data-slice]');
+                                     if (g) {
+                                         const i = parseInt(g.dataset.slice);
+                                         if (i >= paidCount) mySlice = i;
+                                     }
+                                 ">
                             </div>
 
                             {{-- Stepper --}}

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2268,8 +2268,9 @@
                     {{-- ── splitEq: partes iguales con donut (DS) ─── --}}
                     <div x-show="$store.bill.step === 'splitEq'"
                          x-data="{
-                             parts:   $store.bill.splitPeople || 2,
-                             mySlice: 0,
+                             parts:     $store.bill.splitPeople || 2,
+                             mySlice:   0,
+                             paidCount: 0,
                              get maxParts() {
                                  const m = $store.bill.splitMaxParts;
                                  return (m && m > 2) ? m : 10;
@@ -2290,7 +2291,7 @@
                                  }
                              },
                              arc(i) {
-                                 const R_OUT = 46, R_IN = 32, CX = 65, CY = 65;
+                                 const R_OUT = 46, R_IN = 28, CX = 60, CY = 60;
                                  const a0 = (i / this.parts) * Math.PI * 2 - Math.PI / 2;
                                  const a1 = ((i + 1) / this.parts) * Math.PI * 2 - Math.PI / 2;
                                  const lg = (a1 - a0) > Math.PI ? 1 : 0;
@@ -2300,10 +2301,29 @@
                                  const x1i = CX + R_IN *Math.cos(a0), y1i = CY + R_IN *Math.sin(a0);
                                  return `M ${x0o} ${y0o} A ${R_OUT} ${R_OUT} 0 ${lg} 1 ${x1o} ${y1o} L ${x0i} ${y0i} A ${R_IN} ${R_IN} 0 ${lg} 0 ${x1i} ${y1i} Z`;
                              },
-                             labelPos(i, isMine) {
+                             labelPos(i) {
                                  const mid = ((i + 0.5) / this.parts) * Math.PI * 2 - Math.PI / 2;
-                                 const r = isMine ? 39 : 55;
-                                 return { x: 65 + r * Math.cos(mid), y: 65 + r * Math.sin(mid) };
+                                 const inside = (i === this.mySlice || i < this.paidCount);
+                                 const r = inside ? 37 : 53;
+                                 return { x: 60 + r * Math.cos(mid), y: 60 + r * Math.sin(mid) };
+                             },
+                             sliceColor(i) {
+                                 if (i === this.mySlice) return '#16A34A';
+                                 if (i < this.paidCount) return '#E84FAC';
+                                 return 'var(--bg-chip)';
+                             },
+                             sliceLabel(i) {
+                                 if (i === this.mySlice) return 'TÚ';
+                                 if (i < this.paidCount) return '✓';
+                                 return String(i + 1);
+                             },
+                             sliceLabelFill(i) {
+                                 return (i === this.mySlice || i < this.paidCount) ? '#ffffff' : 'var(--fg-secondary)';
+                             },
+                             dotClass(i) {
+                                 if (i < this.paidCount) return 'dot dot--paid';
+                                 if (i === this.mySlice) return 'dot dot--mine';
+                                 return 'dot';
                              },
                          }">
                         <div class="split-equit">
@@ -2323,69 +2343,66 @@
 
                             {{-- Donut --}}
                             <div class="split-equit__pie">
-                                {{-- viewBox 130x130 da margen para las etiquetas exteriores --}}
-                                <svg viewBox="0 0 130 130" width="210" height="210"
+                                <svg viewBox="0 0 120 120" width="200" height="200"
                                      :aria-label="`Reparto en ${parts} partes iguales`">
                                     <template x-for="i in Array.from({length: parts}, (_, k) => k)" :key="i">
-                                        <g @click="mySlice = i"
-                                           @keydown.enter="mySlice = i"
-                                           @keydown.space.prevent="mySlice = i"
+                                        <g @click="if (i >= paidCount) mySlice = i"
+                                           @keydown.enter="if (i >= paidCount) mySlice = i"
+                                           @keydown.space.prevent="if (i >= paidCount) mySlice = i"
                                            tabindex="0" role="button"
-                                           :aria-label="`Porción ${i + 1}${i === mySlice ? ' — la tuya' : ''}`"
+                                           :aria-label="`Porción ${i + 1}${i < paidCount ? ' · pagada' : (i === mySlice ? ' · la tuya' : '')}`"
+                                           :aria-pressed="(i === mySlice).toString()"
                                            style="cursor:pointer"
                                            :class="i === mySlice ? 'slice slice--mine' : 'slice'">
-                                            {{-- Slice path — gap blanco entre slices con stroke --}}
                                             <path :d="arc(i)"
-                                                  :fill="i === mySlice ? 'var(--color-green-600)' : 'var(--bg-chip)'"
-                                                  stroke="#ffffff" stroke-width="2.5"/>
-                                            {{-- Label: dentro del anillo si es mío, fuera si no --}}
-                                            <text :x="labelPos(i, i === mySlice).x"
-                                                  :y="labelPos(i, i === mySlice).y"
+                                                  :fill="sliceColor(i)"
+                                                  stroke="#FFFFFF" stroke-width="3"/>
+                                            <text :x="labelPos(i).x"
+                                                  :y="labelPos(i).y"
                                                   text-anchor="middle" dominant-baseline="middle"
-                                                  font-size="9" font-weight="800"
-                                                  :fill="i === mySlice ? '#ffffff' : 'var(--fg-secondary)'"
-                                                  x-text="i === mySlice ? 'TÚ' : (i + 1)">
+                                                  :font-size="i === mySlice || i < paidCount ? '9' : '9.5'"
+                                                  font-weight="800"
+                                                  :fill="sliceLabelFill(i)"
+                                                  x-text="sliceLabel(i)">
                                             </text>
                                         </g>
                                     </template>
-                                    {{-- Centro: cubre hasta R_IN para ocultar el interior del anillo --}}
-                                    <circle cx="65" cy="65" r="32" fill="var(--bg-surface)"/>
-                                    <text x="65" y="59" text-anchor="middle"
+                                    {{-- Centro blanco (r = R_IN = 28) --}}
+                                    <circle cx="60" cy="60" r="28" fill="var(--bg-surface)"/>
+                                    <text x="60" y="54" text-anchor="middle"
                                           font-size="5.5" font-weight="700" letter-spacing="0.14em"
                                           fill="var(--fg-muted)">TU PARTE</text>
-                                    <text x="65" y="73" text-anchor="middle"
-                                          font-size="12.5" font-weight="900" letter-spacing="-0.02em"
+                                    <text x="60" y="68" text-anchor="middle"
+                                          font-size="13" font-weight="900" letter-spacing="-0.02em"
                                           fill="var(--fg-primary)"
                                           x-text="fmt(slice)">
                                     </text>
                                 </svg>
                             </div>
 
-                            {{-- Stepper ¿Cuántos sois? --}}
+                            {{-- Stepper --}}
                             <div class="split-equit__stepper">
                                 <span class="lab">¿Cuántos sois?</span>
                                 <div class="step">
                                     <button type="button" aria-label="Menos personas"
-                                            @click="dec()"
-                                            :disabled="parts <= 2">−</button>
+                                            @click="dec()" :disabled="parts <= 2">−</button>
                                     <span class="step__num" x-text="parts" aria-live="polite"></span>
                                     <button type="button" aria-label="Más personas"
-                                            @click="inc()"
-                                            :disabled="parts >= maxParts">+</button>
+                                            @click="inc()" :disabled="parts >= maxParts">+</button>
                                 </div>
-                                <span class="hint" x-text="'máx. ' + maxParts"></span>
+                                <span class="hint" x-text="'max. ' + maxParts"></span>
                             </div>
 
-                            {{-- Dots: selector de porción --}}
+                            {{-- Estado de pagos --}}
                             <div class="split-equit__live">
-                                <span x-text="(mySlice + 1) + ' de ' + parts + ' partes'"></span>
-                                <div class="dots" role="group" aria-label="Tu porción">
+                                <span x-text="paidCount + ' de ' + parts + ' han pagado'"></span>
+                                <div class="dots" role="group" aria-label="Estado de pagos">
                                     <template x-for="i in Array.from({length: parts}, (_, k) => k)" :key="i">
                                         <button type="button"
-                                                :class="'dot' + (i === mySlice ? ' dot--mine' : '')"
-                                                @click="mySlice = i"
-                                                :aria-label="`Porción ${i + 1}`"
-                                                :aria-pressed="(i === mySlice).toString()">
+                                                :class="dotClass(i)"
+                                                @click="if (i >= paidCount) mySlice = i"
+                                                :aria-label="`Porción ${i + 1}${i < paidCount ? ': pagada' : (i === mySlice ? ': la tuya' : '')}`"
+                                                :disabled="i < paidCount">
                                         </button>
                                     </template>
                                 </div>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2265,6 +2265,58 @@
                         </div>
                     </div>
 
+                    {{-- ── splitEq: donut helper (función global, sin restricciones de comillas) ─── --}}
+                    <script>
+                    window._donutSvg = function(parts, mySlice, paidCount, sliceVal) {
+                        var R_OUT = 46, R_IN = 28, CX = 60, CY = 60;
+                        var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+                        var gray   = isDark ? '#1E2A4A' : '#E5E7EB';
+                        var cBg    = isDark ? '#0E1A38' : '#FFFFFF';
+                        var muted  = isDark ? '#6E84C0' : '#6B7280';
+                        var fg     = isDark ? '#C8D8FF' : '#111827';
+                        var amt    = Number(sliceVal).toFixed(2).replace('.', ',') + ' €';
+                        var s = '<svg viewBox="0 0 120 120" width="200" height="200" style="overflow:visible;display:block">';
+                        for (var i = 0; i < parts; i++) {
+                            var a0 = (i / parts) * Math.PI * 2 - Math.PI / 2;
+                            var a1 = ((i + 1) / parts) * Math.PI * 2 - Math.PI / 2;
+                            var lg = (a1 - a0) > Math.PI ? 1 : 0;
+                            var x0o = CX + R_OUT*Math.cos(a0), y0o = CY + R_OUT*Math.sin(a0);
+                            var x1o = CX + R_OUT*Math.cos(a1), y1o = CY + R_OUT*Math.sin(a1);
+                            var x0i = CX + R_IN *Math.cos(a1), y0i = CY + R_IN *Math.sin(a1);
+                            var x1i = CX + R_IN *Math.cos(a0), y1i = CY + R_IN *Math.sin(a0);
+                            var d = 'M ' + x0o.toFixed(2) + ' ' + y0o.toFixed(2) +
+                                    ' A ' + R_OUT + ' ' + R_OUT + ' 0 ' + lg + ' 1 ' +
+                                    x1o.toFixed(2) + ' ' + y1o.toFixed(2) +
+                                    ' L ' + x0i.toFixed(2) + ' ' + y0i.toFixed(2) +
+                                    ' A ' + R_IN  + ' ' + R_IN  + ' 0 ' + lg + ' 0 ' +
+                                    x1i.toFixed(2) + ' ' + y1i.toFixed(2) + ' Z';
+                            var fill   = i === mySlice ? '#16A34A' : (i < paidCount ? '#E84FAC' : gray);
+                            var mid    = ((i + 0.5) / parts) * Math.PI * 2 - Math.PI / 2;
+                            var inside = (i === mySlice || i < paidCount);
+                            var r      = inside ? 37 : 53;
+                            var lx     = (CX + r*Math.cos(mid)).toFixed(2);
+                            var ly     = (CY + r*Math.sin(mid)).toFixed(2);
+                            var lbl    = i === mySlice ? 'TÚ' : (i < paidCount ? '✓' : String(i + 1));
+                            var lFill  = inside ? '#FFFFFF' : muted;
+                            var lSize  = inside ? '9' : '9.5';
+                            var cur    = i < paidCount ? 'default' : 'pointer';
+                            s += '<g data-slice="' + i + '" style="cursor:' + cur + '">' +
+                                 '<path d="' + d + '" fill="' + fill + '" stroke="#FFFFFF" stroke-width="3"/>' +
+                                 '<text x="' + lx + '" y="' + ly + '" text-anchor="middle"' +
+                                 ' dominant-baseline="middle" font-size="' + lSize + '"' +
+                                 ' font-weight="800" fill="' + lFill + '">' + lbl + '</text>' +
+                                 '</g>';
+                        }
+                        s += '<circle cx="' + CX + '" cy="' + CY + '" r="' + R_IN + '" fill="' + cBg + '"/>';
+                        s += '<text x="' + CX + '" y="54" text-anchor="middle" font-size="5.5"' +
+                             ' font-weight="700" letter-spacing="2" fill="' + muted + '">TU PARTE</text>';
+                        s += '<text x="' + CX + '" y="68" text-anchor="middle" font-size="13"' +
+                             ' font-weight="900" fill="' + fg + '">' + amt + '</text>';
+                        s += '</svg>';
+                        return s;
+                    };
+                    </script>
+
                     {{-- ── splitEq: partes iguales con donut (DS) ─── --}}
                     <div x-show="$store.bill.step === 'splitEq'"
                          x-data="{
@@ -2296,43 +2348,7 @@
                                  return 'dot';
                              },
                              buildSvg() {
-                                 const P = this.parts, ms = this.mySlice, pc = this.paidCount;
-                                 const R_OUT = 46, R_IN = 28, CX = 60, CY = 60;
-                                 const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-                                 const graySlice  = isDark ? '#1E2A4A' : '#E5E7EB';
-                                 const centerBg   = isDark ? '#0E1A38' : '#FFFFFF';
-                                 const muteClr    = isDark ? '#6E84C0' : '#6B7280';
-                                 const primaryClr = isDark ? '#C8D8FF' : '#111827';
-                                 let svg = '<svg viewBox="0 0 120 120" width="200" height="200" style="overflow:visible;display:block">';
-                                 for (let i = 0; i < P; i++) {
-                                     const a0 = (i / P) * Math.PI * 2 - Math.PI / 2;
-                                     const a1 = ((i + 1) / P) * Math.PI * 2 - Math.PI / 2;
-                                     const lg = (a1 - a0) > Math.PI ? 1 : 0;
-                                     const x0o = CX + R_OUT*Math.cos(a0), y0o = CY + R_OUT*Math.sin(a0);
-                                     const x1o = CX + R_OUT*Math.cos(a1), y1o = CY + R_OUT*Math.sin(a1);
-                                     const x0i = CX + R_IN *Math.cos(a1), y0i = CY + R_IN *Math.sin(a1);
-                                     const x1i = CX + R_IN *Math.cos(a0), y1i = CY + R_IN *Math.sin(a0);
-                                     const d = `M ${x0o.toFixed(2)} ${y0o.toFixed(2)} A ${R_OUT} ${R_OUT} 0 ${lg} 1 ${x1o.toFixed(2)} ${y1o.toFixed(2)} L ${x0i.toFixed(2)} ${y0i.toFixed(2)} A ${R_IN} ${R_IN} 0 ${lg} 0 ${x1i.toFixed(2)} ${y1i.toFixed(2)} Z`;
-                                     const fill  = i === ms ? '#16A34A' : (i < pc ? '#E84FAC' : graySlice);
-                                     const mid   = ((i + 0.5) / P) * Math.PI * 2 - Math.PI / 2;
-                                     const inside = (i === ms || i < pc);
-                                     const r = inside ? 37 : 53;
-                                     const lx = (CX + r*Math.cos(mid)).toFixed(2);
-                                     const ly = (CY + r*Math.sin(mid)).toFixed(2);
-                                     const label = i === ms ? 'TÚ' : (i < pc ? '✓' : String(i + 1));
-                                     const lFill = inside ? '#FFFFFF' : muteClr;
-                                     const lSize = inside ? 9 : 9.5;
-                                     const cursor = i < pc ? 'default' : 'pointer';
-                                     svg += `<g data-slice="${i}" style="cursor:${cursor}">` +
-                                            `<path d="${d}" fill="${fill}" stroke="#FFFFFF" stroke-width="3"/>` +
-                                            `<text x="${lx}" y="${ly}" text-anchor="middle" dominant-baseline="middle" font-size="${lSize}" font-weight="800" fill="${lFill}">${label}</text>` +
-                                            `</g>`;
-                                 }
-                                 svg += `<circle cx="${CX}" cy="${CY}" r="${R_IN}" fill="${centerBg}"/>`;
-                                 svg += `<text x="${CX}" y="54" text-anchor="middle" font-size="5.5" font-weight="700" letter-spacing="2" fill="${muteClr}">TU PARTE</text>`;
-                                 svg += `<text x="${CX}" y="68" text-anchor="middle" font-size="13" font-weight="900" fill="${primaryClr}">${this.fmt(this.slice)}</text>`;
-                                 svg += '</svg>';
-                                 return svg;
+                                 return window._donutSvg(this.parts, this.mySlice, this.paidCount, this.slice);
                              },
                          }">
                         <div class="split-equit">

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2179,16 +2179,26 @@
                         </div>
                     </div>
 
-                    {{-- ── splitItems: reclamar ítems ─── --}}
-                    <div x-show="$store.bill.step === 'splitItems'">
+                    {{-- ── splitItems: reclamar ítems (DS) ─── --}}
+                    <div x-show="$store.bill.step === 'splitItems'"
+                         x-data="{ fmt(n) { return Number(n).toFixed(2).replace('.', ',') + ' €'; } }">
                         <div class="split-items">
+
+                            {{-- Cabecera: cambiar modo --}}
                             <div class="split-items__head">
-                                <button type="button" class="back" @click="$store.bill.setSplitStage('intro')">← Cambiar modo</button>
+                                <button type="button" class="back" @click="$store.bill.setSplitStage('intro')">
+                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
+                                    Cambiar modo
+                                </button>
                             </div>
 
+                            {{-- Barra de progreso + leyenda --}}
                             <div class="split-items__status">
                                 <div class="split-items__progress">
-                                    <div class="bar">
+                                    <div class="bar" role="progressbar"
+                                         :aria-valuenow="$store.bill.splitItems.filter(i => i.claimed).length"
+                                         :aria-valuemax="$store.bill.splitItems.length"
+                                         aria-label="Ítems reclamados">
                                         <div class="bar__fill"
                                              :style="'width: ' + (($store.bill.splitItems.filter(i => i.claimed).length / Math.max(1, $store.bill.splitItems.length)) * 100) + '%'">
                                         </div>
@@ -2198,48 +2208,59 @@
                                     </span>
                                 </div>
                                 <div class="split-items__legend">
-                                    Marca los platos que quieres pagar tú. Los ya marcados por otros están bloqueados.
+                                    Pulsa el círculo de un plato para reclamarlo. Los bloqueados ya los paga otro comensal.
                                 </div>
                             </div>
 
-                            <div class="split-items__list">
+                            {{-- Lista de ítems --}}
+                            <div class="split-items__list" role="list">
                                 <template x-for="item in $store.bill.splitItems" :key="item.id">
-                                    <div class="split-line">
+                                    <div class="split-line" role="listitem"
+                                         :class="{ 'split-line--mine': $store.bill.isItemSelected(item.id), 'split-line--claimed': item.claimed && !$store.bill.isItemSelected(item.id) }">
+
                                         <div class="split-line__photo" aria-hidden="true">🍽️</div>
+
                                         <div class="split-line__main">
                                             <div class="split-line__name" x-text="item.name"></div>
-                                            <div class="split-line__price">
-                                                <span x-text="Number(item.price).toFixed(2).replace('.',',') + ' €'"></span>
-                                                <span>/ ud.</span>
-                                            </div>
+                                            <div class="split-line__total"
+                                                 x-text="fmt(item.total)"></div>
                                         </div>
-                                        <div class="split-line__slots">
-                                            <template x-for="idx in item.quantity" :key="idx">
-                                                <button type="button"
-                                                        :class="'slot' + ($store.bill.isItemSelected(item.id) && idx === 1 ? ' slot--you slot--just' : (item.claimed ? ' slot--other' : ''))"
-                                                        @click="!item.claimed && $store.bill.toggleSplitItem(item.id, item.claimed)"
-                                                        :disabled="item.claimed"
-                                                        :aria-label="item.claimed ? 'Ya reclamado' : 'Reclamar'">
-                                                    <span x-text="$store.bill.isItemSelected(item.id) && idx === 1 ? 'T' : (item.claimed ? '✓' : '+')"></span>
-                                                </button>
+
+                                        {{-- Un slot por ítem (el backend no devuelve qty por unidad) --}}
+                                        <button type="button"
+                                                :class="'slot' + ($store.bill.isItemSelected(item.id) ? ' slot--you' : (item.claimed ? ' slot--other' : ''))"
+                                                @click="$store.bill.toggleSplitItem(item.id, item.claimed)"
+                                                :disabled="item.claimed && !$store.bill.isItemSelected(item.id)"
+                                                :aria-label="$store.bill.isItemSelected(item.id) ? 'Quitar de mi parte' : (item.claimed ? 'Ya reclamado por otro comensal' : 'Reclamar este plato')"
+                                                :aria-pressed="$store.bill.isItemSelected(item.id)">
+                                            {{-- Unclaimed --}}
+                                            <template x-if="!$store.bill.isItemSelected(item.id) && !item.claimed">
+                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
                                             </template>
-                                        </div>
+                                            {{-- Mine --}}
+                                            <template x-if="$store.bill.isItemSelected(item.id)">
+                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+                                            </template>
+                                            {{-- Claimed by other --}}
+                                            <template x-if="item.claimed && !$store.bill.isItemSelected(item.id)">
+                                                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                                            </template>
+                                        </button>
                                     </div>
                                 </template>
                             </div>
 
+                            {{-- Total de tu parte (solo lectura, el CTA está en drawer__foot) --}}
                             <div class="split-items__foot">
                                 <div class="split-items__yourTotal">
                                     <span class="lab">Tu parte</span>
                                     <span class="val"
-                                          x-text="Number($store.bill.splitItemsTotal || 0).toFixed(2).replace('.',',') + ' €'"></span>
+                                          x-text="fmt($store.bill.splitItemsTotal || 0)"></span>
                                 </div>
-                                <button type="button" class="btn-primary"
-                                        :disabled="!$store.bill.splitSelected || $store.bill.splitSelected.length === 0"
-                                        @click="$store.bill.paySelectedItems()">
-                                    Pagar mi parte ·
-                                    <span x-text="Number($store.bill.splitItemsTotal || 0).toFixed(2).replace('.',',') + ' €'"></span>
-                                </button>
+                                <div class="split-items__hint"
+                                     x-show="($store.bill.splitSelected || []).length > 0">
+                                    Confirma en el botón de abajo para pagar con tarjeta.
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1772,7 +1772,7 @@
                 <div class="drawer__head">
 
                     {{-- Botón atrás (pasos intermedios) --}}
-                    <template x-if="['cashConfirm','tip','pay','split','splitItems','splitEq','mixed','mixedTip','splitTip','splitPay','mixedPay'].includes($store.bill.step)">
+                    <template x-if="['cashConfirm','tip','pay','split','mixed','mixedTip','splitTip','splitPay','mixedPay'].includes($store.bill.step)">
                         <button type="button" class="icon-btn icon-btn--back"
                                 @click="$store.bill.step === 'splitItems' ? $store.bill.closeSplitItems()
                                     : $store.bill.step === 'splitEq'   ? $store.bill.closeSplitEq()

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2989,7 +2989,9 @@
 
                     {{-- split --}}
                     <div x-show="$store.bill.step === 'split'">
-                        <button type="button" class="btn-text" @click="$store.bill.closeSplitSelector()">Cancelar</button>
+                        <div class="bill__footRow bill__footRow--stack">
+                            <button type="button" class="btn-secondary" @click="$store.bill.closeSplitSelector()">← Cambiar método</button>
+                        </div>
                     </div>
 
                     {{-- splitItems --}}
@@ -3032,12 +3034,14 @@
 
                     {{-- mixed --}}
                     <div x-show="$store.bill.step === 'mixed'">
-                        <button type="button" class="btn-primary"
-                                :disabled="!$store.bill.mixedCashValid && !($store.bill.mixedCashAmount >= $store.bill.orderTotal - 0.001)"
-                                @click="$store.bill.proceedFromMixed()">
-                            <span x-text="($store.bill.mixedCashAmount >= $store.bill.orderTotal - 0.001) ? 'Continuar · Pago en efectivo' : 'Continuar con tarjeta'"></span>
-                        </button>
-                        <button type="button" class="btn-text" @click="$store.bill.closeMixed()">Cancelar</button>
+                        <div class="bill__footRow bill__footRow--stack">
+                            <button type="button" class="btn-primary"
+                                    :disabled="!$store.bill.mixedCashValid && !($store.bill.mixedCashAmount >= $store.bill.orderTotal - 0.001)"
+                                    @click="$store.bill.proceedFromMixed()">
+                                <span x-text="($store.bill.mixedCashAmount >= $store.bill.orderTotal - 0.001) ? 'Continuar · Pago en efectivo' : 'Continuar con tarjeta'"></span>
+                            </button>
+                            <button type="button" class="btn-secondary" @click="$store.bill.closeMixed()">← Cambiar método</button>
+                        </div>
                     </div>
 
                     {{-- mixedTip --}}

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2342,6 +2342,7 @@
                                      if (this.mySlice >= this.parts) this.mySlice = this.parts - 1;
                                  }
                              },
+                             _pollTimer: null,
                              dotClass(i) {
                                  if (i < this.paidCount) return 'dot dot--paid';
                                  if (i === this.mySlice) return 'dot dot--mine';
@@ -2350,7 +2351,29 @@
                              buildSvg() {
                                  return window._donutSvg(this.parts, this.mySlice, this.paidCount, this.slice);
                              },
-                         }">
+                             async pollEqStatus() {
+                                 try {
+                                     const res  = await fetch('/api/v1/payment/' + $store.bill.tableHash + '/split/eq-status', { headers: { 'Accept': 'application/json' } });
+                                     const data = await res.json();
+                                     if (res.ok && data.success) {
+                                         this.paidCount = data.paid_parts || 0;
+                                         if (data.parts_total > 0 && data.parts_total !== this.parts) {
+                                             this.parts = data.parts_total;
+                                             $store.bill.splitPeople = data.parts_total;
+                                         }
+                                     }
+                                 } catch (_) {}
+                             },
+                             startPoll() {
+                                 this.pollEqStatus();
+                                 this._pollTimer = setInterval(() => this.pollEqStatus(), 5000);
+                             },
+                             stopPoll() {
+                                 if (this._pollTimer) { clearInterval(this._pollTimer); this._pollTimer = null; }
+                             },
+                         }"
+                         x-init="$watch('$store.bill.step', s => { if (s === 'splitEq') startPoll(); else stopPoll(); }); if ($store.bill.step === 'splitEq') startPoll();"
+                         @vue:unmounted.window="stopPoll()"
                         <div class="split-equit">
 
                             {{-- Cabecera --}}

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2267,16 +2267,23 @@
 
                     {{-- ── splitEq: donut helper (función global, sin restricciones de comillas) ─── --}}
                     <script>
-                    window._donutSvg = function(parts, mySlice, paidCount, sliceVal) {
+                    // parts      — número de personas
+                    // mySlice    — índice del slice seleccionado por esta sesión
+                    // slotColors — objeto { index: "#HEX" } de slots ya pagados
+                    // sliceVal   — importe de cada parte
+                    // myColor    — color de sesión del usuario actual
+                    window._donutSvg = function(parts, mySlice, slotColors, sliceVal, myColor) {
                         var R_OUT = 46, R_IN = 28, CX = 60, CY = 60;
                         var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-                        var gray   = isDark ? '#1E2A4A' : '#E5E7EB';
+                        var gray   = isDark ? '#2A3A5E' : '#E5E7EB';
                         var cBg    = isDark ? '#0E1A38' : '#FFFFFF';
                         var muted  = isDark ? '#6E84C0' : '#6B7280';
                         var fg     = isDark ? '#C8D8FF' : '#111827';
                         var amt    = Number(sliceVal).toFixed(2).replace('.', ',') + ' €';
                         var s = '<svg viewBox="0 0 120 120" width="200" height="200" style="overflow:visible;display:block">';
                         for (var i = 0; i < parts; i++) {
+                            var isPaid = !!slotColors[i];
+                            var isMine = (i === mySlice && !isPaid);
                             var a0 = (i / parts) * Math.PI * 2 - Math.PI / 2;
                             var a1 = ((i + 1) / parts) * Math.PI * 2 - Math.PI / 2;
                             var lg = (a1 - a0) > Math.PI ? 1 : 0;
@@ -2290,16 +2297,17 @@
                                     ' L ' + x0i.toFixed(2) + ' ' + y0i.toFixed(2) +
                                     ' A ' + R_IN  + ' ' + R_IN  + ' 0 ' + lg + ' 0 ' +
                                     x1i.toFixed(2) + ' ' + y1i.toFixed(2) + ' Z';
-                            var fill   = i === mySlice ? '#16A34A' : (i < paidCount ? '#E84FAC' : gray);
-                            var mid    = ((i + 0.5) / parts) * Math.PI * 2 - Math.PI / 2;
-                            var inside = (i === mySlice || i < paidCount);
-                            var r      = inside ? 37 : 53;
-                            var lx     = (CX + r*Math.cos(mid)).toFixed(2);
-                            var ly     = (CY + r*Math.sin(mid)).toFixed(2);
-                            var lbl    = i === mySlice ? 'TÚ' : (i < paidCount ? '✓' : String(i + 1));
-                            var lFill  = inside ? '#FFFFFF' : muted;
-                            var lSize  = inside ? '9' : '9.5';
-                            var cur    = i < paidCount ? 'default' : 'pointer';
+                            // Pagado → color del pagador | Mío → mi color | Libre → gris
+                            var fill  = isPaid ? slotColors[i] : (isMine ? myColor : gray);
+                            var mid   = ((i + 0.5) / parts) * Math.PI * 2 - Math.PI / 2;
+                            var inside = isPaid || isMine;
+                            var r     = inside ? 37 : 53;
+                            var lx    = (CX + r*Math.cos(mid)).toFixed(2);
+                            var ly    = (CY + r*Math.sin(mid)).toFixed(2);
+                            var lbl   = isPaid ? '✓' : (isMine ? 'TÚ' : String(i + 1));
+                            var lFill = inside ? '#FFFFFF' : muted;
+                            var lSize = inside ? '9' : '9.5';
+                            var cur   = isPaid ? 'default' : 'pointer';
                             s += '<g data-slice="' + i + '" style="cursor:' + cur + '">' +
                                  '<path d="' + d + '" fill="' + fill + '" stroke="#FFFFFF" stroke-width="3"/>' +
                                  '<text x="' + lx + '" y="' + ly + '" text-anchor="middle"' +
@@ -2320,9 +2328,18 @@
                     {{-- ── splitEq: partes iguales con donut (DS) ─── --}}
                     <div x-show="$store.bill.step === 'splitEq'"
                          x-data="{
-                             parts:     $store.bill.splitPeople || 2,
-                             mySlice:   0,
-                             paidCount: 0,
+                             parts:        $store.bill.splitPeople || 2,
+                             mySlice:      $store.bill.splitEqSlice || 0,
+                             paidCount:    0,
+                             slotColors:   {},
+                             sessionColor: (function() {
+                                 const PALETTE = ['#E84FAC','#3B82F6','#F59E0B','#8B5CF6','#06B6D4','#EF4444','#F97316'];
+                                 const key = 'zampa_color_' + ($store.bill.tableHash || 'x');
+                                 if (!localStorage.getItem(key)) {
+                                     localStorage.setItem(key, PALETTE[Math.floor(Math.random() * PALETTE.length)]);
+                                 }
+                                 return localStorage.getItem(key);
+                             })(),
                              get maxParts() {
                                  const m = $store.bill.splitMaxParts;
                                  return (m && m > 2) ? m : 10;
@@ -2343,27 +2360,37 @@
                                  }
                              },
                              _pollTimer: null,
+                             selectSlice(i) {
+                                 if (this.slotColors[i]) return; // ya pagado
+                                 this.mySlice = i;
+                                 $store.bill.splitEqSlice = i;
+                                 $store.bill.splitEqColor = this.sessionColor;
+                             },
+                             // Dots: verde = pagado, anillo sessionColor = mío, gris = libre
                              dotClass(i) {
                                  if (i < this.paidCount) return 'dot dot--paid';
                                  if (i === this.mySlice) return 'dot dot--mine';
                                  return 'dot';
                              },
                              buildSvg() {
-                                 return window._donutSvg(this.parts, this.mySlice, this.paidCount, this.slice);
+                                 return window._donutSvg(this.parts, this.mySlice, this.slotColors, this.slice, this.sessionColor);
                              },
                              async pollEqStatus() {
                                  try {
                                      const res  = await fetch('/api/v1/payment/' + $store.bill.tableHash + '/split/eq-status', { headers: { 'Accept': 'application/json' } });
                                      const data = await res.json();
                                      if (res.ok && data.success) {
-                                         this.paidCount = data.paid_parts || 0;
+                                         this.slotColors = data.slot_colors || {};
+                                         this.paidCount  = data.paid_parts  || 0;
                                          if (data.parts_total > 0 && data.parts_total !== this.parts) {
                                              this.parts = data.parts_total;
                                              $store.bill.splitPeople = data.parts_total;
                                          }
-                                         // Si mi slice ya está pagado, muevo al primero libre
-                                         if (this.mySlice < this.paidCount) {
-                                             this.mySlice = this.paidCount < this.parts ? this.paidCount : this.parts - 1;
+                                         // Si mi slice quedó pagado, muevo al primero libre
+                                         if (this.slotColors[this.mySlice]) {
+                                             for (let j = 0; j < this.parts; j++) {
+                                                 if (!this.slotColors[j]) { this.mySlice = j; $store.bill.splitEqSlice = j; break; }
+                                             }
                                          }
                                      }
                                  } catch (_) {}
@@ -2400,10 +2427,7 @@
                                  :aria-label="`Reparto en ${parts} partes iguales`"
                                  @click="
                                      const g = $event.target.closest('[data-slice]');
-                                     if (g) {
-                                         const i = parseInt(g.dataset.slice);
-                                         if (i >= paidCount) mySlice = i;
-                                     }
+                                     if (g) selectSlice(parseInt(g.dataset.slice));
                                  ">
                             </div>
 
@@ -2427,9 +2451,9 @@
                                     <template x-for="i in Array.from({length: parts}, (_, k) => k)" :key="i">
                                         <button type="button"
                                                 :class="dotClass(i)"
-                                                @click="if (i >= paidCount) mySlice = i"
-                                                :aria-label="`Porción ${i + 1}${i < paidCount ? ': pagada' : (i === mySlice ? ': la tuya' : '')}`"
-                                                :disabled="i < paidCount">
+                                                @click="selectSlice(i)"
+                                                :aria-label="`Porción ${i + 1}${slotColors[i] ? ': pagada' : (i === mySlice ? ': la tuya' : '')}`"
+                                                :disabled="!!slotColors[i]">
                                         </button>
                                     </template>
                                 </div>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2290,7 +2290,7 @@
                                  }
                              },
                              arc(i) {
-                                 const R_OUT = 48, R_IN = 28, CX = 60, CY = 60;
+                                 const R_OUT = 46, R_IN = 32, CX = 65, CY = 65;
                                  const a0 = (i / this.parts) * Math.PI * 2 - Math.PI / 2;
                                  const a1 = ((i + 1) / this.parts) * Math.PI * 2 - Math.PI / 2;
                                  const lg = (a1 - a0) > Math.PI ? 1 : 0;
@@ -2300,9 +2300,10 @@
                                  const x1i = CX + R_IN *Math.cos(a0), y1i = CY + R_IN *Math.sin(a0);
                                  return `M ${x0o} ${y0o} A ${R_OUT} ${R_OUT} 0 ${lg} 1 ${x1o} ${y1o} L ${x0i} ${y0i} A ${R_IN} ${R_IN} 0 ${lg} 0 ${x1i} ${y1i} Z`;
                              },
-                             labelPos(i) {
+                             labelPos(i, isMine) {
                                  const mid = ((i + 0.5) / this.parts) * Math.PI * 2 - Math.PI / 2;
-                                 return { x: 60 + 38 * Math.cos(mid), y: 60 + 38 * Math.sin(mid) };
+                                 const r = isMine ? 39 : 55;
+                                 return { x: 65 + r * Math.cos(mid), y: 65 + r * Math.sin(mid) };
                              },
                          }">
                         <div class="split-equit">
@@ -2322,7 +2323,8 @@
 
                             {{-- Donut --}}
                             <div class="split-equit__pie">
-                                <svg viewBox="0 0 120 120" width="200" height="200"
+                                {{-- viewBox 130x130 da margen para las etiquetas exteriores --}}
+                                <svg viewBox="0 0 130 130" width="210" height="210"
                                      :aria-label="`Reparto en ${parts} partes iguales`">
                                     <template x-for="i in Array.from({length: parts}, (_, k) => k)" :key="i">
                                         <g @click="mySlice = i"
@@ -2332,26 +2334,27 @@
                                            :aria-label="`Porción ${i + 1}${i === mySlice ? ' — la tuya' : ''}`"
                                            style="cursor:pointer"
                                            :class="i === mySlice ? 'slice slice--mine' : 'slice'">
+                                            {{-- Slice path — gap blanco entre slices con stroke --}}
                                             <path :d="arc(i)"
                                                   :fill="i === mySlice ? 'var(--color-green-600)' : 'var(--bg-chip)'"
-                                                  stroke="var(--bg-surface)" stroke-width="3"
-                                                  stroke-linejoin="round"/>
-                                            <text :x="labelPos(i).x" :y="labelPos(i).y"
+                                                  stroke="#ffffff" stroke-width="2.5"/>
+                                            {{-- Label: dentro del anillo si es mío, fuera si no --}}
+                                            <text :x="labelPos(i, i === mySlice).x"
+                                                  :y="labelPos(i, i === mySlice).y"
                                                   text-anchor="middle" dominant-baseline="middle"
-                                                  :font-size="i === mySlice ? '9' : '10'"
-                                                  font-weight="800"
+                                                  font-size="9" font-weight="800"
                                                   :fill="i === mySlice ? '#ffffff' : 'var(--fg-secondary)'"
                                                   x-text="i === mySlice ? 'TÚ' : (i + 1)">
                                             </text>
                                         </g>
                                     </template>
-                                    {{-- Centro blanco con texto --}}
-                                    <circle cx="60" cy="60" r="26" fill="var(--bg-surface)"/>
-                                    <text x="60" y="54" text-anchor="middle"
-                                          font-size="5.5" font-weight="700" letter-spacing="0.12em"
+                                    {{-- Centro: cubre hasta R_IN para ocultar el interior del anillo --}}
+                                    <circle cx="65" cy="65" r="32" fill="var(--bg-surface)"/>
+                                    <text x="65" y="59" text-anchor="middle"
+                                          font-size="5.5" font-weight="700" letter-spacing="0.14em"
                                           fill="var(--fg-muted)">TU PARTE</text>
-                                    <text x="60" y="68" text-anchor="middle"
-                                          font-size="12" font-weight="900" letter-spacing="-0.02em"
+                                    <text x="65" y="73" text-anchor="middle"
+                                          font-size="12.5" font-weight="900" letter-spacing="-0.02em"
                                           fill="var(--fg-primary)"
                                           x-text="fmt(slice)">
                                     </text>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1772,7 +1772,7 @@
                 <div class="drawer__head">
 
                     {{-- Botón atrás (pasos intermedios) --}}
-                    <template x-if="['cashConfirm','tip','pay','split','mixed','mixedTip','splitTip','splitPay','mixedPay'].includes($store.bill.step)">
+                    <template x-if="['cashConfirm','tip','pay','split','mixed','mixedTip','splitPay','mixedPay'].includes($store.bill.step)">
                         <button type="button" class="icon-btn icon-btn--back"
                                 @click="$store.bill.step === 'splitItems' ? $store.bill.closeSplitItems()
                                     : $store.bill.step === 'splitEq'   ? $store.bill.closeSplitEq()
@@ -2231,13 +2231,6 @@
                          x-data="{ fmt(n) { return Number(n).toFixed(2).replace('.', ',') + ' €'; } }">
                         <div class="split-items">
 
-                            {{-- Cabecera: cambiar modo --}}
-                            <div class="split-items__head">
-                                <button type="button" class="back" @click="$store.bill.closeSplitItems()">
-                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
-                                    Cambiar modo
-                                </button>
-                            </div>
 
                             {{-- Barra de progreso + leyenda --}}
                             <div class="split-items__status">
@@ -2460,11 +2453,6 @@
 
                             {{-- Cabecera --}}
                             <div class="split-items__head">
-                                <button type="button" class="back"
-                                        @click="$store.bill.closeSplitEq()">
-                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
-                                    Cambiar modo
-                                </button>
                                 <div class="split-equit__total-chip">
                                     <span class="k">Total a dividir</span>
                                     <span class="v" x-text="fmt($store.bill.orderTotal)"></span>
@@ -2516,7 +2504,6 @@
                     {{-- ── splitTip: propina para split ─── --}}
                     <div x-show="$store.bill.step === 'splitTip'">
                         <div class="split-pay">
-                            <button type="button" class="back" @click="$store.bill.backToMethod()">← Cambiar método</button>
                             <div class="split-pay__amt">
                                 <span class="lab">Tu parte</span>
                                 <span class="val"
@@ -2948,7 +2935,14 @@
                     {{-- cashDone --}}
                     <div x-show="$store.bill.step === 'cashDone'">
                         <div class="bill__footRow" style="justify-content:center;">
-                            <button type="button" class="btn-text bill__cancelNotice" @click="$store.bill.backToMethod()">Cancelar aviso</button>
+                            <button type="button" class="btn-text bill__cancelNotice" @click="$store.bill.backToMethod()">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                    <circle cx="12" cy="12" r="10"/>
+                                    <line x1="15" y1="9" x2="9" y2="15"/>
+                                    <line x1="9" y1="9" x2="15" y2="15"/>
+                                </svg>
+                                Cancelar aviso
+                            </button>
                         </div>
                     </div>
 
@@ -3009,7 +3003,10 @@
                                     @click="$store.bill.paySelectedItems()">
                                 Pagar mi parte
                             </button>
-                            <button type="button" class="back" @click="$store.bill.closeSplitItems()">Cambiar modo</button>
+                            <button type="button" class="back" @click="$store.bill.closeSplitItems()">
+                                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
+                                Cambiar modo
+                            </button>
                         </div>
                     </div>
 
@@ -3022,7 +3019,10 @@
                                 <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
                                 <span x-text="'Pagar mi parte · ' + Number($store.bill.splitMyPart || 0).toFixed(2).replace('.',',') + ' €'"></span>
                             </button>
-                            <button type="button" class="back" @click="$store.bill.closeSplitEq()">Cambiar modo</button>
+                            <button type="button" class="back" @click="$store.bill.closeSplitEq()">
+                                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
+                                Cambiar modo
+                            </button>
                         </div>
                     </div>
 

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1776,8 +1776,10 @@
                         <button type="button" class="icon-btn icon-btn--back"
                                 @click="$store.bill.step === 'splitItems' ? $store.bill.closeSplitItems()
                                     : $store.bill.step === 'splitEq'   ? $store.bill.closeSplitEq()
+                                    : $store.bill.step === 'splitTip'  ? $store.bill.closeSplitTip()
                                     : $store.bill.step === 'splitPay'  ? $store.bill.closeSplitPayment()
                                     : $store.bill.step === 'mixedPay'  ? $store.bill.closeMixedPayment()
+                                    : $store.bill.step === 'pay'       ? $store.bill.backToTip()
                                     : $store.bill.backToMethod()"
                                 aria-label="Cambiar método de pago">
                             <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
@@ -2981,7 +2983,7 @@
                                 </svg>
                                 <span x-text="$store.bill.sending ? 'Procesando…' : 'Pagar ' + Number($store.bill.grandTotal || $store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></span>
                             </button>
-                            <button type="button" class="back" @click="$store.bill.backToMethod()">← Atrás</button>
+                            <button type="button" class="back" @click="$store.bill.backToTip()">← Atrás</button>
                         </div>
                     </div>
 
@@ -3032,7 +3034,7 @@
                                 Continuar —
                                 <span x-text="Number($store.bill.splitTipGrandTotal || $store.bill.splitTipBase).toFixed(2).replace('.',',') + ' €'"></span>
                             </button>
-                            <button type="button" class="back" @click="$store.bill.backToMethod()">← Atrás</button>
+                            <button type="button" class="back" @click="$store.bill.closeSplitTip()">← Atrás</button>
                         </div>
                     </div>
 

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2420,207 +2420,238 @@
                         </div>
                     </div>
 
-                    {{-- ── mixed: fader efectivo/tarjeta ─── --}}
+                    {{-- ── mixed: split bar efectivo/tarjeta (DS) ─── --}}
                     <div x-show="$store.bill.step === 'mixed'"
                          x-data="{
+                             dragging: false,
+                             setFromX(clientX) {
+                                 const r = this.$refs.track.getBoundingClientRect();
+                                 let ratio = (clientX - r.left) / r.width;
+                                 ratio = Math.max(0, Math.min(1, ratio));
+                                 let cash = ratio * $store.bill.orderTotal;
+                                 cash = Math.round(cash / 0.10) * 0.10;
+                                 const maxCash = Math.max(0.50, Math.round(($store.bill.orderTotal - 0.50) * 100) / 100);
+                                 $store.bill.mixedCashAmount = Math.round(Math.min(maxCash, Math.max(0.50, cash)) * 100) / 100;
+                             },
                              get card() { return Math.max(0, $store.bill.orderTotal - ($store.bill.mixedCashAmount || 0)); },
                              get cashRatio() { return Math.max(0, Math.min(1, ($store.bill.mixedCashAmount || 0) / $store.bill.orderTotal)); },
-                             get cashAllOnly() { return ($store.bill.mixedCashAmount || 0) >= $store.bill.orderTotal - 0.001; },
-                             get cardOnly() { return ($store.bill.mixedCashAmount || 0) <= 0.001; },
-                             get cardBelowMin() { return !this.cashAllOnly && this.card > 0 && this.card < 0.50; },
-                             get canContinue() { return !this.cardBelowMin; },
-                             fmt(n) { return Number(n).toFixed(2).replace('.',',') + ' €'; },
-                             presets: [],
-                             initPresets() {
-                                 const t = $store.bill.orderTotal;
-                                 this.presets = [
-                                     { label: '10 €',       value: 10 },
-                                     { label: '20 €',       value: 20 },
-                                     { label: '50 €',       value: Math.min(50, t) },
-                                     { label: 'Mitad',      value: Math.round(t / 2 * 2) / 2 },
-                                     { label: 'Solo efect.', value: t },
-                                 ];
+                             get maxCash() { return Math.max(0.50, Math.round(($store.bill.orderTotal - 0.50) * 100) / 100); },
+                             fmt(n) { return Number(n).toFixed(2).replace('.', ',') + ' €'; },
+                             presetActive(v) {
+                                 const clamped = Math.min(this.maxCash, Math.max(0.50, v));
+                                 return Math.abs(($store.bill.mixedCashAmount || 0) - clamped) < 0.005;
+                             },
+                             get halfActive() {
+                                 const half = Math.round($store.bill.orderTotal / 2 * 100) / 100;
+                                 const clamped = Math.min(this.maxCash, Math.max(0.50, half));
+                                 return Math.abs(($store.bill.mixedCashAmount || 0) - clamped) < 0.005;
+                             },
+                             nudge(delta) {
+                                 $store.bill.mixedCashAmount = Math.round(Math.min(this.maxCash, Math.max(0.50, ($store.bill.mixedCashAmount || 0) + delta)) * 100) / 100;
+                             },
+                             setPreset(v) {
+                                 if (v >= $store.bill.orderTotal) return;
+                                 $store.bill.mixedCashAmount = Math.round(Math.min(this.maxCash, Math.max(0.50, v)) * 100) / 100;
+                             },
+                             setHalf() {
+                                 const half = Math.round($store.bill.orderTotal / 2 * 100) / 100;
+                                 this.setPreset(half);
                              },
                          }"
-                         x-init="initPresets()">
-                        <div class="mixed-flow">
-                            <div class="mixed-stage">
-                                <div class="mixed-stage__head">
-                                    <div class="mixed-stage__title">¿Cuánto en efectivo?</div>
-                                    <div class="mixed-stage__sub">
-                                        El resto lo cobramos con tarjeta. Total a pagar:
-                                        <strong x-text="Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></strong>
-                                    </div>
-                                </div>
+                         @pointermove.window="dragging && setFromX($event.clientX)"
+                         @pointerup.window="dragging = false"
+                         @pointercancel.window="dragging = false">
 
-                                {{-- Fader visual --}}
-                                <div class="fader">
-                                    <div class="fader__bar">
-                                        <div class="fader__cash"
-                                             :style="'width: ' + (cashRatio * 100) + '%'">
-                                            <span class="fader__lab">EFECTIVO</span>
-                                            <span class="fader__amt"
-                                                  x-text="fmt($store.bill.mixedCashAmount || 0)"></span>
-                                        </div>
-                                        <div class="fader__card"
-                                             :style="'width: ' + ((1 - cashRatio) * 100) + '%'">
-                                            <span class="fader__lab">TARJETA</span>
-                                            <span class="fader__amt" x-text="fmt(card)"></span>
-                                        </div>
-                                    </div>
-                                    <input type="range"
-                                           min="0"
-                                           :max="$store.bill.orderTotal"
-                                           step="0.50"
-                                           :value="$store.bill.mixedCashAmount || 0"
-                                           @input="$store.bill.mixedCashAmount = Number($event.target.value)"
-                                           class="fader__range"
-                                           aria-label="Cantidad en efectivo">
-                                </div>
+                        <p style="text-align:center; font-family:var(--font-body); font-size:13px; color:var(--fg-secondary); margin:0 0 16px;">
+                            El resto lo cobramos con tarjeta. Total a pagar:
+                            <strong style="font-family:var(--font-display); font-weight:900; color:var(--price-gold);"
+                                    x-text="fmt($store.bill.orderTotal)"></strong>
+                        </p>
 
-                                {{-- Chips de presets --}}
-                                <div class="mixed-chips">
-                                    <template x-for="p in presets" :key="p.label">
-                                        <button type="button"
-                                                :class="'mixed-chip' + (Math.abs(p.value - ($store.bill.mixedCashAmount || 0)) < 0.01 ? ' mixed-chip--active' : '')"
-                                                @click="$store.bill.mixedCashAmount = Math.min($store.bill.orderTotal, p.value)">
-                                            <span x-text="p.label"></span>
-                                        </button>
-                                    </template>
-                                </div>
+                        {{-- Barra dividida arrastrable --}}
+                        <div class="split__bar"
+                             :class="{ 'is-dragging': dragging }"
+                             x-ref="track"
+                             role="slider"
+                             aria-label="Reparto entre efectivo y tarjeta"
+                             :aria-valuenow="$store.bill.mixedCashAmount"
+                             :aria-valuetext="`${fmt($store.bill.mixedCashAmount || 0)} en efectivo, ${fmt(card)} con tarjeta`"
+                             tabindex="0"
+                             @pointerdown="dragging = true; setFromX($event.clientX)"
+                             @keydown.arrow-left.prevent="nudge(-0.5)"
+                             @keydown.arrow-right.prevent="nudge(0.5)">
 
-                                {{-- Ajuste fino --}}
-                                <div class="mixed-precise">
-                                    <span class="lab">Ajuste fino</span>
-                                    <button type="button" class="mixed-precise__b"
-                                            @click="$store.bill.mixedCashAmount = Math.max(0, Math.round((($store.bill.mixedCashAmount || 0) - 0.5) * 100) / 100)">
-                                        −0,50
-                                    </button>
-                                    <span class="mixed-precise__num"
-                                          x-text="Number($store.bill.mixedCashAmount || 0).toFixed(2).replace('.',',') + ' €'"></span>
-                                    <button type="button" class="mixed-precise__b"
-                                            @click="$store.bill.mixedCashAmount = Math.min($store.bill.orderTotal, Math.round((($store.bill.mixedCashAmount || 0) + 0.5) * 100) / 100)">
-                                        +0,50
-                                    </button>
-                                </div>
-
-                                {{-- Avisos --}}
-                                <div class="mixed-warn" x-show="cardBelowMin">
-                                    <span class="mixed-warn__ic">!</span>
-                                    <div>
-                                        <strong>La parte de tarjeta debe ser al menos 0,50 €.</strong>
-                                        <span x-text="'Sube el efectivo a ' + fmt($store.bill.orderTotal) + ' (100% efectivo) o bájalo a ' + fmt($store.bill.orderTotal - 0.50) + '.'"></span>
-                                    </div>
-                                </div>
-                                <div class="mixed-note" x-show="cashAllOnly">
-                                    ✓ Pagarás el total en efectivo. Continuando te llevamos al cobro en efectivo.
-                                </div>
-                                <div class="mixed-note" x-show="cardOnly && !cashAllOnly">
-                                    ✓ Pagarás el total con tarjeta.
-                                </div>
+                            <div class="split__side split__side--cash"
+                                 :style="`flex-basis:${cashRatio * 100}%`">
+                                <span class="split__lab">Efectivo</span>
+                                <span class="split__amt" x-text="fmt($store.bill.mixedCashAmount || 0)"></span>
                             </div>
+                            <div class="split__side split__side--card"
+                                 :style="`flex-basis:${(1 - cashRatio) * 100}%`">
+                                <span class="split__lab">Tarjeta</span>
+                                <span class="split__amt" x-text="fmt(card)"></span>
+                            </div>
+
+                            <span class="split__handle" aria-hidden="true"
+                                  :style="`left:${cashRatio * 100}%`"></span>
+                        </div>
+
+                        {{-- Atajos rápidos --}}
+                        <div class="split-chips">
+                            <template x-for="v in [10, 20, 50]" :key="v">
+                                <button type="button" class="split-chip"
+                                        :class="{ 'is-active': presetActive(v) }"
+                                        :disabled="v >= $store.bill.orderTotal"
+                                        @click="setPreset(v)"
+                                        x-text="v + ' €'"></button>
+                            </template>
+                            <button type="button" class="split-chip"
+                                    :class="{ 'is-active': halfActive }"
+                                    @click="setHalf()">Mitad</button>
+                            <button type="button" class="split-chip split-chip--solo"
+                                    @click="$store.bill.mixedCashAmount = $store.bill.orderTotal; $store.bill.proceedFromMixed()">Sólo efectivo</button>
+                        </div>
+
+                        {{-- Ajuste fino --}}
+                        <div class="fine">
+                            <span class="fine__lab">Ajuste fino</span>
+                            <div class="fine__main">
+                                <button type="button" class="fine__btn"
+                                        :disabled="($store.bill.mixedCashAmount || 0) <= 0.5"
+                                        @click="nudge(-0.5)">− 0,50</button>
+                                <span class="fine__val" x-text="fmt($store.bill.mixedCashAmount || 0)"></span>
+                                <button type="button" class="fine__btn"
+                                        :disabled="($store.bill.mixedCashAmount || 0) >= maxCash"
+                                        @click="nudge(0.5)">+ 0,50</button>
+                            </div>
+                        </div>
+
+                        {{-- Desglose efectivo/tarjeta --}}
+                        <div class="breakdown">
+                            <div class="breakdown__cell breakdown__cell--cash">
+                                <span class="k"><span class="dot" aria-hidden="true"></span>Efectivo</span>
+                                <span class="v" x-text="fmt($store.bill.mixedCashAmount || 0)"></span>
+                            </div>
+                            <div class="breakdown__cell breakdown__cell--card">
+                                <span class="k"><span class="dot" aria-hidden="true"></span>Tarjeta</span>
+                                <span class="v" x-text="fmt(card)"></span>
+                            </div>
+                        </div>
+
+                        {{-- Alerta de validación --}}
+                        <div class="mixed-alert" role="alert"
+                             x-show="($store.bill.mixedCashAmount || 0) > 0 && !$store.bill.mixedCashValid && ($store.bill.mixedCashAmount || 0) < $store.bill.orderTotal - 0.001">
+                            <span class="mixed-alert__ic" aria-hidden="true">!</span>
+                            <span>El importe mínimo con tarjeta es 0,50 €. Reduce un poco el efectivo.</span>
                         </div>
                     </div>
 
-                    {{-- ── mixedTip: propina sobre parte tarjeta ─── --}}
+                    {{-- ── mixedTip: propina sobre parte tarjeta (DS) ─── --}}
                     <div x-show="$store.bill.step === 'mixedTip'"
                          x-data="{
-                             get card() { return Math.max(0, $store.bill.orderTotal - ($store.bill.mixedCashAmount || 0)); },
-                             fmt(n) { return Number(n).toFixed(2).replace('.',',') + ' €'; },
+                             fmt(n) { return Number(n).toFixed(2).replace('.', ',') + ' €'; },
                          }">
-                        <div class="mixed-flow">
-                            <div class="mixed-stage">
-                                <div class="mixed-stage__head">
-                                    <div class="mixed-stage__title">Añadir propina</div>
-                                    <div class="mixed-stage__sub">Va incluida en la parte de tarjeta, nunca en el efectivo.</div>
-                                </div>
 
-                                {{-- Resumen del reparto --}}
-                                <div style="display:flex;gap:8px;justify-content:center;flex-wrap:wrap">
-                                    <span class="mixed-tile mixed-tile--cash"
-                                          x-text="'Efectivo ' + fmt($store.bill.mixedCashAmount || 0)"></span>
-                                    <span class="mixed-tile mixed-tile--card"
-                                          x-text="'Tarjeta base ' + fmt(card)"></span>
-                                </div>
-
-                                {{-- Chips de propina --}}
-                                <div class="mixed-tipChips">
-                                    <button type="button"
-                                            :class="'mixed-tipChip' + ($store.bill.mixedTipPercent === 0 ? ' mixed-tipChip--active' : '')"
-                                            :aria-pressed="$store.bill.mixedTipPercent === 0"
-                                            @click="$store.bill.setMixedTipPercent(0)">
-                                        <span class="pct">Sin</span>
-                                        <span class="amt">propina</span>
-                                    </button>
-                                    <template x-for="p in [5, 10, 15, 20]" :key="p">
-                                        <button type="button"
-                                                :class="'mixed-tipChip' + ($store.bill.mixedTipPercent === p ? ' mixed-tipChip--active' : '')"
-                                                :aria-pressed="$store.bill.mixedTipPercent === p"
-                                                @click="$store.bill.setMixedTipPercent(p)">
-                                            <span class="pct" x-text="p + '%'"></span>
-                                            <span class="amt"
-                                                  x-text="fmt(Math.round(card * p) / 100)"></span>
-                                        </button>
-                                    </template>
-                                </div>
-
-                                {{-- Importe libre --}}
-                                <label for="mixed-tip-free" class="sr-only">Propina personalizada en euros</label>
-                                <div class="mixed-tipInput">
-                                    <input id="mixed-tip-free"
-                                           type="number" min="0" max="500" step="0.50" inputmode="decimal"
-                                           placeholder="O introduce un importe…"
-                                           :value="$store.bill.mixedTipPercent === null && $store.bill.mixedTipAmount > 0 ? $store.bill.mixedTipAmount : ''"
-                                           @input="$store.bill.updateCustomMixedTip ? $store.bill.updateCustomMixedTip($event.target.value) : null">
-                                    <span class="mixed-tipInput__cur" aria-hidden="true">€</span>
-                                </div>
-
-                                {{-- Resumen --}}
-                                <div class="mixed-tipSummary" aria-live="polite">
-                                    <div class="mixed-tipSummary__row">
-                                        <span>Parte de tarjeta</span>
-                                        <span class="v" x-text="fmt(card)"></span>
-                                    </div>
-                                    <div class="mixed-tipSummary__row mixed-tipSummary__row--tip"
-                                         x-show="($store.bill.mixedTipAmount || 0) > 0">
-                                        <span>Propina</span>
-                                        <span class="v"
-                                              x-text="'+ ' + fmt($store.bill.mixedTipAmount || 0)"></span>
-                                    </div>
-                                    <div class="mixed-tipSummary__row mixed-tipSummary__row--total">
-                                        <span>Total con tarjeta</span>
-                                        <span class="v"
-                                              x-text="fmt($store.bill.mixedTipGrandTotal || card)"></span>
-                                    </div>
-                                </div>
+                        {{-- Resumen de solo lectura --}}
+                        <div class="recap">
+                            <div class="recap__row recap__row--cash">
+                                <span>Efectivo al camarero</span>
+                                <span class="v" x-text="fmt($store.bill.mixedCashAmount || 0)"></span>
+                            </div>
+                            <div class="recap__row recap__row--card">
+                                <span>Tarjeta · base</span>
+                                <span class="v" x-text="fmt($store.bill.mixedTipBase || 0)"></span>
                             </div>
                         </div>
+
+                        {{-- Selector de propina --}}
+                        <div class="mixed-sec-label">
+                            <span>Propina sobre la tarjeta</span>
+                            <span class="hint">Toca para elegir</span>
+                        </div>
+                        <div class="tip-grid">
+                            <button type="button" class="tip-chip"
+                                    :class="{ 'is-active': $store.bill.mixedTipPercent === 0 }"
+                                    @click="$store.bill.setMixedTipPercent(0)">
+                                <span class="tip-chip__pct">0%</span>
+                                <span class="tip-chip__amt">Sin</span>
+                            </button>
+                            <template x-for="pct in [5, 10, 15, 20]" :key="pct">
+                                <button type="button" class="tip-chip"
+                                        :class="{ 'is-active': $store.bill.mixedTipPercent === pct }"
+                                        @click="$store.bill.setMixedTipPercent(pct)">
+                                    <span class="tip-chip__pct" x-text="pct + '%'"></span>
+                                    <span class="tip-chip__amt"
+                                          x-text="fmt(Math.round(($store.bill.mixedTipBase || 0) * pct) / 100)"></span>
+                                </button>
+                            </template>
+                        </div>
+
+                        {{-- Input propina libre --}}
+                        <label for="mixed-tip-free" class="sr-only">Propina personalizada en euros</label>
+                        <div class="tip-input">
+                            <input id="mixed-tip-free"
+                                   type="number" min="0" max="500" step="0.50" inputmode="decimal"
+                                   placeholder="O introduce un importe…"
+                                   :value="$store.bill.mixedTipPercent === null && ($store.bill.mixedTipAmount || 0) > 0 ? $store.bill.mixedTipAmount : ''"
+                                   @input="$store.bill.updateCustomMixedTip($event.target.value)">
+                            <span class="tip-input__currency" aria-hidden="true">€</span>
+                        </div>
+
+                        {{-- Resumen reactivo --}}
+                        <section class="mixed-summary" aria-live="polite">
+                            <div class="mixed-summary__row">
+                                <span>Parte de tarjeta</span>
+                                <span class="v" x-text="fmt($store.bill.mixedTipBase || 0)"></span>
+                            </div>
+                            <div class="mixed-summary__row mixed-summary__row--tip"
+                                 x-show="($store.bill.mixedTipAmount || 0) > 0">
+                                <span>Propina</span>
+                                <span class="v" x-text="'+ ' + fmt($store.bill.mixedTipAmount || 0)"></span>
+                            </div>
+                            <div class="mixed-summary__row mixed-summary__row--total">
+                                <span>Total con tarjeta</span>
+                                <span class="v"
+                                      x-text="fmt($store.bill.mixedTipGrandTotal || $store.bill.mixedTipBase || 0)"></span>
+                            </div>
+                        </section>
                     </div>
 
-                    {{-- ── mixedPay: Stripe parte tarjeta ─── --}}
+                    {{-- ── mixedPay: Stripe parte tarjeta (DS) ─── --}}
                     <div x-show="$store.bill.step === 'mixedPay'"
                          x-data="{
-                             get card() { return Math.max(0, $store.bill.orderTotal - ($store.bill.mixedCashAmount || 0)); },
-                             fmt(n) { return Number(n).toFixed(2).replace('.',',') + ' €'; },
+                             fmt(n) { return Number(n).toFixed(2).replace('.', ',') + ' €'; },
                          }">
-                        <div class="mixed-flow">
-                            <div class="mixed-stage">
-                                <div class="mixed-stage__head">
-                                    <div class="mixed-stage__title">Pago de la parte tarjeta</div>
-                                    <div class="mixed-stage__sub" style="display:flex;gap:8px;justify-content:center;flex-wrap:wrap">
-                                        <span class="mixed-tile mixed-tile--cash"
-                                              x-text="'Efectivo ' + fmt($store.bill.mixedCashAmount || 0)"></span>
-                                        <span class="mixed-tile mixed-tile--card"
-                                              x-text="'Tarjeta ' + fmt($store.bill.mixedTipGrandTotal || card)"></span>
-                                    </div>
-                                </div>
-                                <div id="mixed-stripe-element"
-                                     style="padding:16px;border:1px solid var(--glass-border);border-radius:12px;background:var(--glass-bg-surface)"></div>
-                                <template x-if="$store.bill.mixedStripeError">
-                                    <p style="color:var(--color-red-400);font-size:13px;margin-top:4px"
-                                       role="alert" x-text="$store.bill.mixedStripeError"></p>
-                                </template>
+
+                        {{-- Resumen de solo lectura --}}
+                        <div class="recap">
+                            <div class="recap__row recap__row--cash">
+                                <span>Efectivo al camarero</span>
+                                <span class="v" x-text="fmt($store.bill.mixedCashAmount || 0)"></span>
                             </div>
+                        </div>
+
+                        {{-- Banner azul: importe del cargo en tarjeta --}}
+                        <div class="stripe-charge">
+                            <span class="k">Cargo en tarjeta ahora</span>
+                            <span class="v" x-text="fmt($store.bill.mixedStripeTotal || $store.bill.mixedTipGrandTotal || 0)"></span>
+                        </div>
+
+                        {{-- Contenedor Stripe con spinner de carga --}}
+                        {{-- #mixed-stripe-element DEBE estar siempre en el DOM (x-show, no x-if) --}}
+                        <div class="stripe-frame">
+                            <div class="stripe-loading" x-show="!$store.bill.mixedStripeReady" aria-live="polite">
+                                <span class="ring" aria-hidden="true"></span>
+                                <span>Cargando pago seguro…</span>
+                            </div>
+                            <div id="mixed-stripe-element" x-show="$store.bill.mixedStripeReady"></div>
+                        </div>
+
+                        {{-- Error de Stripe --}}
+                        <div class="stripe-error" role="alert" aria-live="assertive"
+                             x-show="$store.bill.mixedStripeError">
+                            <span class="stripe-error__ic" aria-hidden="true">!</span>
+                            <span x-text="$store.bill.mixedStripeError"></span>
                         </div>
                     </div>
 

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2462,11 +2462,10 @@
                          @pointerup.window="dragging = false"
                          @pointercancel.window="dragging = false">
 
-                        <p style="text-align:center; font-family:var(--font-body); font-size:13px; color:var(--fg-secondary); margin:0 0 16px;">
-                            El resto lo cobramos con tarjeta. Total a pagar:
-                            <strong style="font-family:var(--font-display); font-weight:900; color:var(--price-gold);"
-                                    x-text="fmt($store.bill.orderTotal)"></strong>
-                        </p>
+                        <div style="text-align:center; margin:0 0 16px; display:flex; flex-direction:column; align-items:center; gap:2px;">
+                            <span style="font-family:var(--font-body); font-size:13px; color:var(--fg-secondary);">El resto lo cobramos con tarjeta.</span>
+                            <span style="font-family:var(--font-mono); font-size:10px; letter-spacing:0.16em; text-transform:uppercase; color:var(--fg-muted);">Total a pagar: <strong style="font-family:var(--font-display); font-weight:900; font-size:16px; color:var(--price-gold); letter-spacing:-0.01em;" x-text="fmt($store.bill.orderTotal)"></strong></span>
+                        </div>
 
                         {{-- Barra dividida arrastrable --}}
                         <div class="split__bar"

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2241,15 +2241,15 @@
                             <div class="split-items__status">
                                 <div class="split-items__progress">
                                     <div class="bar" role="progressbar"
-                                         :aria-valuenow="$store.bill.splitItems.filter(i => i.claimed || $store.bill.splitSelected.includes(i.id)).length"
-                                         :aria-valuemax="$store.bill.splitItems.length"
+                                         :aria-valuenow="$store.bill.splitItems.filter(i => !i.is_courtesy && (i.claimed || $store.bill.splitSelected.includes(i.id))).length"
+                                         :aria-valuemax="$store.bill.splitItems.filter(i => !i.is_courtesy).length"
                                          aria-label="Ítems reclamados">
                                         <div class="bar__fill"
-                                             :style="'width: ' + (($store.bill.splitItems.filter(i => i.claimed || $store.bill.splitSelected.includes(i.id)).length / Math.max(1, $store.bill.splitItems.length)) * 100) + '%'">
+                                             :style="'width: ' + (($store.bill.splitItems.filter(i => !i.is_courtesy && (i.claimed || $store.bill.splitSelected.includes(i.id))).length / Math.max(1, $store.bill.splitItems.filter(i => !i.is_courtesy).length)) * 100) + '%'">
                                         </div>
                                     </div>
                                     <span class="ct"
-                                          x-text="$store.bill.splitItems.filter(i => i.claimed || $store.bill.splitSelected.includes(i.id)).length + '/' + $store.bill.splitItems.length + ' reclamados'">
+                                          x-text="$store.bill.splitItems.filter(i => !i.is_courtesy && (i.claimed || $store.bill.splitSelected.includes(i.id))).length + '/' + $store.bill.splitItems.filter(i => !i.is_courtesy).length + ' reclamados'">
                                     </span>
                                 </div>
                                 <div class="split-items__legend">
@@ -2260,29 +2260,32 @@
                             {{-- Lista de ítems --}}
                             <div class="split-items__list" role="list">
                                 <template x-for="item in $store.bill.splitItems" :key="item.id">
-                                    <div class="split-line" role="button"
-                                         tabindex="0"
-                                         :class="{ 'split-line--mine': $store.bill.isItemSelected(item.id), 'split-line--claimed': item.claimed && !$store.bill.isItemSelected(item.id) }"
-                                         :style="item.claimed && !$store.bill.isItemSelected(item.id) ? 'cursor:not-allowed' : 'cursor:pointer'"
-                                         :aria-label="$store.bill.isItemSelected(item.id) ? 'Quitar de mi parte: ' + item.name : (item.claimed ? 'Ya reclamado: ' + item.name : 'Reclamar: ' + item.name)"
-                                         :aria-pressed="$store.bill.isItemSelected(item.id)"
-                                         @click="$store.bill.toggleSplitItem(item.id, item.claimed)"
-                                         @keydown.enter.prevent="$store.bill.toggleSplitItem(item.id, item.claimed)"
-                                         @keydown.space.prevent="$store.bill.toggleSplitItem(item.id, item.claimed)">
+                                    <div :class="'split-line' + ($store.bill.isItemSelected(item.id) ? ' split-line--mine' : (item.claimed && !$store.bill.isItemSelected(item.id) ? ' split-line--claimed' : (item.is_courtesy ? ' split-line--courtesy' : '')))"
+                                         :role="item.is_courtesy ? 'listitem' : 'button'"
+                                         :tabindex="item.is_courtesy ? '-1' : '0'"
+                                         :style="item.is_courtesy ? 'cursor:default' : (item.claimed && !$store.bill.isItemSelected(item.id) ? 'cursor:not-allowed' : 'cursor:pointer')"
+                                         :aria-label="item.is_courtesy ? 'Cortesía: ' + item.name : ($store.bill.isItemSelected(item.id) ? 'Quitar de mi parte: ' + item.name : (item.claimed ? 'Ya reclamado: ' + item.name : 'Reclamar: ' + item.name))"
+                                         @click="$store.bill.toggleSplitItem(item.id, item.claimed, item.is_courtesy)"
+                                         @keydown.enter.prevent="$store.bill.toggleSplitItem(item.id, item.claimed, item.is_courtesy)"
+                                         @keydown.space.prevent="$store.bill.toggleSplitItem(item.id, item.claimed, item.is_courtesy)">
 
                                         <div class="split-line__photo" aria-hidden="true">🍽️</div>
 
                                         <div class="split-line__main">
                                             <div class="split-line__name" x-text="item.name"></div>
-                                            <div class="split-line__total"
-                                                 x-text="fmt(item.total)"></div>
+                                            <div x-show="item.is_courtesy" class="split-line__badge split-line__badge--courtesy">Cortesía</div>
+                                            <div x-show="!item.is_courtesy" class="split-line__total" x-text="fmt(item.total)"></div>
                                         </div>
 
                                         {{-- Indicador visual del estado del slot --}}
-                                        <div :class="'slot' + ($store.bill.isItemSelected(item.id) ? ' slot--you' : (item.claimed ? ' slot--other' : ''))"
+                                        <div :class="'slot' + ($store.bill.isItemSelected(item.id) ? ' slot--you' : (item.claimed && !$store.bill.isItemSelected(item.id) ? ' slot--other' : (item.is_courtesy ? ' slot--courtesy' : '')))"
                                              aria-hidden="true">
+                                            {{-- Courtesy --}}
+                                            <template x-if="item.is_courtesy">
+                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+                                            </template>
                                             {{-- Unclaimed --}}
-                                            <template x-if="!$store.bill.isItemSelected(item.id) && !item.claimed">
+                                            <template x-if="!item.is_courtesy && !$store.bill.isItemSelected(item.id) && !item.claimed">
                                                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
                                             </template>
                                             {{-- Mine --}}
@@ -2290,12 +2293,13 @@
                                                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
                                             </template>
                                             {{-- Claimed by other --}}
-                                            <template x-if="item.claimed && !$store.bill.isItemSelected(item.id)">
+                                            <template x-if="!item.is_courtesy && item.claimed && !$store.bill.isItemSelected(item.id)">
                                                 <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
                                             </template>
                                         </div>
                                     </div>
                                 </template>
+                            </div>
                             </div>
 
                             {{-- Total de tu parte (solo lectura, el CTA está en drawer__foot) --}}

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2402,8 +2402,7 @@
                                  if (this._pollTimer) { clearInterval(this._pollTimer); this._pollTimer = null; }
                              },
                          }"
-                         x-init="$watch('$store.bill.step', s => { if (s === 'splitEq') startPoll(); else stopPoll(); }); if ($store.bill.step === 'splitEq') startPoll();"
-                         @vue:unmounted.window="stopPoll()"
+                         x-init="$watch('$store.bill.step', s => { if (s === 'splitEq') startPoll(); else stopPoll(); }); if ($store.bill.step === 'splitEq') startPoll();">
                         <div class="split-equit">
 
                             {{-- Cabecera --}}

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2935,11 +2935,11 @@
                                 </span>
                                 <span x-show="!$store.bill.sending"
                                       x-text="($store.bill.cashTipAmount || 0) > 0
-                                          ? 'Solicitar cuenta · ' + Number($store.bill.cashGrandTotal).toFixed(2).replace('.',',') + ' € (con propina)'
-                                          : 'Solicitar cuenta · ' + Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' € (sin propina)'">
+                                          ? 'Solicitar cuenta · ' + Number($store.bill.cashGrandTotal).toFixed(2).replace('.',',') + ' € (con propina)'
+                                          : 'Solicitar cuenta · ' + Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' € (sin propina)'">
                                 </span>
                             </button>
-                            <button type="button" class="btn-secondary" @click="$store.bill.backToMethod()">← Cambiar método</button>
+                            <button type="button" class="back" @click="$store.bill.backToMethod()">← Cambiar método</button>
                         </div>
                     </div>
 
@@ -2966,7 +2966,7 @@
                                           : 'Pagar con tarjeta · ' + Number($store.bill.orderTotal).toFixed(2).replace('.',',') + ' € (sin propina)'">
                                 </span>
                             </button>
-                            <button type="button" class="btn-secondary" @click="$store.bill.backToMethod()">← Cambiar método</button>
+                            <button type="button" class="back" @click="$store.bill.backToMethod()">← Cambiar método</button>
                         </div>
                     </div>
 
@@ -2979,9 +2979,9 @@
                                 <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                     <rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/>
                                 </svg>
-                                <span x-text="$store.bill.sending ? 'Procesando…' : 'Pagar ' + Number($store.bill.grandTotal || $store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></span>
+                                <span x-text="$store.bill.sending ? 'Procesando…' : 'Pagar ' + Number($store.bill.grandTotal || $store.bill.orderTotal).toFixed(2).replace('.',',') + ' €'"></span>
                             </button>
-                            <button type="button" class="btn-secondary" @click="$store.bill.backToMethod()">← Cambiar método</button>
+                            <button type="button" class="back" @click="$store.bill.backToMethod()">← Atrás</button>
                         </div>
                     </div>
 
@@ -2990,22 +2990,25 @@
                     {{-- split --}}
                     <div x-show="$store.bill.step === 'split'">
                         <div class="bill__footRow bill__footRow--stack">
-                            <button type="button" class="btn-secondary" @click="$store.bill.closeSplitSelector()">← Cambiar método</button>
+                            <button type="button" class="back" @click="$store.bill.closeSplitSelector()">← Cambiar método</button>
                         </div>
                     </div>
 
                     {{-- splitItems --}}
                     <div x-show="$store.bill.step === 'splitItems'">
-                        <div style="display:flex;justify-content:space-between;margin-bottom:10px;font-family:var(--font-body);font-size:13px">
-                            <span style="color:var(--fg-muted)">Mi parte</span>
-                            <span style="font-weight:700;color:var(--price-gold)"
-                                  x-text="Number($store.bill.splitItemsTotal || 0).toFixed(2).replace('.',',') + ' €'"></span>
+                        <div class="bill__footRow bill__footRow--stack">
+                            <div style="display:flex;justify-content:space-between;margin-bottom:4px;font-family:var(--font-body);font-size:13px">
+                                <span style="color:var(--fg-muted)">Mi parte</span>
+                                <span style="font-weight:700;color:var(--price-gold)"
+                                      x-text="Number($store.bill.splitItemsTotal || 0).toFixed(2).replace('.',',') + ' €'"></span>
+                            </div>
+                            <button type="button" class="btn-primary"
+                                    :disabled="!$store.bill.splitSelected || $store.bill.splitSelected.length === 0"
+                                    @click="$store.bill.paySelectedItems()">
+                                Pagar mi parte
+                            </button>
+                            <button type="button" class="back" @click="$store.bill.closeSplitItems()">Cambiar modo</button>
                         </div>
-                        <button type="button" class="btn-primary"
-                                :disabled="!$store.bill.splitSelected || $store.bill.splitSelected.length === 0"
-                                @click="$store.bill.paySelectedItems()">
-                            Pagar mi parte
-                        </button>
                     </div>
 
                     {{-- splitEq --}}
@@ -3017,6 +3020,7 @@
                                 <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
                                 <span x-text="'Pagar mi parte · ' + Number($store.bill.splitMyPart || 0).toFixed(2).replace('.',',') + ' €'"></span>
                             </button>
+                            <button type="button" class="back" @click="$store.bill.closeSplitEq()">Cambiar modo</button>
                         </div>
                     </div>
 
@@ -3026,9 +3030,9 @@
                             <button type="button" class="btn-primary"
                                     @click="$store.bill.confirmSplitTip()">
                                 Continuar —
-                                <span x-text="Number($store.bill.splitTipGrandTotal || $store.bill.splitTipBase).toFixed(2).replace('.',',') + ' €'"></span>
+                                <span x-text="Number($store.bill.splitTipGrandTotal || $store.bill.splitTipBase).toFixed(2).replace('.',',') + ' €'"></span>
                             </button>
-                            <button type="button" class="btn-secondary" @click="$store.bill.backToMethod()">← Cambiar método</button>
+                            <button type="button" class="back" @click="$store.bill.backToMethod()">← Atrás</button>
                         </div>
                     </div>
 
@@ -3040,7 +3044,7 @@
                                     @click="$store.bill.proceedFromMixed()">
                                 <span x-text="($store.bill.mixedCashAmount >= $store.bill.orderTotal - 0.001) ? 'Continuar · Pago en efectivo' : 'Continuar con tarjeta'"></span>
                             </button>
-                            <button type="button" class="btn-secondary" @click="$store.bill.closeMixed()">← Cambiar método</button>
+                            <button type="button" class="back" @click="$store.bill.closeMixed()">← Cambiar método</button>
                         </div>
                     </div>
 
@@ -3050,9 +3054,9 @@
                             <button type="button" class="btn-primary"
                                     @click="$store.bill.confirmMixedTip()">
                                 Continuar —
-                                <span x-text="Number($store.bill.mixedTipGrandTotal || $store.bill.mixedCardAmount).toFixed(2).replace('.',',') + ' €'"></span>
+                                <span x-text="Number($store.bill.mixedTipGrandTotal || $store.bill.mixedCardAmount).toFixed(2).replace('.',',') + ' €'"></span>
                             </button>
-                            <button type="button" class="btn-secondary" @click="$store.bill.closeMixedTip()">← Atrás</button>
+                            <button type="button" class="back" @click="$store.bill.closeMixedTip()">← Atrás</button>
                         </div>
                     </div>
 
@@ -3067,7 +3071,7 @@
                                 </svg>
                                 <span x-text="$store.bill.sending ? 'Procesando…' : 'Pagar ' + Number($store.bill.splitStripeTotal || 0).toFixed(2).replace('.',',') + ' €'"></span>
                             </button>
-                            <button type="button" class="btn-secondary" @click="$store.bill.closeSplitPayment()">← Atrás</button>
+                            <button type="button" class="back" @click="$store.bill.closeSplitPayment()">← Atrás</button>
                         </div>
                     </div>
 
@@ -3082,7 +3086,7 @@
                                 </svg>
                                 <span x-text="$store.bill.sending ? 'Procesando…' : 'Pagar ' + Number($store.bill.mixedTipGrandTotal || $store.bill.mixedCardAmount).toFixed(2).replace('.',',') + ' €'"></span>
                             </button>
-                            <button type="button" class="btn-secondary" @click="$store.bill.closeMixedPayment()">← Atrás</button>
+                            <button type="button" class="back" @click="$store.bill.closeMixedPayment()">← Atrás</button>
                         </div>
                     </div>
 

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2361,6 +2361,10 @@
                                              this.parts = data.parts_total;
                                              $store.bill.splitPeople = data.parts_total;
                                          }
+                                         // Si mi slice ya está pagado, muevo al primero libre
+                                         if (this.mySlice < this.paidCount) {
+                                             this.mySlice = this.paidCount < this.parts ? this.paidCount : this.parts - 1;
+                                         }
                                      }
                                  } catch (_) {}
                              },

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2300,7 +2300,6 @@
                                     </div>
                                 </template>
                             </div>
-                            </div>
 
                             {{-- Total de tu parte (solo lectura, el CTA está en drawer__foot) --}}
                             <div class="split-items__foot">

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2268,38 +2268,49 @@
                     {{-- ── splitEq: partes iguales con donut (DS) ─── --}}
                     <div x-show="$store.bill.step === 'splitEq'"
                          x-data="{
+                             parts:   $store.bill.splitPeople || 2,
                              mySlice: 0,
-                             get parts() { return $store.bill.splitPeople || 2; },
-                             get slice() { return $store.bill.splitMyPart || ($store.bill.orderTotal / this.parts); },
-                             fmt(n) { return Number(n).toFixed(2).replace('.', ',') + ' €'; },
-                             decParts() {
-                                 if (this.parts > 2) $store.bill.splitPeople = this.parts - 1;
-                                 if (this.mySlice >= $store.bill.splitPeople) this.mySlice = $store.bill.splitPeople - 1;
+                             get maxParts() {
+                                 const m = $store.bill.splitMaxParts;
+                                 return (m && m > 2) ? m : 10;
                              },
-                             incParts() {
-                                 if (this.parts < ($store.bill.splitMaxParts || 10)) $store.bill.splitPeople = this.parts + 1;
+                             get slice() { return $store.bill.orderTotal / this.parts; },
+                             fmt(n) { return Number(n).toFixed(2).replace('.', ',') + ' €'; },
+                             inc() {
+                                 if (this.parts < this.maxParts) {
+                                     this.parts++;
+                                     $store.bill.splitPeople = this.parts;
+                                 }
+                             },
+                             dec() {
+                                 if (this.parts > 2) {
+                                     this.parts--;
+                                     $store.bill.splitPeople = this.parts;
+                                     if (this.mySlice >= this.parts) this.mySlice = this.parts - 1;
+                                 }
                              },
                              arc(i) {
-                                 const R_OUT = 48, R_IN = 30, CX = 60, CY = 60;
+                                 const R_OUT = 48, R_IN = 28, CX = 60, CY = 60;
                                  const a0 = (i / this.parts) * Math.PI * 2 - Math.PI / 2;
                                  const a1 = ((i + 1) / this.parts) * Math.PI * 2 - Math.PI / 2;
                                  const lg = (a1 - a0) > Math.PI ? 1 : 0;
-                                 const x0o = CX + R_OUT * Math.cos(a0), y0o = CY + R_OUT * Math.sin(a0);
-                                 const x1o = CX + R_OUT * Math.cos(a1), y1o = CY + R_OUT * Math.sin(a1);
-                                 const x0i = CX + R_IN  * Math.cos(a1), y0i = CY + R_IN  * Math.sin(a1);
-                                 const x1i = CX + R_IN  * Math.cos(a0), y1i = CY + R_IN  * Math.sin(a0);
-                                 return 'M '+x0o+' '+y0o+' A '+R_OUT+' '+R_OUT+' 0 '+lg+' 1 '+x1o+' '+y1o+' L '+x0i+' '+y0i+' A '+R_IN+' '+R_IN+' 0 '+lg+' 0 '+x1i+' '+y1i+' Z';
+                                 const x0o = CX + R_OUT*Math.cos(a0), y0o = CY + R_OUT*Math.sin(a0);
+                                 const x1o = CX + R_OUT*Math.cos(a1), y1o = CY + R_OUT*Math.sin(a1);
+                                 const x0i = CX + R_IN *Math.cos(a1), y0i = CY + R_IN *Math.sin(a1);
+                                 const x1i = CX + R_IN *Math.cos(a0), y1i = CY + R_IN *Math.sin(a0);
+                                 return `M ${x0o} ${y0o} A ${R_OUT} ${R_OUT} 0 ${lg} 1 ${x1o} ${y1o} L ${x0i} ${y0i} A ${R_IN} ${R_IN} 0 ${lg} 0 ${x1i} ${y1i} Z`;
                              },
                              labelPos(i) {
                                  const mid = ((i + 0.5) / this.parts) * Math.PI * 2 - Math.PI / 2;
-                                 return { x: 60 + 39 * Math.cos(mid), y: 60 + 39 * Math.sin(mid) };
+                                 return { x: 60 + 38 * Math.cos(mid), y: 60 + 38 * Math.sin(mid) };
                              },
                          }">
                         <div class="split-equit">
 
-                            {{-- Cabecera: cambiar modo + total chip --}}
+                            {{-- Cabecera --}}
                             <div class="split-items__head">
-                                <button type="button" class="back" @click="$store.bill.setSplitStage('intro')">
+                                <button type="button" class="back"
+                                        @click="$store.bill.setSplitStage('intro')">
                                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
                                     Cambiar modo
                                 </button>
@@ -2309,61 +2320,63 @@
                                 </div>
                             </div>
 
-                            {{-- Donut SVG --}}
+                            {{-- Donut --}}
                             <div class="split-equit__pie">
-                                <svg viewBox="0 0 120 120" width="220" height="220"
-                                     role="group" :aria-label="`Donut de ${parts} partes iguales, tu porción ${mySlice + 1}`">
+                                <svg viewBox="0 0 120 120" width="200" height="200"
+                                     :aria-label="`Reparto en ${parts} partes iguales`">
                                     <template x-for="i in Array.from({length: parts}, (_, k) => k)" :key="i">
-                                        <g :class="'slice' + (i === mySlice ? ' slice--mine' : '')"
-                                           @click="mySlice = i"
+                                        <g @click="mySlice = i"
                                            @keydown.enter="mySlice = i"
                                            @keydown.space.prevent="mySlice = i"
                                            tabindex="0" role="button"
-                                           :aria-label="`Porción ${i + 1}${i === mySlice ? ' · tuya' : ''}`"
-                                           style="cursor:pointer; outline:none">
+                                           :aria-label="`Porción ${i + 1}${i === mySlice ? ' — la tuya' : ''}`"
+                                           style="cursor:pointer"
+                                           :class="i === mySlice ? 'slice slice--mine' : 'slice'">
                                             <path :d="arc(i)"
-                                                  :fill="i === mySlice ? 'var(--brand-primary)' : 'var(--bg-chip)'"
-                                                  stroke="var(--bg-canvas)" stroke-width="2.5"/>
+                                                  :fill="i === mySlice ? 'var(--color-green-600)' : 'var(--bg-chip)'"
+                                                  stroke="var(--bg-surface)" stroke-width="3"
+                                                  stroke-linejoin="round"/>
                                             <text :x="labelPos(i).x" :y="labelPos(i).y"
                                                   text-anchor="middle" dominant-baseline="middle"
-                                                  font-size="9" font-weight="800"
-                                                  :fill="i === mySlice ? '#fff' : 'var(--fg-secondary)'"
+                                                  :font-size="i === mySlice ? '9' : '10'"
+                                                  font-weight="800"
+                                                  :fill="i === mySlice ? '#ffffff' : 'var(--fg-secondary)'"
                                                   x-text="i === mySlice ? 'TÚ' : (i + 1)">
                                             </text>
                                         </g>
                                     </template>
-                                    {{-- Centro --}}
-                                    <circle cx="60" cy="60" r="28" fill="var(--bg-surface)"/>
-                                    <text x="60" y="55" text-anchor="middle"
-                                          font-size="6" font-weight="600" letter-spacing="0.08em"
-                                          fill="var(--fg-muted)" font-family="monospace">TU PARTE</text>
-                                    <text x="60" y="70" text-anchor="middle"
-                                          font-size="14" font-weight="900" letter-spacing="-0.02em"
+                                    {{-- Centro blanco con texto --}}
+                                    <circle cx="60" cy="60" r="26" fill="var(--bg-surface)"/>
+                                    <text x="60" y="54" text-anchor="middle"
+                                          font-size="5.5" font-weight="700" letter-spacing="0.12em"
+                                          fill="var(--fg-muted)">TU PARTE</text>
+                                    <text x="60" y="68" text-anchor="middle"
+                                          font-size="12" font-weight="900" letter-spacing="-0.02em"
                                           fill="var(--fg-primary)"
                                           x-text="fmt(slice)">
                                     </text>
                                 </svg>
                             </div>
 
-                            {{-- Stepper --}}
+                            {{-- Stepper ¿Cuántos sois? --}}
                             <div class="split-equit__stepper">
                                 <span class="lab">¿Cuántos sois?</span>
                                 <div class="step">
-                                    <button type="button" aria-label="Reducir número de personas"
-                                            @click="decParts()"
+                                    <button type="button" aria-label="Menos personas"
+                                            @click="dec()"
                                             :disabled="parts <= 2">−</button>
                                     <span class="step__num" x-text="parts" aria-live="polite"></span>
-                                    <button type="button" aria-label="Aumentar número de personas"
-                                            @click="incParts()"
-                                            :disabled="parts >= ($store.bill.splitMaxParts || 10)">+</button>
+                                    <button type="button" aria-label="Más personas"
+                                            @click="inc()"
+                                            :disabled="parts >= maxParts">+</button>
                                 </div>
-                                <span class="hint" x-text="'máx. ' + ($store.bill.splitMaxParts || 10)"></span>
+                                <span class="hint" x-text="'máx. ' + maxParts"></span>
                             </div>
 
-                            {{-- Selector de porción con dots --}}
+                            {{-- Dots: selector de porción --}}
                             <div class="split-equit__live">
-                                <span x-text="'Tu porción: ' + (mySlice + 1) + ' de ' + parts"></span>
-                                <div class="dots" role="group" aria-label="Elige tu porción">
+                                <span x-text="(mySlice + 1) + ' de ' + parts + ' partes'"></span>
+                                <div class="dots" role="group" aria-label="Tu porción">
                                     <template x-for="i in Array.from({length: parts}, (_, k) => k)" :key="i">
                                         <button type="button"
                                                 :class="'dot' + (i === mySlice ? ' dot--mine' : '')"

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -2186,7 +2186,7 @@
 
                             {{-- Cabecera: cambiar modo --}}
                             <div class="split-items__head">
-                                <button type="button" class="back" @click="$store.bill.setSplitStage('intro')">
+                                <button type="button" class="back" @click="$store.bill.closeSplitItems()">
                                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
                                     Cambiar modo
                                 </button>
@@ -2196,15 +2196,15 @@
                             <div class="split-items__status">
                                 <div class="split-items__progress">
                                     <div class="bar" role="progressbar"
-                                         :aria-valuenow="$store.bill.splitItems.filter(i => i.claimed).length"
+                                         :aria-valuenow="$store.bill.splitItems.filter(i => i.claimed || $store.bill.splitSelected.includes(i.id)).length"
                                          :aria-valuemax="$store.bill.splitItems.length"
                                          aria-label="Ítems reclamados">
                                         <div class="bar__fill"
-                                             :style="'width: ' + (($store.bill.splitItems.filter(i => i.claimed).length / Math.max(1, $store.bill.splitItems.length)) * 100) + '%'">
+                                             :style="'width: ' + (($store.bill.splitItems.filter(i => i.claimed || $store.bill.splitSelected.includes(i.id)).length / Math.max(1, $store.bill.splitItems.length)) * 100) + '%'">
                                         </div>
                                     </div>
                                     <span class="ct"
-                                          x-text="$store.bill.splitItems.filter(i => i.claimed).length + '/' + $store.bill.splitItems.length + ' reclamados'">
+                                          x-text="$store.bill.splitItems.filter(i => i.claimed || $store.bill.splitSelected.includes(i.id)).length + '/' + $store.bill.splitItems.length + ' reclamados'">
                                     </span>
                                 </div>
                                 <div class="split-items__legend">
@@ -2215,8 +2215,15 @@
                             {{-- Lista de ítems --}}
                             <div class="split-items__list" role="list">
                                 <template x-for="item in $store.bill.splitItems" :key="item.id">
-                                    <div class="split-line" role="listitem"
-                                         :class="{ 'split-line--mine': $store.bill.isItemSelected(item.id), 'split-line--claimed': item.claimed && !$store.bill.isItemSelected(item.id) }">
+                                    <div class="split-line" role="button"
+                                         tabindex="0"
+                                         :class="{ 'split-line--mine': $store.bill.isItemSelected(item.id), 'split-line--claimed': item.claimed && !$store.bill.isItemSelected(item.id) }"
+                                         :style="item.claimed && !$store.bill.isItemSelected(item.id) ? 'cursor:not-allowed' : 'cursor:pointer'"
+                                         :aria-label="$store.bill.isItemSelected(item.id) ? 'Quitar de mi parte: ' + item.name : (item.claimed ? 'Ya reclamado: ' + item.name : 'Reclamar: ' + item.name)"
+                                         :aria-pressed="$store.bill.isItemSelected(item.id)"
+                                         @click="$store.bill.toggleSplitItem(item.id, item.claimed)"
+                                         @keydown.enter.prevent="$store.bill.toggleSplitItem(item.id, item.claimed)"
+                                         @keydown.space.prevent="$store.bill.toggleSplitItem(item.id, item.claimed)">
 
                                         <div class="split-line__photo" aria-hidden="true">🍽️</div>
 
@@ -2226,26 +2233,22 @@
                                                  x-text="fmt(item.total)"></div>
                                         </div>
 
-                                        {{-- Un slot por ítem (el backend no devuelve qty por unidad) --}}
-                                        <button type="button"
-                                                :class="'slot' + ($store.bill.isItemSelected(item.id) ? ' slot--you' : (item.claimed ? ' slot--other' : ''))"
-                                                @click="$store.bill.toggleSplitItem(item.id, item.claimed)"
-                                                :disabled="item.claimed && !$store.bill.isItemSelected(item.id)"
-                                                :aria-label="$store.bill.isItemSelected(item.id) ? 'Quitar de mi parte' : (item.claimed ? 'Ya reclamado por otro comensal' : 'Reclamar este plato')"
-                                                :aria-pressed="$store.bill.isItemSelected(item.id)">
+                                        {{-- Indicador visual del estado del slot --}}
+                                        <div :class="'slot' + ($store.bill.isItemSelected(item.id) ? ' slot--you' : (item.claimed ? ' slot--other' : ''))"
+                                             aria-hidden="true">
                                             {{-- Unclaimed --}}
                                             <template x-if="!$store.bill.isItemSelected(item.id) && !item.claimed">
-                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
                                             </template>
                                             {{-- Mine --}}
                                             <template x-if="$store.bill.isItemSelected(item.id)">
-                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
                                             </template>
                                             {{-- Claimed by other --}}
                                             <template x-if="item.claimed && !$store.bill.isItemSelected(item.id)">
-                                                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+                                                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
                                             </template>
-                                        </button>
+                                        </div>
                                     </div>
                                 </template>
                             </div>
@@ -2408,7 +2411,7 @@
                             {{-- Cabecera --}}
                             <div class="split-items__head">
                                 <button type="button" class="back"
-                                        @click="$store.bill.setSplitStage('intro')">
+                                        @click="$store.bill.closeSplitEq()">
                                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
                                     Cambiar modo
                                 </button>
@@ -2945,7 +2948,6 @@
                                 @click="$store.bill.paySelectedItems()">
                             Pagar mi parte
                         </button>
-                        <button type="button" class="btn-text" @click="$store.bill.closeSplitItems()">Atrás</button>
                     </div>
 
                     {{-- splitEq --}}
@@ -2957,7 +2959,6 @@
                                 <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>
                                 <span x-text="'Pagar mi parte · ' + Number($store.bill.splitMyPart || 0).toFixed(2).replace('.',',') + ' €'"></span>
                             </button>
-                            <button type="button" class="btn-text" @click="$store.bill.closeSplitEq()">Atrás</button>
                         </div>
                     </div>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -27,6 +27,9 @@ Route::post('/v1/payment/{hash}/confirm', [CardPaymentController::class, 'confir
     ->name('api.payment.confirm');
 
 // Cobro partido — rutas públicas (sin autenticación, contexto por table_hash)
+Route::get('/v1/payment/{hash}/split/eq-status',   [SplitPaymentController::class, 'eqStatus'])
+    ->middleware('throttle:30,1')
+    ->name('api.split.eq-status');
 Route::get('/v1/payment/{hash}/split/items',       [SplitPaymentController::class, 'claimedItems'])
     ->middleware('throttle:30,1')
     ->name('api.split.items');


### PR DESCRIPTION
## Resumen

- Rediseño completo de los componentes de cobro mixto y cobro partido con Design System (barra arrastrable, donut, slots de ítems)
- Corrección de navegación en todos los flujos de pago: botones atrás, flecha SVG, eliminación de botones duplicados en cabecera
- Fix crítico: cobro partido y mixto no abrían al primer intento si `bill_requested = true` en BD al cargar la página
- Botón "Cancelar aviso" en cashDone convertido en botón visual rojo con icono SVG
- Botón "Cambiar modo" eliminado de cabeceras en splitItems/splitEq; conservado solo en pie con flecha atrás
- Botón "Cambiar método" eliminado del cuerpo de splitTip (ya existía en el pie)
- Courtesy items bloqueados en selección y marcados con badge en cobro por ítems
- Panel de propina con tarjeta unificado al mismo diseño que el de efectivo
- Mejoras de accesibilidad y responsive en drawer de cobro en móvil

## Fixes incluidos

- `open()` resetea `requested = false` → split/mixto funcionan en primer intento
- Navegación idempotente en solicitud de cuenta (re-request sin 422)
- `backToMethod()` resetea el flag `requested` correctamente
- Botones de pie `.back` full-width y con padding uniforme en todos los flujos
- Cierre correcto de splitTip vuelve al paso correcto (items o equit)

## Plan de pruebas

- [ ] Abrir carta → solicitar cuenta → cobro partido: funciona sin tocar otros métodos primero
- [ ] Abrir carta → solicitar cuenta → cobro mixto: ídem
- [ ] Recargar página con pedido activo → repetir las pruebas anteriores
- [ ] Cobro partido por ítems: seleccionar ítems, avanzar a propina, pagar
- [ ] Cobro partido a partes iguales: donut, stepper, pagar parte
- [ ] Cobro mixto: barra arrastrable, continuar con tarjeta
- [ ] Botón "Cancelar aviso" visible y rojo tras solicitar cuenta en efectivo
- [ ] Botón "Cambiar modo" solo aparece en pie (no en cabecera) con flecha atrás
- [ ] Propina en splitTip: no aparece "Cambiar método" en la parte superior