### PR TITLE
fix: remove pre-selected tip amount on payment screens

### DIFF
--- a/resources/js/alpine/bill.js
+++ b/resources/js/alpine/bill.js
@@ -484,9 +484,9 @@ export function registerBill() {
 
         openCashTip() {
             this.choosing       = false;
-            this.cashTipPercent = suggestedTipPercent(this.orderTotal);
-            this.cashTipAmount  = calculateTipFromPercent(this.orderTotal, this.cashTipPercent);
-            this.cashGrandTotal = this.orderTotal + this.cashTipAmount;
+            this.cashTipPercent = null;
+            this.cashTipAmount  = 0;
+            this.cashGrandTotal = this.orderTotal;
             this.showingCashTip = true;
             this.step           = 'cashConfirm';
         },

--- a/resources/js/alpine/bill.js
+++ b/resources/js/alpine/bill.js
@@ -520,9 +520,9 @@ export function registerBill() {
             this.splitTipBase       = amount;
             this.splitTipType       = type;
             this.splitTipItemIds    = itemIds || [];
-            this.splitTipPercent    = suggestedTipPercent(amount);
-            this.splitTipAmount     = calculateTipFromPercent(amount, this.splitTipPercent);
-            this.splitTipGrandTotal = amount + this.splitTipAmount;
+            this.splitTipPercent    = null;
+            this.splitTipAmount     = 0;
+            this.splitTipGrandTotal = amount;
             this.splitShowItems     = false;
             this.splitShowEq        = false;
             this.showingSplitTip    = true;

--- a/resources/js/alpine/bill.js
+++ b/resources/js/alpine/bill.js
@@ -623,9 +623,9 @@ export function registerBill() {
         openMixedTip() {
             this.showingMixed       = false;
             this.mixedTipBase       = this.mixedCardAmount;
-            this.mixedTipPercent    = suggestedTipPercent(this.mixedCardAmount);
-            this.mixedTipAmount     = calculateTipFromPercent(this.mixedCardAmount, this.mixedTipPercent);
-            this.mixedTipGrandTotal = this.mixedCardAmount + this.mixedTipAmount;
+            this.mixedTipPercent    = null;
+            this.mixedTipAmount     = 0;
+            this.mixedTipGrandTotal = this.mixedCardAmount;
             this.showingMixedTip    = true;
             this.step               = 'mixedTip';
         },

--- a/resources/js/alpine/bill.js
+++ b/resources/js/alpine/bill.js
@@ -242,9 +242,9 @@ export function registerBill() {
             } catch {
                 // use cached total from page load
             }
-            this.tipPercent = suggestedTipPercent(this.orderTotal);
-            this.tipAmount  = calculateTipFromPercent(this.orderTotal, this.tipPercent);
-            this.grandTotal = this.orderTotal + this.tipAmount;
+            this.tipPercent = null;
+            this.tipAmount  = 0;
+            this.grandTotal = this.orderTotal;
             this.showingTip = true;
             this.step       = 'tip';
         },


### PR DESCRIPTION
## Summary

- `openCardPayment`: tip starts unselected (was: auto-calculated by total range)
- `openCashTip`: tip starts unselected (was: auto-calculated by total range)
- `openSplitTip`: tip starts unselected (was: auto-calculated by split amount)
- `openMixedTip`: tip starts unselected (was: auto-calculated by card portion)

All four payment flows now open with `tipPercent = null` and `tipAmount = 0` so the customer sees no pre-selected option.

## Test plan

- [ ] Open payment screen with card → no tip % highlighted
- [ ] Open payment screen with cash → no tip % highlighted
- [ ] Open split payment tip screen → no tip % highlighted
- [ ] Open mixed payment tip screen → no tip % highlighted
- [ ] Selecting a tip % still works correctly after the fix
- [ ] `php artisan test` → 907/907 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)