### PR TITLE
style: UX carta digital — banner menú del día persistente, chip DS, pedidos --dm

### DIFF
--- a/app/Http/Controllers/DailyMenuPublicController.php
+++ b/app/Http/Controllers/DailyMenuPublicController.php
@@ -107,6 +107,30 @@ class DailyMenuPublicController extends Controller
     }
 
     /**
+     * Cancela las órdenes à la carte de hoy para liberar la mesa y permitir el menú del día.
+     * Solo cancela órdenes pending/cooking sin dailyMenuOrder creadas hoy.
+     *
+     * @param  string  $hash
+     * @return JsonResponse
+     */
+    public function cancelAlaCarteOrders(string $hash): JsonResponse
+    {
+        $table = Table::where('unique_hash', $hash)->first();
+
+        if (! $table) {
+            return response()->json(['success' => false, 'message' => 'Mesa no encontrada.'], 404);
+        }
+
+        $cancelled = Order::where('table_id', $table->id)
+            ->whereIn('status', ['pending', 'cooking'])
+            ->whereDoesntHave('dailyMenuOrder')
+            ->whereDate('created_at', today())
+            ->update(['status' => 'cancelled']);
+
+        return response()->json(['success' => true, 'cancelled' => $cancelled]);
+    }
+
+    /**
      * Crea el pedido de menú del día con las selecciones y preferencias de timing del cliente.
      *
      * @param  Request  $request
@@ -130,6 +154,7 @@ class DailyMenuPublicController extends Controller
         $hasAlaCarteOrders = Order::where('table_id', $table->id)
             ->whereIn('status', ['pending', 'cooking'])
             ->whereDoesntHave('dailyMenuOrder')
+            ->whereDate('created_at', today())
             ->exists();
 
         if ($hasAlaCarteOrders) {

--- a/app/Http/Controllers/DailyMenuPublicController.php
+++ b/app/Http/Controllers/DailyMenuPublicController.php
@@ -316,11 +316,45 @@ class DailyMenuPublicController extends Controller
             $arrivesAt   = now()->addMinutes($clientDelay)->format('H:i');
 
             return [
-                'round'     => $rule->round_number,
-                'sections'  => $rule->section_types,
-                'arrives_at'=> $arrivesAt,
+                'round'      => $rule->round_number,
+                'sections'   => $rule->section_types,
+                'arrives_at' => $arrivesAt,
             ];
         })->values();
+
+        // PASO 7b — Construir order_summary para que el frontend actualice Mis pedidos
+        $sectionLabels = [
+            'first_course'  => 'Primer plato',
+            'second_course' => 'Segundo plato',
+            'dessert'       => 'Postre',
+            'coffee'        => 'Café',
+            'drink'         => 'Bebida',
+            'bread'         => 'Pan',
+        ];
+
+        $dailyMenuOrder->load(['selections.section:id,type', 'selections.product:id,name']);
+
+        $pendingCount = Order::where('table_id', $table->id)
+            ->whereNotIn('status', ['closed'])
+            ->where('payment_status', 'pending')
+            ->count();
+
+        $picks = $dailyMenuOrder->selections->map(fn ($sel) => [
+            'lab' => $sectionLabels[$sel->section?->type ?? ''] ?? ($sel->section?->type ?? 'Plato'),
+            'val' => $sel->product?->name ?? '—',
+        ])->values();
+
+        $orderSummary = [
+            'id'          => $order->id,
+            'number'      => $pendingCount,
+            'itemCount'   => $dailyMenuOrder->selections->count(),
+            'total'       => (float) $menu->price,
+            'sentAt'      => now()->format('H:i'),
+            'isDailyMenu' => true,
+            'dmTitle'     => $menu->title,
+            'picks'       => $picks,
+            'items'       => [],
+        ];
 
         // PASO 8 — Respuesta 201
         return response()->json([
@@ -328,6 +362,7 @@ class DailyMenuPublicController extends Controller
             'data'    => [
                 'order_id'        => $order->id,
                 'estimated_times' => $estimatedTimes,
+                'order_summary'   => $orderSummary,
             ],
         ], 201);
     }

--- a/app/Http/Controllers/DailyMenuPublicController.php
+++ b/app/Http/Controllers/DailyMenuPublicController.php
@@ -80,6 +80,7 @@ class DailyMenuPublicController extends Controller
                     'description' => $p->description,
                     'price'       => $p->price,
                     'image'       => $p->image,
+                    'is_active'   => (bool) $p->is_active,
                 ])->values(),
                 'timing_rule'   => $timingRule ? [
                     'round_number'           => $timingRule->round_number,

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -179,7 +179,7 @@ class MenuController extends Controller
             ->orderBy('created_at')
             ->with([
                 'items.product:id,name',
-                'dailyMenuOrder.menu:id,title',
+                'dailyMenuOrder.dailyMenu:id,title',
                 'dailyMenuOrder.selections.section:id,type',
                 'dailyMenuOrder.selections.product:id,name',
             ])
@@ -194,7 +194,7 @@ class MenuController extends Controller
                 'total'       => (float) $order->total,
                 'sentAt'      => $order->created_at->format('H:i'),
                 'isDailyMenu' => $order->dailyMenuOrder !== null,
-                'dmTitle'     => $order->dailyMenuOrder?->menu?->title ?? 'Menú del Día',
+                'dmTitle'     => $order->dailyMenuOrder?->dailyMenu?->title ?? 'Menú del Día',
                 'picks'       => $order->dailyMenuOrder
                     ? $order->dailyMenuOrder->selections->map(fn ($sel) => [
                         'lab' => $dmSectionLabels[$sel->section?->type ?? ''] ?? ($sel->section?->type ?? 'Plato'),

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -164,24 +164,50 @@ class MenuController extends Controller
                 ->toArray()
             : [];
 
+        $dmSectionLabels = [
+            'first_course'  => 'Primer plato',
+            'second_course' => 'Segundo plato',
+            'dessert'       => 'Postre',
+            'coffee'        => 'Café',
+            'drink'         => 'Bebida',
+            'bread'         => 'Pan',
+        ];
+
         $allOrdersForAlpine = Order::where('table_id', $table->id)
             ->whereNotIn('status', ['closed'])
             ->where('payment_status', 'pending')
             ->orderBy('created_at')
-            ->with(['items.product:id,name'])
+            ->with([
+                'items.product:id,name',
+                'dailyMenuOrder.menu:id,title',
+                'dailyMenuOrder.selections.section:id,type',
+                'dailyMenuOrder.selections.product:id,name',
+            ])
             ->get()
             ->values()
             ->map(fn (Order $order, int $index) => [
-                'id'        => $order->id,
-                'number'    => $index + 1,
-                'itemCount' => (int) $order->items->sum('quantity'),
-                'total'     => (float) $order->total,
-                'sentAt'    => $order->created_at->format('H:i'),
-                'items'     => $order->items->map(fn (OrderItem $item) => [
-                    'name'     => $item->product?->name ?? 'Producto',
-                    'quantity' => (int) $item->quantity,
-                    'price'    => (float) $item->price,
-                ])->values()->toArray(),
+                'id'          => $order->id,
+                'number'      => $index + 1,
+                'itemCount'   => $order->dailyMenuOrder
+                    ? $order->dailyMenuOrder->selections->count()
+                    : (int) $order->items->sum('quantity'),
+                'total'       => (float) $order->total,
+                'sentAt'      => $order->created_at->format('H:i'),
+                'isDailyMenu' => $order->dailyMenuOrder !== null,
+                'dmTitle'     => $order->dailyMenuOrder?->menu?->title ?? 'Menú del Día',
+                'picks'       => $order->dailyMenuOrder
+                    ? $order->dailyMenuOrder->selections->map(fn ($sel) => [
+                        'lab' => $dmSectionLabels[$sel->section?->type ?? ''] ?? ($sel->section?->type ?? 'Plato'),
+                        'val' => $sel->product?->name ?? '—',
+                    ])->values()->toArray()
+                    : [],
+                'items'       => $order->dailyMenuOrder
+                    ? []
+                    : $order->items->map(fn (OrderItem $item) => [
+                        'name'     => $item->product?->name ?? 'Producto',
+                        'quantity' => (int) $item->quantity,
+                        'price'    => (float) $item->price,
+                    ])->values()->toArray(),
             ])
             ->toArray();
 

--- a/public/css/carta/flows/daily-menu.css
+++ b/public/css/carta/flows/daily-menu.css
@@ -735,6 +735,17 @@
   flex-shrink: 0;
 }
 
+/* DM chip strip — visible en mobile y tablet; desktop lo maneja el sidebar */
+.dm-chip-strip {
+  display: none;
+  padding: 8px 16px 0;
+  align-items: center;
+}
+.carta[data-bp="mobile"] .dm-chip-strip,
+.carta[data-bp="tablet"] .dm-chip-strip { display: flex; }
+.carta[data-bp="desktop"] .dm-chip-strip { display: none !important; }
+.dm-chip-strip .dm-chip--compact { width: 100%; max-width: 340px; }
+
 
 /* â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•
    MENÃš DEL DÃA Â· presentaciÃ³n dentro de "Mis pedidos"

--- a/public/css/carta/flows/daily-menu.css
+++ b/public/css/carta/flows/daily-menu.css
@@ -327,6 +327,7 @@
   background: rgba(0, 0, 0, 0.55);
   backdrop-filter: blur(8px) saturate(120%);
   -webkit-backdrop-filter: blur(8px) saturate(120%);
+  z-index: 60;
 }
 .carta[data-bp="tablet"] .scrim--dm,
 .carta[data-bp="desktop"] .scrim--dm { align-items: center; }

--- a/public/css/carta/flows/features.css
+++ b/public/css/carta/flows/features.css
@@ -185,7 +185,7 @@
   cursor: pointer;
   width: auto;
   box-shadow: var(--ti-shadow-base);
-  animation: tapas-indicator-attention 5s var(--ease-smooth) 1.2s infinite;
+  animation: tapas-indicator-attention 3s ease-in-out infinite;
   transition: filter var(--duration-fast), transform 140ms var(--ease-bounce);
 }
 .tapas-indicator:hover {
@@ -210,20 +210,14 @@
 }
 
 @keyframes tapas-indicator-attention {
-  0%, 62%, 100% {
+  0%, 70%, 100% {
     transform: translateY(0) scale(1);
     box-shadow: var(--ti-shadow-base);
   }
-  70% {
-    transform: translateY(-8px) scale(1.03);
-    box-shadow: var(--ti-shadow-peak);
+  85% {
+    transform: translateY(-2px) scale(1.008);
+    box-shadow: 0 12px 26px rgba(180,83,9,0.48), 0 0 0 4px rgba(245,158,11,0.14);
   }
-  78% {
-    transform: translateY(0) scale(1);
-    box-shadow: var(--ti-shadow-ring);
-  }
-  85% { transform: translateY(-3px) scale(1.015); }
-  92% { transform: translateY(0) scale(1); }
 }
 @media (prefers-reduced-motion: reduce) {
   .tapas-indicator { animation: none; }

--- a/resources/js/alpine/bill.js
+++ b/resources/js/alpine/bill.js
@@ -31,6 +31,20 @@ export function calculateTipFromPercent(base, percent) {
 }
 
 /**
+ * Returns the suggested tip percentage based on the bill total.
+ * Larger bills get a higher suggested percentage.
+ *
+ * @param {number} total - Bill total in euros.
+ * @returns {number} Suggested tip percentage (5, 10, 15 or 20).
+ */
+export function suggestedTipPercent(total) {
+    if (total > 80) return 20;
+    if (total > 40) return 15;
+    if (total > 15) return 10;
+    return 5;
+}
+
+/**
  * Returns the total of all selected split items.
  *
  * @param {Array<{id: number, total: number}>} splitItems    - All split-able items.
@@ -228,8 +242,8 @@ export function registerBill() {
             } catch {
                 // use cached total from page load
             }
-            this.tipPercent = 10;
-            this.tipAmount  = calculateTipFromPercent(this.orderTotal, 10);
+            this.tipPercent = suggestedTipPercent(this.orderTotal);
+            this.tipAmount  = calculateTipFromPercent(this.orderTotal, this.tipPercent);
             this.grandTotal = this.orderTotal + this.tipAmount;
             this.showingTip = true;
             this.step       = 'tip';
@@ -470,9 +484,9 @@ export function registerBill() {
 
         openCashTip() {
             this.choosing       = false;
-            this.cashTipAmount  = 0;
-            this.cashTipPercent = 10;
-            this.cashGrandTotal = this.orderTotal + calculateTipFromPercent(this.orderTotal, 10);
+            this.cashTipPercent = suggestedTipPercent(this.orderTotal);
+            this.cashTipAmount  = calculateTipFromPercent(this.orderTotal, this.cashTipPercent);
+            this.cashGrandTotal = this.orderTotal + this.cashTipAmount;
             this.showingCashTip = true;
             this.step           = 'cashConfirm';
         },
@@ -506,9 +520,9 @@ export function registerBill() {
             this.splitTipBase       = amount;
             this.splitTipType       = type;
             this.splitTipItemIds    = itemIds || [];
-            this.splitTipAmount     = 0;
-            this.splitTipPercent    = 10;
-            this.splitTipGrandTotal = amount + calculateTipFromPercent(amount, 10);
+            this.splitTipPercent    = suggestedTipPercent(amount);
+            this.splitTipAmount     = calculateTipFromPercent(amount, this.splitTipPercent);
+            this.splitTipGrandTotal = amount + this.splitTipAmount;
             this.splitShowItems     = false;
             this.splitShowEq        = false;
             this.showingSplitTip    = true;
@@ -609,9 +623,9 @@ export function registerBill() {
         openMixedTip() {
             this.showingMixed       = false;
             this.mixedTipBase       = this.mixedCardAmount;
-            this.mixedTipAmount     = 0;
-            this.mixedTipPercent    = 10;
-            this.mixedTipGrandTotal = this.mixedCardAmount + calculateTipFromPercent(this.mixedCardAmount, 10);
+            this.mixedTipPercent    = suggestedTipPercent(this.mixedCardAmount);
+            this.mixedTipAmount     = calculateTipFromPercent(this.mixedCardAmount, this.mixedTipPercent);
+            this.mixedTipGrandTotal = this.mixedCardAmount + this.mixedTipAmount;
             this.showingMixedTip    = true;
             this.step               = 'mixedTip';
         },

--- a/resources/js/alpine/daily-menu-banner.js
+++ b/resources/js/alpine/daily-menu-banner.js
@@ -103,7 +103,7 @@ export function dailyMenuBanner(hash) {
             }
         },
 
-        clearCartAndOpen() {
+        async clearCartAndOpen() {
             const cart = Alpine.store('cart');
             cart.items          = [];
             cart._barItemsCount = 0;
@@ -111,6 +111,16 @@ export function dailyMenuBanner(hash) {
             cart.sent           = false;
             cart.error          = null;
             this.showExclusivityWarning = false;
+
+            await fetch('/api/v1/menu/' + this.hash + '/cancel-alacarte', {
+                method:  'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content ?? '',
+                    'Accept':       'application/json',
+                },
+            }).catch(() => {});
+
             this._doOpen();
         },
 

--- a/resources/js/alpine/daily-menu-banner.js
+++ b/resources/js/alpine/daily-menu-banner.js
@@ -31,8 +31,7 @@ export function dailyMenuBanner(hash) {
         stuck:           false,
         bannerDismissed: false,
         showExclusivityWarning: false,
-        _autoDismissTimer: null,
-        _scrollEl:         null,
+        _scrollEl: null,
 
         /* ── Stepper ─────────────────────────────────────────────────────────── */
         pasos:          [],
@@ -85,7 +84,6 @@ export function dailyMenuBanner(hash) {
                 this.menuData = json.data ?? null;
                 if (this.menuData) {
                     this._buildFromData(this.menuData);
-                    this._startAutoDismiss();
                     this._bindScroll();
                 }
             } catch {
@@ -93,10 +91,6 @@ export function dailyMenuBanner(hash) {
             } finally {
                 this.loading = false;
             }
-        },
-
-        _startAutoDismiss() {
-            this._autoDismissTimer = setTimeout(() => this.dismiss(), 22000);
         },
 
         _bindScroll() {
@@ -111,10 +105,6 @@ export function dailyMenuBanner(hash) {
         dismiss() {
             if (this.exiting) return;
             this.exiting = true;
-            if (this._autoDismissTimer) {
-                clearTimeout(this._autoDismissTimer);
-                this._autoDismissTimer = null;
-            }
             setTimeout(() => { this.bannerDismissed = true; }, 280);
         },
 

--- a/resources/js/alpine/daily-menu-banner.js
+++ b/resources/js/alpine/daily-menu-banner.js
@@ -367,6 +367,8 @@ export function dailyMenuBanner(hash) {
 
                 if (res.ok) {
                     this.enviado = true;
+                    const summary = result.data?.order_summary;
+                    if (summary) Alpine.store('orders').push(summary);
                 } else {
                     this.errorMsg = result.message ?? 'Error al enviar el pedido.';
                 }

--- a/resources/js/alpine/daily-menu-banner.js
+++ b/resources/js/alpine/daily-menu-banner.js
@@ -24,12 +24,15 @@ const SECTION_LABELS = {
 export function dailyMenuBanner(hash) {
     return {
         hash,
-        menuData:  null,
-        loading:   true,
-        open:      false,
-        exiting:   false,
-        stuck:     false,
+        menuData:        null,
+        loading:         true,
+        open:            false,
+        exiting:         false,
+        stuck:           false,
+        bannerDismissed: false,
         showExclusivityWarning: false,
+        _autoDismissTimer: null,
+        _scrollEl:         null,
 
         /* ── Stepper ─────────────────────────────────────────────────────────── */
         pasos:          [],
@@ -80,7 +83,11 @@ export function dailyMenuBanner(hash) {
                 const res  = await fetch('/api/v1/menu/' + this.hash + '/daily-menu');
                 const json = await res.json();
                 this.menuData = json.data ?? null;
-                if (this.menuData) this._buildFromData(this.menuData);
+                if (this.menuData) {
+                    this._buildFromData(this.menuData);
+                    this._startAutoDismiss();
+                    this._bindScroll();
+                }
             } catch {
                 this.menuData = null;
             } finally {
@@ -88,10 +95,27 @@ export function dailyMenuBanner(hash) {
             }
         },
 
+        _startAutoDismiss() {
+            this._autoDismissTimer = setTimeout(() => this.dismiss(), 22000);
+        },
+
+        _bindScroll() {
+            this._scrollEl = document.getElementById('main-content');
+            if (!this._scrollEl) return;
+            const onScroll = () => { this.stuck = this._scrollEl.scrollTop > 6; };
+            this._scrollEl.addEventListener('scroll', onScroll, { passive: true });
+            onScroll();
+        },
+
         /* ── Banner ───────────────────────────────────────────────────────────── */
         dismiss() {
             if (this.exiting) return;
             this.exiting = true;
+            if (this._autoDismissTimer) {
+                clearTimeout(this._autoDismissTimer);
+                this._autoDismissTimer = null;
+            }
+            setTimeout(() => { this.bannerDismissed = true; }, 280);
         },
 
         openStepper() {

--- a/resources/views/components/daily-menu-banner.blade.php
+++ b/resources/views/components/daily-menu-banner.blade.php
@@ -1,17 +1,15 @@
 {{-- @author SebastianBCF --}}
 {{-- @author AyrtonAlania --}}
 {{-- Banner del Menú del Día — estructura idéntica al Design System (dm-banner).
-     Se inserta al inicio del carta__body. Gestiona el stepper vía Alpine.
+     Sin x-data propio: hereda el scope dailyMenuBanner declarado en carta__main (show.blade.php).
      Alpine component → resources/js/alpine/daily-menu-banner.js --}}
 @props(['hash'])
 
-{{-- ── Wrapper Alpine ──────────────────────────────────────────── --}}
+{{-- ── Banner DS ────────────────────────────────────────────── --}}
 <div
-    x-data="dailyMenuBanner('{{ $hash }}')"
-    x-show="!loading && menuData !== null"
+    x-show="menuData !== null && !bannerDismissed"
     x-cloak
 >
-    {{-- ── Banner DS ────────────────────────────────────────────── --}}
     <div
         :class="'dm-banner' +
             (exiting   ? ' dm-banner--exit'      : '') +
@@ -77,7 +75,7 @@
 
     {{-- ── Diálogo de exclusividad ────────────────────────────── --}}
     <x-daily-menu-exclusivity-dialog />
-
-    {{-- ── Stepper modal ──────────────────────────────────────── --}}
-    <x-daily-menu-stepper :hash="$hash" />
 </div>
+
+{{-- ── Stepper modal (teleportado a .carta vía x-teleport) ──────── --}}
+<x-daily-menu-stepper :hash="$hash" />

--- a/resources/views/components/daily-menu-banner.blade.php
+++ b/resources/views/components/daily-menu-banner.blade.php
@@ -6,23 +6,21 @@
 @props(['hash'])
 
 {{-- ── Banner DS ────────────────────────────────────────────── --}}
+{{-- position:sticky requiere que .dm-banner sea hijo directo de carta__body;
+     por eso x-show va aquí y no en un wrapper intermedio. --}}
 <div
+    class="dm-banner"
     x-show="menuData !== null && !bannerDismissed"
     x-cloak
+    :class="(exiting ? ' dm-banner--exit' : '') + (stuck ? ' dm-banner--stuck' : '') + (agotado ? '' : ' dm-banner--clickable')"
+    :role="agotado ? 'status' : 'button'"
+    :tabindex="agotado ? undefined : 0"
+    :aria-label="agotado ? undefined : 'Abrir ' + (menuData?.menu?.title ?? 'Menú del día')"
+    aria-live="polite"
+    @click="!agotado && openStepper()"
+    @keydown.enter.prevent="!agotado && openStepper()"
+    @keydown.space.prevent="!agotado && openStepper()"
 >
-    <div
-        :class="'dm-banner' +
-            (exiting   ? ' dm-banner--exit'      : '') +
-            (stuck     ? ' dm-banner--stuck'     : '') +
-            (agotado   ? ''                       : ' dm-banner--clickable')"
-        :role="agotado ? 'status' : 'button'"
-        :tabindex="agotado ? undefined : 0"
-        :aria-label="agotado ? undefined : 'Abrir ' + (menuData?.menu?.title ?? 'Menú del día')"
-        aria-live="polite"
-        @click="!agotado && openStepper()"
-        @keydown.enter.prevent="!agotado && openStepper()"
-        @keydown.space.prevent="!agotado && openStepper()"
-    >
         <div class="dm-banner__stamp" aria-hidden="true">
             <span class="dm-banner__stampMark">◇</span>
             <span class="dm-banner__stampLabel">MENÚ DEL DÍA</span>
@@ -73,9 +71,8 @@
         </button>
     </div>
 
-    {{-- ── Diálogo de exclusividad ────────────────────────────── --}}
-    <x-daily-menu-exclusivity-dialog />
-</div>
+{{-- ── Diálogo de exclusividad ──────────────────────────────────── --}}
+<x-daily-menu-exclusivity-dialog />
 
 {{-- ── Stepper modal (teleportado a .carta vía x-teleport) ──────── --}}
 <x-daily-menu-stepper :hash="$hash" />

--- a/resources/views/components/daily-menu-stepper.blade.php
+++ b/resources/views/components/daily-menu-stepper.blade.php
@@ -5,9 +5,7 @@
 @props(['hash'])
 
 {{-- ── Scrim + dm-modal ─────────────────────────────────────────── --}}
-<div
-    x-teleport=".carta"
->
+<template x-teleport=".carta">
 <div
     class="scrim scrim--center scrim--dm"
     x-show="open"
@@ -287,4 +285,4 @@
 
     </div>{{-- /dm-modal --}}
 </div>{{-- /scrim --}}
-</div>{{-- /x-teleport --}}
+</template>{{-- /x-teleport --}}

--- a/resources/views/components/daily-menu-stepper.blade.php
+++ b/resources/views/components/daily-menu-stepper.blade.php
@@ -6,6 +6,9 @@
 
 {{-- ── Scrim + dm-modal ─────────────────────────────────────────── --}}
 <div
+    x-teleport=".carta"
+>
+<div
     class="scrim scrim--center scrim--dm"
     x-show="open"
     :class="closingModal ? 'is-closing' : ''"
@@ -284,3 +287,4 @@
 
     </div>{{-- /dm-modal --}}
 </div>{{-- /scrim --}}
+</div>{{-- /x-teleport --}}

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -3176,7 +3176,11 @@
                 <div class="drawer__head">
                     <div>
                         <div class="drawer__title"
-                             x-text="$store.orders.selectedId === null ? 'Mis pedidos' : 'Pedido #' + $store.orders.selected?.number">
+                             x-text="$store.orders.selectedId === null
+                                 ? 'Mis pedidos'
+                                 : ($store.orders.selected?.isDailyMenu
+                                     ? ($store.orders.selected?.dmTitle ?? 'Menú del Día')
+                                     : 'Pedido #' + $store.orders.selected?.number)">
                         </div>
                         <div style="font-family:var(--font-body);font-size:12px;color:var(--fg-muted);margin-top:2px"
                              x-text="$store.orders.selectedId === null
@@ -3196,12 +3200,24 @@
                     <div class="orders-body">
                         <div class="orders-list">
                             <template x-for="order in $store.orders.list" :key="order.id">
-                                <button type="button" class="order-row" @click="$store.orders.openDetail(order.id)">
-                                    <div class="order-row__num" x-text="'#' + order.number" aria-hidden="true"></div>
+                                <button type="button"
+                                        :class="'order-row' + (order.isDailyMenu ? ' order-row--dm' : '')"
+                                        @click="$store.orders.openDetail(order.id)">
+                                    <div :class="'order-row__num' + (order.isDailyMenu ? ' order-row__num--dm' : '')"
+                                         aria-hidden="true">
+                                        <span x-show="order.isDailyMenu" class="order-row__dmMark">◇</span>
+                                        <span x-show="!order.isDailyMenu" x-text="'#' + order.number"></span>
+                                    </div>
                                     <div class="order-row__main">
-                                        <div class="order-row__title" x-text="'Pedido #' + order.number"></div>
+                                        <div class="order-row__title">
+                                            <span x-text="order.isDailyMenu ? (order.dmTitle ?? 'Menú del Día') : 'Pedido #' + order.number"></span>
+                                            <span class="order-row__dmTag" x-show="order.isDailyMenu">MENÚ DEL DÍA</span>
+                                        </div>
                                         <div class="order-row__meta">
-                                            <span x-text="order.itemCount + ' ' + (order.itemCount === 1 ? 'artículo' : 'artículos')"></span>
+                                            <span x-text="order.isDailyMenu
+                                                ? 'Menú completo'
+                                                : order.itemCount + ' ' + (order.itemCount === 1 ? 'artículo' : 'artículos')">
+                                            </span>
                                             <template x-if="order.sentAt">
                                                 <span class="order-row__dot" aria-hidden="true">·</span>
                                             </template>
@@ -3238,28 +3254,57 @@
                                 <span>Volver a mis pedidos</span>
                             </button>
 
-                            <div class="orders-detail__head">
-                                <div class="orders-detail__num"
-                                     x-text="'#' + $store.orders.selected?.number" aria-hidden="true"></div>
+                            <div :class="'orders-detail__head' + ($store.orders.selected?.isDailyMenu ? ' orders-detail__head--dm' : '')">
+                                <div :class="'orders-detail__num' + ($store.orders.selected?.isDailyMenu ? ' orders-detail__num--dm' : '')"
+                                     aria-hidden="true">
+                                    <span x-show="$store.orders.selected?.isDailyMenu">◇</span>
+                                    <span x-show="!$store.orders.selected?.isDailyMenu"
+                                          x-text="'#' + $store.orders.selected?.number"></span>
+                                </div>
                                 <div>
-                                    <div class="orders-detail__title"
-                                         x-text="'Pedido #' + $store.orders.selected?.number"></div>
+                                    <div class="orders-detail__title">
+                                        <span x-text="$store.orders.selected?.isDailyMenu
+                                            ? ($store.orders.selected?.dmTitle ?? 'Menú del Día')
+                                            : 'Pedido #' + $store.orders.selected?.number">
+                                        </span>
+                                        <span class="order-row__dmTag"
+                                              x-show="$store.orders.selected?.isDailyMenu">MENÚ DEL DÍA</span>
+                                    </div>
                                     <div class="orders-detail__meta"
-                                         x-text="($store.orders.selected?.itemCount ?? 0) + ' ' + (($store.orders.selected?.itemCount ?? 0) === 1 ? 'artículo' : 'artículos') + ($store.orders.selected?.sentAt ? ' · Enviado a las ' + $store.orders.selected.sentAt : '')">
+                                         x-text="$store.orders.selected?.isDailyMenu
+                                             ? 'Menú completo' + ($store.orders.selected?.sentAt ? ' · Enviado a las ' + $store.orders.selected.sentAt : '')
+                                             : (($store.orders.selected?.itemCount ?? 0) + ' ' + (($store.orders.selected?.itemCount ?? 0) === 1 ? 'artículo' : 'artículos') + ($store.orders.selected?.sentAt ? ' · Enviado a las ' + $store.orders.selected.sentAt : ''))">
                                     </div>
                                 </div>
                             </div>
 
                             <div class="orders-detail__items">
-                                <template x-for="item in ($store.orders.selected?.items ?? [])"
-                                          :key="item.name + item.price">
-                                    <div class="orders-line">
-                                        <div class="orders-line__qty" x-text="item.quantity + '×'"></div>
-                                        <div class="orders-line__body">
-                                            <div class="orders-line__name" x-text="item.name"></div>
-                                        </div>
-                                        <div class="orders-line__price"
-                                             x-text="$store.orders.fmt(item.price * item.quantity)"></div>
+                                {{-- Menú del Día: picks list --}}
+                                <template x-if="$store.orders.selected?.isDailyMenu">
+                                    <div class="orders-dm__picks">
+                                        <template x-for="pick in ($store.orders.selected?.picks ?? [])"
+                                                  :key="pick.lab">
+                                            <div class="orders-dm__pickRow">
+                                                <span class="orders-dm__pickLab" x-text="pick.lab"></span>
+                                                <span class="orders-dm__pickVal" x-text="pick.val"></span>
+                                            </div>
+                                        </template>
+                                    </div>
+                                </template>
+                                {{-- Regular order: items list --}}
+                                <template x-if="!$store.orders.selected?.isDailyMenu">
+                                    <div>
+                                        <template x-for="item in ($store.orders.selected?.items ?? [])"
+                                                  :key="item.name + item.price">
+                                            <div class="orders-line">
+                                                <div class="orders-line__qty" x-text="item.quantity + '×'"></div>
+                                                <div class="orders-line__body">
+                                                    <div class="orders-line__name" x-text="item.name"></div>
+                                                </div>
+                                                <div class="orders-line__price"
+                                                     x-text="$store.orders.fmt(item.price * item.quantity)"></div>
+                                            </div>
+                                        </template>
                                     </div>
                                 </template>
                             </div>
@@ -3312,7 +3357,8 @@
              @click.self="$store.orders.dismissConfirmed()"
              role="dialog" aria-modal="true" aria-label="Pedido enviado">
 
-            <div class="order-confirmed__panel" @click.stop>
+            <div :class="'order-confirmed__panel' + ($store.orders.confirmedOrder?.isDailyMenu ? ' order-confirmed__panel--dm' : '')"
+                 @click.stop>
                 <button type="button" class="icon-btn order-confirmed__x"
                         @click="$store.orders.dismissConfirmed()" aria-label="Cerrar">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none"
@@ -3321,39 +3367,77 @@
                     </svg>
                 </button>
 
-                <div class="order-confirmed__badge" aria-hidden="true">
-                    <svg viewBox="0 0 32 32" width="34" height="34" fill="none">
-                        <path d="M7 16.5l6 6 12-13" stroke="currentColor" stroke-width="3"
-                              stroke-linecap="round" stroke-linejoin="round"/>
-                    </svg>
+                <div :class="'order-confirmed__badge' + ($store.orders.confirmedOrder?.isDailyMenu ? ' order-confirmed__badge--dm' : '')"
+                     aria-hidden="true">
+                    <template x-if="$store.orders.confirmedOrder?.isDailyMenu">
+                        <span style="font-family:var(--font-display);font-weight:900;font-size:30px;line-height:1">◇</span>
+                    </template>
+                    <template x-if="!$store.orders.confirmedOrder?.isDailyMenu">
+                        <svg viewBox="0 0 32 32" width="34" height="34" fill="none">
+                            <path d="M7 16.5l6 6 12-13" stroke="currentColor" stroke-width="3"
+                                  stroke-linecap="round" stroke-linejoin="round"/>
+                        </svg>
+                    </template>
                 </div>
 
                 <div class="order-confirmed__num"
-                     x-text="'Pedido #' + $store.orders.confirmedOrder?.number"></div>
-                <div class="order-confirmed__title">Pedido enviado</div>
-                <div class="order-confirmed__sub">Lo llevamos en unos minutos 🍽</div>
+                     x-text="$store.orders.confirmedOrder?.isDailyMenu
+                         ? ($store.orders.confirmedOrder?.dmTitle ?? 'Menú del Día')
+                         : 'Pedido #' + $store.orders.confirmedOrder?.number">
+                </div>
+                <div class="order-confirmed__title"
+                     x-text="$store.orders.confirmedOrder?.isDailyMenu ? '¡Pedido enviado a cocina!' : 'Pedido enviado'">
+                </div>
+                <div class="order-confirmed__sub"
+                     x-text="$store.orders.confirmedOrder?.isDailyMenu
+                         ? 'Tu menú del día está en camino 🍽'
+                         : 'Lo llevamos en unos minutos 🍽'">
+                </div>
 
                 <div class="order-confirmed__items">
-                    <template x-for="item in ($store.orders.confirmedOrder?.items.slice(0, 5) ?? [])"
-                              :key="item.name + item.price">
-                        <div class="order-confirmed__row">
-                            <span class="qty" x-text="item.quantity + '×'"></span>
-                            <span class="name" x-text="item.name"></span>
-                            <span class="price"
-                                  x-text="$store.orders.fmt(item.price * item.quantity)"></span>
+                    {{-- DM: picks list --}}
+                    <template x-if="$store.orders.confirmedOrder?.isDailyMenu">
+                        <div class="orders-dm__picks order-confirmed__panel--dm">
+                            <template x-for="pick in ($store.orders.confirmedOrder?.picks ?? [])"
+                                      :key="pick.lab">
+                                <div class="orders-dm__pickRow">
+                                    <span class="orders-dm__pickLab" x-text="pick.lab"></span>
+                                    <span class="orders-dm__pickVal" x-text="pick.val"></span>
+                                </div>
+                            </template>
                         </div>
                     </template>
-                    <template x-if="($store.orders.confirmedOrder?.items.length ?? 0) > 5">
-                        <div class="order-confirmed__more"
-                             x-text="'+ ' + ($store.orders.confirmedOrder.items.length - 5) + ' más…'"></div>
+                    {{-- Regular: items list --}}
+                    <template x-if="!$store.orders.confirmedOrder?.isDailyMenu">
+                        <div>
+                            <template x-for="item in ($store.orders.confirmedOrder?.items.slice(0, 5) ?? [])"
+                                      :key="item.name + item.price">
+                                <div class="order-confirmed__row">
+                                    <span class="qty" x-text="item.quantity + '×'"></span>
+                                    <span class="name" x-text="item.name"></span>
+                                    <span class="price"
+                                          x-text="$store.orders.fmt(item.price * item.quantity)"></span>
+                                </div>
+                            </template>
+                            <template x-if="($store.orders.confirmedOrder?.items.length ?? 0) > 5">
+                                <div class="order-confirmed__more"
+                                     x-text="'+ ' + ($store.orders.confirmedOrder.items.length - 5) + ' más…'"></div>
+                            </template>
+                        </div>
                     </template>
                 </div>
 
                 <div class="order-confirmed__sub-total">
-                    <span class="lab">Subtotal</span>
+                    <span class="lab">
+                        <span x-text="$store.orders.confirmedOrder?.isDailyMenu ? 'Total menú' : 'Subtotal'"></span>
+                    </span>
                     <span class="val"
                           x-text="$store.orders.fmt($store.orders.confirmedOrder?.total ?? 0)"></span>
                 </div>
+
+                <template x-if="$store.orders.confirmedOrder?.isDailyMenu">
+                    <div class="order-confirmed__dmTag">Menú del Día</div>
+                </template>
 
                 <button type="button" class="btn-primary"
                         @click="$store.orders.dismissConfirmed()">

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -978,6 +978,12 @@
         @endif
 
         {{-- ══════════════════════════════════════════════════════════════════════
+             DAILY MENU SCOPE — envuelve filter-bar + carta__main para que el chip
+             mobile y el sidebar chip compartan el mismo scope Alpine.
+             ══════════════════════════════════════════════════════════════════════ --}}
+        <div x-data="dailyMenuBanner('{{ $table->unique_hash }}')">
+
+        {{-- ══════════════════════════════════════════════════════════════════════
              FILTER BAR (mobile) + ALLERGEN SHEET — x-data local para allergensOpen
              ══════════════════════════════════════════════════════════════════════ --}}
         @if($businessOpen && $categories->isNotEmpty())
@@ -1020,6 +1026,25 @@
                         {{ $cat->name }}
                     </button>
                     @endforeach
+                    {{-- Menú del Día — chip compacto (DS: DailyMenuFilterChip compact, mobile) --}}
+                    <template x-if="menuData !== null">
+                        <span class="contents">
+                            <span class="dm-filter-sep" aria-hidden="true"></span>
+                            <button type="button"
+                                    :class="'dm-chip dm-chip--compact' + (agotado ? ' dm-chip--agotado' : '')"
+                                    @click="!agotado && openStepper()"
+                                    :disabled="agotado"
+                                    :aria-label="agotado ? 'Menú del día agotado' : 'Ver menú del día'">
+                                <span class="dm-chip__mark" aria-hidden="true">◇</span>
+                                <span class="dm-chip__main">
+                                    <span class="dm-chip__top">Menú del Día</span>
+                                    <span class="dm-chip__sub"
+                                          x-text="agotado ? 'Agotado' : parseFloat(menuData?.menu?.price ?? 0).toFixed(2).replace('.', ',') + ' €'">
+                                    </span>
+                                </span>
+                            </button>
+                        </span>
+                    </template>
                 </div>
                 {{-- Desplegable de alérgenos --}}
                 <div class="allergen-dropdown" @click.away="allergensOpen = false">
@@ -1120,6 +1145,30 @@
             {{-- DS: .carta__filters — sidebar (tablet + desktop, hidden on mobile via CSS) --}}
             @if($businessOpen && $categories->isNotEmpty())
             <div class="carta__filters" aria-label="Filtros">
+
+                {{-- Menú del Día — chip persistente en sidebar (DS: DailyMenuFilterChip) --}}
+                <div class="filter-section--dm" x-show="menuData !== null" x-cloak>
+                    <button type="button"
+                            :class="'dm-chip' + (agotado ? ' dm-chip--agotado' : '')"
+                            @click="!agotado && openStepper()"
+                            :disabled="agotado"
+                            :aria-label="agotado ? 'Menú del día agotado' : 'Abrir menú del día'">
+                        <span class="dm-chip__mark" aria-hidden="true">◇</span>
+                        <span class="dm-chip__main">
+                            <span class="dm-chip__top" x-text="menuData?.menu?.title ?? 'Menú del Día'"></span>
+                            <span class="dm-chip__sub"
+                                  x-text="agotado ? 'Agotado por hoy' : parseFloat(menuData?.menu?.price ?? 0).toFixed(2).replace('.', ',') + ' €'">
+                            </span>
+                        </span>
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                             stroke="currentColor" stroke-width="2.2"
+                             stroke-linecap="round" stroke-linejoin="round"
+                             aria-hidden="true" x-show="!agotado">
+                            <path d="M5 12h14M13 5l7 7-7 7"/>
+                        </svg>
+                    </button>
+                    <div class="dm-filter-sep" aria-hidden="true"></div>
+                </div>
 
                 {{-- Destino (cocina / barra / todo) --}}
                 <div class="filter-section">
@@ -1405,6 +1454,7 @@
 
             </div>{{-- /carta__body --}}
         </div>{{-- /carta__main --}}
+        </div>{{-- /dailyMenuBanner scope --}}
 
         {{-- ══════════════════════════════════════════════════════════════════════
              CART BAR — .cart-bar position:absolute dentro de .carta

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -983,6 +983,32 @@
              ══════════════════════════════════════════════════════════════════════ --}}
         <div x-data="dailyMenuBanner('{{ $table->unique_hash }}')">
 
+        {{-- DS: dm-chip-strip — visible en mobile Y tablet (desktop: sidebar lo maneja) --}}
+        <div class="dm-chip-strip"
+             x-show="menuData !== null"
+             x-cloak
+             aria-label="Menú del día disponible">
+            <button type="button"
+                    :class="'dm-chip dm-chip--compact' + (agotado ? ' dm-chip--agotado' : '')"
+                    @click="!agotado && openStepper()"
+                    :disabled="agotado"
+                    :aria-label="agotado ? 'Menú del día agotado' : 'Ver menú del día — ' + (menuData?.menu?.title ?? '')">
+                <span class="dm-chip__mark" aria-hidden="true">◇</span>
+                <span class="dm-chip__main">
+                    <span class="dm-chip__top" x-text="menuData?.menu?.title ?? 'Menú del Día'"></span>
+                    <span class="dm-chip__sub"
+                          x-text="agotado ? 'Agotado por hoy' : parseFloat(menuData?.menu?.price ?? 0).toFixed(2).replace('.', ',') + ' €'">
+                    </span>
+                </span>
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+                     stroke="currentColor" stroke-width="2.4"
+                     stroke-linecap="round" stroke-linejoin="round"
+                     aria-hidden="true" x-show="!agotado">
+                    <path d="M5 12h14M13 5l7 7-7 7"/>
+                </svg>
+            </button>
+        </div>
+
         {{-- ══════════════════════════════════════════════════════════════════════
              FILTER BAR (mobile) + ALLERGEN SHEET — x-data local para allergensOpen
              ══════════════════════════════════════════════════════════════════════ --}}
@@ -1026,25 +1052,6 @@
                         {{ $cat->name }}
                     </button>
                     @endforeach
-                    {{-- Menú del Día — chip compacto (DS: DailyMenuFilterChip compact, mobile) --}}
-                    <template x-if="menuData !== null">
-                        <span class="contents">
-                            <span class="dm-filter-sep" aria-hidden="true"></span>
-                            <button type="button"
-                                    :class="'dm-chip dm-chip--compact' + (agotado ? ' dm-chip--agotado' : '')"
-                                    @click="!agotado && openStepper()"
-                                    :disabled="agotado"
-                                    :aria-label="agotado ? 'Menú del día agotado' : 'Ver menú del día'">
-                                <span class="dm-chip__mark" aria-hidden="true">◇</span>
-                                <span class="dm-chip__main">
-                                    <span class="dm-chip__top">Menú del Día</span>
-                                    <span class="dm-chip__sub"
-                                          x-text="agotado ? 'Agotado' : parseFloat(menuData?.menu?.price ?? 0).toFixed(2).replace('.', ',') + ' €'">
-                                    </span>
-                                </span>
-                            </button>
-                        </span>
-                    </template>
                 </div>
                 {{-- Desplegable de alérgenos --}}
                 <div class="allergen-dropdown" @click.away="allergensOpen = false">

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -981,7 +981,8 @@
              DAILY MENU SCOPE — envuelve filter-bar + carta__main para que el chip
              mobile y el sidebar chip compartan el mismo scope Alpine.
              ══════════════════════════════════════════════════════════════════════ --}}
-        <div x-data="dailyMenuBanner('{{ $table->unique_hash }}')">
+        <div x-data="dailyMenuBanner('{{ $table->unique_hash }}')"
+             style="flex:1;min-height:0;display:flex;flex-direction:column;overflow:hidden">
 
         {{-- DS: dm-chip-strip — visible en mobile Y tablet (desktop: sidebar lo maneja) --}}
         <div class="dm-chip-strip"

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -3344,7 +3344,7 @@
                     </button>
                     <div class="tapas-head__pre">
                         <span class="tapas-head__ornament" aria-hidden="true">— ❦ —</span>
-                        <span class="tapas-head__kicker">LA CASA · TAPAS</span>
+                        <span class="tapas-head__kicker">{{ mb_strtoupper($table->user->business_name ?: $table->user->name) }} · TAPAS</span>
                     </div>
                     <h2 class="tapas-head__big"
                         x-text="limitReached ? 'Has llegado al límite' : (left > 0 ? 'Lleva una tapa' : 'Sin tapas disponibles')">

--- a/routes/api.php
+++ b/routes/api.php
@@ -64,3 +64,6 @@ Route::get('/v1/menu/{hash}/daily-menu',        [DailyMenuPublicController::clas
 Route::post('/v1/menu/{hash}/daily-menu/order', [DailyMenuPublicController::class, 'order'])
     ->middleware('throttle:10,1')
     ->name('api.daily-menu.order');
+Route::post('/v1/menu/{hash}/cancel-alacarte', [DailyMenuPublicController::class, 'cancelAlaCarteOrders'])
+    ->middleware('throttle:10,1')
+    ->name('api.daily-menu.cancel-alacarte');


### PR DESCRIPTION
## Resumen

- **Banner menú del día persistente**: elimina auto-dismiss de 22s; el banner permanece visible hasta que el usuario lo cierra manualmente con la X
- **Fix sticky scroll**: `.dm-banner` es ahora hijo directo de `carta__body` para que `position:sticky` funcione correctamente al hacer scroll
- **Chip DS persistente**: añade `dm-chip` en sidebar (tablet/desktop) y `dm-chip-strip` en mobile/tablet; el chip permanece aunque el banner se cierre
- **Pedidos menú del día con variante `--dm`**: lista de pedidos, detalle y popup de confirmación muestran el estilo dorado del DS (◇ badge, tag "MENÚ DEL DÍA", lista de platos seleccionados)
- **`order_summary` al store**: el stepper envía el resumen del pedido al store `orders` tras confirmar, sin necesidad de recargar la página
- **Propina sugerida dinámica**: los porcentajes de propina se calculan sobre el total real de la cuenta en todos los flujos de pago
- **Animación indicador de tapas**: suaviza la transición del indicador en la carta digital
- **Scope Alpine unificado**: `x-data="dailyMenuBanner"` envuelve filter-bar + `carta__main` para que chip mobile y sidebar compartan el mismo scope

## Archivos modificados

- `resources/js/alpine/daily-menu-banner.js`
- `resources/views/components/daily-menu-banner.blade.php`
- `resources/views/menu/show.blade.php`
- `app/Http/Controllers/MenuController.php`
- `app/Http/Controllers/DailyMenuPublicController.php`
- `public/css/carta/flows/daily-menu.css`