### PR TITLE
feat: reorder toggle for products and categories

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -5,8 +5,10 @@ namespace App\Http\Controllers;
 use App\Models\Category;
 use App\Models\TapaConfig;
 use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 use Illuminate\Http\RedirectResponse;
 
@@ -32,14 +34,52 @@ class CategoryController extends Controller
      */
     public function index(Request $request): View
     {
-        $ownerId    = Auth::user()->ownerUserId();
-        $categories = Category::where('user_id', $ownerId)
-            ->when($request->filled('search'), fn ($q) => $q->where('name', 'like', '%' . $request->search . '%'))
-            ->when($request->filled('destination'), fn ($q) => $q->where('destination', $request->destination))
-            ->paginate(15)
-            ->withQueryString();
+        $ownerId     = Auth::user()->ownerUserId();
+        $reorderMode = $request->boolean('reorder');
 
-        return view('categories.index', compact('categories'));
+        $query = Category::where('user_id', $ownerId)
+            ->orderBy('sort_order')
+            ->orderBy('id');
+
+        if ($reorderMode) {
+            $categories = $query->get();
+        } else {
+            $categories = $query
+                ->when($request->filled('search'), fn ($q) => $q->where('name', 'like', '%' . $request->search . '%'))
+                ->when($request->filled('destination'), fn ($q) => $q->where('destination', $request->destination))
+                ->paginate(15)
+                ->withQueryString();
+        }
+
+        return view('categories.index', compact('categories', 'reorderMode'));
+    }
+
+    /**
+     * Persiste el orden manual de categorías arrastrado por el usuario.
+     *
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function reorder(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'ids'   => 'required|array|min:1',
+            'ids.*' => 'required|integer',
+        ]);
+
+        $ownerId = Auth::user()->ownerUserId();
+
+        DB::transaction(function () use ($validated, $ownerId) {
+            foreach ($validated['ids'] as $index => $id) {
+                Category::where('id', $id)
+                    ->where('user_id', $ownerId)
+                    ->update(['sort_order' => $index]);
+            }
+        });
+
+        Cache::forget("menu:{$ownerId}");
+
+        return response()->json(['success' => true]);
     }
 
     /**

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -38,18 +38,25 @@ class ProductController extends Controller
     $ownerId      = Auth::user()->ownerUserId();
     $categories   = Category::where('user_id', $ownerId)->orderBy('name')->get();
     $allergenTypes = Ingredient::ALLERGEN_TYPES;
+    $reorderMode  = $request->boolean('reorder');
 
-    $products = Product::where('user_id', $ownerId)
+    $query = Product::where('user_id', $ownerId)
       ->with(['allergens', 'variants', 'categories'])
-      ->when($request->filled('search'), fn ($q) => $q->where('name', 'like', '%' . $request->search . '%'))
-      ->when($request->filled('category'), fn ($q) => $q->whereHas('categories', fn ($q2) => $q2->where('categories.id', $request->category)))
-      ->when($request->filled('allergen'), fn ($q) => $q->whereHas('ingredients', fn ($q2) => $q2->whereJsonContains('allergen_types', $request->allergen)))
       ->orderBy('sort_order')
-      ->orderBy('id')
-      ->paginate(15)
-      ->withQueryString();
+      ->orderBy('id');
 
-    return view('products.index', compact('products', 'categories', 'allergenTypes'));
+    if ($reorderMode) {
+      $products = $query->get();
+    } else {
+      $products = $query
+        ->when($request->filled('search'), fn ($q) => $q->where('name', 'like', '%' . $request->search . '%'))
+        ->when($request->filled('category'), fn ($q) => $q->whereHas('categories', fn ($q2) => $q2->where('categories.id', $request->category)))
+        ->when($request->filled('allergen'), fn ($q) => $q->whereHas('ingredients', fn ($q2) => $q2->whereJsonContains('allergen_types', $request->allergen)))
+        ->paginate(15)
+        ->withQueryString();
+    }
+
+    return view('products.index', compact('products', 'categories', 'allergenTypes', 'reorderMode'));
   }
 
   /**

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -21,7 +21,7 @@ class Category extends Model
 {
     use HasFactory, SoftDeletes;
 
-    protected $fillable = ['user_id', 'name', 'destination'];
+    protected $fillable = ['user_id', 'name', 'destination', 'sort_order'];
 
     /**
      * @return BelongsTo

--- a/database/migrations/2026_06_13_014803_add_sort_order_to_categories_table.php
+++ b/database/migrations/2026_06_13_014803_add_sort_order_to_categories_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->unsignedInteger('sort_order')->default(0)->after('destination');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('categories', function (Blueprint $table) {
+            $table->dropColumn('sort_order');
+        });
+    }
+};

--- a/resources/views/categories/index.blade.php
+++ b/resources/views/categories/index.blade.php
@@ -13,22 +13,67 @@
         <div>
           <h1 class="text-2xl font-bold text-gray-900 dark:text-gray-100 leading-tight">Categorías</h1>
           <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
-            {{ $categories->total() }} {{ $categories->total() === 1 ? 'categoría' : 'categorías' }} en tu carta
+            @if($reorderMode)
+              {{ count($categories) }} {{ count($categories) === 1 ? 'categoría' : 'categorías' }} — modo ordenación
+            @else
+              {{ $categories->total() }} {{ $categories->total() === 1 ? 'categoría' : 'categorías' }} en tu carta
+            @endif
           </p>
         </div>
       </div>
-      <a href="{{ route('categories.create') }}"
-         class="inline-flex items-center gap-2 bg-indigo-600 hover:bg-indigo-700 text-white
-                font-semibold text-sm py-2.5 px-4 rounded-lg shadow-md
-                focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2
-                dark:focus:ring-offset-gray-900 transition-colors">
-        <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
-        </svg>
-        Nueva categoría
-      </a>
+      <div class="flex items-center gap-2">
+        {{-- Toggle reordenar --}}
+        @if($reorderMode)
+          <a href="{{ route('categories.index') }}"
+             class="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-600 text-white font-semibold text-sm py-2.5 px-4 rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors">
+            <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+            </svg>
+            Salir de ordenación
+          </a>
+        @else
+          <a href="{{ route('categories.index', ['reorder' => 1]) }}"
+             class="inline-flex items-center gap-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-semibold text-sm py-2.5 px-4 rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition-colors">
+            <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 10h16M4 14h16M4 18h16"/>
+            </svg>
+            Ordenar
+          </a>
+          <a href="{{ route('categories.create') }}"
+             class="inline-flex items-center gap-2 bg-indigo-600 hover:bg-indigo-700 text-white
+                    font-semibold text-sm py-2.5 px-4 rounded-lg shadow-md
+                    focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2
+                    dark:focus:ring-offset-gray-900 transition-colors">
+            <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/>
+            </svg>
+            Nueva categoría
+          </a>
+        @endif
+      </div>
     </div>
 
+    @if($reorderMode)
+    {{-- Banner modo ordenación --}}
+    <div class="rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 p-3 mb-6 flex items-center gap-2.5">
+      <svg class="h-4 w-4 text-amber-500 shrink-0" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 110 20A10 10 0 0112 2z"/>
+      </svg>
+      <p class="text-xs text-amber-800 dark:text-amber-300">Arrastra las categorías para cambiar el orden en la carta. Los cambios se guardan automáticamente.</p>
+    </div>
+    <div id="reorder-feedback" class="hidden rounded-lg bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-700 p-3 mb-4 flex items-center gap-2.5" aria-live="polite">
+      <svg class="h-4 w-4 text-emerald-500 shrink-0" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+      </svg>
+      <p class="text-xs text-emerald-800 dark:text-emerald-300">Orden guardado.</p>
+    </div>
+    <div id="reorder-error" class="hidden rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 p-3 mb-4 flex items-center gap-2.5" aria-live="assertive">
+      <svg class="h-4 w-4 text-red-500 shrink-0" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+      </svg>
+      <p class="text-xs text-red-800 dark:text-red-300">Error al guardar el orden. Inténtalo de nuevo.</p>
+    </div>
+    @else
     {{-- Búsqueda y filtros --}}
     <form method="GET" action="{{ route('categories.index') }}"
           class="mb-6 flex flex-col sm:flex-row gap-3 items-stretch sm:items-center"
@@ -71,6 +116,7 @@
         </a>
       @endif
     </form>
+    @endif
 
     {{-- Flash de éxito --}}
     @if(session('success'))
@@ -83,20 +129,54 @@
     </div>
     @endif
 
-    {{-- Grid de tarjetas --}}
+    @if($reorderMode)
+    {{-- Lista compacta para reordenar --}}
+    <div class="bg-white dark:bg-gray-800 shadow-md rounded-xl overflow-hidden"
+         id="categories-reorder-list"
+         data-reorder-url="{{ route('categories.reorder') }}">
+      @forelse($categories as $category)
+      @php $isKitchen = $category->destination === 'kitchen'; @endphp
+      <div class="flex items-center gap-3 px-4 py-3 border-b border-gray-100 dark:border-gray-700 last:border-b-0 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+           data-category-id="{{ $category->id }}">
+        <span class="drag-handle inline-flex items-center justify-center w-8 h-8 rounded cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors shrink-0"
+              aria-label="Arrastrar para reordenar {{ $category->name }}" role="button" tabindex="0">
+          <svg class="h-4 w-4" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
+            <circle cx="9" cy="5" r="1.5"/><circle cx="15" cy="5" r="1.5"/>
+            <circle cx="9" cy="12" r="1.5"/><circle cx="15" cy="12" r="1.5"/>
+            <circle cx="9" cy="19" r="1.5"/><circle cx="15" cy="19" r="1.5"/>
+          </svg>
+        </span>
+        <span class="p-1.5 rounded-lg bg-gray-100 dark:bg-gray-700 shrink-0" aria-hidden="true">
+          @if($isKitchen)
+          <svg class="h-4 w-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"/>
+          </svg>
+          @else
+          <svg class="h-4 w-4 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+          </svg>
+          @endif
+        </span>
+        <span class="font-medium text-gray-900 dark:text-gray-100 text-sm flex-1">{{ $category->name }}</span>
+        <span class="text-xs px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600 shrink-0">
+          {{ $isKitchen ? 'Cocina' : 'Barra' }}
+        </span>
+      </div>
+      @empty
+      <div class="py-12 text-center text-sm text-gray-500 dark:text-gray-400">No hay categorías.</div>
+      @endforelse
+    </div>
+    @else
+    {{-- Grid normal de tarjetas --}}
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
       @forelse ($categories as $category)
-
       @php $isKitchen = $category->destination === 'kitchen'; @endphp
-
       <article class="flex flex-col bg-white dark:bg-gray-800
                        border border-gray-200 dark:border-gray-700
                        rounded-xl shadow-md hover:shadow-xl
                        transition-shadow duration-200 overflow-hidden"
                aria-label="Categoría {{ $category->name }}">
-
         <div class="flex flex-col flex-1 p-5">
-          {{-- Icono + nombre --}}
           <div class="flex items-start gap-3 mb-4">
             <span class="mt-0.5 p-2 rounded-lg shadow-sm
                          bg-gray-100 dark:bg-gray-700 border border-gray-200 dark:border-gray-600"
@@ -122,8 +202,6 @@
               </span>
             </div>
           </div>
-
-          {{-- Botones --}}
           <div class="mt-auto grid grid-cols-2 gap-2 pt-4 border-t border-gray-200 dark:border-gray-700">
             <a href="{{ route('categories.edit', $category) }}"
                aria-label="Editar categoría {{ $category->name }}"
@@ -160,7 +238,6 @@
           </div>
         </div>
       </article>
-
       @empty
       <div class="col-span-3 py-16 flex flex-col items-center justify-center
                   border border-dashed border-gray-300 dark:border-gray-600 rounded-xl">
@@ -189,6 +266,59 @@
       {{ $categories->links() }}
     </nav>
     @endif
+    @endif
 
   </div>
+
+@if($reorderMode)
+<style>
+  .sortable-ghost { opacity: 0.4; background: #eef2ff; }
+  .dark .sortable-ghost { background: #1e1b4b; }
+  .sortable-drag { box-shadow: 0 8px 24px rgba(0,0,0,.15); background: white; border-radius: 0.5rem; }
+  .dark .sortable-drag { background: #1f2937; }
+</style>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const list = document.getElementById('categories-reorder-list');
+  if (!list) return;
+
+  const url      = list.dataset.reorderUrl;
+  const feedback = document.getElementById('reorder-feedback');
+  const errorEl  = document.getElementById('reorder-error');
+
+  Sortable.create(list, {
+    handle: '.drag-handle',
+    animation: 150,
+    ghostClass: 'sortable-ghost',
+    dragClass: 'sortable-drag',
+    onEnd() {
+      const ids = [...list.querySelectorAll('[data-category-id]')]
+        .map(el => parseInt(el.dataset.categoryId));
+
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+        },
+        body: JSON.stringify({ ids }),
+      })
+      .then(r => r.json())
+      .then(data => {
+        if (data.success) {
+          feedback.classList.remove('hidden');
+          errorEl.classList.add('hidden');
+          setTimeout(() => feedback.classList.add('hidden'), 2500);
+        } else {
+          errorEl.classList.remove('hidden');
+        }
+      })
+      .catch(() => errorEl.classList.remove('hidden'));
+    },
+  });
+});
+</script>
+@endif
+
 </x-app-layout>

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -1,6 +1,5 @@
 @php
-  $filtersActive = request()->hasAny(['search', 'category', 'allergen']);
-  $pageOffset    = $products->firstItem() ? $products->firstItem() - 1 : 0;
+  $filtersActive = !$reorderMode && request()->hasAny(['search', 'category', 'allergen']);
 @endphp
 
 <x-app-layout>
@@ -16,19 +15,66 @@
           Mi Carta Digital
         </h2>
         <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5 ml-8">
-          {{ $products->total() }} {{ $products->total() === 1 ? 'producto registrado' : 'productos registrados' }}
+          @if($reorderMode)
+            {{ count($products) }} {{ count($products) === 1 ? 'producto' : 'productos' }} — modo ordenación
+          @else
+            {{ $products->total() }} {{ $products->total() === 1 ? 'producto registrado' : 'productos registrados' }}
+          @endif
         </p>
       </div>
-      <a href="{{ route('products.create') }}"
-         class="inline-flex items-center gap-2 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-sm py-2.5 px-4 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition">
-        <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
-        </svg>
-        Añadir Producto
-      </a>
+      <div class="flex items-center gap-2">
+        {{-- Toggle reordenar --}}
+        @if($reorderMode)
+          <a href="{{ route('products.index') }}"
+             class="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-600 text-white font-semibold text-sm py-2.5 px-4 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition">
+            <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+            </svg>
+            Salir de ordenación
+          </a>
+        @else
+          <a href="{{ route('products.index', ['reorder' => 1]) }}"
+             class="inline-flex items-center gap-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 font-semibold text-sm py-2.5 px-4 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition">
+            <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"/>
+            </svg>
+            Ordenar carta
+          </a>
+        @endif
+        @if(!$reorderMode)
+        <a href="{{ route('products.create') }}"
+           class="inline-flex items-center gap-2 bg-indigo-600 hover:bg-indigo-700 text-white font-semibold text-sm py-2.5 px-4 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900 transition">
+          <svg class="h-4 w-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+          </svg>
+          Añadir Producto
+        </a>
+        @endif
+      </div>
     </div>
 
-    {{-- Filtros: búsqueda, categoría y alérgeno --}}
+    @if($reorderMode)
+    {{-- Banner modo ordenación --}}
+    <div class="rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 p-3 mb-4 flex items-center gap-2.5">
+      <svg class="h-4 w-4 text-amber-500 shrink-0" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 110 20A10 10 0 0112 2z"/>
+      </svg>
+      <p class="text-xs text-amber-800 dark:text-amber-300">Arrastra los productos para cambiar el orden de la carta. Los cambios se guardan automáticamente.</p>
+    </div>
+    <div id="reorder-feedback" class="hidden rounded-md bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-700 p-3 mb-4 flex items-center gap-2.5" aria-live="polite">
+      <svg class="h-4 w-4 text-emerald-500 shrink-0" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
+      </svg>
+      <p class="text-xs text-emerald-800 dark:text-emerald-300">Orden guardado en la carta.</p>
+    </div>
+    <div id="reorder-error" class="hidden rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 p-3 mb-4 flex items-center gap-2.5" aria-live="assertive">
+      <svg class="h-4 w-4 text-red-500 shrink-0" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+      </svg>
+      <p class="text-xs text-red-800 dark:text-red-300">Error al guardar el orden. Inténtalo de nuevo.</p>
+    </div>
+    @else
+    {{-- Filtros --}}
     <form method="GET" action="{{ route('products.index') }}"
           class="mb-4 flex flex-col sm:flex-row gap-3 items-stretch sm:items-center flex-wrap"
           role="search" aria-label="Filtrar productos">
@@ -87,28 +133,6 @@
         </a>
       @endif
     </form>
-
-    {{-- Banner reordenación --}}
-    @if($filtersActive)
-    <div class="rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 p-3 mb-4 flex items-center gap-2.5">
-      <svg class="h-4 w-4 text-amber-500 shrink-0" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 110 20A10 10 0 0112 2z"/>
-      </svg>
-      <p class="text-xs text-amber-800 dark:text-amber-300">Desactiva los filtros para reordenar la carta con drag & drop.</p>
-    </div>
-    @else
-    <div id="reorder-feedback" class="hidden rounded-md bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-700 p-3 mb-4 flex items-center gap-2.5" aria-live="polite">
-      <svg class="h-4 w-4 text-emerald-500 shrink-0" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
-      </svg>
-      <p class="text-xs text-emerald-800 dark:text-emerald-300">Orden guardado en la carta.</p>
-    </div>
-    <div id="reorder-error" class="hidden rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 p-3 mb-4 flex items-center gap-2.5" aria-live="assertive">
-      <svg class="h-4 w-4 text-red-500 shrink-0" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
-      </svg>
-      <p class="text-xs text-red-800 dark:text-red-300">Error al guardar el orden. Inténtalo de nuevo.</p>
-    </div>
     @endif
 
     {{-- Flash de éxito --}}
@@ -128,14 +152,11 @@
         <caption class="sr-only">Listado de productos de mi carta digital</caption>
         <thead class="bg-gray-50 dark:bg-gray-700">
           <tr>
-            {{-- Drag handle --}}
-            <th scope="col" class="w-10 px-3 py-3 @if($filtersActive) opacity-30 @endif" aria-label="Reordenar">
+            <th scope="col" class="w-10 px-3 py-3" aria-label="Reordenar">
               <svg class="h-4 w-4 text-gray-400 mx-auto" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/>
               </svg>
             </th>
-
-            {{-- Imagen --}}
             <th scope="col" class="hidden sm:table-cell px-4 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
               <span class="inline-flex items-center gap-1.5">
                 <svg class="h-3.5 w-3.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -144,8 +165,6 @@
                 Imagen
               </span>
             </th>
-
-            {{-- Nombre --}}
             <th scope="col" class="px-4 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
               <span class="inline-flex items-center gap-1.5">
                 <svg class="h-3.5 w-3.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -154,8 +173,7 @@
                 Nombre
               </span>
             </th>
-
-            {{-- Precio --}}
+            @if(!$reorderMode)
             <th scope="col" class="hidden md:table-cell px-4 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
               <span class="inline-flex items-center gap-1.5">
                 <svg class="h-3.5 w-3.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -164,8 +182,6 @@
                 Precio
               </span>
             </th>
-
-            {{-- Alérgenos --}}
             <th scope="col" class="hidden lg:table-cell px-4 sm:px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
               <span class="inline-flex items-center gap-1.5">
                 <svg class="h-3.5 w-3.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -174,22 +190,21 @@
                 Alérgenos
               </span>
             </th>
-
-            {{-- Acciones --}}
             <th scope="col" class="px-4 sm:px-6 py-3 relative">
               <span class="sr-only">Acciones</span>
             </th>
+            @endif
           </tr>
         </thead>
 
         <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700"
-               @if(!$filtersActive) data-reorder-url="{{ route('products.reorder') }}" data-offset="{{ $pageOffset }}" @endif>
+               @if($reorderMode) data-reorder-url="{{ route('products.reorder') }}" data-offset="0" @endif>
           @forelse($products as $product)
           <tr class="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors" data-product-id="{{ $product->id }}">
 
             {{-- Drag handle --}}
             <td class="w-10 px-3 py-4 text-center">
-              @if(!$filtersActive)
+              @if($reorderMode)
               <span class="drag-handle inline-flex items-center justify-center w-7 h-7 rounded cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors"
                     aria-label="Arrastrar para reordenar {{ $product->name }}" role="button" tabindex="0">
                 <svg class="h-4 w-4" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
@@ -199,7 +214,7 @@
                 </svg>
               </span>
               @else
-              <span class="inline-flex items-center justify-center w-7 h-7 text-gray-300 dark:text-gray-600 cursor-not-allowed" aria-hidden="true">
+              <span class="inline-flex items-center justify-center w-7 h-7 text-gray-300 dark:text-gray-600" aria-hidden="true">
                 <svg class="h-4 w-4" aria-hidden="true" fill="currentColor" viewBox="0 0 24 24">
                   <circle cx="9" cy="5" r="1.5"/><circle cx="15" cy="5" r="1.5"/>
                   <circle cx="9" cy="12" r="1.5"/><circle cx="15" cy="12" r="1.5"/>
@@ -209,7 +224,7 @@
               @endif
             </td>
 
-            {{-- Imagen / Placeholder --}}
+            {{-- Imagen --}}
             <td class="hidden sm:table-cell px-4 sm:px-6 py-4 whitespace-nowrap">
               @if($product->image)
                 <img src="{{ asset('storage/' . $product->image) }}"
@@ -226,15 +241,13 @@
               @endif
             </td>
 
-            {{-- Nombre + estado activo/inactivo + categoría --}}
+            {{-- Nombre + estado + categoría --}}
             <td class="px-4 sm:px-6 py-4">
               <div class="flex flex-col gap-1">
                 <span class="font-medium text-gray-900 dark:text-gray-100 text-sm sm:text-base leading-tight">
                   {{ $product->name }}
                 </span>
-
                 <div class="flex items-center flex-wrap gap-2">
-                  {{-- Estado activo / inactivo --}}
                   @if($product->is_active)
                     <span class="inline-flex items-center gap-1 text-xs text-emerald-700 dark:text-emerald-400">
                       <span class="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden="true"></span>
@@ -248,19 +261,8 @@
                       Oculto en carta
                     </span>
                   @endif
-
-                  {{-- Categorías --}}
                   @foreach($product->categories as $cat)
                     <span class="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
-                      @if($cat->destination === 'kitchen')
-                        <svg class="h-3 w-3" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/>
-                        </svg>
-                      @else
-                        <svg class="h-3 w-3" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
-                        </svg>
-                      @endif
                       {{ $cat->name }}
                     </span>
                   @endforeach
@@ -268,13 +270,11 @@
               </div>
             </td>
 
+            @if(!$reorderMode)
             {{-- Precio --}}
             <td class="hidden md:table-cell px-4 sm:px-6 py-4 text-gray-600 dark:text-gray-300 text-sm">
               @if($product->variants->isNotEmpty())
                 <div class="flex items-center gap-1 mb-1 text-gray-500 dark:text-gray-400 text-xs">
-                  <svg class="h-3 w-3" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/>
-                  </svg>
                   desde {{ number_format($product->getEffectivePrice(), 2, ',', '.') }} €
                 </div>
                 <div class="flex flex-wrap gap-1">
@@ -285,10 +285,7 @@
                   @endforeach
                 </div>
               @else
-                <span class="inline-flex items-center gap-1.5 font-semibold text-gray-800 dark:text-gray-200">
-                  <svg class="h-3.5 w-3.5 text-gray-400 dark:text-gray-500" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
-                  </svg>
+                <span class="font-semibold text-gray-800 dark:text-gray-200">
                   {{ number_format($product->price, 2, ',', '.') }} €
                 </span>
               @endif
@@ -308,12 +305,7 @@
                   @endforeach
                 </div>
               @else
-                <span class="inline-flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
-                  <svg class="h-3.5 w-3.5" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/>
-                  </svg>
-                  Sin alérgenos
-                </span>
+                <span class="text-xs text-gray-400 dark:text-gray-500">Sin alérgenos</span>
               @endif
             </td>
 
@@ -343,12 +335,12 @@
                 </form>
               </div>
             </td>
+            @endif
 
           </tr>
           @empty
-          {{-- Estado vacío --}}
           <tr>
-            <td colspan="6" class="px-6 py-16 text-center">
+            <td colspan="{{ $reorderMode ? 3 : 6 }}" class="px-6 py-16 text-center">
               <div class="flex flex-col items-center gap-3">
                 <div class="h-16 w-16 rounded-full bg-gray-100 dark:bg-gray-700 flex items-center justify-center">
                   <svg class="h-8 w-8 text-gray-300 dark:text-gray-600" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -374,7 +366,7 @@
       </table>
     </div>
 
-    @if($products->hasPages())
+    @if(!$reorderMode && $products->hasPages())
     <nav aria-label="Paginación de productos" class="mt-4">
       {{ $products->links() }}
     </nav>
@@ -382,13 +374,55 @@
 
   </div>
 
-@if(!$filtersActive)
+@if($reorderMode)
 <style>
   .sortable-ghost { opacity: 0.4; background: #eef2ff; }
   .dark .sortable-ghost { background: #1e1b4b; }
   .sortable-drag { box-shadow: 0 8px 24px rgba(0,0,0,.15); background: white; }
   .dark .sortable-drag { background: #1f2937; }
 </style>
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  const tbody = document.querySelector('tbody[data-reorder-url]');
+  if (!tbody) return;
+
+  const url      = tbody.dataset.reorderUrl;
+  const feedback = document.getElementById('reorder-feedback');
+  const errorEl  = document.getElementById('reorder-error');
+
+  Sortable.create(tbody, {
+    handle: '.drag-handle',
+    animation: 150,
+    ghostClass: 'sortable-ghost',
+    dragClass: 'sortable-drag',
+    onEnd() {
+      const ids = [...tbody.querySelectorAll('tr[data-product-id]')]
+        .map(r => parseInt(r.dataset.productId));
+
+      fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+        },
+        body: JSON.stringify({ ids, offset: 0 }),
+      })
+      .then(r => r.json())
+      .then(data => {
+        if (data.success) {
+          feedback.classList.remove('hidden');
+          errorEl.classList.add('hidden');
+          setTimeout(() => feedback.classList.add('hidden'), 2500);
+        } else {
+          errorEl.classList.remove('hidden');
+        }
+      })
+      .catch(() => errorEl.classList.remove('hidden'));
+    },
+  });
+});
+</script>
 @endif
 
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,7 @@ Route::middleware(['auth', 'business.active'])->group(function () {
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
     Route::resource('categories', CategoryController::class);
+    Route::post('/categorias/reorder', [CategoryController::class, 'reorder'])->name('categories.reorder');
     Route::resource('ingredients', IngredientController::class);
     Route::post('/productos/reorder', [ProductController::class, 'reorder'])->name('products.reorder');
     Route::resource('products', ProductController::class);


### PR DESCRIPTION
## Summary
- Add on/off reorder toggle button to products index — activates full list (no pagination) with SortableJS drag & drop, solves cross-page ordering limitation
- Add drag & drop reorder to categories index (previously not implemented) — same toggle pattern, compact list view when active
- Migration adds `sort_order` column to `categories` table
- `categories.reorder` POST endpoint persists new order via `CategoryController@reorder`

## Test plan
- [ ] Go to `/products`, click "Ordenar carta" — all products load, drag handles active, no pagination
- [ ] Drag product from bottom to top — order saves automatically, green toast appears
- [ ] Click "Salir de ordenación" — returns to normal paginated view with filters
- [ ] Go to `/categories`, click "Ordenar" — compact list loads with drag handles
- [ ] Drag categories to reorder — order saves automatically
- [ ] Reload carta digital — verify products and categories appear in new order