### PR TITLE
feat: add SecurityHeaders middleware (CSP, X-Frame-Options, HSTS)

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Añade cabeceras de seguridad HTTP a todas las respuestas.
+ *
+ * Cubre: CSP, X-Frame-Options, X-Content-Type-Options,
+ * Referrer-Policy, Permissions-Policy y HSTS (producción).
+ *
+ * @author BenjaminDTS
+ */
+class SecurityHeaders
+{
+    /**
+     * @param  Request  $request
+     * @param  Closure  $next
+     * @return Response
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('X-XSS-Protection', '1; mode=block');
+        $response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+        $response->headers->set(
+            'Permissions-Policy',
+            'camera=(), microphone=(), geolocation=(self), payment=(self)'
+        );
+        $response->headers->set(
+            'Content-Security-Policy',
+            implode('; ', [
+                "default-src 'self'",
+                "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com",
+                "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+                "font-src 'self' https://fonts.gstatic.com",
+                "img-src 'self' data: blob: https:",
+                "connect-src 'self' https://api.stripe.com https://api.openai.com https://api.x.ai",
+                "frame-src https://js.stripe.com https://hooks.stripe.com",
+                "object-src 'none'",
+                "base-uri 'self'",
+                "form-action 'self'",
+                "upgrade-insecure-requests",
+            ])
+        );
+
+        if (config('app.env') === 'production') {
+            $response->headers->set(
+                'Strict-Transport-Security',
+                'max-age=31536000; includeSubDomains; preload'
+            );
+        }
+
+        return $response;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -15,6 +15,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->trustProxies(at: '*');
         $middleware->web(append: [
             \App\Http\Middleware\PreserveFlashForAjax::class,
+            \App\Http\Middleware\SecurityHeaders::class,
         ]);
         $middleware->alias([
             'role'            => \App\Http\Middleware\EnsureRole::class,


### PR DESCRIPTION
## Summary

- Nuevo middleware `SecurityHeaders` aplicado a todo el stack web
- Cabeceras implementadas: `Content-Security-Policy`, `X-Frame-Options`, `X-Content-Type-Options`, `X-XSS-Protection`, `Referrer-Policy`, `Permissions-Policy`, `Strict-Transport-Security` (solo producción)
- CSP configurada para permitir exactamente lo que Zampa usa: Stripe JS, Google Fonts, OpenAI/xAI API

## Cabeceras añadidas

| Header | Valor | Protección |
|--------|-------|------------|
| `Content-Security-Policy` | `default-src 'self'` + Stripe + Fonts + xAI | XSS, injection |
| `X-Frame-Options` | `SAMEORIGIN` | Clickjacking |
| `X-Content-Type-Options` | `nosniff` | MIME sniffing |
| `X-XSS-Protection` | `1; mode=block` | XSS legacy browsers |
| `Referrer-Policy` | `strict-origin-when-cross-origin` | Fuga de URLs |
| `Permissions-Policy` | camera/mic off, geo/payment self | Feature abuse |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains; preload` | Solo producción — MITM/downgrade |

## Test plan

- [ ] `php artisan serve` arranca sin errores
- [ ] Navegar a `/login` — verificar headers en DevTools > Network > Response Headers
- [ ] Verificar que Stripe (checkout), Google Fonts y el chatbot siguen funcionando
- [ ] En producción: confirmar que HSTS aparece en respuesta HTTPS

## Motivación

Mejora de rúbrica DAW — criterio Seguridad (6 → 5/5 pts). Cubre ataques OWASP: XSS, Clickjacking, MIME sniffing, downgrade attacks.