### PR TITLE
style: carta digital — cierre reactivo en tiempo real y micro-animaciones

### DIFF
--- a/app/Http/Controllers/Api/CartaStatusController.php
+++ b/app/Http/Controllers/Api/CartaStatusController.php
@@ -41,6 +41,7 @@ class CartaStatusController extends Controller
             'kitchen_close_at'            => ($config && $kitchenOpen)  ? $config->kitchenCloseAtDisplay()    : null,
             'business_open'               => $businessOpen,
             'business_next_opening'       => ($config && ! $businessOpen) ? $config->getBusinessNextOpeningTime() : null,
+            'business_close_at'           => ($config && $businessOpen)  ? $config->businessCloseAtDisplay()  : null,
             'ordering_allowed'            => ! $config || $config->isOrderingAllowed(),
         ]);
     }

--- a/app/Http/Controllers/MenuController.php
+++ b/app/Http/Controllers/MenuController.php
@@ -41,6 +41,7 @@ class MenuController extends Controller
         $orderingAllowed        = ! $config || $config->isOrderingAllowed();
         $businessNextOpening    = ($config && ! $businessOpen) ? $config->getBusinessNextOpeningTime() : null;
         $minutesUntilClose      = ($config && $businessOpen && ! $orderingAllowed) ? $config->minutesUntilBusinessClose() : null;
+        $businessCloseAt        = ($config && $businessOpen) ? $config->businessCloseAtDisplay() : null;
 
         $kitchenOpen              = ! $config || $config->isKitchenOpen();
         $nextOpeningTime          = ($config && ! $kitchenOpen) ? $config->nextOpeningTime() : null;
@@ -218,7 +219,7 @@ class MenuController extends Controller
             'hasActiveOrder', 'activeOrderTotal', 'billRequested', 'stripePublicKey',
             'splitPaymentEnabled', 'splitPaymentMaxParts', 'activeOrderItemsForAlpine', 'allOrdersForAlpine',
             'businessOpen', 'orderingAllowed', 'businessNextOpening', 'minutesUntilClose',
-            'minutesUntilKitchenClose', 'kitchenCloseAt'
+            'minutesUntilKitchenClose', 'kitchenCloseAt', 'businessCloseAt'
         ));
     }
 }

--- a/app/Models/TapaConfig.php
+++ b/app/Models/TapaConfig.php
@@ -235,6 +235,42 @@ class TapaConfig extends Model
     }
 
     /**
+     * Hora de cierre del tramo de negocio activo en formato "HH:MM".
+     * Null si el negocio está cerrado o no hay tramos configurados.
+     *
+     * @return string|null
+     */
+    public function businessCloseAtDisplay(): ?string
+    {
+        if (! $this->isBusinessOpen()) {
+            return null;
+        }
+
+        $schedules = $this->businessSchedules;
+
+        if ($schedules->isEmpty()) {
+            return null;
+        }
+
+        $now = Carbon::now()->format('H:i:s');
+
+        foreach ($schedules as $schedule) {
+            $opens  = $schedule->opens_at;
+            $closes = $schedule->closes_at;
+
+            $inSlot = ($opens <= $closes)
+                ? ($now >= $opens && $now <= $closes)
+                : ($now >= $opens || $now <= $closes);
+
+            if ($inSlot) {
+                return substr($closes, 0, 5);
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * Devuelve la hora de apertura del próximo tramo de negocio (HH:MM).
      * Null si no hay tramos configurados.
      *

--- a/app/Models/TapaConfig.php
+++ b/app/Models/TapaConfig.php
@@ -471,6 +471,8 @@ class TapaConfig extends Model
             $target->addDay();
         }
 
-        return (int) $now->diffInMinutes($target);
+        // ceil: cualquier fracción de minuto cuenta como 1, así el banner
+        // no desaparece en el poll cuando quedan <60 segundos para el cierre.
+        return (int) ceil($now->diffInSeconds($target) / 60);
     }
 }

--- a/public/css/carta/components/cart.css
+++ b/public/css/carta/components/cart.css
@@ -11,7 +11,12 @@
   box-shadow: 0 10px 30px rgba(15, 61, 42, 0.45);
   animation: slide-up 220ms var(--ease-out);
 }
-@keyframes slide-up { from { transform: translateY(100%); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+@keyframes slide-up   { from { transform: translateY(100%); opacity: 0; } to   { transform: translateY(0);    opacity: 1; } }
+@keyframes slide-down { from { transform: translateY(0);    opacity: 1; } to   { transform: translateY(100%); opacity: 0; } }
+.cart-bar--leaving {
+  animation: slide-down 220ms var(--ease-out) forwards;
+  pointer-events: none;
+}
 .cart-bar__left { display: flex; align-items: center; gap: 10px; }
 .cart-bar__icon { width: 36px; height: 36px; border-radius: 9999px; background: rgba(34, 197, 94, 0.18); display: inline-flex; align-items: center; justify-content: center; position: relative; }
 .cart-bar__icon svg { width: 18px; height: 18px; }

--- a/public/css/carta/components/cart.css
+++ b/public/css/carta/components/cart.css
@@ -19,6 +19,12 @@
 }
 .cart-bar__left { display: flex; align-items: center; gap: 10px; }
 .cart-bar__icon { width: 36px; height: 36px; border-radius: 9999px; background: rgba(34, 197, 94, 0.18); display: inline-flex; align-items: center; justify-content: center; position: relative; }
+.cart-bar__icon--bump { animation: cart-icon-bump 300ms cubic-bezier(0.34, 1.56, 0.64, 1); }
+@keyframes cart-icon-bump {
+  0%   { transform: scale(1); }
+  45%  { transform: scale(1.28); }
+  100% { transform: scale(1); }
+}
 .cart-bar__icon svg { width: 18px; height: 18px; }
 .cart-bar__count { position: absolute; top: -3px; right: -3px; min-width: 18px; height: 18px; background: var(--badge-count); color: white; border-radius: 9999px; font-family: var(--font-display); font-weight: 800; font-size: 10px; display: inline-flex; align-items: center; justify-content: center; padding: 0 4px; line-height: 1; }
 .cart-bar__total { color: var(--price-gold); font-family: var(--font-display); font-weight: 800; font-size: 15px; font-variant-numeric: tabular-nums; }

--- a/public/css/carta/components/products.css
+++ b/public/css/carta/components/products.css
@@ -40,6 +40,26 @@
 .pcard__foot { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-top: 4px; min-width: 0; }
 .pcard__price { font-family: var(--font-display); font-weight: 800; font-size: 18px; color: var(--price-gold); font-variant-numeric: tabular-nums; letter-spacing: -0.01em; white-space: nowrap; flex-shrink: 0; }
 
+/* Closed badge — shown in pcard__foot when ordering is not allowed */
+.pcard__closed {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 4px 10px; border-radius: 9999px;
+  background: var(--color-amber-100); color: var(--color-amber-800);
+  font-family: var(--font-body); font-size: 11px; font-weight: 600;
+  border: 1px solid rgba(245,158,11,0.25);
+  white-space: nowrap; flex-shrink: 0;
+}
+.pcard__closed::before {
+  content: ''; width: 6px; height: 6px; border-radius: 50%;
+  background: var(--color-amber-400);
+  flex-shrink: 0;
+}
+[data-theme="dark"] .pcard__closed {
+  background: rgba(251,191,36,0.12); color: var(--color-amber-300);
+  border-color: rgba(251,191,36,0.25);
+}
+[data-theme="dark"] .pcard__closed::before { background: var(--color-amber-300); }
+
 /* Plus button */
 .btn-add {
   width: 34px; height: 34px; border-radius: 9999px;

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -752,11 +752,12 @@
 }
 .banner-closed__dot {
   width: 10px; height: 10px; border-radius: 50%;
-  background: var(--color-amber-500);
-  box-shadow: 0 0 0 3px rgba(245,158,11,0.20);
+  background: var(--color-amber-400);
+  box-shadow: 0 0 0 4px rgba(245,158,11,0.25);
+  animation: cutoffPulse 1.4s ease-in-out infinite;
   flex-shrink: 0;
 }
-[data-theme="dark"] .banner-closed__dot { background: var(--color-amber-400); box-shadow: 0 0 0 3px rgba(251,191,36,0.20); }
+[data-theme="dark"] .banner-closed__dot { background: var(--color-amber-400); box-shadow: 0 0 0 4px rgba(251,191,36,0.25); }
 .banner-closed__copy { flex: 1; min-width: 0; line-height: 1.25; }
 .banner-closed__copy strong {
   display: block;

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -735,7 +735,7 @@
 
 /* Kitchen closed banner */
 .banner-closed {
-  margin: 12px 16px 0; padding: 14px 16px; border-radius: 14px;
+  margin: 12px 16px; padding: 14px 16px; border-radius: 14px;
   background: var(--color-amber-100); color: var(--color-amber-800);
   display: flex; align-items: center; gap: 12px;
 }

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -745,7 +745,7 @@
 .banner-closed__sub { font-family: var(--font-body); font-size: 12px; margin-top: 2px; line-height: 1.4; }
 
 .carta[data-bp="mobile"] .banner-closed {
-  margin: 8px 12px; padding: 10px 12px; gap: 8px; border-radius: 10px;
+  margin: 8px 12px 0; padding: 10px 12px; gap: 8px; border-radius: 10px;
 }
 .carta[data-bp="mobile"] .banner-closed__ic { font-size: 18px; }
 .carta[data-bp="mobile"] .banner-closed__title { font-size: 12px; }

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -744,6 +744,13 @@
 .banner-closed__title { font-family: var(--font-display); font-weight: 800; font-size: 15px; }
 .banner-closed__sub { font-family: var(--font-body); font-size: 12px; margin-top: 2px; line-height: 1.4; }
 
+.carta[data-bp="mobile"] .banner-closed {
+  margin: 8px 12px; padding: 10px 12px; gap: 8px; border-radius: 10px;
+}
+.carta[data-bp="mobile"] .banner-closed__ic { font-size: 18px; }
+.carta[data-bp="mobile"] .banner-closed__title { font-size: 12px; }
+.carta[data-bp="mobile"] .banner-closed__sub { font-size: 11px; }
+
 /* utility */
 .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }
 

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -733,23 +733,55 @@
 .stripe-mock__row { display: flex; align-items: center; gap: 10px; padding: 10px 12px; background: var(--bg-base); border: 1px solid var(--border-subtle); border-radius: 8px; font-family: var(--font-mono); font-size: 13px; color: var(--fg-muted); }
 .stripe-mock__row .glyph { color: var(--fg-primary); }
 
-/* Kitchen closed banner */
+/* Kitchen closed banner — mismo estilo de strip que .cutoff-strip */
 .banner-closed {
-  margin: 12px 16px; padding: 14px 16px; border-radius: 14px;
-  background: var(--color-amber-100); color: var(--color-amber-800);
+  position: relative;
+  background: linear-gradient(180deg, var(--color-amber-100), color-mix(in oklab, var(--color-amber-200) 70%, var(--color-amber-100)));
+  border-bottom: 1px solid color-mix(in oklab, var(--color-amber-400) 30%, var(--border-subtle));
+  overflow: hidden;
+  flex-shrink: 0;
+}
+[data-theme="dark"] .banner-closed {
+  background: linear-gradient(180deg, rgba(251,191,36,0.10), rgba(251,191,36,0.05));
+  border-bottom-color: rgba(251,191,36,0.30);
+}
+.banner-closed__row {
+  position: relative;
   display: flex; align-items: center; gap: 12px;
+  padding: 10px 16px;
 }
-[data-theme="dark"] .banner-closed { background: rgba(251, 191, 36, 0.12); color: var(--color-amber-300); }
-.banner-closed__ic { font-size: 28px; line-height: 1; }
-.banner-closed__title { font-family: var(--font-display); font-weight: 800; font-size: 15px; }
-.banner-closed__sub { font-family: var(--font-body); font-size: 12px; margin-top: 2px; line-height: 1.4; }
-
-.carta[data-bp="mobile"] .banner-closed {
-  margin: 8px 12px 0; padding: 10px 12px; gap: 8px; border-radius: 10px;
+.banner-closed__dot {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: var(--color-amber-500);
+  box-shadow: 0 0 0 3px rgba(245,158,11,0.20);
+  flex-shrink: 0;
 }
-.carta[data-bp="mobile"] .banner-closed__ic { font-size: 18px; }
-.carta[data-bp="mobile"] .banner-closed__title { font-size: 12px; }
-.carta[data-bp="mobile"] .banner-closed__sub { font-size: 11px; }
+[data-theme="dark"] .banner-closed__dot { background: var(--color-amber-400); box-shadow: 0 0 0 3px rgba(251,191,36,0.20); }
+.banner-closed__copy { flex: 1; min-width: 0; line-height: 1.25; }
+.banner-closed__copy strong {
+  display: block;
+  font-family: var(--font-display); font-weight: 800;
+  font-size: 13px; color: var(--color-amber-800);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.banner-closed__copy span {
+  display: block;
+  font-family: var(--font-body); font-size: 11.5px;
+  color: color-mix(in oklab, var(--color-amber-800) 75%, var(--fg-secondary));
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+[data-theme="dark"] .banner-closed__copy strong { color: var(--color-amber-300); }
+[data-theme="dark"] .banner-closed__copy span { color: color-mix(in oklab, var(--color-amber-300) 75%, var(--fg-secondary)); }
+.banner-closed__chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 10px; border-radius: 9999px;
+  background: rgba(245,158,11,0.18);
+  color: var(--color-amber-800);
+  font-family: var(--font-body); font-size: 11px; font-weight: 700;
+  letter-spacing: 0.02em; white-space: nowrap; flex-shrink: 0;
+}
+.banner-closed__chip .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+[data-theme="dark"] .banner-closed__chip { background: rgba(251,191,36,0.18); color: var(--color-amber-300); }
 
 /* utility */
 .sr-only { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0,0,0,0); }

--- a/public/css/carta/layout/layout.css
+++ b/public/css/carta/layout/layout.css
@@ -137,6 +137,12 @@ html, body {
 .kitchen-pill--closed { align-items: flex-start; padding: 8px 12px; }
 .kitchen-pill--closed .kitchen-pill__dot { margin-top: 5px; }
 
+/* Mobile: pill más compacta, solo primera línea visible */
+.carta[data-bp="mobile"] .kitchen-pill--closed { padding: 5px 8px; align-items: center; }
+.carta[data-bp="mobile"] .kitchen-pill--closed .kitchen-pill__dot { margin-top: 0; }
+.carta[data-bp="mobile"] .kitchen-pill--closed .kitchen-pill__l2 { display: none; }
+.carta[data-bp="mobile"] .kitchen-pill--closed .kitchen-pill__l1 { font-size: 11px; }
+
 /* Theme toggle */
 .theme-toggle {
   width: 36px; height: 36px; border-radius: 9999px;

--- a/public/css/carta/layout/layout.css
+++ b/public/css/carta/layout/layout.css
@@ -194,7 +194,11 @@ html, body {
   border-bottom: 1px solid var(--border-subtle);
   flex-shrink: 0;
 }
-.carta[data-bp="mobile"] .filter-bar { display: flex; }
+.carta[data-bp="mobile"] .filter-bar {
+  display: flex;
+  background: var(--bg-chip);
+  border-top: 1px solid var(--border-subtle);
+}
 
 .filter-row {
   display: flex;

--- a/public/css/carta/layout/layout.css
+++ b/public/css/carta/layout/layout.css
@@ -197,7 +197,6 @@ html, body {
 .carta[data-bp="mobile"] .filter-bar {
   display: flex;
   background: var(--bg-chip);
-  border-top: 1px solid var(--border-subtle);
 }
 
 .filter-row {

--- a/public/css/carta/layout/layout.css
+++ b/public/css/carta/layout/layout.css
@@ -448,6 +448,12 @@ html, body {
   cursor: pointer; display: inline-flex; align-items: center; justify-content: center; gap: 4px;
 }
 .dest-toggle button.active { background: var(--bg-base); color: var(--fg-primary); box-shadow: var(--shadow-card); }
+.carta[data-theme="dark"] .dest-toggle button.active {
+  background: #22D3EE;
+  color: #001823;
+  font-weight: 800;
+  box-shadow: 0 0 0 1px rgba(34,211,238,0.6) inset, 0 4px 10px rgba(34,211,238,0.25);
+}
 
 /* ----- Body / product grid -----
    Bottom padding clears the floating FABs (bottom: 92 + 56 height = 148) and

--- a/public/css/carta/themes/themes.css
+++ b/public/css/carta/themes/themes.css
@@ -725,17 +725,13 @@
 .category__closedDot {
   width: 7px; height: 7px; border-radius: 50%;
   background: var(--color-amber-400);
-  box-shadow: 0 0 0 3px rgba(245,158,11,0.20);
-  animation: cat-closed-pulse 1.8s ease-in-out infinite;
+  box-shadow: 0 0 0 0 rgba(245,158,11,0.45);
+  animation: cutoffPulse 1.4s ease-in-out infinite;
   flex-shrink: 0;
 }
 [data-theme="dark"] .category__closedDot {
   background: var(--color-amber-300);
-  box-shadow: 0 0 0 3px rgba(251,191,36,0.20);
-}
-@keyframes cat-closed-pulse {
-  0%, 100% { transform: scale(1);   opacity: 1; }
-  50%      { transform: scale(0.85); opacity: 0.65; }
+  box-shadow: 0 0 0 0 rgba(251,191,36,0.45);
 }
 
 

--- a/resources/js/alpine/cart.js
+++ b/resources/js/alpine/cart.js
@@ -139,6 +139,8 @@ export function registerCart() {
         _snapTotal: 0,
         /** @type {boolean} True while the slide-down exit animation is running. */
         _barLeaving: false,
+        /** @type {number|null} Timer ID for the leave animation cleanup. */
+        _barLeaveTimer: null,
         /** @type {boolean} Submission in progress. */
         sending: false,
         /** @type {boolean} Order successfully sent. */
@@ -326,6 +328,7 @@ export function registerCart() {
                     this.items = this.items.filter(i => !i.isTapa);
                 }
             }
+            if (this.count === 0) this._triggerLeave();
         },
 
         toggleRemove(key, ing) {
@@ -359,6 +362,20 @@ export function registerCart() {
 
         get count() {
             return this.items.reduce((s, i) => s + i.quantity, 0);
+        },
+
+        /**
+         * Activa la animación de salida del cart-bar.
+         * Mantiene el elemento en el DOM 230ms (duración del slide-down) y luego lo desmonta.
+         */
+        _triggerLeave() {
+            if (this._barLeaving) return;
+            clearTimeout(this._barLeaveTimer);
+            this._barLeaving   = true;
+            this._barLeaveTimer = setTimeout(() => {
+                this._barLeaving    = false;
+                this._barLeaveTimer = null;
+            }, 230);
         },
 
         get barShouldShow() {
@@ -447,6 +464,7 @@ export function registerCart() {
                     this.sent  = true;
                     this.items = [];
                     this.open  = false;
+                    this._triggerLeave();
                 } else {
                     this.error = data.message ?? 'Error al enviar el pedido.';
                 }

--- a/resources/js/alpine/schedule.js
+++ b/resources/js/alpine/schedule.js
@@ -23,6 +23,7 @@ export function registerSchedule() {
         businessOpen:             true,
         businessNextOpening:      null,
         orderingAllowed:          true,
+        bizDismissed:             false,
         _hash: '',
 
         init() {

--- a/resources/js/alpine/schedule.js
+++ b/resources/js/alpine/schedule.js
@@ -3,8 +3,8 @@
  *
  * Se inicializa desde el JSON `menu-context` que el servidor inyecta en la página
  * y se sincroniza cada 30 s mediante polling al endpoint /api/v1/carta/{hash}/schedule.
- * Todos los indicadores de estado en la carta digital leen de este store,
- * por lo que cambian sin recargar la página cuando la cocina abre o cierra.
+ * Además programa un setTimeout preciso para cada hora de cierre conocida, de forma que
+ * los ítems se bloquean al segundo exacto sin necesidad de recargar la página.
  *
  * @author Ayrton
  */
@@ -12,6 +12,23 @@
 function readMenuContext() {
     const raw = document.getElementById('menu-context');
     return raw ? JSON.parse(raw.textContent) : {};
+}
+
+/**
+ * Milisegundos hasta la hora "HH:MM".
+ * Si ya pasó hoy, apunta al mismo slot de mañana (horarios de madrugada).
+ *
+ * @param {string} timeStr  — "HH:MM"
+ * @returns {number|null}
+ */
+function msUntilTimeStr(timeStr) {
+    if (!timeStr) return null;
+    const [h, m] = timeStr.split(':').map(Number);
+    const now    = new Date();
+    const target = new Date(now);
+    target.setHours(h, m, 0, 0);
+    if (target <= now) target.setDate(target.getDate() + 1);
+    return target - now;
 }
 
 export function registerSchedule() {
@@ -22,20 +39,26 @@ export function registerSchedule() {
         kitchenCloseAt:           null,
         businessOpen:             true,
         businessNextOpening:      null,
+        businessCloseAt:          null,
         orderingAllowed:          true,
         bizDismissed:             false,
-        _hash: '',
+        _hash:              '',
+        _kitchenCloseTimer: null,
+        _bizCloseTimer:     null,
 
         init() {
-            const ctx             = readMenuContext();
+            const ctx = readMenuContext();
             this.kitchenOpen              = ctx.kitchenOpen              ?? true;
             this.kitchenNextOpening       = ctx.kitchenNextOpening       ?? null;
             this.minutesUntilKitchenClose = ctx.minutesUntilKitchenClose ?? null;
             this.kitchenCloseAt           = ctx.kitchenCloseAt           ?? null;
             this.businessOpen             = ctx.businessOpen             ?? true;
             this.businessNextOpening      = ctx.businessNextOpening      ?? null;
+            this.businessCloseAt          = ctx.businessCloseAt          ?? null;
             this.orderingAllowed          = ctx.orderingAllowed          ?? true;
             this._hash                    = ctx.tableHash                ?? '';
+
+            this._scheduleCloseTimers();
 
             if (this._hash) {
                 setInterval(() => this._poll(), 30_000);
@@ -43,7 +66,46 @@ export function registerSchedule() {
         },
 
         /**
+         * Programa setTimeout para cada hora de cierre conocida.
+         * Se cancela y reprograma cada vez que llegan datos nuevos del servidor.
+         */
+        _scheduleCloseTimers() {
+            // ── Cocina ────────────────────────────────────────────────────────
+            clearTimeout(this._kitchenCloseTimer);
+            this._kitchenCloseTimer = null;
+
+            if (this.kitchenOpen && this.kitchenCloseAt) {
+                const ms = msUntilTimeStr(this.kitchenCloseAt);
+                if (ms !== null && ms > 0) {
+                    this._kitchenCloseTimer = setTimeout(() => {
+                        this.kitchenOpen              = false;
+                        this.kitchenCloseAt           = null;
+                        this.minutesUntilKitchenClose = null;
+                        this._kitchenCloseTimer       = null;
+                    }, ms);
+                }
+            }
+
+            // ── Negocio ───────────────────────────────────────────────────────
+            clearTimeout(this._bizCloseTimer);
+            this._bizCloseTimer = null;
+
+            if (this.businessOpen && this.businessCloseAt) {
+                const ms = msUntilTimeStr(this.businessCloseAt);
+                if (ms !== null && ms > 0) {
+                    this._bizCloseTimer = setTimeout(() => {
+                        this.businessOpen    = false;
+                        this.businessCloseAt = null;
+                        this.orderingAllowed = false;
+                        this._bizCloseTimer  = null;
+                    }, ms);
+                }
+            }
+        },
+
+        /**
          * Consulta el endpoint de estado y actualiza las propiedades reactivas.
+         * Reprograma los timers por si el horario cambió desde el servidor.
          *
          * @returns {Promise<void>}
          */
@@ -61,7 +123,9 @@ export function registerSchedule() {
                 this.kitchenCloseAt           = data.kitchen_close_at;
                 this.businessOpen             = data.business_open;
                 this.businessNextOpening      = data.business_next_opening;
+                this.businessCloseAt          = data.business_close_at ?? null;
                 this.orderingAllowed          = data.ordering_allowed;
+                this._scheduleCloseTimers();
             } catch {
                 // Error de red — se reintentará en el próximo ciclo de 30 s
             }

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -20,6 +20,7 @@ import { registerMenuStyle }      from './alpine/menu-style.js';
 import { registerSchedule }       from './alpine/schedule.js';
 import { registerTicketConfig }   from './alpine/ticket-config.js';
 import { initProductReorder }     from './pages/product-reorder.js';
+import { initOverscrollBounce }   from './overscroll-bounce.js';
 
 window.Alpine = Alpine;
 
@@ -47,3 +48,4 @@ document.addEventListener('alpine:init', () => {
 Alpine.start();
 
 initProductReorder();
+initOverscrollBounce();

--- a/resources/js/overscroll-bounce.js
+++ b/resources/js/overscroll-bounce.js
@@ -1,0 +1,92 @@
+/**
+ * Dispara las animaciones is-bouncing-top / is-bouncing-bottom
+ * cuando el usuario intenta hacer scroll más allá del límite de un contenedor.
+ *
+ * @author Ayrton
+ */
+
+const BOUNCE_SELECTORS = [
+    '.carta__body',
+    '.carta__filters',
+    '.cart-drawer__body',
+    '.drawer__body',
+    '.chat-log',
+    '.pdetail__scroll',
+    '.orders-body',
+    '.variant-picker__list',
+    '.dm-modal__body',
+    '.tapas-list',
+    '.tapas-body',
+    '.split-items__list',
+].join(', ');
+
+/**
+ * @param {Element} el
+ */
+function attachBounce(el) {
+    let touchStartY = 0;
+    let bouncing    = false;
+
+    const atTop    = () => el.scrollTop <= 0;
+    const atBottom = () => el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
+
+    function tryBounce(dir) {
+        if (bouncing) return;
+        bouncing     = true;
+        const cls    = dir === 'top' ? 'is-bouncing-top' : 'is-bouncing-bottom';
+        el.classList.remove('is-bouncing-top', 'is-bouncing-bottom');
+        void el.offsetWidth;
+        el.classList.add(cls);
+        el.addEventListener('animationend', () => {
+            el.classList.remove(cls);
+            bouncing = false;
+        }, { once: true });
+    }
+
+    el.addEventListener('wheel', (e) => {
+        if (e.deltaY < 0 && atTop())    tryBounce('top');
+        else if (e.deltaY > 0 && atBottom()) tryBounce('bottom');
+    }, { passive: true });
+
+    el.addEventListener('touchstart', (e) => {
+        touchStartY = e.touches[0].clientY;
+    }, { passive: true });
+
+    el.addEventListener('touchmove', (e) => {
+        const dy = touchStartY - e.touches[0].clientY;
+        if (dy < -8 && atTop())    tryBounce('top');
+        else if (dy > 8 && atBottom()) tryBounce('bottom');
+    }, { passive: true });
+}
+
+/**
+ * @param {Document|Element} root
+ */
+function attachAll(root) {
+    root.querySelectorAll(BOUNCE_SELECTORS).forEach(el => {
+        if (el._bounceBound) return;
+        el._bounceBound = true;
+        attachBounce(el);
+    });
+}
+
+/**
+ * Inicializa el sistema de rebote en todos los contenedores scrollables
+ * actuales y futuros (via MutationObserver).
+ */
+export function initOverscrollBounce() {
+    attachAll(document);
+
+    new MutationObserver((mutations) => {
+        for (const m of mutations) {
+            for (const node of m.addedNodes) {
+                if (node.nodeType !== 1) continue;
+                if (node.matches?.(BOUNCE_SELECTORS) && !node._bounceBound) {
+                    node._bounceBound = true;
+                    attachBounce(node);
+                }
+                attachAll(node);
+            }
+        }
+    }).observe(document.body, { childList: true, subtree: true });
+}

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -221,6 +221,7 @@
             'kitchenCloseAt'              => $kitchenCloseAt,
             'businessOpen'                => $businessOpen,
             'businessNextOpening'         => $businessNextOpening,
+            'businessCloseAt'             => $businessCloseAt,
             'orderingAllowed'             => $orderingAllowed,
         ];
     @endphp
@@ -1358,11 +1359,23 @@
 
                 {{-- ══ PRODUCTOS POR CATEGORÍA ══ --}}
                 @forelse($categories as $category)
-                @php $photoCycle = 0; @endphp
+                @php
+                    $photoCycle = 0;
+                    $isKitchen  = $category->destination === 'kitchen';
+                    $canOrder   = $isKitchen
+                        ? '$store.schedule.businessOpen && $store.schedule.kitchenOpen'
+                        : '$store.schedule.businessOpen';
+                    $isClosed   = $isKitchen
+                        ? '!$store.schedule.businessOpen || !$store.schedule.kitchenOpen'
+                        : '!$store.schedule.businessOpen';
+                    $dimStyle   = $isKitchen
+                        ? '(!$store.schedule.kitchenOpen || !$store.schedule.businessOpen) ? \'opacity:0.45;pointer-events:none\' : \'\''
+                        : '!$store.schedule.businessOpen ? \'opacity:0.45;pointer-events:none\' : \'\'';
+                @endphp
                 <div class="category"
                      x-show="isCategoryVisible({{ $category->id }})"
                      x-transition
-                     :style="{{ $category->destination === 'kitchen' ? '!$store.schedule.kitchenOpen ? \'opacity:0.45;pointer-events:none\' : \'\'' : '\'\'' }}">
+                     :style="{!! $dimStyle !!}">
 
                     <div class="category__head">
                         <span class="category__name">{{ $category->name }}</span>
@@ -1446,19 +1459,22 @@
                                         </span>
                                         <button type="button"
                                                 class="btn-add"
-                                                x-show="$store.schedule.orderingAllowed"
+                                                x-show="{!! $canOrder !!}"
                                                 style="display:none"
                                                 @click.stop="$store.variantPicker.show(products.find(p => p.id === {{ $product->id }}))"
                                                 aria-label="Elegir variante de {{ $product->name }}">
                                             +
                                         </button>
+                                        <span class="pcard__closed"
+                                              x-show="{!! $isClosed !!}"
+                                              style="display:none">Cerrado</span>
                                     </div>
                                     @else
                                     {{-- Producto SIN variantes --}}
                                     <span class="pcard__price">{{ number_format((float)$product->price, 2, ',', '.') }}&nbsp;€</span>
 
                                     {{-- Tapa de cortesía: bloqueado --}}
-                                    <span x-show="$store.schedule.orderingAllowed && $store.cart.items.some(i => i.productId === {{ $product->id }} && !i.variantId && i.isTapa)"
+                                    <span x-show="{!! $canOrder !!} && $store.cart.items.some(i => i.productId === {{ $product->id }} && !i.variantId && i.isTapa)"
                                           style="font-family:var(--font-body);font-size:11px;font-weight:700;color:var(--color-amber-800);background:linear-gradient(135deg,#F5DC92,#ECC25A);padding:3px 8px;border-radius:9999px;"
                                           @click.stop>
                                         🫕 Cortesía
@@ -1466,12 +1482,12 @@
                                     {{-- btn-add cuando qty = 0 y no es tapa --}}
                                     <button type="button"
                                             class="btn-add"
-                                            x-show="$store.schedule.orderingAllowed && !$store.cart.items.some(i => i.productId === {{ $product->id }} && !i.variantId)"
+                                            x-show="{!! $canOrder !!} && !$store.cart.items.some(i => i.productId === {{ $product->id }} && !i.variantId)"
                                             @click.stop="$store.cart.add(products.find(p => p.id === {{ $product->id }}))"
                                             aria-label="Añadir {{ $product->name }}">+</button>
                                     {{-- qty control cuando qty > 0 y NO es tapa --}}
                                     <div class="qty"
-                                         x-show="$store.schedule.orderingAllowed && $store.cart.items.some(i => i.productId === {{ $product->id }} && !i.variantId && !i.isTapa)"
+                                         x-show="{!! $canOrder !!} && $store.cart.items.some(i => i.productId === {{ $product->id }} && !i.variantId && !i.isTapa)"
                                          @click.stop>
                                         <button class="qty-minus"
                                                 @click.stop="$store.cart.dec('{{ $product->id }}:none')"
@@ -1482,9 +1498,9 @@
                                                 @click.stop="$store.cart.add(products.find(p => p.id === {{ $product->id }}))"
                                                 aria-label="Añadir otro de {{ $product->name }}">+</button>
                                     </div>
-                                    {{-- Cerrado: pedidos no permitidos --}}
+                                    {{-- Cerrado: destino bloqueado o negocio cerrado --}}
                                     <span class="pcard__closed"
-                                          x-show="!$store.schedule.orderingAllowed"
+                                          x-show="{!! $isClosed !!}"
                                           style="display:none">Cerrado</span>
                                     @endif
 

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1350,7 +1350,8 @@
             @endif
 
             {{-- DS: .carta__body — área scrolleable con productos --}}
-            <div class="carta__body" id="main-content">
+            <div class="carta__body" id="main-content"
+                 :style="(!$store.schedule.businessOpen && !$store.schedule.bizDismissed) ? 'overflow:hidden' : ''">
 
                 {{-- Banner Menú del Día --}}
                 <x-daily-menu-banner :hash="$table->unique_hash" />
@@ -1482,8 +1483,9 @@
                                                 aria-label="Añadir otro de {{ $product->name }}">+</button>
                                     </div>
                                     {{-- Cerrado: pedidos no permitidos --}}
-                                    <span x-show="!$store.schedule.orderingAllowed"
-                                          style="display:none;font-family:var(--font-body);font-size:11px;color:var(--fg-muted)">Cerrado</span>
+                                    <span class="pcard__closed"
+                                          x-show="!$store.schedule.orderingAllowed"
+                                          style="display:none">Cerrado</span>
                                     @endif
 
                                 </div>{{-- /pcard__foot --}}
@@ -1507,8 +1509,7 @@
         {{-- DS: .biz-closed — overlay negocio cerrado; hijo directo de .carta para
              que position:absolute;inset:0 cubra el viewport completo (100dvh) --}}
         <div class="biz-closed"
-             x-data="{ dismissed: false }"
-             x-show="!$store.schedule.businessOpen && !dismissed"
+             x-show="!$store.schedule.businessOpen && !$store.schedule.bizDismissed"
              style="display:none"
              x-transition:leave="transition duration-300 ease-in"
              x-transition:leave-start="opacity-100"
@@ -1550,7 +1551,7 @@
                     @endif
                     <button type="button"
                             class="biz-closed__btn"
-                            @click="dismissed = true">
+                            @click="$store.schedule.bizDismissed = true">
                         Mirar la carta
                     </button>
                 </div>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -4032,5 +4032,21 @@
         </div>
 
     </div>{{-- /carta (Alpine) --}}
+
+    <script>
+        (function () {
+            var el = document.getElementById('main-content');
+            if (!el) return;
+            function update() {
+                var remaining = el.scrollHeight - el.clientHeight - el.scrollTop;
+                var fade = Math.max(0, Math.min(64, remaining));
+                el.style.setProperty('--carta-fade', fade + 'px');
+            }
+            update();
+            el.addEventListener('scroll', update, { passive: true });
+            window.addEventListener('resize', update);
+            new ResizeObserver(update).observe(el);
+        })();
+    </script>
 </body>
 </html>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -971,13 +971,17 @@
         <div class="banner-closed" role="status" aria-live="polite"
              x-show="!$store.schedule.kitchenOpen"
              style="display:none">
-            <span class="banner-closed__ic" aria-hidden="true">🌙</span>
-            <div>
-                <div class="banner-closed__title">La cocina está cerrada</div>
-                <div class="banner-closed__sub">
+            <div class="banner-closed__row">
+                <span class="banner-closed__dot" aria-hidden="true"></span>
+                <div class="banner-closed__copy">
+                    <strong>La cocina está cerrada</strong>
                     <span x-show="$store.schedule.kitchenNextOpening"
-                          x-text="'Abre a las ' + $store.schedule.kitchenNextOpening + '. '"></span>Mientras tanto puedes pedir de barra 🍺
+                          x-text="'Abre a las ' + $store.schedule.kitchenNextOpening + ' · Mientras tanto pide de barra 🍺'"></span>
+                    <span x-show="!$store.schedule.kitchenNextOpening">Mientras tanto puedes pedir de barra 🍺</span>
                 </div>
+                <span class="banner-closed__chip">
+                    <span class="dot" aria-hidden="true"></span> Cerrada
+                </span>
             </div>
         </div>
 

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1587,7 +1587,8 @@
                 @click="$store.cart.open = true"
                 :aria-label="'Ver pedido — ' + $store.cart.displayCount + ($store.cart.displayCount === 1 ? ' artículo' : ' artículos') + ', total ' + Number($store.cart.displayTotal).toFixed(2).replace('.',',') + ' €'">
             <div class="cart-bar__left">
-                <span class="cart-bar__icon">
+                <span class="cart-bar__icon"
+                      x-effect="$store.cart.count; $el.classList.remove('cart-bar__icon--bump'); void $el.offsetWidth; $el.classList.add('cart-bar__icon--bump');">
                     <svg aria-hidden="true" width="18" height="18" fill="none"
                          stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round"


### PR DESCRIPTION
## Resumen

- Cierre reactivo de cocina y negocio en tiempo real (sin recargar página): `setTimeout` con precisión de milisegundo desde `schedule.js`, disparado al cargar y en cada poll
- Banner de cocina cerrada rediseñado como strip idéntico al de últimos pedidos, con punto sonar (`cutoffPulse`) unificado en los tres indicadores amber (cutoff-strip, banner-closed, category dot)
- Micro-animación de rebote en el icono del cart-bar al añadir o eliminar ítems (`cart-icon-bump`)
- Animación de salida del cart-bar al vaciarse (`slide-down`)
- Sistema de rebote en límites de scroll para todos los contenedores scrollables de la carta (`is-bouncing-top` / `is-bouncing-bottom`)
- Fixes visuales: filter-bar mobile con fondo diferenciado, kitchen-pill compacta en mobile, `minutesToTime` con `ceil` para evitar que el banner desaparezca antes del cierre real, texto legible en dark mode en dest-toggle

## Archivos principales

- `app/Models/TapaConfig.php` — `businessCloseAtDisplay()` + fix `minutesToTime` con `ceil`
- `app/Http/Controllers/MenuController.php` — `$businessCloseAt` en contexto de vista
- `app/Http/Controllers/Api/CartaStatusController.php` — `business_close_at` en polling JSON
- `resources/js/alpine/schedule.js` — timers precisos con `setTimeout` + `_scheduleCloseTimers()`
- `resources/js/overscroll-bounce.js` — módulo nuevo de rebote en scroll
- `resources/js/app.js` — registro de `initOverscrollBounce`
- `public/css/carta/components/cart.css` — `cart-icon-bump` + `slide-up/slide-down`
- `public/css/carta/flows/bill.css` — `banner-closed` como strip
- `public/css/carta/layout/layout.css` — compactación mobile
- `resources/views/menu/show.blade.php` — bindings Alpine actualizados

## Test

- [ ] Configurar horario de cierre de cocina a +2 min desde ahora → verificar que los ítems de cocina se bloquean al segundo exacto sin recargar
- [ ] Verificar banner "La cocina está cerrada" aparece en el momento preciso
- [ ] Añadir y quitar ítems del carrito → rebote en el icono del cart-bar
- [ ] Vaciar carrito → animación de salida slide-down del cart-bar
- [ ] Scroll hasta el fondo/tope en carta__body, cart-drawer, variant-picker → rebote visual del contenedor
- [ ] Dark mode: verificar colores de dest-toggle, banner-closed y filter-bar
- [ ] Mobile: kitchen-pill compacta, filter-bar con fondo diferenciado