### PR TITLE
fix: Vite dev environment (IPv4, HMR CSS, CSP)

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -33,21 +33,25 @@ class SecurityHeaders
             'Permissions-Policy',
             'camera=(), microphone=(), geolocation=(self), payment=(self)'
         );
+        $isLocal  = config('app.env') === 'local';
+        $viteSrc  = $isLocal ? ' http://127.0.0.1:5173' : '';
+        $viteWs   = $isLocal ? ' ws://127.0.0.1:5173'   : '';
+
         $response->headers->set(
             'Content-Security-Policy',
-            implode('; ', [
+            implode('; ', array_filter([
                 "default-src 'self'",
-                "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com",
-                "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-                "font-src 'self' https://fonts.gstatic.com",
+                "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com{$viteSrc}",
+                "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com{$viteSrc}",
+                "font-src 'self' https://fonts.gstatic.com{$viteSrc}",
                 "img-src 'self' data: blob: https:",
-                "connect-src 'self' https://api.stripe.com https://api.openai.com https://api.x.ai",
+                "connect-src 'self' https://api.stripe.com https://api.openai.com https://api.x.ai{$viteSrc}{$viteWs}",
                 "frame-src https://js.stripe.com https://hooks.stripe.com",
                 "object-src 'none'",
                 "base-uri 'self'",
                 "form-action 'self'",
-                "upgrade-insecure-requests",
-            ])
+                $isLocal ? null : "upgrade-insecure-requests",
+            ]))
         );
 
         if (config('app.env') === 'production') {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,3 +1,4 @@
+import '../css/app.css';
 import './bootstrap';
 
 import Alpine from 'alpinejs';

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,7 +14,7 @@
         <link href="https://fonts.bunny.net/css?family=plus-jakarta-sans:400,500,600,700|playfair-display:400,600,700&display=swap" rel="stylesheet" />
 
         <!-- Scripts -->
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @vite(['resources/js/app.js'])
 
         <!-- Dark mode: apply before paint to avoid flash -->
         <script>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -14,7 +14,7 @@
         <link href="https://fonts.bunny.net/css?family=plus-jakarta-sans:400,500,600,700|playfair-display:400,600,700&display=swap" rel="stylesheet" />
 
         <!-- Scripts -->
-        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @vite(['resources/js/app.js'])
 
         <!-- Dark mode: apply before paint to avoid flash -->
         <script>

--- a/resources/views/layouts/superadmin.blade.php
+++ b/resources/views/layouts/superadmin.blade.php
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{{ config('app.name', 'Zampa') }} — Superadmin</title>
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @vite(['resources/js/app.js'])
     @stack('styles')
 </head>
 <body class="h-full font-sans antialiased">

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -15,7 +15,7 @@
     @else
     <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@700;800;900&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
     @endif
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @vite(['resources/js/app.js'])
     <link rel="stylesheet" href="{{ asset('css/carta/colors_and_type.css') }}">
     <link rel="stylesheet" href="{{ asset('css/carta/styles.css') }}">
     <meta name="stripe-key" content="{{ $stripePublicKey }}">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -12,7 +12,7 @@
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=plus-jakarta-sans:400,500,600,700|playfair-display:400,600,700,700i&display=swap" rel="stylesheet">
 
-    @vite(['resources/css/app.css', 'resources/js/app.js'])
+    @vite(['resources/js/app.js'])
 
     {{-- Dark mode: apply before paint to avoid flash --}}
     <script>

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,9 @@ import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
 
 export default defineConfig({
+    server: {
+        host: '127.0.0.1',
+    },
     plugins: [
         laravel({
             input: [


### PR DESCRIPTION
## Summary

- **IPv4 forzado en Vite**: Node 18+ resuelve `localhost` como `::1` (IPv6). Algunos navegadores fallaban al cargar `http://[::1]:5173`. Añadido `server.host: '127.0.0.1'` en `vite.config.js`.
- **CSS importado desde `app.js`**: En Vite dev mode, los entry points CSS se sirven como módulos JS (para HMR). Un `<link rel="stylesheet">` que apunte a ellos es rechazado por el browser por `Content-Type: text/javascript`. Al importar el CSS desde `app.js`, Vite lo inyecta correctamente vía el sistema de módulos.
- **`@vite` limpiado en todos los layouts**: Eliminado `resources/css/app.css` del directive `@vite` en los 5 layouts (ya lo gestiona `app.js`).
- **CSP permite Vite en local**: `SecurityHeaders` bloqueaba silenciosamente todos los scripts y estilos de `127.0.0.1:5173`. Añadido el origen de Vite a `script-src`, `style-src`, `font-src` y `connect-src` (incluido `ws://` para HMR) cuando `APP_ENV=local`. En producción el comportamiento no cambia.

## Test plan

- [ ] Lanzar con `/launch` y comprobar que los estilos cargan en `http://localhost:8000`
- [ ] Verificar que el HMR funciona (editar un archivo Blade y ver recarga automática)
- [ ] Verificar que en producción el CSP no incluye los orígenes de Vite
- [ ] `php artisan test` pasa sin errores
