### PR TITLE
style: rediseño alérgenos oficiales DS en panel admin

### DIFF
--- a/public/images/allergens/altramuces.svg
+++ b/public/images/allergens/altramuces.svg
@@ -1,5 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-altramuces">
-  <title id="title-altramuces">Altramuces</title>
-  <circle cx="32" cy="32" r="32" fill="#FF8C00"/>
-  <path fill="white" d="M32 14 C32 14 36 20 32 26 C28 20 32 14 32 14 Z M32 26 L32 50 M22 20 C22 20 28 24 26 30 C22 26 22 20 22 20 Z M42 20 C42 20 36 24 38 30 C42 26 42 20 42 20 Z M18 32 C18 32 24 34 24 40 C18 38 18 32 18 32 Z M46 32 C46 32 40 34 40 40 C46 38 46 32 46 32 Z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="t">
+<title id="t">Contiene altramuces</title>
+<circle cx="48" cy="48" r="48" fill="#F0D04A"></circle>
+
+<g>
+  
+  <circle cx="36" cy="38" r="10" fill="#ffffff"></circle>
+  <circle cx="36" cy="38" r="3.3333333333333335" fill="#F0D04A" opacity="0.4"></circle>
+</g>
+<g>
+  
+  <circle cx="58" cy="36" r="11" fill="#ffffff"></circle>
+  <circle cx="58" cy="36" r="3.6666666666666665" fill="#F0D04A" opacity="0.4"></circle>
+</g>
+<g>
+  
+  <circle cx="34" cy="60" r="11" fill="#ffffff"></circle>
+  <circle cx="34" cy="60" r="3.6666666666666665" fill="#F0D04A" opacity="0.4"></circle>
+</g>
+<g>
+  
+  <circle cx="58" cy="62" r="10" fill="#ffffff"></circle>
+  <circle cx="58" cy="62" r="3.3333333333333335" fill="#F0D04A" opacity="0.4"></circle>
+</g>
 </svg>

--- a/public/images/allergens/apio.svg
+++ b/public/images/allergens/apio.svg
@@ -1,5 +1,34 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-apio">
-  <title id="title-apio">Apio</title>
-  <circle cx="32" cy="32" r="32" fill="#2E7D32"/>
-  <path fill="none" stroke="white" stroke-width="3" stroke-linecap="round" d="M32 52 L32 28 M32 28 C32 28 22 20 20 12 M32 28 C32 28 42 20 44 12 M32 36 C32 36 24 32 20 24 M32 36 C32 36 40 32 44 24"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="t">
+<title id="t">Contiene apio</title>
+<circle cx="48" cy="48" r="48" fill="#95C93F"></circle>
+
+<g>
+  
+
+  
+  <path d="M42 74 Q36 60 34 44 Q34 36 36 32 L44 32 Q44 40 45 56 Q46 68 47 76 Z" fill="#ffffff"></path>
+  
+  <path d="M54 74 Q60 60 62 44 Q62 36 60 32 L52 32 Q52 40 51 56 Q50 68 49 76 Z" fill="#ffffff"></path>
+  
+  <path d="M44 76 L52 76 Q53 60 51 40 Q50 32 50 28 L46 28 Q46 32 45 40 Q43 60 44 76 Z" fill="#ffffff"></path>
+
+  
+  <path d="M38 78 Q40 72 48 72 Q56 72 58 78 Z" fill="#ffffff"></path>
+
+  
+  <path d="M40 38 Q40 56 42 72" stroke="#95C93F" stroke-width="1.2" stroke-linecap="round" fill="none" opacity="0.55"></path>
+  <path d="M48 32 Q48 54 48 72" stroke="#95C93F" stroke-width="1.2" stroke-linecap="round" fill="none" opacity="0.55"></path>
+  <path d="M56 38 Q56 56 54 72" stroke="#95C93F" stroke-width="1.2" stroke-linecap="round" fill="none" opacity="0.55"></path>
+
+  
+  <g>
+    
+    <ellipse cx="48" cy="18" rx="5" ry="7" fill="#ffffff"></ellipse>
+    <ellipse cx="48" cy="12" rx="4" ry="5.5" fill="#ffffff"></ellipse>
+    <ellipse cx="40" cy="22" rx="4.5" ry="7" fill="#ffffff" transform="rotate(-22 40 22)"></ellipse>
+    <ellipse cx="36" cy="16" rx="3.5" ry="5" fill="#ffffff" transform="rotate(-32 36 16)"></ellipse>
+    <ellipse cx="56" cy="22" rx="4.5" ry="7" fill="#ffffff" transform="rotate(22 56 22)"></ellipse>
+    <ellipse cx="60" cy="16" rx="3.5" ry="5" fill="#ffffff" transform="rotate(32 60 16)"></ellipse>
+  </g>
+</g>
 </svg>

--- a/public/images/allergens/cacahuetes.svg
+++ b/public/images/allergens/cacahuetes.svg
@@ -1,6 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-cacahuetes">
-  <title id="title-cacahuetes">Cacahuetes</title>
-  <circle cx="32" cy="32" r="32" fill="#8B4513"/>
-  <path fill="white" d="M32 14 C26 14 22 18 22 23 C22 26 24 29 26 30 C24 31 22 34 22 37 C22 42 26 46 32 46 C38 46 42 42 42 37 C42 34 40 31 38 30 C40 29 42 26 42 23 C42 18 38 14 32 14 Z"/>
-  <path stroke="white" stroke-width="1.5" fill="none" d="M26 30 Q32 28 38 30"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="t">
+<title id="t">Contiene cacahuetes</title>
+<circle cx="48" cy="48" r="48" fill="#C97847"></circle>
+
+<g>
+  
+  <ellipse cx="48" cy="34" rx="14" ry="16" fill="#ffffff"></ellipse>
+  <ellipse cx="48" cy="62" rx="16" ry="18" fill="#ffffff"></ellipse>
+  
+  <path d="M38 26 Q40 32 38 38 M48 22 Q50 28 48 34 M58 26 Q56 32 58 38" stroke="#C97847" stroke-width="2" fill="none" stroke-linecap="round"></path>
+  <path d="M36 54 Q40 62 36 70 M48 50 Q52 62 48 74 M60 54 Q56 62 60 70" stroke="#C97847" stroke-width="2" fill="none" stroke-linecap="round"></path>
+</g>
 </svg>

--- a/public/images/allergens/crustaceos.svg
+++ b/public/images/allergens/crustaceos.svg
@@ -1,5 +1,27 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-crustaceos">
-  <title id="title-crustaceos">Crustáceos</title>
-  <circle cx="32" cy="32" r="32" fill="#D95B2E"/>
-  <path d="M32 16 C26 16 22 20 22 26 C22 32 26 38 32 42 C38 38 42 32 42 26 C42 20 38 16 32 16 Z M24 30 L18 28 M24 34 L18 36 M40 30 L46 28 M40 34 L46 36 M29 20 L26 14 M35 20 L38 14" stroke="white" stroke-width="2" fill="none"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="t">
+<title id="t">Contiene crustáceos</title>
+<circle cx="48" cy="48" r="48" fill="#4FAFD4"></circle>
+
+
+<ellipse cx="48" cy="56" rx="20" ry="13" fill="#ffffff"></ellipse>
+
+<path d="M42 48 L42 42 M54 48 L54 42" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"></path>
+<circle cx="42" cy="40" r="2.5" fill="#ffffff"></circle>
+<circle cx="54" cy="40" r="2.5" fill="#ffffff"></circle>
+
+<path d="M32 56 L20 54 M32 60 L18 62 M32 64 L22 72" stroke="#ffffff" stroke-width="3" stroke-linecap="round" fill="none"></path>
+
+<path d="M64 56 L76 54 M64 60 L78 62 M64 64 L74 72" stroke="#ffffff" stroke-width="3" stroke-linecap="round" fill="none"></path>
+
+<g>
+  
+  <path d="M32 50 L22 38 L18 30 L24 32 L30 42 Z" fill="#ffffff"></path>
+  <path d="M22 38 L14 32 L20 30 Z" fill="#ffffff"></path>
+</g>
+
+<g>
+  
+  <path d="M64 50 L74 38 L78 30 L72 32 L66 42 Z" fill="#ffffff"></path>
+  <path d="M74 38 L82 32 L76 30 Z" fill="#ffffff"></path>
+</g>
 </svg>

--- a/public/images/allergens/frutos-cascara.svg
+++ b/public/images/allergens/frutos-cascara.svg
@@ -1,6 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-frutos-cascara">
-  <title id="title-frutos-cascara">Frutos de cáscara</title>
-  <circle cx="32" cy="32" r="32" fill="#A0522D"/>
-  <path fill="white" d="M32 16 C24 16 18 22 18 30 C18 38 24 48 32 50 C40 48 46 38 46 30 C46 22 40 16 32 16 Z"/>
-  <path stroke="#A0522D" stroke-width="1.5" fill="none" d="M18 30 Q32 26 46 30 M26 20 Q32 28 38 20"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="t">
+<title id="t">Contiene frutos de cáscara</title>
+<circle cx="48" cy="48" r="48" fill="#BD5A4F"></circle>
+
+<g>
+  
+  
+  <path d="&#xA;    M48 22&#xA;    Q26 22 22 44&#xA;    Q20 64 32 76&#xA;    Q40 82 48 82&#xA;    Q56 82 64 76&#xA;    Q76 64 74 44&#xA;    Q70 22 48 22 Z" fill="#ffffff"></path>
+  
+  <path d="M44 22 Q44 14 50 14 Q54 14 54 22" fill="#ffffff"></path>
+  <circle cx="50" cy="14" r="2" fill="#BD5A4F"></circle>
+  
+  <path d="M48 26 Q49 50 48 80" stroke="#BD5A4F" stroke-width="1.8" stroke-linecap="round" fill="none" opacity="0.7"></path>
+  
+  <path d="M30 38 Q34 50 30 72" stroke="#BD5A4F" stroke-width="2.6" stroke-linecap="round" fill="none"></path>
+  <path d="M39 28 Q42 50 39 78" stroke="#BD5A4F" stroke-width="2.4" stroke-linecap="round" fill="none"></path>
+  <path d="M57 28 Q54 50 57 78" stroke="#BD5A4F" stroke-width="2.4" stroke-linecap="round" fill="none"></path>
+  <path d="M66 38 Q62 50 66 72" stroke="#BD5A4F" stroke-width="2.6" stroke-linecap="round" fill="none"></path>
+</g>
 </svg>

--- a/public/images/allergens/gluten.svg
+++ b/public/images/allergens/gluten.svg
@@ -1,5 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-gluten">
-  <title id="title-gluten">Gluten</title>
-  <circle cx="32" cy="32" r="32" fill="#E8821A"/>
-  <path d="M32 8 L32 56 M28 20 C28 20 24 18 24 14 C24 10 28 10 28 14 M36 20 C36 20 40 18 40 14 C40 10 36 10 36 14 M28 28 C28 28 24 26 24 22 C24 18 28 18 28 22 M36 28 C36 28 40 26 40 22 C40 18 36 18 36 22 M28 36 C28 36 24 34 24 30 C24 26 28 26 28 30 M36 36 C36 36 40 34 40 30 C40 26 36 26 36 30" stroke="white" stroke-width="2" fill="none"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="t">
+<title id="t">Contiene gluten</title>
+<circle cx="48" cy="48" r="48" fill="#E27B2D"></circle>
+
+<g transform-origin="48 80">
+  
+  <path d="M48 80 L48 28" stroke="#ffffff" stroke-width="3" stroke-linecap="round" fill="none"></path>
+  <ellipse cx="48" cy="30" rx="5" ry="9" fill="#ffffff"></ellipse>
+  <ellipse cx="40" cy="40" rx="4.5" ry="8" fill="#ffffff" transform="rotate(-30 40 40)"></ellipse>
+  <ellipse cx="56" cy="40" rx="4.5" ry="8" fill="#ffffff" transform="rotate(30 56 40)"></ellipse>
+  <ellipse cx="37" cy="52" rx="4.5" ry="8" fill="#ffffff" transform="rotate(-30 37 52)"></ellipse>
+  <ellipse cx="59" cy="52" rx="4.5" ry="8" fill="#ffffff" transform="rotate(30 59 52)"></ellipse>
+  <ellipse cx="35" cy="64" rx="4.5" ry="8" fill="#ffffff" transform="rotate(-30 35 64)"></ellipse>
+  <ellipse cx="61" cy="64" rx="4.5" ry="8" fill="#ffffff" transform="rotate(30 61 64)"></ellipse>
+</g>
 </svg>

--- a/public/images/allergens/huevos.svg
+++ b/public/images/allergens/huevos.svg
@@ -1,6 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-huevos">
-  <title id="title-huevos">Huevos</title>
-  <circle cx="32" cy="32" r="32" fill="#F5C400"/>
-  <ellipse cx="32" cy="34" rx="14" ry="18" fill="none" stroke="white" stroke-width="3"/>
-  <ellipse cx="32" cy="36" rx="7" ry="8" fill="white"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="t">
+<title id="t">Contiene huevos</title>
+<circle cx="48" cy="48" r="48" fill="#F2D374"></circle>
+
+<g>
+  
+  
+  <ellipse cx="32" cy="46" rx="14" ry="18" fill="#FAF3DC"></ellipse>
+  <path d="M26 38 Q28 32 31 30" stroke="#ffffff" stroke-width="3" stroke-linecap="round" fill="none"></path>
+  
+  <ellipse cx="64" cy="42" rx="14" ry="18" fill="#FAF3DC"></ellipse>
+  <path d="M58 34 Q60 28 63 26" stroke="#ffffff" stroke-width="3" stroke-linecap="round" fill="none"></path>
+  
+  <ellipse cx="48" cy="62" rx="16" ry="20" fill="#FAF3DC"></ellipse>
+  <path d="M40 52 Q43 44 47 42" stroke="#ffffff" stroke-width="3.2" stroke-linecap="round" fill="none"></path>
+</g>
 </svg>

--- a/public/images/allergens/lacteos.svg
+++ b/public/images/allergens/lacteos.svg
@@ -1,7 +1,18 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-lacteos">
-  <title id="title-lacteos">Lácteos</title>
-  <circle cx="32" cy="32" r="32" fill="#5DADE2"/>
-  <rect x="22" y="20" width="20" height="28" rx="3" fill="none" stroke="white" stroke-width="3"/>
-  <path d="M22 28 Q32 24 42 28" stroke="white" stroke-width="2" fill="none"/>
-  <path d="M24 16 L22 20 M32 14 L32 20 M40 16 L42 20" stroke="white" stroke-width="2"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="t">
+<title id="t">Contiene lácteos</title>
+<circle cx="48" cy="48" r="48" fill="#6B3F2A"></circle>
+
+
+<ellipse cx="46" cy="16" rx="2.5" ry="3.5" fill="#ffffff" opacity="0">
+  
+  
+</ellipse>
+
+<path d="M30 34 L30 70 Q30 78 38 78 L54 78 Q62 78 62 70 L62 36 L56 32 L36 32 Z" fill="#ffffff"></path>
+
+<path d="M56 32 L56 24 L48 22 L48 30 Z" fill="#ffffff"></path>
+
+<path d="M62 42 Q70 42 70 52 Q70 60 62 60" stroke="#ffffff" stroke-width="3" fill="none" stroke-linecap="round"></path>
+
+<rect x="32" y="50" width="28" height="6" fill="#6B3F2A"></rect>
 </svg>

--- a/public/images/allergens/moluscos.svg
+++ b/public/images/allergens/moluscos.svg
@@ -1,7 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-moluscos">
-  <title id="title-moluscos">Moluscos</title>
-  <circle cx="32" cy="32" r="32" fill="#1A3A5C"/>
-  <path fill="white" d="M32 48 C20 48 14 40 14 32 C14 22 22 16 32 16 C42 16 50 22 50 32 C50 40 44 48 32 48 Z"/>
-  <path stroke="#1A3A5C" stroke-width="2" fill="none" d="M32 16 L32 48 M14 32 Q32 28 50 32 M18 22 Q32 36 46 22 M20 42 Q32 38 44 42"/>
-  <path fill="white" d="M32 48 L26 56 L32 52 L38 56 Z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="t">
+<title id="t">Contiene moluscos</title>
+<circle cx="48" cy="48" r="48" fill="#6FB6D8"></circle>
+
+<g>
+  
+  
+  
+  <path d="&#xA;    M48 72&#xA;    L24 60&#xA;    Q22 50 26 30&#xA;    Q30 26 32 30&#xA;    Q34 24 38 26&#xA;    Q40 20 44 24&#xA;    Q46 18 50 22&#xA;    Q54 20 56 26&#xA;    Q58 22 62 26&#xA;    Q64 24 66 30&#xA;    Q70 28 70 30&#xA;    Q74 50 72 60&#xA;    Z" fill="#ffffff"></path>
+  
+  <path d="M48 70 L28 36" stroke="#6FB6D8" stroke-width="1.6" stroke-linecap="round" fill="none"></path>
+  <path d="M48 70 L36 24" stroke="#6FB6D8" stroke-width="1.6" stroke-linecap="round" fill="none"></path>
+  <path d="M48 70 L44 22" stroke="#6FB6D8" stroke-width="1.6" stroke-linecap="round" fill="none"></path>
+  <path d="M48 70 L52 22" stroke="#6FB6D8" stroke-width="1.6" stroke-linecap="round" fill="none"></path>
+  <path d="M48 70 L60 24" stroke="#6FB6D8" stroke-width="1.6" stroke-linecap="round" fill="none"></path>
+  <path d="M48 70 L68 36" stroke="#6FB6D8" stroke-width="1.6" stroke-linecap="round" fill="none"></path>
+  
+  <ellipse cx="48" cy="72" rx="6" ry="2.5" fill="#ffffff"></ellipse>
+</g>
 </svg>

--- a/public/images/allergens/mostaza.svg
+++ b/public/images/allergens/mostaza.svg
@@ -1,6 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-mostaza">
-  <title id="title-mostaza">Mostaza</title>
-  <circle cx="32" cy="32" r="32" fill="#C8A400"/>
-  <circle cx="32" cy="32" r="8" fill="none" stroke="white" stroke-width="3"/>
-  <path fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" d="M32 14 L32 22 M32 42 L32 50 M14 32 L22 32 M42 32 L50 32 M20 20 L26 26 M38 38 L44 44 M44 20 L38 26 M26 38 L20 44"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="t">
+<title id="t">Contiene mostaza</title>
+<circle cx="48" cy="48" r="48" fill="#C68A1F"></circle>
+
+<ellipse cx="48" cy="14" rx="3" ry="4" fill="#ffffff" opacity="0">
+  
+  
+</ellipse>
+<path d="M34 38 L34 70 Q34 78 42 78 L54 78 Q62 78 62 70 L62 38 Z" fill="#ffffff"></path>
+<path d="M40 38 L40 28 L36 24 L42 22 L54 22 L60 24 L56 28 L56 38 Z" fill="#ffffff"></path>
+<rect x="34" y="52" width="28" height="5" fill="#C68A1F"></rect>
 </svg>

--- a/public/images/allergens/pescado.svg
+++ b/public/images/allergens/pescado.svg
@@ -1,6 +1,29 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-pescado">
-  <title id="title-pescado">Pescado</title>
-  <circle cx="32" cy="32" r="32" fill="#1E73BE"/>
-  <path fill="white" d="M44 32 C44 32 36 22 24 24 C16 25 14 32 14 32 C14 32 16 39 24 40 C36 42 44 32 44 32 Z M44 32 L52 24 M44 32 L52 40 M52 24 L52 40 M28 30 C28 30 28 32 28 32" stroke="white" stroke-width="0" />
-  <circle cx="26" cy="30" r="2" fill="#1E73BE"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="t">
+<title id="t">Contiene pescado</title>
+<circle cx="48" cy="48" r="48" fill="#1E3F7D"></circle>
+
+<g>
+  
+  
+  <path d="M15 48 Q27 32 49 32 Q63 32 69 48 Q63 64 49 64 Q27 64 15 48 Z" fill="#ffffff"></path>
+  
+  <path d="M69 48 L81 36 L79 48 L81 60 Z" fill="#ffffff"></path>
+  
+  <circle cx="27" cy="44" r="3.2" fill="#1E3F7D"></circle>
+  <circle cx="28" cy="43" r="1.3" fill="#ffffff"></circle>
+  
+  <path d="M16 50 Q19 52 21 51" stroke="#1E3F7D" stroke-width="1.6" stroke-linecap="round" fill="none"></path>
+  
+  <path d="M37 40 Q33 48 37 56" stroke="#1E3F7D" stroke-width="2" stroke-linecap="round" fill="none"></path>
+  
+  <path d="M37 32 Q45 24 53 32" stroke="#1E3F7D" stroke-width="1.5" fill="none"></path>
+</g>
+<circle cx="22" cy="38" r="3" fill="#ffffff" opacity="0">
+  
+  
+</circle>
+<circle cx="16" cy="44" r="2" fill="#ffffff" opacity="0">
+  
+  
+</circle>
 </svg>

--- a/public/images/allergens/sesamo.svg
+++ b/public/images/allergens/sesamo.svg
@@ -1,9 +1,29 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-sesamo">
-  <title id="title-sesamo">Sésamo</title>
-  <circle cx="32" cy="32" r="32" fill="#D4A843"/>
-  <ellipse cx="24" cy="24" rx="5" ry="8" fill="white" transform="rotate(-20 24 24)"/>
-  <ellipse cx="32" cy="20" rx="5" ry="8" fill="white" transform="rotate(10 32 20)"/>
-  <ellipse cx="40" cy="24" rx="5" ry="8" fill="white" transform="rotate(20 40 24)"/>
-  <ellipse cx="26" cy="38" rx="5" ry="8" fill="white" transform="rotate(-10 26 38)"/>
-  <ellipse cx="38" cy="38" rx="5" ry="8" fill="white" transform="rotate(15 38 38)"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="t">
+<title id="t">Contiene granos de sésamo</title>
+<circle cx="48" cy="48" r="48" fill="#B5A082"></circle>
+
+<g transform="translate(32 40) rotate(-25)">
+  
+  <ellipse cx="0" cy="0" rx="5" ry="9" fill="#ffffff"></ellipse>
+</g>
+<g transform="translate(48 32) rotate(10)">
+  
+  <ellipse cx="0" cy="0" rx="5" ry="9" fill="#ffffff"></ellipse>
+</g>
+<g transform="translate(64 40) rotate(25)">
+  
+  <ellipse cx="0" cy="0" rx="5" ry="9" fill="#ffffff"></ellipse>
+</g>
+<g transform="translate(36 60) rotate(-15)">
+  
+  <ellipse cx="0" cy="0" rx="5" ry="9" fill="#ffffff"></ellipse>
+</g>
+<g transform="translate(52 62) rotate(20)">
+  
+  <ellipse cx="0" cy="0" rx="5" ry="9" fill="#ffffff"></ellipse>
+</g>
+<g transform="translate(64 58) rotate(-10)">
+  
+  <ellipse cx="0" cy="0" rx="5" ry="9" fill="#ffffff"></ellipse>
+</g>
 </svg>

--- a/public/images/allergens/soja.svg
+++ b/public/images/allergens/soja.svg
@@ -1,5 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-soja">
-  <title id="title-soja">Soja</title>
-  <circle cx="32" cy="32" r="32" fill="#4CAF50"/>
-  <path fill="white" d="M32 12 C32 12 44 20 44 32 C44 44 32 52 32 52 C32 52 20 44 20 32 C20 20 32 12 32 12 Z M32 12 L32 52 M32 32 C32 32 24 28 22 20 M32 32 C32 32 40 28 42 20"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="t">
+<title id="t">Contiene soja</title>
+<circle cx="48" cy="48" r="48" fill="#6DBE5A"></circle>
+
+<g>
+  
+  
+  <path d="M48 50 L48 78" stroke="#ffffff" stroke-width="3" stroke-linecap="round" fill="none"></path>
+  
+  <ellipse cx="48" cy="32" rx="11" ry="16" fill="#ffffff"></ellipse>
+  <path d="M48 22 L48 44" stroke="#6DBE5A" stroke-width="1.5" stroke-linecap="round" fill="none"></path>
+  
+  <g transform="rotate(-55 48 50)">
+    <ellipse cx="48" cy="32" rx="10" ry="14" fill="#ffffff"></ellipse>
+    <path d="M48 22 L48 42" stroke="#6DBE5A" stroke-width="1.5" stroke-linecap="round" fill="none"></path>
+  </g>
+  
+  <g transform="rotate(55 48 50)">
+    <ellipse cx="48" cy="32" rx="10" ry="14" fill="#ffffff"></ellipse>
+    <path d="M48 22 L48 42" stroke="#6DBE5A" stroke-width="1.5" stroke-linecap="round" fill="none"></path>
+  </g>
+</g>
 </svg>

--- a/public/images/allergens/sulfitos.svg
+++ b/public/images/allergens/sulfitos.svg
@@ -1,6 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title-sulfitos">
-  <title id="title-sulfitos">Sulfitos</title>
-  <circle cx="32" cy="32" r="32" fill="#C0392B"/>
-  <text x="32" y="38" font-family="Arial,sans-serif" font-size="18" font-weight="bold" fill="white" text-anchor="middle">SO₂</text>
-  <circle cx="32" cy="32" r="20" fill="none" stroke="white" stroke-width="2.5"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" role="img" aria-labelledby="t">
+<title id="t">Contiene sulfitos y dióxido de azufre</title>
+<circle cx="48" cy="48" r="48" fill="#6E2A4D"></circle>
+
+<g>
+  
+  <polygon points="48,22 66,33 66,55 48,66 30,55 30,33" stroke="#ffffff" stroke-width="3.5" fill="none" stroke-linejoin="round"></polygon>
+  <polygon points="48,28 60,35 60,52 48,58 36,52 36,35" stroke="#ffffff" stroke-width="1.5" fill="none" stroke-linejoin="round" opacity="0.5"></polygon>
+</g>
+<g>
+  
+  <text x="48" y="49" text-anchor="middle" fill="#ffffff" font-family="Nunito, system-ui, sans-serif" font-weight="900" font-size="14">E-X</text>
+</g>
 </svg>

--- a/resources/views/components/allergen-badge.blade.php
+++ b/resources/views/components/allergen-badge.blade.php
@@ -5,13 +5,13 @@
 @endphp
 
 <span class="inline-flex items-center gap-1.5 px-2 py-1 rounded-lg
-             bg-amber-50 dark:bg-amber-900/20
-             border border-amber-200 dark:border-amber-800
-             text-xs font-medium text-amber-900 dark:text-amber-200"
-      role="listitem" title="{{ $label }}">
+             bg-white dark:bg-gray-800
+             border border-gray-200 dark:border-gray-700
+             text-xs font-medium text-gray-700 dark:text-gray-300 shrink-0"
+      role="listitem">
     <img src="{{ asset('images/allergens/' . $slug . '.svg') }}"
-         alt=""
-         aria-hidden="true"
-         class="h-5 w-5 object-contain shrink-0">
+         width="24" height="24"
+         class="shrink-0"
+         alt="{{ $label }}">
     {{ $label }}
 </span>

--- a/resources/views/components/allergen-badge.blade.php
+++ b/resources/views/components/allergen-badge.blade.php
@@ -4,13 +4,14 @@
     $label = \App\Models\Ingredient::ALLERGEN_TYPES[$slug] ?? $slug;
 @endphp
 
-<div class="flex flex-col items-center gap-1 w-16" title="{{ $label }}">
-    <div class="w-12 h-12 rounded-full bg-white border-2 border-gray-300 flex items-center justify-center shadow-sm p-2">
-        <img src="{{ asset('images/allergens/' . $slug . '.svg') }}"
-             alt="{{ $label }}"
-             class="w-full h-full object-contain">
-    </div>
-    <span class="text-xs text-center font-medium text-gray-600 dark:text-gray-400 leading-tight">
-        {{ $label }}
-    </span>
-</div>
+<span class="inline-flex items-center gap-1.5 px-2 py-1 rounded-lg
+             bg-amber-50 dark:bg-amber-900/20
+             border border-amber-200 dark:border-amber-800
+             text-xs font-medium text-amber-900 dark:text-amber-200"
+      role="listitem" title="{{ $label }}">
+    <img src="{{ asset('images/allergens/' . $slug . '.svg') }}"
+         alt=""
+         aria-hidden="true"
+         class="h-5 w-5 object-contain shrink-0">
+    {{ $label }}
+</span>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -631,13 +631,10 @@
                                                                 {{-- Badges alérgenos --}}
                                                                 <div class="pcard__badges">
                                                                     <template x-for="al in (card.allergens || []).filter(a => a.svgId).slice(0, 5)" :key="al.name">
-                                                                        <svg class="allergen-img"
-                                                                             :data-al="al.svgId"
-                                                                             :aria-label="al.label"
-                                                                             viewBox="0 0 100 100"
-                                                                             width="22" height="22"
-                                                                             role="img">
-                                                                        </svg>
+                                                                        <img class="allergen-img"
+                                                                             :src="'/images/allergens/' + al.svgId + '.svg'"
+                                                                             :alt="al.label"
+                                                                             width="22" height="22">
                                                                     </template>
                                                                 </div>
                                                                 {{-- Nombre --}}
@@ -1080,13 +1077,10 @@
                                     :class="activeAllergens.includes('{{ $slug }}') ? 'allergen-chip--active' : ''"
                                     @click="toggleAllergen('{{ $slug }}')"
                                     :aria-pressed="activeAllergens.includes('{{ $slug }}').toString()">
-                                <svg class="allergen-img"
-                                     data-al="{{ $slug }}"
-                                     viewBox="0 0 100 100"
+                                <img class="allergen-img"
+                                     src="{{ asset('images/allergens/' . $slug . '.svg') }}"
                                      width="22" height="22"
-                                     role="img"
-                                     aria-label="{{ $name }}">
-                                </svg>
+                                     alt="{{ $name }}">
                                 <span>Sin {{ $allergenShortLabels[$slug] ?? $name }}</span>
                             </button>
                             @endforeach
@@ -1202,13 +1196,10 @@
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
                                 </svg>
                             </span>
-                            <svg class="allergen-img"
-                                 data-al="{{ $slug }}"
-                                 viewBox="0 0 100 100"
+                            <img class="allergen-img"
+                                 src="{{ asset('images/allergens/' . $slug . '.svg') }}"
                                  width="22" height="22"
-                                 role="img"
-                                 aria-label="{{ $name }}">
-                            </svg>
+                                 alt="{{ $name }}">
                             <span style="font-size:13px">Sin {{ $allergenShortLabels[$slug] ?? $name }}</span>
                         </div>
                         @endforeach
@@ -1310,13 +1301,10 @@
                                 {{-- Badges alérgenos — pictogramas oficiales DS --}}
                                 <div class="pcard__badges">
                                     @foreach($allergenSlugs->take(5) as $slug)
-                                    <svg class="allergen-img"
-                                         data-al="{{ $slug }}"
-                                         viewBox="0 0 100 100"
+                                    <img class="allergen-img"
+                                         src="{{ asset('images/allergens/' . $slug . '.svg') }}"
                                          width="22" height="22"
-                                         role="img"
-                                         aria-label="Contiene {{ \App\Models\Ingredient::ALLERGEN_TYPES[$slug] ?? $slug }}">
-                                    </svg>
+                                         alt="Contiene {{ \App\Models\Ingredient::ALLERGEN_TYPES[$slug] ?? $slug }}">
                                     @endforeach
                                 </div>
 
@@ -3838,13 +3826,10 @@
                                 <div class="pdetail__allergens">
                                     <template x-for="al in (selectedProduct?.allergenTypes || [])" :key="al">
                                         <span class="pdetail__allergen">
-                                            <svg class="allergen-img"
-                                                 :data-al="al"
-                                                 viewBox="0 0 100 100"
+                                            <img class="allergen-img"
+                                                 :src="'/images/allergens/' + al + '.svg'"
                                                  width="22" height="22"
-                                                 role="img"
-                                                 :aria-label="'Contiene ' + (window.ZAMPA_ALLERGEN_LABELS?.[al] || al)">
-                                            </svg>
+                                                 :alt="'Contiene ' + (window.ZAMPA_ALLERGEN_LABELS?.[al] || al)">
                                             <span x-text="window.ZAMPA_ALLERGEN_LABELS?.[al] || al"></span>
                                         </span>
                                     </template>

--- a/resources/views/menu/show.blade.php
+++ b/resources/views/menu/show.blade.php
@@ -631,10 +631,13 @@
                                                                 {{-- Badges alérgenos --}}
                                                                 <div class="pcard__badges">
                                                                     <template x-for="al in (card.allergens || []).filter(a => a.svgId).slice(0, 5)" :key="al.name">
-                                                                        <img class="allergen-img"
-                                                                             :src="'/images/allergens/' + al.svgId + '.svg'"
-                                                                             :alt="al.label"
-                                                                             width="22" height="22">
+                                                                        <svg class="allergen-img"
+                                                                             :data-al="al.svgId"
+                                                                             :aria-label="al.label"
+                                                                             viewBox="0 0 100 100"
+                                                                             width="22" height="22"
+                                                                             role="img">
+                                                                        </svg>
                                                                     </template>
                                                                 </div>
                                                                 {{-- Nombre --}}
@@ -1077,10 +1080,13 @@
                                     :class="activeAllergens.includes('{{ $slug }}') ? 'allergen-chip--active' : ''"
                                     @click="toggleAllergen('{{ $slug }}')"
                                     :aria-pressed="activeAllergens.includes('{{ $slug }}').toString()">
-                                <img class="allergen-img"
-                                     src="{{ asset('images/allergens/' . $slug . '.svg') }}"
+                                <svg class="allergen-img"
+                                     data-al="{{ $slug }}"
+                                     viewBox="0 0 100 100"
                                      width="22" height="22"
-                                     alt="{{ $name }}">
+                                     role="img"
+                                     aria-label="{{ $name }}">
+                                </svg>
                                 <span>Sin {{ $allergenShortLabels[$slug] ?? $name }}</span>
                             </button>
                             @endforeach
@@ -1196,10 +1202,13 @@
                                     <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
                                 </svg>
                             </span>
-                            <img class="allergen-img"
-                                 src="{{ asset('images/allergens/' . $slug . '.svg') }}"
+                            <svg class="allergen-img"
+                                 data-al="{{ $slug }}"
+                                 viewBox="0 0 100 100"
                                  width="22" height="22"
-                                 alt="{{ $name }}">
+                                 role="img"
+                                 aria-label="{{ $name }}">
+                            </svg>
                             <span style="font-size:13px">Sin {{ $allergenShortLabels[$slug] ?? $name }}</span>
                         </div>
                         @endforeach
@@ -1301,10 +1310,13 @@
                                 {{-- Badges alérgenos — pictogramas oficiales DS --}}
                                 <div class="pcard__badges">
                                     @foreach($allergenSlugs->take(5) as $slug)
-                                    <img class="allergen-img"
-                                         src="{{ asset('images/allergens/' . $slug . '.svg') }}"
+                                    <svg class="allergen-img"
+                                         data-al="{{ $slug }}"
+                                         viewBox="0 0 100 100"
                                          width="22" height="22"
-                                         alt="Contiene {{ \App\Models\Ingredient::ALLERGEN_TYPES[$slug] ?? $slug }}">
+                                         role="img"
+                                         aria-label="Contiene {{ \App\Models\Ingredient::ALLERGEN_TYPES[$slug] ?? $slug }}">
+                                    </svg>
                                     @endforeach
                                 </div>
 
@@ -3826,10 +3838,13 @@
                                 <div class="pdetail__allergens">
                                     <template x-for="al in (selectedProduct?.allergenTypes || [])" :key="al">
                                         <span class="pdetail__allergen">
-                                            <img class="allergen-img"
-                                                 :src="'/images/allergens/' + al + '.svg'"
+                                            <svg class="allergen-img"
+                                                 :data-al="al"
+                                                 viewBox="0 0 100 100"
                                                  width="22" height="22"
-                                                 :alt="'Contiene ' + (window.ZAMPA_ALLERGEN_LABELS?.[al] || al)">
+                                                 role="img"
+                                                 :aria-label="'Contiene ' + (window.ZAMPA_ALLERGEN_LABELS?.[al] || al)">
+                                            </svg>
                                             <span x-text="window.ZAMPA_ALLERGEN_LABELS?.[al] || al"></span>
                                         </span>
                                     </template>

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -326,7 +326,7 @@
                 </svg>
                 Alérgenos detectados
             </p>
-            <div class="flex flex-wrap gap-2" role="list" aria-label="Alérgenos de {{ $product->name }}">
+            <div class="flex flex-wrap gap-1.5" role="list" aria-label="Alérgenos de {{ $product->name }}">
                 @foreach($product->allergens->flatMap(fn($i) => $i->allergen_types ?? [])->unique()->values() as $slug)
                     <x-allergen-badge :slug="$slug" />
                 @endforeach

--- a/resources/views/products/index.blade.php
+++ b/resources/views/products/index.blade.php
@@ -299,7 +299,7 @@
                     ->unique()->values();
               @endphp
               @if($allergenSlugs->isNotEmpty())
-                <div class="flex flex-wrap gap-3" role="list" aria-label="Alérgenos de {{ $product->name }}">
+                <div class="flex flex-wrap gap-1.5" role="list" aria-label="Alérgenos de {{ $product->name }}">
                   @foreach($allergenSlugs as $slug)
                     <x-allergen-badge :slug="$slug" />
                   @endforeach


### PR DESCRIPTION
## Resumen

- Sustituidos los 14 SVG de alérgenos en `public/images/allergens/` por los archivos oficiales del DS (`CARTA MENU DIGITAL Design System/assets/allergens/`), que incluyen el pictograma completo: círculo de color por alérgeno + silueta blanca, `viewBox="0 0 96 96"`, idénticos a los que usa la carta digital
- Rediseñado el componente `allergen-badge` para mostrar el icono oficial (24×24 px) + etiqueta en un chip horizontal compacto, en lugar del antiguo formato circular grande (48×48) con nombre centrado debajo

## Páginas afectadas

- `/ingredients` — badges de alérgenos por ingrediente
- `/ingredients/create` y `/ingredients/{id}/edit` — selector de tipos de alérgeno
- `/products` — columna Alérgenos de la tabla
- `/products/{id}/edit` — sección "Alérgenos detectados"

## Plan de pruebas

- [ ] Visitar `/ingredients` y verificar que los badges muestran el pictograma de color correcto
- [ ] Visitar `/products` y verificar la columna Alérgenos con los iconos oficiales
- [ ] Visitar `/products/{id}/edit` con producto con alérgenos y ver la sección "Alérgenos detectados"
- [ ] Visitar `/ingredients/create` y comprobar que el selector de alérgenos muestra los SVG correctos