### PR TITLE
fix: import Alpine in extracted JS modules so register functions work

### DIFF
--- a/resources/js/alpine/daily-menu-banner.js
+++ b/resources/js/alpine/daily-menu-banner.js
@@ -6,6 +6,8 @@
  * @author AyrtonAlania
  */
 
+import Alpine from 'alpinejs';
+
 const SECTION_LABELS = {
     first_course:  'Primer plato',
     second_course: 'Segundo plato',
@@ -347,6 +349,6 @@ export function dailyMenuBanner(hash) {
  * @param {import('alpinejs').Alpine} Alpine
  * @returns {void}
  */
-export function registerDailyMenuBanner(Alpine) {
+export function registerDailyMenuBanner() {
     Alpine.data('dailyMenuBanner', (hash) => dailyMenuBanner(hash));
 }

--- a/resources/js/alpine/menu-style.js
+++ b/resources/js/alpine/menu-style.js
@@ -5,6 +5,8 @@
  * @author BenjaminDTS
  */
 
+import Alpine from 'alpinejs';
+
 /**
  * @param {string} initialStyle  One of 'modern' | 'classic' | 'minimal'.
  * @returns {object}
@@ -152,6 +154,6 @@ export function menuStylePage(initialStyle) {
  * @param {import('alpinejs').Alpine} Alpine
  * @returns {void}
  */
-export function registerMenuStyle(Alpine) {
+export function registerMenuStyle() {
     Alpine.data('menuStylePage', (initialStyle) => menuStylePage(initialStyle));
 }

--- a/resources/js/alpine/ticket-config.js
+++ b/resources/js/alpine/ticket-config.js
@@ -6,6 +6,8 @@
  * @author BenjaminDTS
  */
 
+import Alpine from 'alpinejs';
+
 /**
  * @returns {object}
  */
@@ -45,6 +47,6 @@ export function ticketConfigData() {
  * @param {import('alpinejs').Alpine} Alpine
  * @returns {void}
  */
-export function registerTicketConfig(Alpine) {
+export function registerTicketConfig() {
     Alpine.data('ticketConfigData', () => ticketConfigData());
 }

--- a/resources/js/alpine/variant-editor.js
+++ b/resources/js/alpine/variant-editor.js
@@ -5,6 +5,8 @@
  * @author BenjaminDTS
  */
 
+import Alpine from 'alpinejs';
+
 /**
  * @param {Array<{name: string, price: string|number, sort_order: number}>} initialVariants
  * @returns {object}
@@ -42,6 +44,6 @@ export function variantEditor(initialVariants) {
  * @param {import('alpinejs').Alpine} Alpine
  * @returns {void}
  */
-export function registerVariantEditor(Alpine) {
+export function registerVariantEditor() {
     Alpine.data('variantEditor', (initialVariants) => variantEditor(initialVariants));
 }


### PR DESCRIPTION
## Problema

El commit `753dbfd` extrajo 4 componentes Alpine de Blade a módulos JS independientes. Las funciones `register*` usaban `Alpine` como parámetro (sin importarlo en el módulo), y en `app.js` se llaman sin argumento → `Alpine` es `undefined` → `Alpine.data()` falla silenciosamente → el componente no se registra → los bindings `x-model`/`x-show` quedan rotos.

**Síntomas visibles:**
- Sección Precio/Variantes desaparecida del formulario de productos
- Selector de plantilla de ticket: todas las opciones aparecen seleccionadas
- Selector de estilo de carta digital: no permite cambiar la selección

## Solución

Añadir `import Alpine from 'alpinejs'` en cada módulo afectado y quitar el parámetro `Alpine` de la función `register*`, siguiendo el mismo patrón que usan los módulos no afectados (ej. `layout-badges.js`).

## Archivos modificados

- `resources/js/alpine/variant-editor.js`
- `resources/js/alpine/ticket-config.js`
- `resources/js/alpine/menu-style.js`
- `resources/js/alpine/daily-menu-banner.js`