### PR TITLE
fix: carta digital - variantes e ingredientes unificados en pdetail

### DIFF
--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -1077,6 +1077,15 @@
   background: var(--color-red-600, #DC2626);
   color: white;
 }
+.pdetail__chip--variant {
+  border-color: var(--border-subtle);
+}
+.pdetail__chip--variant-on {
+  background: color-mix(in oklab, var(--color-accent, var(--color-indigo-500)) 14%, var(--bg-base));
+  border-color: var(--color-accent, var(--color-indigo-500));
+  color: var(--color-accent, var(--color-indigo-600));
+  font-weight: 600;
+}
 
 /* Extras como lista de filas */
 .pdetail__extras { display: flex; flex-direction: column; gap: 6px; }

--- a/resources/js/alpine/cart.js
+++ b/resources/js/alpine/cart.js
@@ -257,8 +257,8 @@ export function registerCart() {
                     quantity:    1,
                     destination: productData?.destination ?? null,
                     mods:        [],
-                    removable:   [],
-                    extras:      [],
+                    removable:   productData?.removable || [],
+                    extras:      productData?.extras    || [],
                 });
             }
             if (productData?.destination === 'bar') {

--- a/resources/js/alpine/menu-filters.js
+++ b/resources/js/alpine/menu-filters.js
@@ -102,6 +102,8 @@ export function registerMenuFilters() {
             pdetailRemovedIds: [],
             /** @type {number[]} Extra ingredient IDs selected. */
             pdetailExtraIds:   [],
+            /** @type {number|null} Selected variant ID in the detail drawer. */
+            pdetailVariantId:  null,
             /** @type {boolean} Whether the kitchen is currently open. */
             kitchenOpen:       ctx.kitchenOpen ?? true,
 
@@ -113,9 +115,38 @@ export function registerMenuFilters() {
              */
             openProduct(product) {
                 if (!product) return;
-                this.selectedProduct = product;
-                this.pdetailClosing  = false;
-                const key      = product.id + ':none';
+                this.selectedProduct  = product;
+                this.pdetailClosing   = false;
+                // Default to first variant (null for products without variants)
+                this.pdetailVariantId = (product.variants && product.variants.length > 0)
+                    ? product.variants[0].id
+                    : null;
+                this._syncPdetailFromCart();
+                this.$nextTick(() => this._fillPdetailAllergens());
+            },
+
+            /**
+             * Switches the selected variant in the detail drawer and resyncs cart state.
+             *
+             * @param {number} variantId
+             * @returns {void}
+             */
+            selectVariant(variantId) {
+                this.pdetailVariantId = variantId;
+                this._syncPdetailFromCart();
+            },
+
+            /**
+             * Reads qty and mods for the current product+variant combo from the cart.
+             *
+             * @returns {void}
+             */
+            _syncPdetailFromCart() {
+                const product  = this.selectedProduct;
+                if (!product) return;
+                const key      = this.pdetailVariantId
+                    ? product.id + ':' + this.pdetailVariantId
+                    : product.id + ':none';
                 const cartItem = Alpine.store('cart').items.find(i => i._key === key);
                 this.pdetailQty        = cartItem ? cartItem.quantity : 1;
                 this.pdetailRemovedIds = cartItem
@@ -124,7 +155,6 @@ export function registerMenuFilters() {
                 this.pdetailExtraIds   = cartItem
                     ? cartItem.mods.filter(m => m.action === 'add').map(m => m.ingredientId)
                     : [];
-                this.$nextTick(() => this._fillPdetailAllergens());
             },
 
             /**
@@ -165,21 +195,26 @@ export function registerMenuFilters() {
              */
             pdetailAddToCart() {
                 if (!this.selectedProduct) return;
-                const cart       = Alpine.store('cart');
-                const product    = this.selectedProduct;
-                const key        = product.id + ':none';
-                const cartItem   = cart.items.find(i => i._key === key);
+                const cart      = Alpine.store('cart');
+                const product   = this.selectedProduct;
+                const variantId = this.pdetailVariantId;
+                const key       = variantId ? product.id + ':' + variantId : product.id + ':none';
+                const cartItem  = cart.items.find(i => i._key === key);
                 const currentQty = cartItem ? cartItem.quantity : 0;
                 const targetQty  = this.pdetailQty;
 
                 if (targetQty > currentQty) {
                     if (!cartItem) {
-                        // Primer añadido: usa add() para inicializar el item en el store
-                        cart.add(product);
+                        if (variantId) {
+                            const variant = product.variants.find(v => v.id === variantId);
+                            if (!variant) return;
+                            cart.addWithVariant(product.id, variant.id, variant.name, variant.price, product);
+                        } else {
+                            cart.add(product);
+                        }
                         const added = cart.items.find(i => i._key === key);
                         if (added && targetQty > 1) added.quantity = targetQty;
                     } else {
-                        // Item ya existe: actualiza quantity directamente y notifica tapas
                         cartItem.quantity = targetQty;
                         if (product.destination === 'bar') cart._checkTapaSuggestion();
                     }

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1465,7 +1465,7 @@
                                                 class="btn-add"
                                                 x-show="{!! $canOrder !!}"
                                                 style="display:none"
-                                                @click.stop="$store.variantPicker.show(products.find(p => p.id === {{ $product->id }}))"
+                                                @click.stop="openProduct(products.find(p => p.id === {{ $product->id }}))"
                                                 aria-label="Elegir variante de {{ $product->name }}">
                                             +
                                         </button>
@@ -1483,11 +1483,11 @@
                                           @click.stop>
                                         🫕 Cortesía
                                     </span>
-                                    {{-- btn-add cuando qty = 0 y no es tapa --}}
+                                    {{-- btn-add cuando qty = 0 y no es tapa — abre pdetail para configurar mods --}}
                                     <button type="button"
                                             class="btn-add"
                                             x-show="{!! $canOrder !!} && !$store.cart.items.some(i => i.productId === {{ $product->id }} && !i.variantId)"
-                                            @click.stop="$store.cart.add(products.find(p => p.id === {{ $product->id }}))"
+                                            @click.stop="openProduct(products.find(p => p.id === {{ $product->id }}))"
                                             aria-label="Añadir {{ $product->name }}">+</button>
                                     {{-- qty control cuando qty > 0 y NO es tapa --}}
                                     <div class="qty"
@@ -3881,7 +3881,31 @@
 
                             <h2 class="pdetail__name" x-text="selectedProduct?.name"></h2>
                             <div class="pdetail__price"
-                                 x-text="Number(selectedProduct?.price || 0).toFixed(2).replace('.', ',') + ' €'"></div>
+                                 x-text="Number(
+                                     pdetailVariantId
+                                         ? ((selectedProduct?.variants || []).find(v => v.id === pdetailVariantId)?.price || 0)
+                                         : (selectedProduct?.price || 0)
+                                 ).toFixed(2).replace('.', ',') + ' €'"></div>
+
+                            {{-- Variantes --}}
+                            <section class="pdetail__section"
+                                     x-show="(selectedProduct?.variants || []).length > 0">
+                                <div class="pdetail__label">Elige una opción</div>
+                                <div class="pdetail__chips" style="flex-wrap:wrap;gap:8px">
+                                    <template x-for="v in (selectedProduct?.variants || [])" :key="v.id">
+                                        <button type="button"
+                                                :class="pdetailVariantId === v.id
+                                                    ? 'pdetail__chip pdetail__chip--variant-on'
+                                                    : 'pdetail__chip pdetail__chip--variant'"
+                                                @click="selectVariant(v.id)"
+                                                :aria-pressed="pdetailVariantId === v.id">
+                                            <span x-text="v.name"></span>
+                                            <span style="opacity:.7;font-size:.82em;margin-left:6px"
+                                                  x-text="Number(v.price).toFixed(2).replace('.', ',') + ' €'"></span>
+                                        </button>
+                                    </template>
+                                </div>
+                            </section>
                             <p class="pdetail__desc"
                                x-text="selectedProduct?.description"
                                x-show="selectedProduct?.description"></p>
@@ -3976,10 +4000,16 @@
                                     @click="pdetailAddToCart()"
                                     :disabled="selectedProduct?.destination === 'kitchen' && !$store.schedule.kitchenOpen">
                                 <span class="pdetail__cta-lab"
-                                      x-text="$store.cart.items.some(i => i.productId === selectedProduct?.id && !i.variantId)
+                                      x-text="$store.cart.items.some(i => i._key === (pdetailVariantId ? selectedProduct?.id + ':' + pdetailVariantId : selectedProduct?.id + ':none'))
                                           ? 'Actualizar carrito' : 'Añadir al carrito'"></span>
                                 <span class="pdetail__cta-price"
-                                      x-text="Number(((selectedProduct?.price || 0) + (selectedProduct?.extras || []).filter(e => pdetailExtraIds.includes(e.id)).reduce((s, e) => s + e.price, 0)) * pdetailQty).toFixed(2).replace('.',',') + ' €'"></span>
+                                      x-text="Number(
+                                          ((pdetailVariantId
+                                              ? ((selectedProduct?.variants || []).find(v => v.id === pdetailVariantId)?.price || 0)
+                                              : (selectedProduct?.price || 0))
+                                          + (selectedProduct?.extras || []).filter(e => pdetailExtraIds.includes(e.id)).reduce((s, e) => s + e.price, 0))
+                                          * pdetailQty
+                                      ).toFixed(2).replace('.',',') + ' €'"></span>
                             </button>
                         </div>
 


### PR DESCRIPTION
## Summary

- El botón `+` de todas las tarjetas (variantes y no-variantes) ahora abre el pdetail, igual que hacer click en la tarjeta
- Productos con variantes muestran selector de variante dentro del pdetail (antes abrían un modal separado)
- Al cambiar variante en pdetail, se resetean y sincronizan los mods del carrito para esa combinación
- `addWithVariant()` ahora pasa `removable` y `extras` al item del carrito, permitiendo modificar ingredientes en items con variante
- El carrito refleja los cambios (`Sin X` / `+ X`) vía `citem__customTag` badges que ya existían
- Añadidos estilos CSS para chips de variante seleccionada (`pdetail__chip--variant-on`)

## Test plan

- [ ] Click en tarjeta de producto sin variantes → abre pdetail
- [ ] Click en `+` de tarjeta de producto sin variantes → abre pdetail (mismo comportamiento)
- [ ] Click en tarjeta de producto con variantes → abre pdetail con selector de variante
- [ ] Click en `+` de tarjeta de producto con variantes → abre pdetail con selector de variante (mismo comportamiento)
- [ ] Seleccionar variante → precio del pdetail se actualiza
- [ ] Cambiar variante → mods se resetean
- [ ] Quitar/añadir ingrediente en pdetail con variante seleccionada → se guarda en carrito
- [ ] Carrito muestra badges `Sin X` y `+ X` para items con mods