### PR TITLE
style: carta digital — CTA pedido, marquee CSS y notificación de borrado

### DIFF
--- a/public/css/carta/components/cart.css
+++ b/public/css/carta/components/cart.css
@@ -249,7 +249,9 @@
   font-family: var(--font-body); font-size: 13px; font-weight: 500;
   animation: pill-in 200ms var(--ease-out);
 }
-@keyframes pill-in { from { transform: translateY(20px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+@keyframes pill-in  { from { transform: translateY(20px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+@keyframes pill-out { from { transform: translateY(0); opacity: 1; } to { transform: translateY(20px); opacity: 0; } }
+.delete-pill--leaving { animation: pill-out 200ms var(--ease-out) forwards; }
 .delete-pill strong { color: white; font-weight: 700; }
 
 /* ----- Chat panel ----- */

--- a/public/css/carta/components/cart.css
+++ b/public/css/carta/components/cart.css
@@ -242,7 +242,7 @@
 
 /* Delete pill */
 .delete-pill {
-  position: absolute; left: 16px; right: 16px; bottom: 86px; z-index: 35;
+  position: absolute; left: 16px; right: 16px; bottom: 93px; z-index: 35;
   display: inline-flex; align-items: center; gap: 10px; justify-content: center;
   padding: 10px 16px; border-radius: 9999px;
   background: var(--delete-pill-bg); color: #FECACA; border: 1px solid var(--delete-pill-border);

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -1177,8 +1177,6 @@
 
 .pdetail__cta {
   flex: 1;
-  min-width: 0;
-  overflow: hidden;
   display: flex; align-items: center; justify-content: space-between;
   gap: 12px;
   padding: 14px 18px;
@@ -1193,15 +1191,8 @@
 .pdetail__cta:hover:not(:disabled) { filter: brightness(1.06); transform: translateY(-1px); }
 .pdetail__cta:active:not(:disabled) { transform: translateY(0); }
 .pdetail__cta:disabled { opacity: 0.5; cursor: not-allowed; }
-.pdetail__cta-lab {
-  flex: 1;
-  min-width: 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+.pdetail__cta-lab { white-space: nowrap; }
 .pdetail__cta-price {
-  flex-shrink: 0;
   font-family: var(--font-display);
   font-weight: 900;
   font-size: 16px;
@@ -1211,6 +1202,12 @@
   border-radius: 9999px;
   white-space: nowrap;
 }
+/* Móvil: qty encima del CTA → el botón ocupa todo el ancho y el texto cabe */
+.carta[data-bp="mobile"] .pdetail__foot {
+  flex-direction: column;
+  align-items: stretch;
+}
+.carta[data-bp="mobile"] .pdetail__qty { align-self: center; }
 
 /* Tarjeta clicable: hover sutil */
 .pcard { cursor: pointer; transition: transform var(--duration-fast) var(--ease-out), box-shadow var(--duration-fast), border-color var(--duration-fast); }

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -765,14 +765,19 @@
   font-size: 13px; color: var(--color-amber-800);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-.banner-closed__copy span {
-  display: block;
+.banner-closed__sub {
+  display: block; overflow: hidden;
   font-family: var(--font-body); font-size: 11.5px;
   color: color-mix(in oklab, var(--color-amber-800) 75%, var(--fg-secondary));
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.banner-closed__sub-txt { display: inline-block; white-space: nowrap; }
+.carta:not([data-bp="desktop"]) .banner-closed__sub-txt { animation: banner-marquee 6s ease-in-out infinite; }
+@keyframes banner-marquee {
+  0%, 30%   { transform: translateX(0); }
+  70%, 100% { transform: translateX(-70px); }
 }
 [data-theme="dark"] .banner-closed__copy strong { color: var(--color-amber-300); }
-[data-theme="dark"] .banner-closed__copy span { color: color-mix(in oklab, var(--color-amber-300) 75%, var(--fg-secondary)); }
+[data-theme="dark"] .banner-closed__sub { color: color-mix(in oklab, var(--color-amber-300) 75%, var(--fg-secondary)); }
 .banner-closed__chip {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 5px 10px; border-radius: 9999px;
@@ -1192,10 +1197,10 @@
 .pdetail__cta:disabled { opacity: 0.5; cursor: not-allowed; }
 .pdetail__cta-lab { flex: 1; min-width: 0; overflow: hidden; }
 .pdetail__cta-lab-txt { display: inline-block; white-space: nowrap; }
-.pdetail__cta-lab-txt--scroll { animation: pdetail-marquee 6s ease-in-out infinite; }
+.carta:not([data-bp="desktop"]) .pdetail__cta-lab-txt { animation: pdetail-marquee 6s ease-in-out infinite; }
 @keyframes pdetail-marquee {
   0%, 30%   { transform: translateX(0); }
-  70%, 100% { transform: translateX(var(--cta-overflow, -60px)); }
+  70%, 100% { transform: translateX(-60px); }
 }
 .pdetail__cta-price {
   flex-shrink: 0;

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -1190,7 +1190,13 @@
 .pdetail__cta:hover:not(:disabled) { filter: brightness(1.06); transform: translateY(-1px); }
 .pdetail__cta:active:not(:disabled) { transform: translateY(0); }
 .pdetail__cta:disabled { opacity: 0.5; cursor: not-allowed; }
-.pdetail__cta-lab { flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; }
+.pdetail__cta-lab { flex: 1; min-width: 0; overflow: hidden; }
+.pdetail__cta-lab-txt { display: inline-block; white-space: nowrap; }
+.pdetail__cta-lab-txt--scroll { animation: pdetail-marquee 3.6s ease-in-out infinite; }
+@keyframes pdetail-marquee {
+  0%, 30%   { transform: translateX(0); }
+  70%, 100% { transform: translateX(var(--cta-overflow, -60px)); }
+}
 .pdetail__cta-price {
   flex-shrink: 0;
   font-family: var(--font-display);

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -1179,6 +1179,7 @@
   gap: 12px;
   padding: 14px 18px;
   border-radius: 9999px;
+  overflow: hidden;
   background: var(--cta-view-order);
   color: white;
   border: none; cursor: pointer;
@@ -1189,8 +1190,9 @@
 .pdetail__cta:hover:not(:disabled) { filter: brightness(1.06); transform: translateY(-1px); }
 .pdetail__cta:active:not(:disabled) { transform: translateY(0); }
 .pdetail__cta:disabled { opacity: 0.5; cursor: not-allowed; }
-.pdetail__cta-lab { white-space: nowrap; }
+.pdetail__cta-lab { flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; }
 .pdetail__cta-price {
+  flex-shrink: 0;
   font-family: var(--font-display);
   font-weight: 900;
   font-size: 16px;

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -1175,8 +1175,6 @@
 
 .pdetail__cta {
   flex: 1;
-  min-width: 0;
-  overflow: hidden;
   display: flex; align-items: center; justify-content: space-between;
   gap: 12px;
   padding: 14px 18px;
@@ -1191,15 +1189,8 @@
 .pdetail__cta:hover:not(:disabled) { filter: brightness(1.06); transform: translateY(-1px); }
 .pdetail__cta:active:not(:disabled) { transform: translateY(0); }
 .pdetail__cta:disabled { opacity: 0.5; cursor: not-allowed; }
-.pdetail__cta-lab {
-  flex: 1;
-  min-width: 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+.pdetail__cta-lab { white-space: nowrap; }
 .pdetail__cta-price {
-  flex-shrink: 0;
   font-family: var(--font-display);
   font-weight: 900;
   font-size: 16px;

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -1175,6 +1175,8 @@
 
 .pdetail__cta {
   flex: 1;
+  min-width: 0;
+  overflow: hidden;
   display: flex; align-items: center; justify-content: space-between;
   gap: 12px;
   padding: 14px 18px;
@@ -1189,8 +1191,15 @@
 .pdetail__cta:hover:not(:disabled) { filter: brightness(1.06); transform: translateY(-1px); }
 .pdetail__cta:active:not(:disabled) { transform: translateY(0); }
 .pdetail__cta:disabled { opacity: 0.5; cursor: not-allowed; }
-.pdetail__cta-lab { white-space: nowrap; }
+.pdetail__cta-lab {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .pdetail__cta-price {
+  flex-shrink: 0;
   font-family: var(--font-display);
   font-weight: 900;
   font-size: 16px;
@@ -1200,12 +1209,6 @@
   border-radius: 9999px;
   white-space: nowrap;
 }
-/* Móvil: qty encima del CTA → el botón ocupa todo el ancho y el texto cabe */
-.carta[data-bp="mobile"] .pdetail__foot {
-  flex-direction: column;
-  align-items: stretch;
-}
-.carta[data-bp="mobile"] .pdetail__qty { align-self: center; }
 
 /* Tarjeta clicable: hover sutil */
 .pcard { cursor: pointer; transition: transform var(--duration-fast) var(--ease-out), box-shadow var(--duration-fast), border-color var(--duration-fast); }

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -771,7 +771,7 @@
   color: color-mix(in oklab, var(--color-amber-800) 75%, var(--fg-secondary));
 }
 .banner-closed__sub-txt { display: inline-block; white-space: nowrap; }
-.carta:not([data-bp="desktop"]) .banner-closed__sub-txt { animation: banner-marquee 6s ease-in-out infinite; }
+.carta:not([data-bp="desktop"]) .banner-closed__sub-txt { animation: banner-marquee 9s ease-in-out infinite; }
 @keyframes banner-marquee {
   0%, 30%   { transform: translateX(0); }
   70%, 100% { transform: translateX(-70px); }
@@ -1197,7 +1197,7 @@
 .pdetail__cta:disabled { opacity: 0.5; cursor: not-allowed; }
 .pdetail__cta-lab { flex: 1; min-width: 0; overflow: hidden; }
 .pdetail__cta-lab-txt { display: inline-block; white-space: nowrap; }
-.carta:not([data-bp="desktop"]) .pdetail__cta-lab-txt { animation: pdetail-marquee 6s ease-in-out infinite; }
+.carta:not([data-bp="desktop"]) .pdetail__cta-lab-txt { animation: pdetail-marquee 9s ease-in-out infinite; }
 @keyframes pdetail-marquee {
   0%, 30%   { transform: translateX(0); }
   70%, 100% { transform: translateX(-60px); }

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -1078,9 +1078,11 @@
   color: white;
 }
 .pdetail__chip--variant {
+  padding: 8px 14px;
   border-color: var(--border-subtle);
 }
 .pdetail__chip--variant-on {
+  padding: 8px 14px;
   background: color-mix(in oklab, var(--color-accent, var(--color-indigo-500)) 14%, var(--bg-base));
   border-color: var(--color-accent, var(--color-indigo-500));
   color: var(--color-accent, var(--color-indigo-600));
@@ -1175,6 +1177,8 @@
 
 .pdetail__cta {
   flex: 1;
+  min-width: 0;
+  overflow: hidden;
   display: flex; align-items: center; justify-content: space-between;
   gap: 12px;
   padding: 14px 18px;
@@ -1189,8 +1193,15 @@
 .pdetail__cta:hover:not(:disabled) { filter: brightness(1.06); transform: translateY(-1px); }
 .pdetail__cta:active:not(:disabled) { transform: translateY(0); }
 .pdetail__cta:disabled { opacity: 0.5; cursor: not-allowed; }
-.pdetail__cta-lab { white-space: nowrap; }
+.pdetail__cta-lab {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .pdetail__cta-price {
+  flex-shrink: 0;
   font-family: var(--font-display);
   font-weight: 900;
   font-size: 16px;

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -1078,11 +1078,9 @@
   color: white;
 }
 .pdetail__chip--variant {
-  padding: 8px 14px;
   border-color: var(--border-subtle);
 }
 .pdetail__chip--variant-on {
-  padding: 8px 14px;
   background: color-mix(in oklab, var(--color-accent, var(--color-indigo-500)) 14%, var(--bg-base));
   border-color: var(--color-accent, var(--color-indigo-500));
   color: var(--color-accent, var(--color-indigo-600));

--- a/public/css/carta/flows/bill.css
+++ b/public/css/carta/flows/bill.css
@@ -1192,7 +1192,7 @@
 .pdetail__cta:disabled { opacity: 0.5; cursor: not-allowed; }
 .pdetail__cta-lab { flex: 1; min-width: 0; overflow: hidden; }
 .pdetail__cta-lab-txt { display: inline-block; white-space: nowrap; }
-.pdetail__cta-lab-txt--scroll { animation: pdetail-marquee 3.6s ease-in-out infinite; }
+.pdetail__cta-lab-txt--scroll { animation: pdetail-marquee 6s ease-in-out infinite; }
 @keyframes pdetail-marquee {
   0%, 30%   { transform: translateX(0); }
   70%, 100% { transform: translateX(var(--cta-overflow, -60px)); }

--- a/public/css/carta/flows/features.css
+++ b/public/css/carta/flows/features.css
@@ -47,14 +47,19 @@
   font-variant-numeric: tabular-nums;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-.cutoff-strip__copy span {
-  display: block;
+.cutoff-strip__sub {
+  display: block; overflow: hidden;
   font-family: var(--font-body); font-size: 11.5px;
   color: color-mix(in oklab, var(--color-amber-800) 75%, var(--fg-secondary));
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.cutoff-strip__sub-txt { display: inline-block; white-space: nowrap; }
+.carta:not([data-bp="desktop"]) .cutoff-strip__sub-txt { animation: cutoff-marquee 6s ease-in-out infinite; }
+@keyframes cutoff-marquee {
+  0%, 30%   { transform: translateX(0); }
+  70%, 100% { transform: translateX(-70px); }
 }
 [data-theme="dark"] .cutoff-strip__copy strong { color: var(--color-amber-300); }
-[data-theme="dark"] .cutoff-strip__copy span { color: color-mix(in oklab, var(--color-amber-300) 75%, var(--fg-secondary)); }
+[data-theme="dark"] .cutoff-strip__sub { color: color-mix(in oklab, var(--color-amber-300) 75%, var(--fg-secondary)); }
 .cutoff-strip__chip {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 5px 10px; border-radius: 9999px;

--- a/public/css/carta/flows/features.css
+++ b/public/css/carta/flows/features.css
@@ -53,7 +53,7 @@
   color: color-mix(in oklab, var(--color-amber-800) 75%, var(--fg-secondary));
 }
 .cutoff-strip__sub-txt { display: inline-block; white-space: nowrap; }
-.carta:not([data-bp="desktop"]) .cutoff-strip__sub-txt { animation: cutoff-marquee 6s ease-in-out infinite; }
+.carta:not([data-bp="desktop"]) .cutoff-strip__sub-txt { animation: cutoff-marquee 9s ease-in-out infinite; }
 @keyframes cutoff-marquee {
   0%, 30%   { transform: translateX(0); }
   70%, 100% { transform: translateX(-70px); }

--- a/resources/js/alpine/cart.js
+++ b/resources/js/alpine/cart.js
@@ -133,6 +133,30 @@ export function registerCart() {
         open:    false,
         /** @type {boolean} True while the close animation is running. */
         closing: false,
+
+        showDeletePill(name) {
+            clearTimeout(this._deletePillTimer);
+            clearTimeout(this._deletePillLeaveTimer);
+            this._deletePill.leaving = false;
+            this._deletePill.name    = name;
+            this._deletePill.visible = true;
+            this._deletePillTimer = setTimeout(() => {
+                this._deletePill.leaving = true;
+                this._deletePillLeaveTimer = setTimeout(() => {
+                    this._deletePill.visible = false;
+                }, 200);
+            }, 2000);
+        },
+
+        hideDeletePill() {
+            clearTimeout(this._deletePillTimer);
+            clearTimeout(this._deletePillLeaveTimer);
+            this._deletePill.leaving = true;
+            this._deletePillLeaveTimer = setTimeout(() => {
+                this._deletePill.visible = false;
+            }, 200);
+        },
+
         /** @type {number} Last non-zero count — keeps cart bar display stable during leave animation. */
         _snapCount: 0,
         /** @type {number} Last non-zero total — keeps cart bar display stable during leave animation. */
@@ -141,6 +165,11 @@ export function registerCart() {
         _barLeaving: false,
         /** @type {number|null} Timer ID for the leave animation cleanup. */
         _barLeaveTimer: null,
+        /** @type {{ visible: boolean, name: string, leaving: boolean }} Delete notification state. */
+        _deletePill:           { visible: false, name: '', leaving: false },
+        _deletePillTimer:      null,
+        _deletePillLeaveTimer: null,
+
         /** @type {boolean} Submission in progress. */
         sending: false,
         /** @type {boolean} Order successfully sent. */
@@ -319,7 +348,10 @@ export function registerCart() {
             const item = this.items[idx];
             const wasBarItem = item.destination === 'bar' && !item.isTapa;
             item.quantity--;
-            if (item.quantity <= 0) this.items.splice(idx, 1);
+            if (item.quantity <= 0) {
+                this.showDeletePill(item.name);
+                this.items.splice(idx, 1);
+            }
             if (wasBarItem) {
                 const cartBarCount = this.items
                     .filter(i => i.destination === 'bar' && !i.isTapa)

--- a/resources/js/alpine/menu-filters.js
+++ b/resources/js/alpine/menu-filters.js
@@ -104,6 +104,8 @@ export function registerMenuFilters() {
             pdetailExtraIds:   [],
             /** @type {number|null} Selected variant ID in the detail drawer. */
             pdetailVariantId:  null,
+            /** @type {boolean} True when the CTA label text overflows its container. */
+            ctaLabScrolls:     false,
             /** @type {boolean} Whether the kitchen is currently open. */
             kitchenOpen:       ctx.kitchenOpen ?? true,
 
@@ -122,7 +124,15 @@ export function registerMenuFilters() {
                     ? product.variants[0].id
                     : null;
                 this._syncPdetailFromCart();
-                this.$nextTick(() => this._fillPdetailAllergens());
+                this.$nextTick(() => {
+                    this._fillPdetailAllergens();
+                    const lab = this.$refs.ctaLab;
+                    if (lab) {
+                        const overflow = lab.scrollWidth - lab.offsetWidth;
+                        this.ctaLabScrolls = overflow > 0;
+                        lab.style.setProperty('--cta-overflow', `-${overflow}px`);
+                    }
+                });
             },
 
             /**

--- a/resources/js/alpine/menu-filters.js
+++ b/resources/js/alpine/menu-filters.js
@@ -104,8 +104,6 @@ export function registerMenuFilters() {
             pdetailExtraIds:   [],
             /** @type {number|null} Selected variant ID in the detail drawer. */
             pdetailVariantId:  null,
-            /** @type {boolean} True when the CTA label text overflows its container. */
-            ctaLabScrolls:     false,
             /** @type {boolean} Whether the kitchen is currently open. */
             kitchenOpen:       ctx.kitchenOpen ?? true,
 
@@ -124,15 +122,7 @@ export function registerMenuFilters() {
                     ? product.variants[0].id
                     : null;
                 this._syncPdetailFromCart();
-                this.$nextTick(() => {
-                    this._fillPdetailAllergens();
-                    const lab = this.$refs.ctaLab;
-                    if (lab) {
-                        const overflow = lab.scrollWidth - lab.offsetWidth;
-                        this.ctaLabScrolls = overflow > 0;
-                        lab.style.setProperty('--cta-overflow', `-${overflow}px`);
-                    }
-                });
+                this.$nextTick(() => this._fillPdetailAllergens());
             },
 
             /**

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -3999,9 +3999,12 @@
                                     class="pdetail__cta"
                                     @click="pdetailAddToCart()"
                                     :disabled="selectedProduct?.destination === 'kitchen' && !$store.schedule.kitchenOpen">
-                                <span class="pdetail__cta-lab"
-                                      x-text="$store.cart.items.some(i => i._key === (pdetailVariantId ? selectedProduct?.id + ':' + pdetailVariantId : selectedProduct?.id + ':none'))
-                                          ? 'Actualizar Pedido' : 'Añadir al Pedido'"></span>
+                                <span class="pdetail__cta-lab" x-ref="ctaLab">
+                                    <span class="pdetail__cta-lab-txt"
+                                          :class="ctaLabScrolls ? 'pdetail__cta-lab-txt--scroll' : ''"
+                                          x-text="$store.cart.items.some(i => i._key === (pdetailVariantId ? selectedProduct?.id + ':' + pdetailVariantId : selectedProduct?.id + ':none'))
+                                              ? 'Actualizar Pedido' : 'Añadir al Pedido'"></span>
+                                </span>
                                 <span class="pdetail__cta-price"
                                       x-text="Number(
                                           ((pdetailVariantId

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -975,9 +975,15 @@
                 <span class="banner-closed__dot" aria-hidden="true"></span>
                 <div class="banner-closed__copy">
                     <strong>La cocina está cerrada</strong>
-                    <span x-show="$store.schedule.kitchenNextOpening"
-                          x-text="'Abre a las ' + $store.schedule.kitchenNextOpening + ' · Mientras tanto pide de barra 🍺'"></span>
-                    <span x-show="!$store.schedule.kitchenNextOpening">Mientras tanto puedes pedir de barra 🍺</span>
+                    <span class="banner-closed__sub"
+                          x-show="$store.schedule.kitchenNextOpening">
+                        <span class="banner-closed__sub-txt"
+                              x-text="'Abre a las ' + $store.schedule.kitchenNextOpening + ' · Mientras tanto pide de barra 🍺'"></span>
+                    </span>
+                    <span class="banner-closed__sub"
+                          x-show="!$store.schedule.kitchenNextOpening">
+                        <span class="banner-closed__sub-txt">Mientras tanto puedes pedir de barra 🍺</span>
+                    </span>
                 </div>
                 <span class="banner-closed__chip">
                     <span class="dot" aria-hidden="true"></span> Cerrada
@@ -1009,7 +1015,10 @@
                 <span class="cutoff-strip__pulse" aria-hidden="true"></span>
                 <div class="cutoff-strip__copy">
                     <strong x-text="`Últimos pedidos · cierre en ${mm}:${ss}`"></strong>
-                    <span x-text="'Cocina cierra a las ' + ($store.schedule.kitchenCloseAt || '') + ' — después solo barra 🍺'"></span>
+                    <span class="cutoff-strip__sub">
+                        <span class="cutoff-strip__sub-txt"
+                              x-text="'Cocina cierra en ' + ($store.schedule.kitchenCloseAt || '') + ' · después solo barra 🍺'"></span>
+                    </span>
                 </div>
                 <span class="cutoff-strip__chip">
                     <span class="dot" aria-hidden="true"></span> Cerrando
@@ -4020,9 +4029,8 @@
                                     class="pdetail__cta"
                                     @click="pdetailAddToCart()"
                                     :disabled="selectedProduct?.destination === 'kitchen' && !$store.schedule.kitchenOpen">
-                                <span class="pdetail__cta-lab" x-ref="ctaLab">
+                                <span class="pdetail__cta-lab">
                                     <span class="pdetail__cta-lab-txt"
-                                          :class="ctaLabScrolls ? 'pdetail__cta-lab-txt--scroll' : ''"
                                           x-text="$store.cart.items.some(i => i._key === (pdetailVariantId ? selectedProduct?.id + ':' + pdetailVariantId : selectedProduct?.id + ':none'))
                                               ? 'Actualizar Pedido' : 'Añadir al Pedido'"></span>
                                 </span>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -1579,6 +1579,27 @@
         </div>
 
         {{-- ══════════════════════════════════════════════════════════════════════
+             DELETE PILL — notificación al eliminar un artículo del carrito
+             ══════════════════════════════════════════════════════════════════════ --}}
+        <template x-if="$store.cart._deletePill.visible">
+            <div :class="$store.cart._deletePill.leaving ? 'delete-pill delete-pill--leaving' : 'delete-pill'"
+                 role="status" aria-live="polite">
+                <span aria-hidden="true">🗑</span>
+                <span><strong x-text="$store.cart._deletePill.name"></strong> eliminado</span>
+                <button type="button" class="icon-btn"
+                        @click="$store.cart.hideDeletePill()"
+                        aria-label="Cerrar notificación"
+                        style="width:22px;height:22px;margin-left:4px;background:rgba(254,202,202,0.2);color:#FECACA;">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                         stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <line x1="18" y1="6" x2="6" y2="18"></line>
+                        <line x1="6" y1="6" x2="18" y2="18"></line>
+                    </svg>
+                </button>
+            </div>
+        </template>
+
+        {{-- ══════════════════════════════════════════════════════════════════════
              CART BAR — .cart-bar position:absolute dentro de .carta
              ══════════════════════════════════════════════════════════════════════ --}}
         <template x-if="$store.cart.barShouldShow">

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -4001,7 +4001,7 @@
                                     :disabled="selectedProduct?.destination === 'kitchen' && !$store.schedule.kitchenOpen">
                                 <span class="pdetail__cta-lab"
                                       x-text="$store.cart.items.some(i => i._key === (pdetailVariantId ? selectedProduct?.id + ':' + pdetailVariantId : selectedProduct?.id + ':none'))
-                                          ? 'Actualizar carrito' : 'Añadir al carrito'"></span>
+                                          ? 'Actualizar Pedido' : 'Añadir al Pedido'"></span>
                                 <span class="pdetail__cta-price"
                                       x-text="Number(
                                           ((pdetailVariantId


### PR DESCRIPTION
## Resumen

- **Texto CTA pdetail**: botón de acción cambiado a _Añadir al Pedido_ / _Actualizar Pedido_
- **Marquee CSS puro**: textos largos que no caben en mobile se deslizan automáticamente en CTA del pdetail, banner cocina cerrada y strip de cierre próximo — usando `carta:not([data-bp="desktop"])`, sin JS
- **Notificación de borrado**: al eliminar un artículo del carrito aparece una _delete-pill_ encima del cart-bar (slide-in 200ms, hold 2s, slide-out 200ms) con botón de cierre manual
- **Texto cocina cierra**: actualizado a _"Cocina cierra en HH:MM · después solo barra 🍺"_

## Plan de prueba

- [ ] Abrir pdetail en mobile — el botón CTA desliza el texto si no cabe
- [ ] Bajar cantidad de un artículo a 0 desde el carrito — aparece pill roja encima del cart-bar y desaparece sola a los 2s
- [ ] Simular cocina cerrando pronto (≤15 min) — el subtexto del strip desliza
- [ ] Simular cocina cerrada — el subtexto del banner desliza
- [ ] En desktop ninguno de los tres textos anima (data-bp="desktop")